### PR TITLE
feat: add obs-cli wrapper for Obsidian CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
             'setup-windows.ps1',
             'scripts/init-project.ps1',
             'scripts/knowledge-crystallize.ps1',
+            'scripts/obs-cli.ps1',
             'powershell/profile.ps1'
           )
           $failed = $false

--- a/ai/claude/CLAUDE.md
+++ b/ai/claude/CLAUDE.md
@@ -272,6 +272,23 @@ tags: [tag1, tag2]
 * Do NOT use for: boilerplate, single-file edits, syntax fixes, CSS changes.
 * Pairs well with Context7: use Sequential Thinking to plan, Context7 to validate API choices.
 
+### Obsidian CLI (Vault Graph Queries)
+
+**Available via:** `obs-cli.sh <command>` (Linux) / `obs-cli.ps1 <command>` (Windows).
+Requires Obsidian GUI running. Falls back with exit 2 if GUI is down.
+Set `OBS_VAULT` env var to override default vault (default: `knowledge`).
+
+**Unique commands (not covered by Hive MCP):**
+* `backlinks file="path/to/note.md"` — notes linking to a given file
+* `orphans` — files with no incoming links
+* `dead-ends` — files with no outgoing links
+* `unresolved` — broken wikilinks
+* `tags` / `tags:rename old=X new=Y` — list or bulk-rename tags
+* `eval "expression"` — execute JS against Obsidian internal API
+
+**When to use:** Vault maintenance, graph analysis, bulk tag operations.
+**When NOT to use:** File CRUD and search — use Hive MCP instead (headless, always available).
+
 ## Response Protocol
 
 1. **Classify Task:** Determine if Low Load (Execute) or High Load (Mentor).

--- a/scripts/init-project.ps1
+++ b/scripts/init-project.ps1
@@ -101,14 +101,14 @@ See [[../00-context|$Family family context]] for all repos.
 "@
 
     Set-Content -Path "$SdkDir\memory\MEMORY.md" -Encoding UTF8 -Value @"
-# $Component — Work SDK Session Memory
+# $Component - Work SDK Session Memory
 
 ## Session Handoff
 > Updated: $Today
 **Last task:** Vault entry initialized
 **Decisions:** None
 **Open threads:** Fill source_path in 00-context.md with real repo path
-**Next action:** Open Claude in real repo — session hook creates junction automatically
+**Next action:** Open Claude in real repo -- session hook creates junction automatically
 
 ## User Preferences
 - Follow global CLAUDE.md + workflow-protocol.md rules
@@ -123,7 +123,7 @@ type: lesson
 status: active
 tags: [work, sdk, $Family]
 ---
-# Lessons Learned — $Component
+# Lessons Learned - $Component
 
 *Record non-trivial bugs and decisions here. Promoted to 00_meta/patterns/ if recurring.*
 "@
@@ -285,7 +285,7 @@ created: "$Today"
 ## Development Flow
 1. Feature branch from ``main``
 2. PR with tests
-3. Merge → deploy
+3. Merge -> deploy
 "@
 }
 
@@ -344,7 +344,7 @@ type: lesson
 status: active
 tags: []
 ---
-# Lessons Learned — $ProjectBaseName
+# Lessons Learned - $ProjectBaseName
 
 *Non-trivial bugs and decisions. Promoted to 00_meta/patterns/ if recurring across projects.*
 "@

--- a/scripts/obs-cli.ps1
+++ b/scripts/obs-cli.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+    Thin wrapper around Obsidian CLI for Windows.
+
+.DESCRIPTION
+    Handles default vault name and GUI connectivity check.
+    Passes all arguments through to the Obsidian CLI.
+
+    Exit codes:
+      0 = success
+      1 = error
+      2 = GUI not running
+
+.PARAMETER Command
+    The Obsidian CLI command to execute (e.g., backlinks, orphans, tags).
+
+.PARAMETER Args
+    Additional arguments passed through to the Obsidian CLI.
+
+.EXAMPLE
+    obs-cli.ps1 backlinks file="path/to/note.md"
+    obs-cli.ps1 orphans
+    obs-cli.ps1 tags
+    obs-cli.ps1 tags:rename old=wip new=in-progress
+    obs-cli.ps1 search query="pattern"
+    obs-cli.ps1 eval "app.vault.getFiles().length"
+
+.NOTES
+    Requires Obsidian desktop app running (CLI communicates via IPC).
+    Set $env:OBS_VAULT to override the default vault name.
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$OBS_VAULT = if ($env:OBS_VAULT) { $env:OBS_VAULT } else { 'knowledge' }
+
+function Write-Info { param([string]$Message) Write-Host "[INFO] $Message" -ForegroundColor Cyan }
+function Write-Err  { param([string]$Message) Write-Host "[ERROR] $Message" -ForegroundColor Red }
+
+if ($args.Count -eq 0 -or $args[0] -eq '--help' -or $args[0] -eq '-h') {
+    Write-Host @"
+Usage: obs-cli.ps1 <command> [args...]
+
+Wrapper for Obsidian CLI with default vault.
+
+Environment:
+  OBS_VAULT   Vault name (default: knowledge)
+
+Examples:
+  obs-cli.ps1 backlinks file="path/to/note.md"
+  obs-cli.ps1 orphans
+  obs-cli.ps1 tags
+  obs-cli.ps1 tags:rename old=wip new=in-progress
+  obs-cli.ps1 search query="pattern"
+  obs-cli.ps1 eval "app.vault.getFiles().length"
+"@
+    exit 0
+}
+
+# Check obsidian is in PATH
+$obsCmd = Get-Command obsidian -ErrorAction SilentlyContinue
+if (-not $obsCmd) {
+    Write-Err 'Obsidian not found in PATH'
+    exit 1
+}
+
+# Connectivity check: verify GUI is running
+try {
+    $null = & obsidian vault --vault $OBS_VAULT 2>&1
+    if ($LASTEXITCODE -ne 0) { throw 'not running' }
+} catch {
+    Write-Err 'Cannot reach Obsidian GUI. Is Obsidian running?'
+    Write-Info 'Start Obsidian desktop app first.'
+    exit 2
+}
+
+& obsidian @args --vault $OBS_VAULT
+exit $LASTEXITCODE

--- a/scripts/obs-cli.sh
+++ b/scripts/obs-cli.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# obs-cli.sh: Thin wrapper around Obsidian CLI
+# Handles --no-sandbox (Linux), default vault, and GUI connectivity check.
+# Usage: obs-cli.sh <command> [args...]
+# Exit: 0 = success, 1 = error, 2 = GUI not running
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+if [ -f "$SCRIPT_DIR/utils.sh" ]; then
+    # shellcheck source=utils.sh disable=SC1091
+    . "$SCRIPT_DIR/utils.sh"
+else
+    echo "Error: utils.sh not found in $SCRIPT_DIR" >&2
+    exit 1
+fi
+
+OBS_VAULT="${OBS_VAULT:-knowledge}"
+
+usage() {
+    printf 'Usage: obs-cli.sh <command> [args...]\n\n'
+    printf 'Wrapper for Obsidian CLI with --no-sandbox and default vault.\n\n'
+    printf 'Environment:\n'
+    printf '  OBS_VAULT   Vault name (default: knowledge)\n\n'
+    printf 'Examples:\n'
+    printf '  obs-cli.sh backlinks file="path/to/note.md"\n'
+    printf '  obs-cli.sh orphans\n'
+    printf '  obs-cli.sh tags\n'
+    printf '  obs-cli.sh tags:rename old=wip new=in-progress\n'
+    printf '  obs-cli.sh search query="pattern"\n'
+    printf '  obs-cli.sh eval "app.vault.getFiles().length"\n'
+}
+
+if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    usage
+    exit 0
+fi
+
+if ! command_exists obsidian; then
+    log_error "Obsidian not found in PATH"
+    exit 1
+fi
+
+# Connectivity check: verify GUI is running
+if ! obsidian --no-sandbox vault --vault "$OBS_VAULT" >/dev/null 2>&1; then
+    log_error "Cannot reach Obsidian GUI. Is Obsidian running?"
+    log_info "Start Obsidian or run: obsidian --no-sandbox &"
+    exit 2
+fi
+
+exec obsidian --no-sandbox "$@" --vault "$OBS_VAULT"

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -585,6 +585,14 @@ if (Test-Path $syncSource) {
     Write-Warn "dotfiles-sync.ps1 not found at $syncSource"
 }
 
+$obsCliSource = "$DotfilesDir\scripts\obs-cli.ps1"
+if (Test-Path $obsCliSource) {
+    Copy-Item $obsCliSource "$ScriptsDir\" -Force
+    Write-Success "Deployed obs-cli.ps1 to $ScriptsDir\"
+} else {
+    Write-Warn "obs-cli.ps1 not found at $obsCliSource"
+}
+
 $loadSecretsSource = "$DotfilesDir\scripts\load-secrets.ps1"
 if (Test-Path $loadSecretsSource) {
     Ensure-Directory "$DotfilesDest\scripts"

--- a/tests/obs-cli-ps1.bats
+++ b/tests/obs-cli-ps1.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# Tests for scripts/obs-cli.ps1 (structural + PSScriptAnalyzer)
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    export SCRIPTS_DIR="$DOTFILES_DIR/scripts"
+    export PS1_SCRIPT="$SCRIPTS_DIR/obs-cli.ps1"
+}
+
+@test "obs-cli.ps1 exists" {
+    [[ -f "$PS1_SCRIPT" ]]
+}
+
+@test "obs-cli.ps1 has .SYNOPSIS block" {
+    grep -q '\.SYNOPSIS' "$PS1_SCRIPT"
+}
+
+@test "obs-cli.ps1 has .DESCRIPTION block" {
+    grep -q '\.DESCRIPTION' "$PS1_SCRIPT"
+}
+
+@test "obs-cli.ps1 has .EXAMPLE block" {
+    grep -q '\.EXAMPLE' "$PS1_SCRIPT"
+}
+
+@test "obs-cli.ps1 uses Set-StrictMode" {
+    grep -q 'Set-StrictMode' "$PS1_SCRIPT"
+}
+
+@test "obs-cli.ps1 has ErrorActionPreference Stop" {
+    grep -q "ErrorActionPreference = 'Stop'" "$PS1_SCRIPT"
+}
+
+@test "obs-cli.ps1 defaults vault to knowledge" {
+    grep -q "'knowledge'" "$PS1_SCRIPT"
+}
+
+@test "obs-cli.ps1 checks obsidian in PATH" {
+    grep -q 'Get-Command obsidian' "$PS1_SCRIPT"
+}
+
+@test "obs-cli.ps1 exits 2 when GUI not running" {
+    grep -q 'exit 2' "$PS1_SCRIPT"
+}
+
+@test "obs-cli.ps1 passes PSScriptAnalyzer (if pwsh available)" {
+    if ! command -v pwsh >/dev/null 2>&1; then
+        skip "pwsh not available"
+    fi
+    run pwsh -NonInteractive -Command "
+        \$ErrorActionPreference = 'Stop'
+        try {
+            Install-Module PSScriptAnalyzer -Force -Scope CurrentUser -ErrorAction SilentlyContinue
+            \$results = Invoke-ScriptAnalyzer -Path '$PS1_SCRIPT' -Settings '$DOTFILES_DIR/.PSScriptAnalyzerSettings.psd1' -Severity Error,Warning
+            if (\$results) {
+                \$results | Format-Table -AutoSize
+                exit 1
+            }
+            Write-Host 'PSScriptAnalyzer: OK'
+        } catch {
+            Write-Warning \"PSScriptAnalyzer not available: \$_\"
+            exit 0
+        }
+    "
+    [[ "$status" -eq 0 ]]
+}
+
+@test "obs-cli.ps1 valid PowerShell syntax (if pwsh available)" {
+    if ! command -v pwsh >/dev/null 2>&1; then
+        skip "pwsh not available"
+    fi
+    run pwsh -NonInteractive -Command "
+        \$errors = \$null
+        [System.Management.Automation.Language.Parser]::ParseFile(
+            '$PS1_SCRIPT', [ref]\$null, [ref]\$errors
+        ) | Out-Null
+        if (\$errors) {
+            \$errors | ForEach-Object { Write-Error \$_.Message }
+            exit 1
+        }
+        Write-Host 'Syntax OK'
+    "
+    [[ "$status" -eq 0 ]]
+}

--- a/tests/obs-cli.bats
+++ b/tests/obs-cli.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# Tests for scripts/obs-cli.sh
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    export SCRIPTS_DIR="$DOTFILES_DIR/scripts"
+}
+
+@test "obs-cli.sh valid bash syntax" {
+    bash -n "$SCRIPTS_DIR/obs-cli.sh"
+}
+
+@test "obs-cli.sh valid zsh syntax" {
+    zsh -n "$SCRIPTS_DIR/obs-cli.sh"
+}
+
+@test "obs-cli.sh is executable" {
+    [[ -x "$SCRIPTS_DIR/obs-cli.sh" ]]
+}
+
+@test "obs-cli.sh sources utils.sh" {
+    grep -q 'utils.sh' "$SCRIPTS_DIR/obs-cli.sh"
+}
+
+@test "obs-cli.sh uses set -euo pipefail" {
+    grep -q 'set -euo pipefail' "$SCRIPTS_DIR/obs-cli.sh"
+}
+
+@test "obs-cli.sh defaults OBS_VAULT to knowledge" {
+    grep -q 'OBS_VAULT:-knowledge' "$SCRIPTS_DIR/obs-cli.sh"
+}
+
+@test "obs-cli.sh checks obsidian command exists" {
+    grep -q 'command_exists obsidian' "$SCRIPTS_DIR/obs-cli.sh"
+}
+
+@test "obs-cli.sh exits 2 when GUI not running" {
+    grep -q 'exit 2' "$SCRIPTS_DIR/obs-cli.sh"
+}
+
+@test "obs-cli.sh passes --no-sandbox flag" {
+    grep -q '\-\-no-sandbox' "$SCRIPTS_DIR/obs-cli.sh"
+}
+
+@test "obs-cli.sh has usage function" {
+    grep -q 'usage()' "$SCRIPTS_DIR/obs-cli.sh"
+}
+
+@test "obs-cli.sh shows help with --help flag" {
+    grep -q '\-\-help' "$SCRIPTS_DIR/obs-cli.sh"
+}
+
+@test "obs-cli.sh passes shellcheck" {
+    if command -v shellcheck >/dev/null 2>&1; then
+        shellcheck "$SCRIPTS_DIR/obs-cli.sh"
+    elif [[ -x "$HOME/.local/bin/shellcheck" ]]; then
+        "$HOME/.local/bin/shellcheck" "$SCRIPTS_DIR/obs-cli.sh"
+    else
+        skip "shellcheck not available"
+    fi
+}

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -72,6 +72,10 @@ setup() {
     grep -q 'dotfiles-sync.ps1' "$PS1_SCRIPT"
 }
 
+@test "setup-windows.ps1 deploys obs-cli.ps1" {
+    grep -q 'obs-cli.ps1' "$PS1_SCRIPT"
+}
+
 @test "setup-windows.ps1 deploys load-secrets.ps1" {
     grep -q 'load-secrets.ps1' "$PS1_SCRIPT"
 }


### PR DESCRIPTION
## Summary
- Adds `obs-cli.sh` (Linux) and `obs-cli.ps1` (Windows) wrapper scripts for Obsidian CLI
- Handles `--no-sandbox` (Linux), default vault name (`OBS_VAULT`), and GUI connectivity check (exit 2 if GUI down)
- Enables Claude Code agents to use Obsidian graph queries (`backlinks`, `orphans`, `tags:rename`, `eval`) with a simple interface
- Documents available CLI commands in `ai/claude/CLAUDE.md` for cross-machine agent discovery

## Changes
- `scripts/obs-cli.sh` — Linux wrapper (sources utils.sh, shellcheck clean)
- `scripts/obs-cli.ps1` — Windows PowerShell equivalent (Set-StrictMode, ErrorActionPreference Stop)
- `setup-windows.ps1` — deploys obs-cli.ps1 to user scripts dir
- `ai/claude/CLAUDE.md` — new "Obsidian CLI" section under MCP Server Usage Rules
- `.github/workflows/ci.yml` — adds obs-cli.ps1 to PSScriptAnalyzer lint list
- `tests/obs-cli.bats` + `tests/obs-cli-ps1.bats` — 23 new tests
- `tests/setup-windows.bats` — 1 new deployment parity test

## Test plan
- [x] shellcheck passes on obs-cli.sh
- [x] bash + zsh syntax validation
- [x] 23/23 new obs-cli tests pass
- [x] 369/369 full suite passes (zero regressions)
- [x] CI: lint (shellcheck), lint-powershell (PSScriptAnalyzer), test (bats), integration