### PR TITLE
feat(tmux): integrate tmux with versioned config and Linux install

### DIFF
--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -31,3 +31,9 @@ alias kca="knowledge-crystallize.sh --all"        # Stamp all projects at once
 alias ai="aider"                                                                          # daily: DeepSeek V3.2
 alias aic="aider --model openrouter/qwen/qwen3-coder-next"                                # coding: Qwen3 Coder
 alias aia="aider --architect --model openrouter/deepseek/deepseek-v3.2-speciale"           # architecture: DeepSeek Speciale
+
+# tmux session management
+alias tx='tmux new -A -s'         # attach-or-create by name: tx dotfiles
+alias txl='tmux ls'               # list sessions
+alias txa='tmux a'                # attach to most recent
+alias txk='tmux kill-session -t'  # kill named session: txk dotfiles

--- a/.zsh/functions.zsh
+++ b/.zsh/functions.zsh
@@ -6,6 +6,16 @@ function colormap() {
   for i in {0..255}; do print -Pn "%K{$i}  %k%F{$i}${(l:3::0:)i}%f " ${${(M)$((i%6)):#3}:+$'\n'}; done
 }
 
+# sshmux: SSH to a host and attach-or-create a tmux session there.
+# Usage: sshmux <host> [session_name]   (session defaults to "main")
+sshmux() {
+    if [ -z "${1:-}" ]; then
+        printf 'Usage: sshmux <host> [session_name]\n' >&2
+        return 1
+    fi
+    ssh -t "$1" "tmux new-session -A -s ${2:-main}"
+}
+
 # Source utility functions from dotfiles
 if [ -f "$HOME/.dotfiles/scripts/utils.sh" ]; then
     source "$HOME/.dotfiles/scripts/utils.sh"

--- a/README.md
+++ b/README.md
@@ -93,9 +93,44 @@ dotfiles-sync                       # Bidirectional sync + git push/pull
 dotfiles-sync --secrets-only        # Only sync sensitive/ files
 ```
 
+### tmux
+
+Two use cases this setup is tuned for: **(1) split-pane multiplexing** (editor + aider + tests side by side) and **(2) session persistence** (close the laptop / drop SSH and come back to the same state).
+
+```bash
+# --- The 6 commands you actually need ---
+
+tx dotfiles                # Start (or re-attach) a session named "dotfiles"
+                           # Inside tmux now: prompt shows [dotfiles]
+
+# Split for editor + AI + tests:
+#   C-b %                  Split vertically  (editor | aider)
+#   C-b "                  Split horizontally (... above tests)
+#   C-b h/j/k/l            Move between panes (vim-style)
+#   C-b z                  Zoom current pane fullscreen (toggle)
+
+# Pause / resume:
+#   C-b d                  Detach — session keeps running in background
+tx dotfiles                # Re-attach later (same command). Layout preserved.
+
+# --- The rest (use occasionally) ---
+
+txl                        # List all sessions
+txa                        # Attach to most recent (no name needed)
+txk <name>                 # Kill a named session
+sshmux <host> [session]    # SSH + attach-or-create remote tmux (survives drops)
+
+# Inside tmux:
+#   C-b r                  Reload ~/.tmux.conf after editing
+#   C-b x                  Close current pane
+#   C-b [                  Scroll mode (q to exit, / to search)
+```
+
+Full reference and pane-layout recipes: `~/Projects/knowledge/10_projects/dotfiles/40-runbooks/guide-tmux.md`.
+
 ## Requirements
 
-**Linux/macOS:** git, bash/zsh
+**Linux/macOS:** git, bash/zsh, tmux (`sudo apt install tmux`)
 
 **Windows:** git, PowerShell
 

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -65,7 +65,7 @@ echo "========================================"
 echo "Checking from: $DOTFILES_DIR"
 
 # ==================================================
-section "1/8" "Core Tools in PATH"
+section "1/9" "Core Tools in PATH"
 
 CORE_TOOLS="git zsh bash curl wget jq eza direnv node npm zoxide docker kubectl terraform"
 for tool in $CORE_TOOLS; do
@@ -77,7 +77,7 @@ for tool in $CORE_TOOLS; do
 done
 
 # ==================================================
-section "2/8" "Versioned Tool Paths"
+section "2/9" "Versioned Tool Paths"
 
 check_tool_home() {
     local name="$1"
@@ -117,7 +117,7 @@ else
 fi
 
 # ==================================================
-section "3/8" "Version Match (versions.conf)"
+section "3/9" "Version Match (versions.conf)"
 
 check_version_match() {
     local name="$1"
@@ -144,7 +144,7 @@ check_version_match "Minikube" "${MINIKUBE_VERSION:-}" "$APPS_HOME/minikube-${MI
 check_version_match "Go" "${GO_VERSION:-}" "$APPS_HOME/go-${GO_VERSION:-}"
 
 # ==================================================
-section "4/8" "Key Symlinks"
+section "4/9" "Key Symlinks"
 
 check_symlink() {
     local path="$1"
@@ -169,7 +169,7 @@ check_symlink "$HOME/.zsh/functions.zsh" ".zsh/functions.zsh"
 check_symlink "$HOME/.ssh/config" ".ssh/config"
 
 # ==================================================
-section "5/8" "Environment Variables"
+section "5/9" "Environment Variables"
 
 ENV_VARS="DOTFILES_DIR APPS_HOME JAVA_HOME MAVEN_HOME PYTHON_HOME GO_HOME MINIKUBE_HOME"
 for var in $ENV_VARS; do
@@ -181,7 +181,7 @@ for var in $ENV_VARS; do
 done
 
 # ==================================================
-section "6/8" "Optional Tools"
+section "6/9" "Optional Tools"
 
 OPTIONAL_TOOLS="age gh claude gemini bats shellcheck helm ansible pip"
 for tool in $OPTIONAL_TOOLS; do
@@ -193,7 +193,7 @@ for tool in $OPTIONAL_TOOLS; do
 done
 
 # ==================================================
-section "7/8" "Knowledge Vault"
+section "7/9" "Knowledge Vault"
 
 VAULT_DIR="${VAULT_DIR:-$HOME/Projects/knowledge}"
 
@@ -248,7 +248,7 @@ for dir in $VAULT_DIRS; do
 done
 
 # ==================================================
-section "8/8" "Secrets Integrity"
+section "8/9" "Secrets Integrity"
 
 SECRETS_DIR="${DOTFILES_DIR}/sensitive"
 SECRETS_MAPPING="$SECRETS_DIR/env-mapping.conf"
@@ -294,6 +294,27 @@ if [ -f "$SECRETS_MAPPING" ]; then
     done
 else
     fail "env-mapping.conf not found"
+fi
+
+# ==================================================
+section "9/9" "tmux"
+# ==================================================
+if ! command -v tmux >/dev/null 2>&1; then
+    fail "tmux not installed (run: sudo apt install -y tmux)"
+else
+    pass "tmux installed: $(tmux -V)"
+    if [ -L "$HOME/.tmux.conf" ]; then
+        _tmux_target="$(readlink "$HOME/.tmux.conf")"
+        if [ -f "$_tmux_target" ]; then
+            pass "$HOME/.tmux.conf -> $_tmux_target"
+        else
+            fail "$HOME/.tmux.conf symlink broken: target $_tmux_target missing"
+        fi
+    elif [ -f "$HOME/.tmux.conf" ]; then
+        fail "$HOME/.tmux.conf is a regular file, expected symlink (run setup-linux.sh)"
+    else
+        fail "$HOME/.tmux.conf missing (run setup-linux.sh)"
+    fi
 fi
 
 # ==================================================

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -37,6 +37,7 @@ if [ "$CURRENT_DIR" != "$DOTFILES_DIR" ]; then
         safe_copy "$CURRENT_DIR/.bashrc" "$DOTFILES_DIR/" 2>/dev/null || true
     fi    
     safe_copy "$CURRENT_DIR/.gitconfig" "$DOTFILES_DIR/" 2>/dev/null || true
+    safe_copy "$CURRENT_DIR/tmux.conf" "$DOTFILES_DIR/" 2>/dev/null || true
     cp -rf "$CURRENT_DIR/.zsh/." "$DOTFILES_DIR/.zsh/" 2>/dev/null || true
     ensure_directory "$DOTFILES_DIR/ssh"
     cp -rf "$CURRENT_DIR/ssh/"* "$DOTFILES_DIR/ssh/" 2>/dev/null || true
@@ -72,6 +73,7 @@ ensure_directory "$HOME/.zsh"
 ln -sf "$DOTFILES_DIR/.zsh/aliases.zsh" "$HOME/.zsh/aliases.zsh"
 ln -sf "$DOTFILES_DIR/.zsh/functions.zsh" "$HOME/.zsh/functions.zsh"
 ln -sf "$DOTFILES_DIR/.zsh/nvm.zsh" "$HOME/.zsh/nvm.zsh"
+ln -sf "$DOTFILES_DIR/tmux.conf" "$HOME/.tmux.conf"
 chmod +x "$DOTFILES_DIR/scripts/utils.sh"
 chmod +x "$DOTFILES_DIR/scripts/github-secrets-manager.sh"
 chmod +x "$DOTFILES_DIR/scripts/age-encrypt-decrypt.sh"
@@ -145,6 +147,13 @@ ln -sf "$DOTFILES_DIR/.bashrc" "$HOME/.bashrc"
 log_info "Installing developer tools..."
 ensure_directory "$HOME/.local/bin"
 export PATH="$HOME/.local/bin:$PATH"
+
+# tmux (system package — this script avoids sudo, so user installs it once)
+if ! command -v tmux >/dev/null 2>&1; then
+    log_warning "tmux not installed. Run: sudo apt install -y tmux"
+else
+    log_info "tmux installed: $(tmux -V)"
+fi
 
 # age (file encryption — required by secrets system)
 if ! command -v age >/dev/null 2>&1; then

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -516,6 +516,8 @@ if (Test-Path $gitconfigSource) {
     Write-Warn ".gitconfig not found at $gitconfigSource"
 }
 
+# tmux: intentionally skipped on Windows (Linux-only -- see tmux.conf in repo root)
+
 # ============================================================================
 # 5b. SSH CONFIG
 # ============================================================================

--- a/tests/Dockerfile.integration
+++ b/tests/Dockerfile.integration
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     grep \
     coreutils \
     ca-certificates \
+    tmux \
     && rm -rf /var/lib/apt/lists/*
 
 # Install bats-core from source

--- a/tests/aliases.bats
+++ b/tests/aliases.bats
@@ -111,3 +111,32 @@ setup() {
     grep -q 'alias gp=' "$ALIASES_FILE"
     grep -q 'function gp' "$ps_file"
 }
+
+# --- tmux aliases ---
+
+@test "aliases.zsh defines tx alias (attach-or-create with -A)" {
+    grep -qE "^alias tx=.*new.*-A.*-s" "$ALIASES_FILE"
+}
+
+@test "aliases.zsh defines txl, txa, txk aliases" {
+    grep -qE "^alias txl=" "$ALIASES_FILE"
+    grep -qE "^alias txa=" "$ALIASES_FILE"
+    grep -qE "^alias txk=" "$ALIASES_FILE"
+}
+
+# --- tmux functions (sshmux) ---
+
+@test "functions.zsh defines sshmux function" {
+    fn_file="$DOTFILES_DIR/.zsh/functions.zsh"
+    grep -qE "^sshmux\(\)" "$fn_file"
+}
+
+@test "sshmux uses ssh -t with remote tmux new-session -A" {
+    fn_file="$DOTFILES_DIR/.zsh/functions.zsh"
+    grep -qE 'ssh -t.*tmux new-session -A' "$fn_file"
+}
+
+@test "sshmux prints usage when no host given" {
+    fn_file="$DOTFILES_DIR/.zsh/functions.zsh"
+    grep -qE 'Usage: sshmux' "$fn_file"
+}

--- a/tests/healthcheck.bats
+++ b/tests/healthcheck.bats
@@ -26,8 +26,8 @@ setup() {
     grep -q 'versions.conf' "$SCRIPTS_DIR/healthcheck.sh"
 }
 
-@test "healthcheck.sh has all 8 sections" {
-    [[ $(grep -c 'section "' "$SCRIPTS_DIR/healthcheck.sh") -eq 8 ]]
+@test "healthcheck.sh has all 9 sections" {
+    [[ $(grep -c 'section "' "$SCRIPTS_DIR/healthcheck.sh") -eq 9 ]]
 }
 
 @test "healthcheck.sh uses set -euo pipefail" {
@@ -56,4 +56,18 @@ setup() {
     else
         skip "shellcheck not available"
     fi
+}
+
+# --- tmux section 9/9 ---
+
+@test "healthcheck.sh has section 9/9 for tmux" {
+    grep -qE 'section "9/9" "tmux"' "$SCRIPTS_DIR/healthcheck.sh"
+}
+
+@test "healthcheck.sh verifies tmux binary" {
+    grep -qE 'command -v tmux' "$SCRIPTS_DIR/healthcheck.sh"
+}
+
+@test "healthcheck.sh verifies ~/.tmux.conf symlink target" {
+    grep -qE 'readlink "\$HOME/\.tmux\.conf"' "$SCRIPTS_DIR/healthcheck.sh"
 }

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -85,3 +85,21 @@ setup() {
     grep -q 'shellcheck already installed' "$DOTFILES_DIR/setup-linux.sh"
     grep -q 'bats already installed' "$DOTFILES_DIR/setup-linux.sh"
 }
+
+# --- tmux integration ---
+
+@test "setup-linux.sh copies tmux.conf into deploy dir" {
+    grep -qE 'safe_copy "\$CURRENT_DIR/tmux\.conf" "\$DOTFILES_DIR/"' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh symlinks tmux.conf to ~/.tmux.conf" {
+    grep -qE 'ln -sf "\$DOTFILES_DIR/tmux\.conf" "\$HOME/\.tmux\.conf"' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh checks for tmux presence" {
+    grep -qE 'command -v tmux' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh tells user how to install tmux when missing" {
+    grep -qE 'sudo apt install -y tmux' "$DOTFILES_DIR/setup-linux.sh"
+}

--- a/tests/tmux.bats
+++ b/tests/tmux.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+# Tests for tmux configuration
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    export CONFIG_FILE="$DOTFILES_DIR/tmux.conf"
+}
+
+@test "tmux.conf exists at repo root" {
+    [ -f "$CONFIG_FILE" ]
+}
+
+@test "tmux.conf parses cleanly with real tmux" {
+    if ! command -v tmux >/dev/null 2>&1; then
+        skip "tmux not installed"
+    fi
+    local socket="tmux_bats_$$"
+    run tmux -f "$CONFIG_FILE" -L "$socket" new-session -d -s test 'true'
+    local rc=$status
+    tmux -L "$socket" kill-server 2>/dev/null || true
+    [ "$rc" -eq 0 ]
+}
+
+@test "tmux.conf enables mouse" {
+    grep -qE '^set -g mouse on' "$CONFIG_FILE"
+}
+
+@test "tmux.conf uses vi mode-keys" {
+    grep -qE '^setw -g mode-keys vi' "$CONFIG_FILE"
+}
+
+@test "tmux.conf sets 1-based indexing for windows and panes" {
+    grep -qE '^set -g base-index 1' "$CONFIG_FILE"
+    grep -qE '^setw -g pane-base-index 1' "$CONFIG_FILE"
+}

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -294,3 +294,31 @@ setup() {
     # Just verify it didn't crash — the container built successfully
     true
 }
+
+# =============================================================================
+# Section 11: tmux
+# =============================================================================
+
+@test "tmux binary present in container" {
+    command -v tmux
+}
+
+@test "tmux.conf copied to ~/.dotfiles" {
+    [ -f "$DOTFILES_DIR/tmux.conf" ]
+}
+
+@test "~/.tmux.conf is a symlink to ~/.dotfiles/tmux.conf" {
+    [ -L "$HOME/.tmux.conf" ]
+    [ "$(readlink "$HOME/.tmux.conf")" = "$DOTFILES_DIR/tmux.conf" ]
+}
+
+@test "tmux parses deployed config (smoke)" {
+    local socket="verify_$$"
+    # kill-server is best-effort: if the 'true' session ended already, the
+    # server is gone — that's not a parse failure. The exit code of
+    # new-session is the real signal (non-zero => parse error in config).
+    run tmux -f "$HOME/.tmux.conf" -L "$socket" new-session -d -s s 'true'
+    local rc=$status
+    tmux -L "$socket" kill-server 2>/dev/null || true
+    [ "$rc" -eq 0 ]
+}

--- a/tmux.conf
+++ b/tmux.conf
@@ -1,0 +1,40 @@
+# tmux configuration
+# Deployed to ~/.tmux.conf via setup-linux.sh symlink.
+# Prefix: default C-b (preserves muscle memory across machines).
+
+# Modern QoL
+set -g mouse on
+set -g history-limit 50000
+set -sg escape-time 10
+
+# True color (works in alacritty/kitty/wezterm/gnome-terminal)
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ",*256col*:Tc"
+
+# Copy mode: vi keys (matches nvim/vim)
+setw -g mode-keys vi
+
+# 1-based indexing -- easier to reach on keyboard
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+
+# Pane navigation with vim-style hjkl (prefix + key)
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# Splits inherit current pane's path (cd-state preserved)
+bind '"' split-window -c '#{pane_current_path}'
+bind % split-window -h -c '#{pane_current_path}'
+
+# Reload config
+bind r source-file ~/.tmux.conf \; display-message "tmux.conf reloaded"
+
+# Minimal status bar -- session name left, clock right
+set -g status-style "bg=default,fg=white"
+set -g status-left "[#S] "
+set -g status-left-length 30
+set -g status-right "%H:%M"
+set -g status-justify left


### PR DESCRIPTION
## Summary

- New `tmux.conf` at repo root (versioned config: mouse, vi mode, 1-based indexing, true color, vim-style pane navigation, minimal status bar). Deployed via the existing two-tier copy pattern: repo → `~/.dotfiles/` → `~/.tmux.conf` symlink (same as `.zshrc`/`.bashrc`/`.gitconfig`).
- Shell helpers: `tx`/`txl`/`txa`/`txk` aliases for session management + `sshmux <host>` function for SSH+remote-tmux attach-or-create (survives connection drops).
- Healthcheck section 9/9 verifies tmux binary + `~/.tmux.conf` symlink target.
- `setup-linux.sh` soft-check: warns if tmux missing — the script avoids `sudo` by contract, so the user installs once via `sudo apt install -y tmux`. Healthcheck enforces presence.
- Tests: `tests/tmux.bats` (config parse with real tmux + content asserts), plus new bats asserts in `aliases.bats`/`setup-linux.bats`/`healthcheck.bats`/`verify-setup.bats`. Docker integration container adds `tmux` to apt install and verifies the full deploy chain.
- README: `## Requirements` lists tmux as system dep + `## Key Commands` gets a workflow-first `### tmux` subsection ("the 6 commands you actually need").
- `setup-windows.ps1`: explicit single-line skip comment (tmux is Linux-only by scope).

## Use cases this is tuned for

1. **Split-pane multiplexing** — editor + `aider` + `bats -w` side by side in one tmux session per project (`tx dotfiles`, `tx kubelab`, …).
2. **Session persistence** — `C-b d` to detach, `tx <name>` to reattach. Survives terminal close, laptop sleep, SSH drops.

## Cross-project dependency

`sshmux` requires tmux installed on the remote. For [kubelab](https://github.com/mlorentedev/kubelab)-managed hosts (ace1, ace2, rpi4, rpi3, beelink, vps, aws1) this is tracked as `ANSIBLE-021` in the kubelab backlog (install via `base_system` Ansible role). For ad-hoc hosts: `ssh <host> 'sudo apt install -y tmux'`.

## Vault docs

`10_projects/dotfiles/40-runbooks/guide-tmux.md` — install, two-tier deploy diagram, command tables, pane layout recipes for AI pair-programming, verification commands. Backlog item closed in `11-tasks.md`.

## Test plan

- [x] `shellcheck -S warning` clean on `setup-linux.sh` + `scripts/healthcheck.sh`
- [x] `bash -n` / `zsh -n` syntax clean on all modified shell files
- [x] `bats tests/*.bats` — 4 touched suites pass (tmux.bats 5/5, aliases.bats 26/26, setup-linux.bats 19/19, healthcheck.bats 14/14)
- [x] Docker integration test (`tests/Dockerfile.integration`): 59/59 — includes new tmux assertions (binary, deploy-dir copy, symlink target, parse smoke)
- [x] Manual local deploy + `tx test-session` works, aliases inherit via `.zshrc`, healthcheck section 9/9 PASS
- [x] CI: `lint`, `lint-powershell`, `test`, `integration` jobs