### PR TITLE
feat(tmux): copy selection to system clipboard via xclip

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -155,6 +155,13 @@ else
     log_info "tmux installed: $(tmux -V)"
 fi
 
+# xclip (X11 clipboard bridge — required for tmux mouse-copy to system clipboard)
+if ! command -v xclip >/dev/null 2>&1; then
+    log_warning "xclip not installed. Run: sudo apt install -y xclip  (needed for tmux clipboard integration on X11)"
+else
+    log_info "xclip installed: $(xclip -version 2>&1 | head -n1)"
+fi
+
 # age (file encryption — required by secrets system)
 if ! command -v age >/dev/null 2>&1; then
     log_info "Installing age..."

--- a/tests/tmux.bats
+++ b/tests/tmux.bats
@@ -33,3 +33,11 @@ setup() {
     grep -qE '^set -g base-index 1' "$CONFIG_FILE"
     grep -qE '^setw -g pane-base-index 1' "$CONFIG_FILE"
 }
+
+@test "tmux.conf binds 'y' to copy selection to system clipboard via xclip" {
+    grep -qE "^bind -T copy-mode-vi y .*copy-pipe-and-cancel .*xclip" "$CONFIG_FILE"
+}
+
+@test "tmux.conf pipes mouse-drag-end selection to system clipboard" {
+    grep -qE "^bind -T copy-mode-vi MouseDragEnd1Pane .*copy-pipe-and-cancel .*xclip" "$CONFIG_FILE"
+}

--- a/tmux.conf
+++ b/tmux.conf
@@ -14,6 +14,12 @@ set -ga terminal-overrides ",*256col*:Tc"
 # Copy mode: vi keys (matches nvim/vim)
 setw -g mode-keys vi
 
+# Clipboard integration: 'y' and mouse-drag-end copy to system clipboard.
+# Uses xclip (X11). For Wayland, swap to: wl-copy
+bind -T copy-mode-vi y                 send-keys -X copy-pipe-and-cancel 'xclip -selection clipboard -in'
+bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'xclip -selection clipboard -in'
+bind -T copy-mode-vi DoubleClick1Pane  select-pane \; send-keys -X select-word \; send-keys -X copy-pipe-and-cancel 'xclip -selection clipboard -in'
+
 # 1-based indexing -- easier to reach on keyboard
 set -g base-index 1
 setw -g pane-base-index 1


### PR DESCRIPTION
## Summary

- Three new `copy-mode-vi` bindings in `tmux.conf` (`y`, `MouseDragEnd1Pane`, `DoubleClick1Pane`) pipe selections through `xclip -selection clipboard -in` so text selected inside tmux is immediately pasteable with `Ctrl+V` in any GUI app.
- `setup-linux.sh` gains a warn-if-missing block for `xclip` — same pattern as the existing `tmux` block (no sudo from the script; user installs once with `sudo apt install -y xclip`).
- Two new assertions in `tests/tmux.bats` lock in the bindings.

For Wayland: swap `xclip -selection clipboard -in` for `wl-copy` in `tmux.conf` and install `wl-clipboard` instead. Documented in the vault runbook (`guide-tmux.md`, "Copy / paste" section) and in `90-lessons.md` (entry 2026-05-11).

## Test plan

- [x] `~/.local/bin/bats tests/*.bats` — 392/392 pass
- [x] `~/.local/bin/shellcheck -S warning setup-linux.sh` — exit 0
- [x] `bash -n` syntax check on `setup-linux.sh`
- [x] Manual: select with mouse inside tmux → paste in browser → text appears
- [x] Manual: copy-mode `C-b [` → navigate → `Space` → `y` → paste in browser → text appears
- [ ] CI: `lint`, `lint-powershell`, `test`, `integration` (will run automatically)