### PR TITLE
feat(scripts): add diff-check.sh to detect repo ↔ deploy-dir drift

### DIFF
--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -27,6 +27,9 @@ alias gp="git pull"
 alias kc="knowledge-crystallize.sh"               # Stamp current project MEMORY.md
 alias kca="knowledge-crystallize.sh --all"        # Stamp all projects at once
 
+# Repo maintenance
+alias dch="diff-check.sh"                         # Detect drift between repo and ~/.dotfiles
+
 # Aider tiers (OpenRouter)
 alias ai="aider"                                                                          # daily: DeepSeek V3.2
 alias aic="aider --model openrouter/qwen/qwen3-coder-next"                                # coding: Qwen3 Coder

--- a/scripts/diff-check.sh
+++ b/scripts/diff-check.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# diff-check.sh: Detect drift between repo and deploy-dir (~/.dotfiles).
+#
+# The repo (~/Projects/dotfiles) is the source of truth. Setup-linux.sh
+# COPIES files into ~/.dotfiles (the deploy-dir), then symlinks from $HOME
+# into the deploy-dir. If you edit a file in the repo without re-running
+# setup, the repo and deploy-dir diverge silently — every shell still reads
+# the stale deploy-dir copy. This script reports those divergences.
+#
+# Usage: ./scripts/diff-check.sh [--verbose|-v] [--help|-h]
+# Exit:  0 if no drift, 1 if drift detected, 2 on usage/setup error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+if [ -f "$SCRIPT_DIR/utils.sh" ]; then
+    # shellcheck source=utils.sh disable=SC1091
+    . "$SCRIPT_DIR/utils.sh"
+else
+    echo "Error: utils.sh not found in $SCRIPT_DIR" >&2
+    exit 2
+fi
+
+verbose=false
+for arg in "$@"; do
+    case "$arg" in
+        --verbose|-v) verbose=true ;;
+        --help|-h)
+            cat <<'EOF'
+Usage: diff-check.sh [--verbose|-v]
+
+Reports files that differ between the repo and the deploy-dir (~/.dotfiles).
+Both must exist; only files tracked by git in the repo are checked.
+
+Env:
+  DOTFILES_REPO_DIR   Repo root (default: parent of script's dir)
+  DOTFILES_DIR        Deploy-dir (default: ~/.dotfiles)
+
+Exit codes:
+  0  no drift
+  1  drift detected
+  2  setup error (missing dirs, not a git repo, etc.)
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            echo "Run with --help for usage" >&2
+            exit 2
+            ;;
+    esac
+done
+
+REPO_DIR="${DOTFILES_REPO_DIR:-$(dirname "$SCRIPT_DIR")}"
+DEPLOY_DIR="${DOTFILES_DIR:-$HOME/.dotfiles}"
+
+[ -d "$REPO_DIR" ]   || { echo "Error: repo not found: $REPO_DIR" >&2; exit 2; }
+[ -d "$DEPLOY_DIR" ] || { echo "Error: deploy-dir not found: $DEPLOY_DIR" >&2; exit 2; }
+[ -d "$REPO_DIR/.git" ] || { echo "Error: not a git repo: $REPO_DIR" >&2; exit 2; }
+
+# Top-level files and dirs that setup-linux.sh copies into DEPLOY_DIR.
+# MUST mirror the copy block in setup-linux.sh (around the DOTFILES_DIR section).
+# Anything else in DEPLOY_DIR is legacy cruft from older sync mechanisms or
+# runtime state — not "drift" against current setup, so we skip it.
+_is_managed() {
+    case "$1" in
+        versions.conf|.zshrc|.bashrc|.profile|.gitconfig|tmux.conf) return 0 ;;
+        .zsh/*|ssh/*|scripts/*|sensitive/*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+log_info "Checking drift: $REPO_DIR ↔ $DEPLOY_DIR"
+
+drift_count=0
+checked_count=0
+unmanaged_count=0
+
+while IFS= read -r rel_path; do
+    [ -z "$rel_path" ] && continue
+
+    if ! _is_managed "$rel_path"; then
+        unmanaged_count=$((unmanaged_count + 1))
+        continue
+    fi
+
+    repo_file="$REPO_DIR/$rel_path"
+    deploy_file="$DEPLOY_DIR/$rel_path"
+
+    [ -f "$deploy_file" ] || continue
+    [ -f "$repo_file" ]   || continue
+
+    checked_count=$((checked_count + 1))
+
+    if ! cmp -s "$repo_file" "$deploy_file"; then
+        drift_count=$((drift_count + 1))
+        printf '  %bDRIFT%b: %s\n' "${RED:-}" "${NC:-}" "$rel_path"
+        if $verbose; then
+            diff -u "$deploy_file" "$repo_file" | sed 's/^/    /'
+        fi
+    fi
+done < <(cd "$REPO_DIR" && git ls-files)
+
+echo ""
+log_info "Checked: $checked_count managed files (ignored $unmanaged_count tracked but not deployed)"
+
+if [ $drift_count -eq 0 ]; then
+    log_success "No drift detected — repo and deploy-dir agree"
+    exit 0
+fi
+
+log_warning "Drift detected in $drift_count file(s)"
+echo "  Run './setup-linux.sh' to refresh the deploy-dir from the repo"
+echo "  (or use --verbose to see the diff)"
+exit 1

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -65,7 +65,7 @@ echo "========================================"
 echo "Checking from: $DOTFILES_DIR"
 
 # ==================================================
-section "1/9" "Core Tools in PATH"
+section "1/10" "Core Tools in PATH"
 
 CORE_TOOLS="git zsh bash curl wget jq eza direnv node npm zoxide docker kubectl terraform"
 for tool in $CORE_TOOLS; do
@@ -77,7 +77,7 @@ for tool in $CORE_TOOLS; do
 done
 
 # ==================================================
-section "2/9" "Versioned Tool Paths"
+section "2/10" "Versioned Tool Paths"
 
 check_tool_home() {
     local name="$1"
@@ -117,7 +117,7 @@ else
 fi
 
 # ==================================================
-section "3/9" "Version Match (versions.conf)"
+section "3/10" "Version Match (versions.conf)"
 
 check_version_match() {
     local name="$1"
@@ -144,7 +144,7 @@ check_version_match "Minikube" "${MINIKUBE_VERSION:-}" "$APPS_HOME/minikube-${MI
 check_version_match "Go" "${GO_VERSION:-}" "$APPS_HOME/go-${GO_VERSION:-}"
 
 # ==================================================
-section "4/9" "Key Symlinks"
+section "4/10" "Key Symlinks"
 
 check_symlink() {
     local path="$1"
@@ -169,7 +169,7 @@ check_symlink "$HOME/.zsh/functions.zsh" ".zsh/functions.zsh"
 check_symlink "$HOME/.ssh/config" ".ssh/config"
 
 # ==================================================
-section "5/9" "Environment Variables"
+section "5/10" "Environment Variables"
 
 ENV_VARS="DOTFILES_DIR APPS_HOME JAVA_HOME MAVEN_HOME PYTHON_HOME GO_HOME MINIKUBE_HOME"
 for var in $ENV_VARS; do
@@ -181,7 +181,7 @@ for var in $ENV_VARS; do
 done
 
 # ==================================================
-section "6/9" "Optional Tools"
+section "6/10" "Optional Tools"
 
 OPTIONAL_TOOLS="age gh claude gemini bats shellcheck helm ansible pip"
 for tool in $OPTIONAL_TOOLS; do
@@ -193,7 +193,7 @@ for tool in $OPTIONAL_TOOLS; do
 done
 
 # ==================================================
-section "7/9" "Knowledge Vault"
+section "7/10" "Knowledge Vault"
 
 VAULT_DIR="${VAULT_DIR:-$HOME/Projects/knowledge}"
 
@@ -248,7 +248,7 @@ for dir in $VAULT_DIRS; do
 done
 
 # ==================================================
-section "8/9" "Secrets Integrity"
+section "8/10" "Secrets Integrity"
 
 SECRETS_DIR="${DOTFILES_DIR}/sensitive"
 SECRETS_MAPPING="$SECRETS_DIR/env-mapping.conf"
@@ -297,7 +297,7 @@ else
 fi
 
 # ==================================================
-section "9/9" "tmux"
+section "9/10" "tmux"
 # ==================================================
 if ! command -v tmux >/dev/null 2>&1; then
     fail "tmux not installed (run: sudo apt install -y tmux)"
@@ -315,6 +315,19 @@ else
     else
         fail "$HOME/.tmux.conf missing (run setup-linux.sh)"
     fi
+fi
+
+# ==================================================
+section "10/10" "Repo ↔ Deploy-Dir Drift"
+# ==================================================
+if [ -x "$SCRIPT_DIR/diff-check.sh" ]; then
+    if "$SCRIPT_DIR/diff-check.sh" >/dev/null 2>&1; then
+        pass "no drift between repo and $DOTFILES_DIR"
+    else
+        fail "drift detected (run: $SCRIPT_DIR/diff-check.sh to inspect, then ./setup-linux.sh)"
+    fi
+else
+    skip "diff-check.sh not found at $SCRIPT_DIR/diff-check.sh"
 fi
 
 # ==================================================

--- a/tests/diff-check.bats
+++ b/tests/diff-check.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+# Tests for scripts/diff-check.sh — drift detection between repo and deploy-dir
+
+setup() {
+    SCRIPTS_DIR="$BATS_TEST_DIRNAME/../scripts"
+    REPO_FIXTURE="/tmp/bats_diff_repo_$$"
+    DEPLOY_FIXTURE="/tmp/bats_diff_deploy_$$"
+    mkdir -p "$REPO_FIXTURE/scripts" "$REPO_FIXTURE/.zsh" "$REPO_FIXTURE/tests"
+    mkdir -p "$DEPLOY_FIXTURE/scripts" "$DEPLOY_FIXTURE/.zsh" "$DEPLOY_FIXTURE/tests"
+
+    # Initialize a git repo so `git ls-files` works
+    cd "$REPO_FIXTURE" || exit
+    git init -q
+    git config user.email test@test
+    git config user.name test
+}
+
+teardown() {
+    rm -rf "$REPO_FIXTURE" "$DEPLOY_FIXTURE"
+}
+
+# Stage and commit one file in the repo fixture
+_track() {
+    cd "$REPO_FIXTURE" || return 1
+    git add "$1" 2>/dev/null
+    git commit -q -m "add $1" 2>/dev/null
+}
+
+@test "diff-check.sh --help shows usage and exits 0" {
+    run "$SCRIPTS_DIR/diff-check.sh" --help
+    [[ $status -eq 0 ]]
+    [[ "$output" == *"Usage"* ]]
+    [[ "$output" == *"DOTFILES_REPO_DIR"* ]]
+}
+
+@test "diff-check.sh rejects unknown args" {
+    run "$SCRIPTS_DIR/diff-check.sh" --bogus
+    [[ $status -eq 2 ]]
+    [[ "$output" == *"Unknown argument"* ]]
+}
+
+@test "diff-check.sh exits 2 when repo is not a git repo" {
+    rm -rf "$REPO_FIXTURE/.git"
+    run env DOTFILES_REPO_DIR="$REPO_FIXTURE" DOTFILES_DIR="$DEPLOY_FIXTURE" \
+        "$SCRIPTS_DIR/diff-check.sh"
+    [[ $status -eq 2 ]]
+    [[ "$output" == *"not a git repo"* ]]
+}
+
+@test "diff-check.sh exits 2 when deploy-dir is missing" {
+    rm -rf "$DEPLOY_FIXTURE"
+    echo "x" > "$REPO_FIXTURE/tmux.conf"
+    _track "tmux.conf"
+    run env DOTFILES_REPO_DIR="$REPO_FIXTURE" DOTFILES_DIR="$DEPLOY_FIXTURE" \
+        "$SCRIPTS_DIR/diff-check.sh"
+    [[ $status -eq 2 ]]
+    [[ "$output" == *"deploy-dir not found"* ]]
+}
+
+@test "diff-check.sh exits 0 when managed files match" {
+    echo "same content" > "$REPO_FIXTURE/tmux.conf"
+    echo "same content" > "$DEPLOY_FIXTURE/tmux.conf"
+    _track "tmux.conf"
+    run env DOTFILES_REPO_DIR="$REPO_FIXTURE" DOTFILES_DIR="$DEPLOY_FIXTURE" \
+        "$SCRIPTS_DIR/diff-check.sh"
+    [[ $status -eq 0 ]]
+    [[ "$output" == *"No drift"* ]]
+}
+
+@test "diff-check.sh exits 1 and reports drifted file" {
+    echo "repo version" > "$REPO_FIXTURE/tmux.conf"
+    echo "deployed version" > "$DEPLOY_FIXTURE/tmux.conf"
+    _track "tmux.conf"
+    run env DOTFILES_REPO_DIR="$REPO_FIXTURE" DOTFILES_DIR="$DEPLOY_FIXTURE" \
+        "$SCRIPTS_DIR/diff-check.sh"
+    [[ $status -eq 1 ]]
+    [[ "$output" == *"DRIFT"* ]]
+    [[ "$output" == *"tmux.conf"* ]]
+    [[ "$output" == *"setup-linux.sh"* ]]
+}
+
+@test "diff-check.sh ignores tracked files outside the managed allowlist" {
+    # tests/ is tracked in the repo but NOT deployed by setup-linux.sh.
+    # A divergent copy in the deploy-dir should NOT be flagged as drift.
+    echo "repo test" > "$REPO_FIXTURE/tests/example.bats"
+    echo "stale test" > "$DEPLOY_FIXTURE/tests/example.bats"
+    _track "tests/example.bats"
+    run env DOTFILES_REPO_DIR="$REPO_FIXTURE" DOTFILES_DIR="$DEPLOY_FIXTURE" \
+        "$SCRIPTS_DIR/diff-check.sh"
+    [[ $status -eq 0 ]]
+    [[ "$output" == *"No drift"* ]]
+}
+
+@test "diff-check.sh ignores managed files not yet deployed" {
+    # tmux.conf in repo but not in deploy-dir is "not yet deployed", not drift.
+    echo "new" > "$REPO_FIXTURE/tmux.conf"
+    _track "tmux.conf"
+    run env DOTFILES_REPO_DIR="$REPO_FIXTURE" DOTFILES_DIR="$DEPLOY_FIXTURE" \
+        "$SCRIPTS_DIR/diff-check.sh"
+    [[ $status -eq 0 ]]
+    [[ "$output" == *"No drift"* ]]
+}
+
+@test "diff-check.sh --verbose includes diff output for drifted files" {
+    printf 'line1\nline2 repo\n' > "$REPO_FIXTURE/.zshrc"
+    printf 'line1\nline2 deploy\n' > "$DEPLOY_FIXTURE/.zshrc"
+    _track ".zshrc"
+    run env DOTFILES_REPO_DIR="$REPO_FIXTURE" DOTFILES_DIR="$DEPLOY_FIXTURE" \
+        "$SCRIPTS_DIR/diff-check.sh" --verbose
+    [[ $status -eq 1 ]]
+    [[ "$output" == *"line2 repo"* ]]
+    [[ "$output" == *"line2 deploy"* ]]
+}
+
+@test "diff-check.sh detects drift in nested managed dir (.zsh/)" {
+    echo "alias x=1" > "$REPO_FIXTURE/.zsh/aliases.zsh"
+    echo "alias x=2" > "$DEPLOY_FIXTURE/.zsh/aliases.zsh"
+    _track ".zsh/aliases.zsh"
+    run env DOTFILES_REPO_DIR="$REPO_FIXTURE" DOTFILES_DIR="$DEPLOY_FIXTURE" \
+        "$SCRIPTS_DIR/diff-check.sh"
+    [[ $status -eq 1 ]]
+    [[ "$output" == *".zsh/aliases.zsh"* ]]
+}
+
+@test "diff-check.sh runs under zsh" {
+    echo "x" > "$REPO_FIXTURE/tmux.conf"
+    echo "x" > "$DEPLOY_FIXTURE/tmux.conf"
+    _track "tmux.conf"
+    run zsh -c 'DOTFILES_REPO_DIR="$1" DOTFILES_DIR="$2" "$3/diff-check.sh"' \
+        -- "$REPO_FIXTURE" "$DEPLOY_FIXTURE" "$SCRIPTS_DIR"
+    [[ $status -eq 0 ]]
+}

--- a/tests/healthcheck.bats
+++ b/tests/healthcheck.bats
@@ -26,8 +26,8 @@ setup() {
     grep -q 'versions.conf' "$SCRIPTS_DIR/healthcheck.sh"
 }
 
-@test "healthcheck.sh has all 9 sections" {
-    [[ $(grep -c 'section "' "$SCRIPTS_DIR/healthcheck.sh") -eq 9 ]]
+@test "healthcheck.sh has all 10 sections" {
+    [[ $(grep -c 'section "' "$SCRIPTS_DIR/healthcheck.sh") -eq 10 ]]
 }
 
 @test "healthcheck.sh uses set -euo pipefail" {
@@ -58,10 +58,10 @@ setup() {
     fi
 }
 
-# --- tmux section 9/9 ---
+# --- tmux section 9/10 ---
 
-@test "healthcheck.sh has section 9/9 for tmux" {
-    grep -qE 'section "9/9" "tmux"' "$SCRIPTS_DIR/healthcheck.sh"
+@test "healthcheck.sh has section 9/10 for tmux" {
+    grep -qE 'section "9/10" "tmux"' "$SCRIPTS_DIR/healthcheck.sh"
 }
 
 @test "healthcheck.sh verifies tmux binary" {
@@ -70,4 +70,14 @@ setup() {
 
 @test "healthcheck.sh verifies ~/.tmux.conf symlink target" {
     grep -qE 'readlink "\$HOME/\.tmux\.conf"' "$SCRIPTS_DIR/healthcheck.sh"
+}
+
+# --- drift section 10/10 ---
+
+@test "healthcheck.sh has section 10/10 for drift" {
+    grep -qE 'section "10/10" "Repo' "$SCRIPTS_DIR/healthcheck.sh"
+}
+
+@test "healthcheck.sh invokes diff-check.sh" {
+    grep -q 'diff-check.sh' "$SCRIPTS_DIR/healthcheck.sh"
 }


### PR DESCRIPTION
Closes the dotfiles backlog item "Dotfiles diff/drift detection" (P2 in vault).

## Why now

Two recent incidents motivated this:
1. **tmux clipboard work** (PR #6) — config changes in the repo were invisible to running tmux because `~/.dotfiles/tmux.conf` (the middle-layer copy) hadn't been refreshed via `./setup-linux.sh`. Vault lesson captured.
2. **issue #7** — `secrets_rotate` was thought to silently fail; it had actually worked, but the same kind of "did my edit really propagate?" confusion. PR #9 fixed the env-vs-disk drift; this PR makes the file-vs-deploy drift visible too.

## What it does

`scripts/diff-check.sh` walks files tracked by git in the repo, compares each one against its counterpart in `~/.dotfiles/`, and reports any divergences.

- Filters to an **explicit allowlist** mirroring what `setup-linux.sh` actually deploys (`versions.conf`, `.zshrc`, `.bashrc`, `.profile`, `.gitconfig`, `tmux.conf`, `.zsh/`, `ssh/`, `scripts/`, `sensitive/`). Legacy cruft in the deploy-dir from older sync mechanisms is ignored — no noise.
- **Exit codes**: 0 (clean), 1 (drift), 2 (setup error)
- **`--verbose`**: shows the per-file diff
- Wired as **healthcheck section 10/10** (existing 9 sections renumbered to /10)
- Alias **`dch`** added to `.zsh/aliases.zsh`

## Test plan

- [x] `~/.local/bin/bats tests/*.bats` → all green (11 new tests for diff-check, healthcheck section count test updated)
- [x] `~/.local/bin/shellcheck scripts/diff-check.sh` → clean
- [x] Manual smoke against current state → reports `.bashrc`, `.zshrc`, `tmux.conf` as drifted (expected: I haven't run `./setup-linux.sh` after recent edits)
- [ ] After merge: run `./setup-linux.sh`, then `dch` should report no drift