### PR TITLE
feat(tmux): focus-events, vi visual-mode bindings, slower status refresh

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -6,6 +6,7 @@
 set -g mouse on
 set -g history-limit 50000
 set -sg escape-time 10
+set -g focus-events on
 
 # True color (works in alacritty/kitty/wezterm/gnome-terminal)
 set -g default-terminal "tmux-256color"
@@ -13,6 +14,8 @@ set -ga terminal-overrides ",*256col*:Tc"
 
 # Copy mode: vi keys (matches nvim/vim)
 setw -g mode-keys vi
+bind -T copy-mode-vi v   send-keys -X begin-selection
+bind -T copy-mode-vi C-v send-keys -X rectangle-toggle
 
 # Clipboard integration: 'y' and mouse-drag-end copy to system clipboard.
 # Uses xclip (X11). For Wayland, swap to: wl-copy
@@ -39,6 +42,7 @@ bind % split-window -h -c '#{pane_current_path}'
 bind r source-file ~/.tmux.conf \; display-message "tmux.conf reloaded"
 
 # Minimal status bar -- session name left, clock right
+set -g status-interval 60
 set -g status-style "bg=default,fg=white"
 set -g status-left "[#S] "
 set -g status-left-length 30


### PR DESCRIPTION
## Summary
- `set -g focus-events on` — lets nvim/vim `autoread`/`checktime` react when switching panes
- `v` / `C-v` bindings in copy-mode-vi — visual + rectangle selection parity with vim muscle memory (we already use `mode-keys vi`)
- `set -g status-interval 60` — the status bar only shows `%H:%M`, refreshing every 15s (default) is wasted wakeups

## Test plan
- [ ] After merge, run `./setup-linux.sh` to refresh `~/.dotfiles/tmux.conf`
- [ ] Reload with `prefix + r` (or `tmux source-file ~/.tmux.conf`)
- [ ] Verify `v` enters selection in copy-mode and `C-v` toggles rectangle
- [ ] Verify nvim `:set autoread` reacts to external file changes when switching panes