### PR TITLE
fix(secrets): keep env, deployed, and repo in sync after every mutation

### DIFF
--- a/scripts/load-secrets.sh
+++ b/scripts/load-secrets.sh
@@ -114,31 +114,59 @@ _secrets_load_file_entry() {
     fi
 }
 
-# Helper to get repo dir dynamically
+# Resolve the repo's sensitive/ dir for sync operations.
+# Priority: $DOTFILES_REPO_DIR (explicit) → $HOME/Projects/dotfiles (auto-detected default).
+# Returns empty string if neither path has a sensitive/ subdir.
 _get_secrets_repo_dir() {
-    echo "${DOTFILES_REPO_DIR:+${DOTFILES_REPO_DIR}/sensitive}"
+    if [[ -n "${DOTFILES_REPO_DIR:-}" && -d "${DOTFILES_REPO_DIR}/sensitive" ]]; then
+        echo "${DOTFILES_REPO_DIR}/sensitive"
+        return
+    fi
+    local default_repo="$HOME/Projects/dotfiles"
+    if [[ -d "${default_repo}/sensitive" ]]; then
+        echo "${default_repo}/sensitive"
+        return
+    fi
+    echo ""
 }
 
-# Sync file to repo if DOTFILES_REPO_DIR is configured
+# Sync (or remove) a file to/from the repo's sensitive/ dir.
+# Args:
+#   $1 filename       — relative to SECRETS_DIR (e.g. "github.token.secret.age")
+#   $2 sync_mapping   — true|false, also copy env-mapping.conf to repo (default false)
+#   $3 silent         — true|false, suppress success/skip notices (default false)
+#   $4 mode           — copy|delete, "delete" removes the file from the repo (default copy)
 _secrets_sync_to_repo() {
     filename="$1"
     sync_mapping="${2:-false}"
     silent="${3:-false}"
+    mode="${4:-copy}"
 
     local repo_dir
     repo_dir="$(_get_secrets_repo_dir)"
 
-    [[ -z "$repo_dir" ]] && return 0
-    [[ "$repo_dir" == "$SECRETS_DIR" ]] && return 0
-    [[ ! -d "$repo_dir" ]] && return 0
-
-    # Sync file
-    if [[ -f "$SECRETS_DIR/${filename}" ]]; then
-        command cp "$SECRETS_DIR/${filename}" "$repo_dir/${filename}"
-        [[ "$silent" != "true" ]] && echo "  Synced to repo: $repo_dir/${filename}"
+    if [[ -z "$repo_dir" ]]; then
+        [[ "$silent" != "true" ]] && \
+            echo "  Note: repo not synced (set DOTFILES_REPO_DIR or clone to ~/Projects/dotfiles)" >&2
+        return 0
     fi
+    [[ "$repo_dir" == "$SECRETS_DIR" ]] && return 0
 
-    # Sync mapping file if requested
+    case "$mode" in
+        copy)
+            if [[ -f "$SECRETS_DIR/${filename}" ]]; then
+                command cp "$SECRETS_DIR/${filename}" "$repo_dir/${filename}"
+                [[ "$silent" != "true" ]] && echo "  Synced to repo: $repo_dir/${filename}"
+            fi
+            ;;
+        delete)
+            if [[ -f "$repo_dir/${filename}" ]]; then
+                rm -f "$repo_dir/${filename}"
+                [[ "$silent" != "true" ]] && echo "  Removed from repo: $repo_dir/${filename}"
+            fi
+            ;;
+    esac
+
     if [[ "$sync_mapping" == "true" && -f "$SECRETS_MAPPING_FILE" ]]; then
         command cp "$SECRETS_MAPPING_FILE" "$repo_dir/env-mapping.conf"
     fi
@@ -470,15 +498,15 @@ secrets_add() {
     # Update audit log
     _secrets_audit_log "$var_name" "added"
 
-    echo "Secret added successfully:"
-    echo "  Variable: $var_name"
-    echo "  File: ${filename}.secret.age"
-
     # Sync to repo if configured
     _secrets_sync_to_repo "${filename}.secret.age" true
 
-    echo ""
-    echo "Run 'secrets_refresh' or restart terminal to load"
+    # Auto-export into current shell so $var_name is immediately usable
+    export_var "$var_name" "$value"
+
+    echo "Secret added successfully:"
+    echo "  Variable: $var_name (exported in current shell)"
+    echo "  File: ${filename}.secret.age"
 }
 
 # Validate mapping integrity - check for missing .age files or orphaned mappings
@@ -667,12 +695,99 @@ secrets_rotate() {
     # Update audit log
     _secrets_audit_log "$var_name" "rotated"
 
-    echo "Secret rotated successfully: $var_name"
+    # Sync to repo if configured (sync_mapping=true is defensive — keeps repo idempotent)
+    _secrets_sync_to_repo "${filename}.secret.age" true
 
-    # Sync to repo if configured
-    _secrets_sync_to_repo "${filename}.secret.age" false
+    # Auto-export the new value so the env doesn't drift from disk
+    export_var "$var_name" "$value"
 
-    echo "Run 'secrets_refresh' or restart terminal to reload"
+    echo "Secret rotated successfully: $var_name (env updated in current shell)"
+}
+
+# Remove a secret (plain or file): unmap, delete .age, sync deletion to repo,
+# unset the env var. For file secrets, also removes the deployed plaintext file.
+# Usage: secrets_remove VAR_NAME [--yes|-y]
+secrets_remove() {
+    var_name="$1"
+    local skip_confirm=false
+    [[ "$2" == "--yes" || "$2" == "-y" ]] && skip_confirm=true
+
+    if [[ -z "$var_name" ]]; then
+        echo "Usage: secrets_remove VAR_NAME [--yes]"
+        echo "Example: secrets_remove OLD_API_TOKEN"
+        return 1
+    fi
+
+    file_exists "$SECRETS_MAPPING_FILE" || { echo "Mapping file not found" >&2; return 1; }
+
+    # Locate mapping: try plain VAR= first, then @VAR= for file secrets
+    local mapping_line is_file=false
+    mapping_line=$(grep "^${var_name}=" "$SECRETS_MAPPING_FILE" 2>/dev/null | head -1)
+    if [[ -z "$mapping_line" ]]; then
+        mapping_line=$(grep "^@${var_name}=" "$SECRETS_MAPPING_FILE" 2>/dev/null | head -1)
+        [[ -n "$mapping_line" ]] && is_file=true
+    fi
+
+    if [[ -z "$mapping_line" ]]; then
+        echo "Error: No mapping found for $var_name" >&2
+        return 1
+    fi
+
+    # Extract filename (strip @VAR= prefix and >dest suffix)
+    local mapping_value="${mapping_line#*=}"
+    local fs_filename="${mapping_value%%>*}"
+    local fs_dest=""
+    if [[ "$is_file" == "true" ]]; then
+        fs_dest="${mapping_value#*>}"
+        case "$fs_dest" in
+            "~"/*) fs_dest="$HOME/${fs_dest#"~/"}" ;;
+            "~") fs_dest="$HOME" ;;
+        esac
+    fi
+
+    local encrypted_file="$SECRETS_DIR/${fs_filename}.secret.age"
+
+    if [[ "$skip_confirm" != "true" ]]; then
+        echo "About to remove: $var_name"
+        echo "  Encrypted file: $encrypted_file"
+        [[ "$is_file" == "true" ]] && echo "  Deployed file:  $fs_dest"
+        echo "  Mapping line:   $mapping_line"
+        printf "Continue? [y/N]: "
+        read -r reply
+        if [[ "$reply" != "y" && "$reply" != "Y" ]]; then
+            echo "Aborted"
+            return 1
+        fi
+    fi
+
+    # Remove encrypted file from deployed sensitive/
+    if [[ -f "$encrypted_file" ]]; then
+        rm -f "$encrypted_file"
+        echo "Removed: $encrypted_file"
+    fi
+
+    # Remove deployed plaintext (file secret only)
+    if [[ "$is_file" == "true" && -n "$fs_dest" && -f "$fs_dest" ]]; then
+        rm -f "$fs_dest"
+        echo "Removed: $fs_dest"
+    fi
+
+    # Strip mapping line in-place (|| true: grep -v exits 1 if every line matches)
+    local tmp_mapping="${SECRETS_MAPPING_FILE}.tmp.$$"
+    if [[ "$is_file" == "true" ]]; then
+        grep -v "^@${var_name}=" "$SECRETS_MAPPING_FILE" > "$tmp_mapping" || true
+    else
+        grep -v "^${var_name}=" "$SECRETS_MAPPING_FILE" > "$tmp_mapping" || true
+    fi
+    mv "$tmp_mapping" "$SECRETS_MAPPING_FILE"
+
+    # Sync deletion + updated mapping to repo
+    _secrets_sync_to_repo "${fs_filename}.secret.age" true false delete
+
+    _secrets_audit_log "$var_name" "removed"
+    unset_var "$var_name"
+
+    echo "Secret removed: $var_name"
 }
 
 # Sync all secrets to repo
@@ -682,13 +797,13 @@ secrets_sync() {
     repo_dir="$(_get_secrets_repo_dir)"
 
     if [[ -z "$repo_dir" ]]; then
-        echo "Error: DOTFILES_REPO_DIR not set"
+        echo "Error: no repo found (DOTFILES_REPO_DIR unset and \$HOME/Projects/dotfiles/sensitive missing)"
         echo "Set it in your shell config: export DOTFILES_REPO_DIR=\"\$HOME/Projects/dotfiles\""
         return 1
     fi
 
     if [[ "$repo_dir" == "$SECRETS_DIR" ]]; then
-        echo "DOTFILES_REPO_DIR is same as SECRETS_DIR, nothing to sync"
+        echo "Repo sensitive/ is the same as SECRETS_DIR, nothing to sync"
         return 0
     fi
 
@@ -794,16 +909,16 @@ secrets_add_file() {
     # Update audit log
     _secrets_audit_log "$var_name" "added (file)"
 
-    echo "File secret added successfully:"
-    echo "  Variable:  $var_name"
-    echo "  Encrypted: ${filename}.secret.age"
-    echo "  Deploys to: $dest_path"
-
     # Sync to repo if configured
     _secrets_sync_to_repo "${filename}.secret.age" true
 
-    echo ""
-    echo "Run 'secrets_refresh' or restart terminal to deploy"
+    # Auto-deploy: secrets_refresh handles decrypt-to-disk + env export for file secrets
+    secrets_refresh >/dev/null 2>&1
+
+    echo "File secret added successfully:"
+    echo "  Variable:   $var_name (deployed in current shell)"
+    echo "  Encrypted:  ${filename}.secret.age"
+    echo "  Deploys to: $dest_path"
 }
 
 # Show help for all secrets commands
@@ -826,6 +941,11 @@ MANAGEMENT
   secrets_rotate VAR    Update an existing secret's value
                         Example: secrets_rotate GITHUB_TOKEN
 
+  secrets_remove VAR    Remove a secret (mapping + .age + repo sync)
+                        For file secrets, also removes the deployed plaintext file
+                        Example: secrets_remove OLD_API_TOKEN
+                        Use --yes to skip the confirmation prompt
+
   secrets_check         Validate mapping integrity (find missing/orphaned files)
 
   secrets_clean         Remove plaintext .dec and .secret files
@@ -844,13 +964,18 @@ FILES
   Audit log:  $DOTFILES_DIR/sensitive/.secrets-audit.log
 
 REPO SYNC
-  Set DOTFILES_REPO_DIR to auto-sync secrets to your repo:
-    export DOTFILES_REPO_DIR="$HOME/Projects/dotfiles"
+  Auto-detected: $HOME/Projects/dotfiles (override with DOTFILES_REPO_DIR).
+  If neither is found, ops complete normally and a one-line note goes to stderr.
 
-  When configured:
-    - secrets_add/secrets_rotate auto-sync .age files and mapping
-    - Audit log is synced automatically on changes
-    - Use secrets_sync for manual full sync
+  When a repo is detected:
+    - secrets_add/secrets_rotate/secrets_remove auto-sync .age files and mapping
+    - secrets_remove also propagates the deletion to the repo
+    - Audit log is synced automatically on every change
+    - Use secrets_sync for a manual full re-sync (.age + mapping + audit log)
+
+POST-OP STATE
+  All mutating commands (add/rotate/remove/add_file) auto-update the current
+  shell's env so $VAR matches disk immediately. No manual secrets_refresh needed.
 
 EXAMPLES
   # Add a new secret (auto-syncs to repo if configured)

--- a/tests/load-secrets.bats
+++ b/tests/load-secrets.bats
@@ -37,6 +37,7 @@ teardown() {
         type secrets_audit >/dev/null 2>&1 && echo "audit:ok"
         type secrets_sync >/dev/null 2>&1 && echo "sync:ok"
         type secrets_add_file >/dev/null 2>&1 && echo "add_file:ok"
+        type secrets_remove >/dev/null 2>&1 && echo "remove:ok"
     ' -- "$SCRIPTS_DIR"
     [[ "$output" == *"load:ok"* ]]
     [[ "$output" == *"list:ok"* ]]
@@ -50,6 +51,7 @@ teardown() {
     [[ "$output" == *"audit:ok"* ]]
     [[ "$output" == *"sync:ok"* ]]
     [[ "$output" == *"add_file:ok"* ]]
+    [[ "$output" == *"remove:ok"* ]]
 }
 
 @test "secrets_help shows usage information" {
@@ -90,14 +92,17 @@ teardown() {
     [[ "$output" == *"Dry run complete"* ]]
 }
 
-@test "secrets_sync requires DOTFILES_REPO_DIR" {
+@test "secrets_sync errors when no repo can be resolved" {
+    # HOME points to a path with no Projects/dotfiles, so auto-detect must also fail
     run bash -c '
         unset DOTFILES_REPO_DIR
+        export HOME="/tmp/bats_no_repo_anywhere_$$"
         source "$1/utils.sh"
         source "$1/load-secrets.sh"
         secrets_sync
     ' -- "$SCRIPTS_DIR"
-    [[ "$output" == *"DOTFILES_REPO_DIR"* ]]
+    [[ $status -ne 0 ]]
+    [[ "$output" == *"no repo found"* ]]
 }
 
 # --- File secret helpers (bash) ---
@@ -483,4 +488,150 @@ CONF
     rm -f "$dest_file"
     [[ $status -eq 0 ]]
     [[ "$output" == *"zsh-file-content"* ]]
+}
+
+# --- secrets_remove + repo sync auto-detect ---
+
+@test "secrets_remove validates inputs" {
+    run bash -c 'source "$1/utils.sh"; source "$1/load-secrets.sh"; secrets_remove' -- "$SCRIPTS_DIR"
+    [[ $status -ne 0 ]]
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "secrets_remove rejects unknown var" {
+    cat > "$SECRETS_DIR/env-mapping.conf" <<'CONF'
+TOKEN=my.token
+CONF
+    run bash -c '
+        source "$1/utils.sh"; source "$1/load-secrets.sh"
+        SECRETS_DIR="'"$SECRETS_DIR"'"
+        SECRETS_MAPPING_FILE="'"$SECRETS_DIR"'/env-mapping.conf"
+        secrets_remove NONEXISTENT --yes
+    ' -- "$SCRIPTS_DIR"
+    [[ $status -ne 0 ]]
+    [[ "$output" == *"No mapping found"* ]]
+}
+
+@test "secrets_remove --yes drops mapping line and .age file (plain)" {
+    cat > "$SECRETS_DIR/env-mapping.conf" <<'CONF'
+TOKEN=my.token
+KEEPER=keeper.token
+CONF
+    touch "$SECRETS_DIR/my.token.secret.age"
+    touch "$SECRETS_DIR/keeper.token.secret.age"
+
+    run bash -c '
+        unset DOTFILES_REPO_DIR
+        export HOME="/tmp/bats_no_repo_$$"
+        source "$1/utils.sh"; source "$1/load-secrets.sh"
+        SECRETS_DIR="'"$SECRETS_DIR"'"
+        SECRETS_MAPPING_FILE="'"$SECRETS_DIR"'/env-mapping.conf"
+        SECRETS_AUDIT_FILE="'"$SECRETS_DIR"'/.audit"
+        secrets_remove TOKEN --yes
+    ' -- "$SCRIPTS_DIR"
+    [[ $status -eq 0 ]]
+    [[ ! -f "$SECRETS_DIR/my.token.secret.age" ]]
+    [[ -f "$SECRETS_DIR/keeper.token.secret.age" ]]
+    ! grep -q "^TOKEN=" "$SECRETS_DIR/env-mapping.conf"
+    grep -q "^KEEPER=" "$SECRETS_DIR/env-mapping.conf"
+}
+
+@test "secrets_remove --yes drops file secret mapping and deployed file" {
+    local dest_file="/tmp/bats_remove_dest_$$"
+    echo "deployed-content" > "$dest_file"
+    cat > "$SECRETS_DIR/env-mapping.conf" <<CONF
+@MYFILE=myfile.data>${dest_file}
+CONF
+    touch "$SECRETS_DIR/myfile.data.secret.age"
+
+    run bash -c '
+        unset DOTFILES_REPO_DIR
+        export HOME="/tmp/bats_no_repo_$$"
+        source "$1/utils.sh"; source "$1/load-secrets.sh"
+        SECRETS_DIR="'"$SECRETS_DIR"'"
+        SECRETS_MAPPING_FILE="'"$SECRETS_DIR"'/env-mapping.conf"
+        SECRETS_AUDIT_FILE="'"$SECRETS_DIR"'/.audit"
+        secrets_remove MYFILE --yes
+    ' -- "$SCRIPTS_DIR"
+    [[ $status -eq 0 ]]
+    [[ ! -f "$SECRETS_DIR/myfile.data.secret.age" ]]
+    [[ ! -f "$dest_file" ]]
+    ! grep -q "^@MYFILE=" "$SECRETS_DIR/env-mapping.conf"
+}
+
+@test "secrets_remove aborts on negative confirmation" {
+    cat > "$SECRETS_DIR/env-mapping.conf" <<'CONF'
+TOKEN=my.token
+CONF
+    touch "$SECRETS_DIR/my.token.secret.age"
+
+    run bash -c '
+        unset DOTFILES_REPO_DIR
+        export HOME="/tmp/bats_no_repo_$$"
+        source "$1/utils.sh"; source "$1/load-secrets.sh"
+        SECRETS_DIR="'"$SECRETS_DIR"'"
+        SECRETS_MAPPING_FILE="'"$SECRETS_DIR"'/env-mapping.conf"
+        SECRETS_AUDIT_FILE="'"$SECRETS_DIR"'/.audit"
+        echo "n" | secrets_remove TOKEN
+    ' -- "$SCRIPTS_DIR"
+    [[ $status -ne 0 ]]
+    [[ "$output" == *"Aborted"* ]]
+    [[ -f "$SECRETS_DIR/my.token.secret.age" ]]
+    grep -q "^TOKEN=" "$SECRETS_DIR/env-mapping.conf"
+}
+
+@test "_get_secrets_repo_dir prefers DOTFILES_REPO_DIR when its sensitive/ exists" {
+    local repo="/tmp/bats_repo_$$"
+    mkdir -p "$repo/sensitive"
+    run bash -c '
+        export DOTFILES_REPO_DIR="'"$repo"'"
+        source "$1/utils.sh"; source "$1/load-secrets.sh"
+        _get_secrets_repo_dir
+    ' -- "$SCRIPTS_DIR"
+    rm -rf "$repo"
+    [[ "$output" == "$repo/sensitive" ]]
+}
+
+@test "_get_secrets_repo_dir auto-detects \$HOME/Projects/dotfiles when DOTFILES_REPO_DIR unset" {
+    local fake_home="/tmp/bats_home_$$"
+    mkdir -p "$fake_home/Projects/dotfiles/sensitive"
+    run bash -c '
+        unset DOTFILES_REPO_DIR
+        export HOME="'"$fake_home"'"
+        source "$1/utils.sh"; source "$1/load-secrets.sh"
+        _get_secrets_repo_dir
+    ' -- "$SCRIPTS_DIR"
+    rm -rf "$fake_home"
+    [[ "$output" == "$fake_home/Projects/dotfiles/sensitive" ]]
+}
+
+@test "_get_secrets_repo_dir returns empty when no repo found" {
+    run bash -c '
+        unset DOTFILES_REPO_DIR
+        export HOME="/tmp/bats_nohome_$$"
+        source "$1/utils.sh"; source "$1/load-secrets.sh"
+        _get_secrets_repo_dir
+    ' -- "$SCRIPTS_DIR"
+    [[ -z "$output" ]]
+}
+
+@test "_secrets_sync_to_repo warns on stderr when no repo resolved" {
+    run bash -c '
+        unset DOTFILES_REPO_DIR
+        export HOME="/tmp/bats_nohome_$$"
+        source "$1/utils.sh"; source "$1/load-secrets.sh"
+        SECRETS_DIR="'"$SECRETS_DIR"'"
+        _secrets_sync_to_repo "any.secret.age" false false 2>&1 1>/dev/null
+    ' -- "$SCRIPTS_DIR"
+    [[ "$output" == *"repo not synced"* ]]
+}
+
+@test "secrets_help mentions secrets_remove" {
+    run bash -c 'source "$1/utils.sh"; source "$1/load-secrets.sh"; secrets_help' -- "$SCRIPTS_DIR"
+    [[ "$output" == *"secrets_remove"* ]]
+}
+
+@test "secrets_remove defined under zsh" {
+    run zsh -c '. "$1/utils.sh"; . "$1/load-secrets.sh"; type secrets_remove >/dev/null && echo ok' -- "$SCRIPTS_DIR"
+    [[ "$output" == *"ok"* ]]
 }


### PR DESCRIPTION
Closes #7.

## Root cause of #7 (TL;DR)

`secrets_rotate` was working correctly — the deployed `.age` file was being updated. The bug was env-vs-disk drift: `load-secrets.sh` exports `$VAR` once at shell startup, and rotate didn't refresh it, so any verification that read `$VAR` (gh, curl, `secrets_show` without `--raw`, etc.) saw the old value and looked like rotate had failed silently.

## What this PR does

| Concern | Before | After |
|---|---|---|
| Env-vs-disk drift after rotate/add | Manual `secrets_refresh` required (easy to forget) | Auto-exported in current shell |
| Repo sync without `DOTFILES_REPO_DIR` | Silent no-op | Auto-detects `$HOME/Projects/dotfiles`; warns if neither resolves |
| Deleting a secret | No function — manual editing of mapping + `rm` + sync | New `secrets_remove VAR_NAME [--yes]` |
| `_secrets_sync_to_repo` deletion path | Not supported | New `mode=delete` arg |
| `secrets_rotate` mapping sync to repo | `false` (mapping never changes in rotate) | `true` (defensive idempotency) |

`secrets_remove` covers both plain and file secrets. For file secrets it also removes the deployed plaintext file at `dest_path`.

## Test plan

- [x] `~/.local/bin/bats tests/*.bats` → 403/403 (11 new tests for remove + auto-detect + sync warning)
- [x] `~/.local/bin/shellcheck scripts/load-secrets.sh` → only pre-existing SC1091 info
- [x] `bash -n` and `zsh -n` syntax check on `load-secrets.sh`
- [ ] **Manual smoke after merge** (two-tier deploy reminder — repo edit alone won't take effect):
  1. `./setup-linux.sh` to refresh `~/.dotfiles/scripts/load-secrets.sh`
  2. New shell → `secrets_rotate <SOME_TEST_VAR>` → confirm `echo $VAR` shows new value immediately, no manual refresh
  3. `git status` in repo → confirm `sensitive/<file>.secret.age` shows as modified (sync to repo worked)
  4. `secrets_remove <SOME_TEST_VAR>` → confirm mapping line gone, `.age` deleted, repo also reflects deletion

## Notes

- Local `*.dec` files in `sensitive/` were stale plaintext from old `secrets_decrypt` runs. Already covered by `.gitignore`. Not deleted in this PR — run `secrets_clean` locally to remove them.
- `secrets_help` updated to document `secrets_remove`, the auto-detect behavior, and the no-manual-refresh guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)