### PR TITLE
feat(scripts): claude-mem self-heal + Hive-first MCP rule

### DIFF
--- a/ai/claude/CLAUDE.md
+++ b/ai/claude/CLAUDE.md
@@ -297,6 +297,25 @@ tags: [tag1, tag2]
 * Do NOT use for: boilerplate, single-file edits, syntax fixes, CSS changes.
 * Pairs well with Context7: use Sequential Thinking to plan, Context7 to validate API choices.
 
+### Hive (Obsidian Vault Operations)
+
+**Auto-invoke for any read/search/write against the vault.** Hive saves tokens
+by returning excerpts (not full files) and offloading work server-side.
+
+* `vault_search` over `grep`+`Read` (5–10× cheaper, returns excerpts).
+* `vault_query(section=context|tasks|lessons|roadmap)` over `Read` of whole files.
+* `vault_patch` / `vault_write` over `Edit`/`Write` — auto-commits as `vault: patch …`.
+* `capture_lesson` over manual `90-lessons.md` writes.
+* `vault_health` over Bash + `vault-validate.py`.
+* `delegate_task` for bulk summaries — keeps main context lean.
+* `vault_list` before `ls`/`find` to browse structure.
+
+Native `Read`/`Edit`/`Write`/`grep` remain correct for code repos, scripts,
+configs — anything outside the vault. Vault auto-commits are intentional;
+do NOT also create a manual git commit for vault edits.
+
+See `00_meta/patterns/pattern-hive-first-vault-access.md` for full rationale.
+
 ### Obsidian CLI (Vault Graph Queries)
 
 **Available via:** `obs-cli.sh <command>` (Linux) / `obs-cli.ps1 <command>` (Windows).

--- a/scripts/claude-mem-heal.sh
+++ b/scripts/claude-mem-heal.sh
@@ -1,0 +1,116 @@
+#!/bin/sh
+# claude-mem-heal.sh: idempotently repair the thedotmack/claude-mem plugin
+# cache when the published artifact ships broken (v12.7.4, v13.0.0).
+#
+# Two known issues this script papers over:
+#
+#   1. .mcp.json embeds shell parameter expansion (${_R%/}) that Claude
+#      Code's MCP loader misreads as an env-var name. See upstream
+#      issue #2385. We rewrite the file to the simpler v10.6.3 form.
+#
+#   2. v13.0.0 declares "zod": "^4.3.6" in package.json but the published
+#      bun.lock and node_modules/ omit it, so worker-service.cjs crashes
+#      with "Cannot find module 'zod/v3'". We install zod in place.
+#
+# Both upstream errors revert on /plugin update, so this runs from
+# claude-session-start.sh to self-heal at session start.
+#
+# Behaviour: silent on healthy installs (exit 0, no output). Prints one
+# line per heal action taken so the SessionStart hook can surface it.
+# Always exits 0 — never blocks session start on transient failures.
+#
+# Usage:
+#   claude-mem-heal.sh           # silent unless something was healed
+#   claude-mem-heal.sh --verbose # always log what was checked
+
+set -eu
+
+VERBOSE=0
+[ "${1:-}" = "--verbose" ] && VERBOSE=1
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CACHE_ROOT="$CLAUDE_DIR/plugins/cache/thedotmack/claude-mem"
+MARKETPLACE_DIR="$CLAUDE_DIR/plugins/marketplaces/thedotmack/plugin"
+
+log() { printf '[claude-mem-heal] %s\n' "$1"; }
+verbose() { if [ "$VERBOSE" -eq 1 ]; then log "$1"; fi; }
+
+# Replace a broken .mcp.json with the v10.6.3 form. Idempotent: only
+# rewrites if the file contains the offending ${_R%/} pattern.
+heal_mcp_json() {
+    target="$1"
+    [ -f "$target" ] || { verbose "no .mcp.json at $target"; return 0; }
+
+    # shellcheck disable=SC2016 # literal pattern, intentionally not expanded
+    if ! grep -qF '${_R%/}' "$target" 2>/dev/null; then
+        verbose ".mcp.json already healthy: $target"
+        return 0
+    fi
+
+    cat > "$target" <<'EOF'
+{
+  "mcpServers": {
+    "mcp-search": {
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/scripts/mcp-server.cjs"
+      ]
+    }
+  }
+}
+EOF
+    log "patched .mcp.json: $target"
+}
+
+# Install the zod runtime dep if package.json declares it but it isn't
+# installed. Idempotent: skips when node_modules/zod exists.
+heal_zod() {
+    plugin_dir="$1"
+    pkg="$plugin_dir/package.json"
+    [ -f "$pkg" ] || { verbose "no package.json at $plugin_dir"; return 0; }
+
+    # Only act if package.json declares zod and node_modules/zod is missing.
+    grep -q '"zod"' "$pkg" 2>/dev/null || { verbose "no zod dep in $pkg"; return 0; }
+    [ -d "$plugin_dir/node_modules/zod" ] && { verbose "zod present in $plugin_dir"; return 0; }
+
+    if ! command -v npm >/dev/null 2>&1; then
+        log "ERROR: zod missing in $plugin_dir but npm not on PATH — skipping"
+        return 0
+    fi
+
+    # Use a subshell so we don't leak the cd. Suppress output unless verbose.
+    if [ "$VERBOSE" -eq 1 ]; then
+        ( cd "$plugin_dir" && npm install --no-save --no-package-lock --no-audit --no-fund zod@^4.3.6 ) || {
+            log "ERROR: npm install zod failed in $plugin_dir"
+            return 0
+        }
+    else
+        ( cd "$plugin_dir" && npm install --no-save --no-package-lock --no-audit --no-fund --silent zod@^4.3.6 >/dev/null 2>&1 ) || {
+            log "ERROR: npm install zod failed in $plugin_dir"
+            return 0
+        }
+    fi
+    log "installed missing zod dep in $plugin_dir"
+}
+
+heal_dir() {
+    dir="$1"
+    [ -d "$dir" ] || return 0
+    heal_mcp_json "$dir/.mcp.json"
+    heal_zod "$dir"
+}
+
+# Heal every cached version (so a rolled-back /plugin doesn't surprise us)
+# plus the marketplace copy used as fallback by the discovery logic.
+if [ -d "$CACHE_ROOT" ]; then
+    for d in "$CACHE_ROOT"/*/; do
+        heal_dir "${d%/}"
+    done
+else
+    verbose "no cache dir at $CACHE_ROOT"
+fi
+
+heal_dir "$MARKETPLACE_DIR"
+
+exit 0

--- a/scripts/claude-session-start.sh
+++ b/scripts/claude-session-start.sh
@@ -81,7 +81,7 @@ find_work_sdk_project() {
     local dev_dir="$KNOWLEDGE_VAULT/50_work/45-development"
     [ -d "$dev_dir" ] || return 0
 
-    local cwd_slug family_dir family_name family_slug cwd_path_slug comp_dir comp_name comp_slug
+    local family_dir family_name family_slug cwd_path_slug comp_dir comp_name comp_slug
     # Slugify CWD: lowercase, remove non-alphanumeric except /
     cwd_path_slug=$(printf '%s' "$CWD" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9/')
 

--- a/scripts/claude-session-start.sh
+++ b/scripts/claude-session-start.sh
@@ -23,6 +23,19 @@ if [ -z "$CWD" ]; then
     CWD="$(pwd)"
 fi
 
+# --- Self-heal claude-mem plugin if marketplace shipped broken artifacts ---
+# Patches .mcp.json (${_R%/} regression, upstream #2385) and installs the
+# missing zod runtime dep. Silent on healthy installs.
+CLAUDE_MEM_HEAL="$SCRIPT_DIR/claude-mem-heal.sh"
+CONTEXT_LINES=""
+if [ -x "$CLAUDE_MEM_HEAL" ]; then
+    HEAL_OUTPUT=$(bash "$CLAUDE_MEM_HEAL" 2>&1) || true
+    if [ -n "$HEAL_OUTPUT" ]; then
+        CONTEXT_LINES="[claude-mem] self-healed plugin install:
+$HEAL_OUTPUT"
+    fi
+fi
+
 # Walk up from CWD to find an Obsidian vault (.obsidian/ directory)
 find_vault_root() {
     local dir="$1"
@@ -39,7 +52,6 @@ find_vault_root() {
 VAULT_ROOT=$(find_vault_root "$CWD") || true
 KNOWLEDGE_VAULT="$HOME/Projects/knowledge"
 VAULT_NAME=""
-CONTEXT_LINES=""
 
 # --- Hive: detect project and suggest vault queries ---
 # If CWD is a git repo, check if there's a matching vault project entry.


### PR DESCRIPTION
## Summary

Two changes shipped together in commit 053bad8:

**1. `scripts/claude-mem-heal.sh` (new)** — POSIX, idempotent script that papers over two upstream packaging bugs in the `thedotmack/claude-mem` plugin (v12.7.4 + v13.0.0):

- `.mcp.json` ships shell parameter expansion `${_R%/}` that Claude Code's MCP loader misreads as an env-var name → rewrites to the v10.6.3 form. (Upstream issue [#2385](https://github.com/thedotmack/claude-mem/issues/2385).)
- v13.0.0 declares `zod: ^4.3.6` in `package.json` but ships no `node_modules/zod`, crashing `worker-service.cjs` with `Cannot find module 'zod/v3'` → installs zod in place.

Wired into `scripts/claude-session-start.sh` so heals run on every session start (silent on healthy installs, one log line per heal action). Both upstream errors revert on `/plugin update`, so self-heal at SessionStart is the right enforcement point per Standing Order #1 ("automate, don't instruct").

**2. `ai/claude/CLAUDE.md`** — new `Hive (Obsidian Vault Operations)` subsection under `MCP Server Usage Rules`. Mandates Hive MCP for vault operations to save 5–10× tokens on search and preserve the `vault: patch …` auto-commit history convention. Companion vault pattern lives at `00_meta/patterns/pattern-hive-first-vault-access.md`.

> Note: both changes are bundled in a single commit whose subject only reflects the `feat(scripts)` part — they are logically independent. Kept together at the user's request to avoid PR churn.

## Test plan

- [x] `shellcheck scripts/claude-mem-heal.sh` — clean
- [x] `bash -n scripts/claude-mem-heal.sh` and `scripts/claude-session-start.sh` — no syntax errors
- [x] CI green (shellcheck + bats)
- [x] `claude-mem-heal.sh` no-op on a healthy install (silent exit 0)
- [x] `claude-mem-heal.sh` patches a synthetic broken `.mcp.json` containing `${_R%/}`
- [x] `claude-mem-heal.sh` installs missing `zod` when `package.json` declares it but `node_modules/zod` is absent
- [x] After merge: `cd ~/Projects/dotfiles && git pull && ./setup-linux.sh` deploys the updated CLAUDE.md to `~/.claude/CLAUDE.md`
- [x] `grep "Hive (Obsidian Vault Operations)" ~/.claude/CLAUDE.md` returns the new section