### PR TITLE
feat(scripts): add changelog-gen.sh + initial CHANGELOG.md

### DIFF
--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -29,6 +29,7 @@ alias kca="knowledge-crystallize.sh --all"        # Stamp all projects at once
 
 # Repo maintenance
 alias dch="diff-check.sh"                         # Detect drift between repo and ~/.dotfiles
+alias cl="changelog-gen.sh"                       # Regenerate CHANGELOG.md from git log
 
 # Aider tiers (OpenRouter)
 alias ai="aider"                                                                          # daily: DeepSeek V3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,133 @@
+# Changelog
+
+Generated from conventional commits via `scripts/changelog-gen.sh`. Do not edit by hand.
+
+## Features
+
+- 2026-05-12: feat(tmux): add focus-events, vi visual-mode bindings, slower status refresh (c23ec99)
+- 2026-05-11: feat(tmux): copy selection to system clipboard via xclip (fd361f6)
+- 2026-05-11: feat(tmux): integrate tmux with versioned config and Linux install (239e715)
+- 2026-05-08: feat(scripts): add claude-mem-heal for upstream v12/v13 packaging bugs (053bad8)
+- 2026-03-29: feat: skills ecosystem overhaul — 23 to 17 skills, CSO audit, Standing Orders (61c4b38)
+- 2026-03-27: feat: add obs-cli wrapper for Obsidian CLI (Linux + Windows) (91ba19d)
+- 2026-03-26: feat: unified workflow protocol — area-agnostic CLAUDE.md, full vault entry in init-project, work SDK detection in session hooks (3884d4f)
+- 2026-03-26: feat(hooks): auto-create memory junction/symlink on session start (999a478)
+- 2026-03-26: feat(setup): bidirectional memory sync on Windows via junctions (ef53bd4)
+- 2026-03-25: feat(ai,secrets): add engineering discipline rules, secrets reconciliation, cleanup (a9fb76a)
+- 2026-03-24: feat(claude): add self-maintaining memory system (0204133)
+- 2026-03-16: feat(setup): auto-install 10 developer tools on Linux and 7 on Windows (e1e4746)
+- 2026-03-10: feat(ai): add aider integration with 3-tier OpenRouter model config (c515c69)
+- 2026-03-07: feat(setup): add hive MCP server with auto-upgrade to both Linux and Windows (3ddc041)
+- 2026-02-28: feat(ai): add kc / kca shortcuts for quick access as aliases (e153f7e)
+- 2026-02-28: feat(ai): knowledge crystallization system — bash + PowerShell + auto-discovery (067ee84)
+- 2026-02-27: feat(setup): auto-register Claude Code SessionStart hook (03cb64e)
+- 2026-02-27: feat: add Claude Code SessionStart hook for vault health context (917c03b)
+- 2026-02-27: feat: add vault-health.sh and integrate Obsidian CLI checks (fc85d1d)
+- 2026-02-27: feat(shell): add obsidian alias with --no-sandbox for Linux AppImage (dfe4c37)
+- 2026-02-26: feat(ci): add container-based integration test for setup-linux.sh (465fd2a)
+- 2026-02-26: feat: add versions.conf and healthcheck.sh (P1 backlog) (72fdb29)
+- 2026-02-26: feat(shell): standardize set -euo pipefail across standalone scripts (fd5ef7e)
+- 2026-02-26: feat(ai): add auto-memory to Neural Hive context sync phase (b01af3e)
+- 2026-02-26: feat: persist MCP servers globally and auto-memory via vault (46abe35)
+- 2026-02-26: feat: persist MCP servers and auto-memory across machines (ffd56fa)
+- 2026-02-23: feat(claude): add no Co-Authored-By policy to global CLAUDE.md (4befe55)
+- 2026-02-23: feat: set nano as default UNIX editor (3fa1bea)
+- 2026-02-22: feat(ai): implement neural hive protocol and standardize vault (6c32d26)
+- 2026-02-22: feat: add PSScriptAnalyzer linting to CI for PowerShell scripts (34b94d5)
+- 2026-02-22: feat: add PSScriptAnalyzer linting to CI for PowerShell scripts (4197b4d)
+- 2026-02-22: feat: add secrets_show command and SSH config deployment (9712196)
+- 2026-02-21: feat: add file-based secrets support for kubeconfig and multiline files (9da08d8)
+- 2026-02-21: feat: add prd, qa-plan, prd-to-issues skills and automate plugin installation (e1a9ad9)
+- 2026-02-21: feat: add prd skill for interactive requirements gathering (ce7263e)
+- 2026-02-18: feat: auto-install claude-mem plugin in setup scripts (8af28a7)
+- 2026-02-16: feat: apply Anthropic Claude Code best practices across project and global config (5bb8aae)
+- 2026-02-16: feat: apply Anthropic Claude Code best practices across project and global config (0fd3557)
+- 2026-02-13: feat: add POLLEX_API_KEY (4e2bafe)
+- 2026-02-11: feat: add excalidraw MCP server registration to setup scripts (2148176)
+- 2026-02-10: feat: auto-create python symlink in setup for version-agnostic command (37950fe)
+- 2026-02-10: feat: upgrade Go to 1.26.0 and prepend tool paths for system override (83e938a)
+- 2026-02-08: feat: add bun PATH to .bashrc and .zshrc for persistent installation (c7d7590)
+- 2026-02-04: feat: add USB backup of secrets with VeraCrypt support (032965b)
+- 2026-02-02: feat: add Windows PowerShell support and rename setup scripts   - Add setup-windows.ps1, powershell/profile.ps1, scripts/init-project.ps1   - Rename install.sh → setup-linux.sh, change claude-init → project-init   - Delete obsolete .bat files   - Update all documentation (5a568af)
+- 2026-02-01: feat: consolidate AI configuration and implement Claude Code skills   - Refactor CLAUDE.md and GEMINI.md   - Restructure skills to official format (SKILL.md with YAML frontmatter)   - Add skills: audit, refactor, test, doc, docker   - Update install.sh to copy skill directories and extract Gemini prompts   - Update init-project.sh for new skill structure   - Add docs/AI.md with complete setup and workflow guide   - Clean up deprecated versioned files (6037ada)
+- 2026-01-14: feat: implement dotfiles sync and enhance secrets management 	- Add `dotfiles-sync` workflow for local vs repo synchronization 	- Update `github-secrets-manager` to support uploading from `env-mapping.conf` 	- Add auto-sync capabilities to `secrets_add` and `secrets_rotate` 	- Register `PYPI_TOKEN` in secrets mapping 	- Update documentation and test suite (87eab20)
+- 2026-01-14: feat: implement dotfiles sync and enhance secrets management 	- Add `dotfiles-sync` workflow for local vs repo synchronization 	- Update `github-secrets-manager` to support uploading from `env-mapping.conf` 	- Add auto-sync capabilities to `secrets_add` and `secrets_rotate` 	- Register `PYPI_TOKEN` in secrets mapping 	- Update documentation and test suite (290c362)
+- 2026-01-11: feat: add secrets availability in bash based on encrypted files with a config file mapping, add test suite as part of precommit hook. (09235cb)
+- 2025-11-19: feat: introduce Claude AI aliases and prompt function,  and restructure documentation. (6280f4c)
+- 2025-11-19: feat: initial commit with Claude optimization (25e7324)
+- 2025-11-18: feat: support gemini-cli with custom GEMINI.md and prompts for easy use common to all projects (5018898)
+- 2025-03-23: feat: add env file path as input parameter to setup-gh-secrets (5a3f6c6)
+
+## Bug Fixes
+
+- 2026-05-12: fix(secrets): keep env, deployed, and repo in sync after every mutation (295b6f3)
+- 2026-05-08: fix(scripts): remove unused cwd_slug local in claude-session-start (f030959)
+- 2026-03-29: fix(ci): update skill count threshold from 18 to 15 after ecosystem overhaul (103ec41)
+- 2026-03-29: fix(ci): guard crontab call for environments without cron (8262808)
+- 2026-03-27: fix(ci): replace remaining non-ASCII chars in init-project.ps1 (27dc6af)
+- 2026-03-26: fix(ssh): aws1 uses MagicDNS instead of hardcoded Tailscale IP (c6ab454)
+- 2026-03-26: fix(ci): replace non-ASCII chars in init-project.ps1 to pass PSScriptAnalyzer (60417ce)
+- 2026-03-25: fix(setup): always deploy AI config regardless of CLI presence (c3be688)
+- 2026-03-25: fix(tests): skip Gemini integration tests when CLI not installed (13c07a1)
+- 2026-03-25: fix(tests): update healthcheck section count from 7 to 8 (f2c1c13)
+- 2026-03-22: fix(ssh): sync config with live host inventory (14edd90)
+- 2026-03-18: fix(setup): symlink .gitconfig instead of copying (6c60d20)
+- 2026-03-17: fix(sync): replace git pull with rsync for local installation (73cdc2e)
+- 2026-03-16: fix(ci): resolve 3 CI failures from developer tools addition (971e01e)
+- 2026-03-12: fix: resolve 26 bugs and close Windows/Linux parity gaps (82481ef)
+- 2026-02-28: fix(ci): remove non-ascii characters to resolve PSScriptAnalyzer BOM error (b36fac7)
+- 2026-02-26: fix(ci): remove false CLAUDE.md assertion from integration tests (e2cbd36)
+- 2026-02-23: fix: close setup parity gaps between Linux and Windows (866314e)
+- 2026-02-22: fix: harden AI rules deployment and fix SSH directory copy (0736c74)
+- 2026-02-18: fix: replace non-interactive claude plugin install with manual instruction (add9285)
+- 2026-02-16: fix: handle zsh nomatch error in secrets_clean glob patterns (791c0e6)
+- 2026-02-16: fix: install zsh in CI for zsh compatibility tests (409c347)
+- 2026-02-07: fix: harden all shell scripts for POSIX/zsh compatibility and add 95 bats-core tests (196a4e5)
+- 2026-01-15: fix: add shellcheck disable for zsh-specific syntax (544a8fe)
+- 2026-01-14: fix: remove local keyword, skip GITHUB_ secrets, add CI workflow (6886c3b)
+- 2025-03-23: fix: issue in .bashrc (4496a06)
+
+## Refactoring
+
+- 2026-02-28: refactor(ai): align project init and agent prompts with Neural Hive protocol (2e1eda8)
+- 2025-11-28: refactor: standardize shell configs and fix APPS_HOME path (ed02dc3)
+
+## Documentation
+
+- 2026-03-12: docs(readme): update test count, add aider aliases and new scripts (6e687b1)
+- 2026-01-12: docs: add SECRETS.md and reorganize documentation structure (c84292e)
+
+## Tests
+
+- 2026-02-28: test(ci): pass PSScriptAnalyzer settings to bats test (b4b178c)
+
+## Chores
+
+- 2025-12-05: chore: add sops age key file path as env variable (f4a58a7)
+- 2025-11-19: chore: Remove claude boost.sh script and its installation command from install.sh. (7f96a05)
+- 2025-11-14: chore: prioritize ~/go/bin in $PATH to use correct go-task v3 from v2 (ad8a9a8)
+- 2025-08-29: chore: add zoho codes (bdc088a)
+- 2025-08-29: chore: add cloudflare token (9ac5a47)
+- 2025-08-26: chore: add pre-commit hooks and validation script (117dbc9)
+- 2025-08-26: chore: add sensitive scripts and refactor documentation (141b1f3)
+- 2025-06-20: chore: add age encryption for secrets (3f7ba2d)
+- 2025-03-23: chore: add gh secrets configuration from env file (12391d1)
+- 2025-03-23: chore: add node dependencies checkout (e91d2f2)
+- 2025-03-23: chore: add dependencies checkout for aliases (79dacc2)
+- 2025-03-22: chore: add custom functions to zsh terminal (32de27b)
+
+## Other
+
+- 2026-03-01: secrets: add openrouter api key (0df59eb)
+- 2026-02-22: doc: migrate docs/ to private vault and extract ADRs (5a045cb)
+- 2026-02-21: doc: minor details (01abc2b)
+- 2026-02-18: doc: remove excalidraw MCP server from all configs and docs (babdcb1)
+- 2026-02-10: git commit -m "feat: add drawio MCP server registration to setup scripts" (7340e37)
+- 2026-02-08: doc: update LLM files with obsidian vault info (d002719)
+- 2026-02-07: doc: add backlog file (4e88cd0)
+- 2026-02-04: doc: add claude code plugins installation (81e88dd)
+- 2025-03-24: bug: remove --icon flag from eza aliases (250bd8c)
+- 2025-03-23: bug: fix issue in nvm alias inizialiation (fc73945)
+- 2024-11-01: First commit (c40614f)
+- 2024-11-01: Initial commit (3cb97d3)
+

--- a/scripts/changelog-gen.sh
+++ b/scripts/changelog-gen.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+# changelog-gen.sh: regenerate CHANGELOG.md from conventional-commit history.
+#
+# Reads `git log` (no merges), groups commits by Conventional Commit type
+# (feat, fix, refactor, …), and writes a Markdown changelog grouped by type
+# in reverse-chronological order. Deterministic: running it twice on the
+# same history produces the same file (idempotent).
+#
+# Usage: ./scripts/changelog-gen.sh [--output FILE] [--since REV] [--check]
+# Exit:  0 success, 1 if --check and CHANGELOG would change, 2 on error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# Resolve repo: env override > git toplevel from cwd > script's parent dir.
+if [ -n "${DOTFILES_REPO_DIR:-}" ]; then
+    REPO_DIR="$DOTFILES_REPO_DIR"
+elif REPO_DIR="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+else
+    REPO_DIR="$(dirname "$SCRIPT_DIR")"
+fi
+OUTPUT="$REPO_DIR/CHANGELOG.md"
+SINCE=""
+CHECK_MODE=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --output) OUTPUT="$2"; shift 2 ;;
+        --since)  SINCE="$2"; shift 2 ;;
+        --check)  CHECK_MODE=true; shift ;;
+        --help|-h)
+            cat <<'EOF'
+Usage: changelog-gen.sh [--output FILE] [--since REV] [--check]
+
+Regenerate CHANGELOG.md from conventional commits.
+
+Options:
+  --output FILE   Write to FILE instead of CHANGELOG.md at repo root
+  --since REV     Only include commits after REV (e.g. --since v1.0.0)
+  --check         Don't write; exit 1 if the file would change (CI use)
+
+The script groups commits by Conventional Commit type:
+  feat, fix, perf, refactor, docs, test, ci, build, chore.
+Anything else lands under "Other".
+EOF
+            exit 0
+            ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+cd "$REPO_DIR"
+[ -d .git ] || { echo "Error: not a git repo: $REPO_DIR" >&2; exit 2; }
+
+range="HEAD"
+[ -n "$SINCE" ] && range="${SINCE}..HEAD"
+
+# Type → heading (order matters; this is the order in the output).
+type_headings=(
+    "feat:Features"
+    "fix:Bug Fixes"
+    "perf:Performance"
+    "refactor:Refactoring"
+    "docs:Documentation"
+    "test:Tests"
+    "ci:CI"
+    "build:Build"
+    "chore:Chores"
+)
+
+declare -A buckets
+for entry in "${type_headings[@]}"; do
+    buckets["${entry%%:*}"]=""
+done
+buckets[other]=""
+
+# Read git log: <ISO-date>|<short-hash>|<subject>
+while IFS='|' read -r date hash subject; do
+    [ -z "$subject" ] && continue
+    line="- ${date}: ${subject} (${hash})"$'\n'
+
+    if [[ "$subject" =~ ^([a-z]+)(\([^\)]+\))?(!)?:\ .+$ ]]; then
+        type="${BASH_REMATCH[1]}"
+        if [ -n "${buckets[$type]+set}" ]; then
+            buckets[$type]+="$line"
+        else
+            buckets[other]+="$line"
+        fi
+    else
+        buckets[other]+="$line"
+    fi
+done < <(git log "$range" --no-merges --pretty=tformat:'%cs|%h|%s')
+
+# Render to a temp buffer first so --check can compare without writing.
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+{
+    echo "# Changelog"
+    echo ""
+    echo "Generated from conventional commits via \`scripts/changelog-gen.sh\`. Do not edit by hand."
+    echo ""
+
+    for entry in "${type_headings[@]}"; do
+        type="${entry%%:*}"
+        heading="${entry#*:}"
+        if [ -n "${buckets[$type]}" ]; then
+            echo "## $heading"
+            echo ""
+            printf '%s' "${buckets[$type]}"
+            echo ""
+        fi
+    done
+
+    if [ -n "${buckets[other]}" ]; then
+        echo "## Other"
+        echo ""
+        printf '%s' "${buckets[other]}"
+        echo ""
+    fi
+} > "$tmp"
+
+if $CHECK_MODE; then
+    if [ ! -f "$OUTPUT" ] || ! cmp -s "$tmp" "$OUTPUT"; then
+        echo "CHANGELOG out of date — run scripts/changelog-gen.sh" >&2
+        exit 1
+    fi
+    echo "CHANGELOG up to date"
+    exit 0
+fi
+
+mv "$tmp" "$OUTPUT"
+trap - EXIT
+echo "CHANGELOG written to $OUTPUT"

--- a/tests/changelog-gen.bats
+++ b/tests/changelog-gen.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+# Tests for scripts/changelog-gen.sh
+
+setup() {
+    SCRIPTS_DIR="$BATS_TEST_DIRNAME/../scripts"
+    REPO_FIXTURE="/tmp/bats_changelog_$$"
+    mkdir -p "$REPO_FIXTURE"
+    cd "$REPO_FIXTURE" || exit
+    git init -q
+    git config user.email test@test
+    git config user.name test
+    git commit -q --allow-empty -m "feat(core): initial commit"
+    git commit -q --allow-empty -m "fix(api): correct null check"
+    git commit -q --allow-empty -m "docs(readme): clarify install"
+    git commit -q --allow-empty -m "random subject without type"
+}
+
+teardown() {
+    rm -rf "$REPO_FIXTURE"
+}
+
+@test "changelog-gen.sh --help prints usage" {
+    run "$SCRIPTS_DIR/changelog-gen.sh" --help
+    [[ $status -eq 0 ]]
+    [[ "$output" == *"Usage"* ]]
+    [[ "$output" == *"Conventional"* ]]
+}
+
+@test "changelog-gen.sh rejects unknown args" {
+    run "$SCRIPTS_DIR/changelog-gen.sh" --bogus
+    [[ $status -eq 2 ]]
+    [[ "$output" == *"Unknown"* ]]
+}
+
+@test "changelog-gen.sh exits 2 outside a git repo" {
+    rm -rf "$REPO_FIXTURE/.git"
+    run env DOTFILES_REPO_DIR="$REPO_FIXTURE" "$SCRIPTS_DIR/changelog-gen.sh" --output "$REPO_FIXTURE/CHANGELOG.md"
+    [[ $status -eq 2 ]]
+    [[ "$output" == *"not a git repo"* ]]
+}
+
+@test "changelog-gen.sh writes a CHANGELOG with type sections" {
+    run env DOTFILES_REPO_DIR="$REPO_FIXTURE" "$SCRIPTS_DIR/changelog-gen.sh" --output "$REPO_FIXTURE/CHANGELOG.md"
+    [[ $status -eq 0 ]]
+    [[ -f "$REPO_FIXTURE/CHANGELOG.md" ]]
+    grep -q "^## Features" "$REPO_FIXTURE/CHANGELOG.md"
+    grep -q "^## Bug Fixes" "$REPO_FIXTURE/CHANGELOG.md"
+    grep -q "^## Documentation" "$REPO_FIXTURE/CHANGELOG.md"
+}
+
+@test "changelog-gen.sh buckets non-conventional commits under Other" {
+    env DOTFILES_REPO_DIR="$REPO_FIXTURE" "$SCRIPTS_DIR/changelog-gen.sh" --output "$REPO_FIXTURE/CHANGELOG.md"
+    grep -q "^## Other" "$REPO_FIXTURE/CHANGELOG.md"
+    grep -q "random subject without type" "$REPO_FIXTURE/CHANGELOG.md"
+}
+
+@test "changelog-gen.sh entry format includes date and short hash" {
+    env DOTFILES_REPO_DIR="$REPO_FIXTURE" "$SCRIPTS_DIR/changelog-gen.sh" --output "$REPO_FIXTURE/CHANGELOG.md"
+    # Format: "- YYYY-MM-DD: subject (hash)"
+    grep -qE '^- [0-9]{4}-[0-9]{2}-[0-9]{2}: .+ \([0-9a-f]+\)$' "$REPO_FIXTURE/CHANGELOG.md"
+}
+
+@test "changelog-gen.sh is idempotent (running twice produces same file)" {
+    env DOTFILES_REPO_DIR="$REPO_FIXTURE" "$SCRIPTS_DIR/changelog-gen.sh" --output "$REPO_FIXTURE/CHANGELOG.md"
+    cp "$REPO_FIXTURE/CHANGELOG.md" "$REPO_FIXTURE/first.md"
+    env DOTFILES_REPO_DIR="$REPO_FIXTURE" "$SCRIPTS_DIR/changelog-gen.sh" --output "$REPO_FIXTURE/CHANGELOG.md"
+    cmp -s "$REPO_FIXTURE/first.md" "$REPO_FIXTURE/CHANGELOG.md"
+}
+
+@test "changelog-gen.sh --check exits 0 when CHANGELOG is current" {
+    env DOTFILES_REPO_DIR="$REPO_FIXTURE" "$SCRIPTS_DIR/changelog-gen.sh" --output "$REPO_FIXTURE/CHANGELOG.md"
+    run env DOTFILES_REPO_DIR="$REPO_FIXTURE" "$SCRIPTS_DIR/changelog-gen.sh" --output "$REPO_FIXTURE/CHANGELOG.md" --check
+    [[ $status -eq 0 ]]
+    [[ "$output" == *"up to date"* ]]
+}
+
+@test "changelog-gen.sh --check exits 1 when CHANGELOG is stale" {
+    env DOTFILES_REPO_DIR="$REPO_FIXTURE" "$SCRIPTS_DIR/changelog-gen.sh" --output "$REPO_FIXTURE/CHANGELOG.md"
+    git commit --allow-empty -q -m "feat(new): added since"
+    run env DOTFILES_REPO_DIR="$REPO_FIXTURE" "$SCRIPTS_DIR/changelog-gen.sh" --output "$REPO_FIXTURE/CHANGELOG.md" --check
+    [[ $status -eq 1 ]]
+    [[ "$output" == *"out of date"* ]]
+}
+
+@test "changelog-gen.sh --check exits 1 when CHANGELOG is missing" {
+    rm -f "$REPO_FIXTURE/CHANGELOG.md"
+    run env DOTFILES_REPO_DIR="$REPO_FIXTURE" "$SCRIPTS_DIR/changelog-gen.sh" --output "$REPO_FIXTURE/CHANGELOG.md" --check
+    [[ $status -eq 1 ]]
+}
+
+@test "changelog-gen.sh --since limits to commits after revision" {
+    local baseline
+    baseline="$(git rev-parse HEAD)"
+    git commit --allow-empty -q -m "feat(post): after baseline"
+    env DOTFILES_REPO_DIR="$REPO_FIXTURE" "$SCRIPTS_DIR/changelog-gen.sh" --output "$REPO_FIXTURE/CHANGELOG.md" --since "$baseline"
+    grep -q "after baseline" "$REPO_FIXTURE/CHANGELOG.md"
+    ! grep -q "initial commit" "$REPO_FIXTURE/CHANGELOG.md"
+}


### PR DESCRIPTION
Closes the dotfiles backlog item "CHANGELOG.md" (P2 in vault).

## Why

Conventional commits are already the project convention (`feat(tmux):`, `fix(secrets):`). A generator that reads `git log` and emits a grouped Markdown changelog is essentially free maintenance — the same commit messages serve double duty as CHANGELOG entries, no manual upkeep.

## What it does

`scripts/changelog-gen.sh` reads `git log --no-merges`, groups commits by Conventional Commit type, and writes `CHANGELOG.md`. Deterministic: same input → same output (idempotent).

- Type → heading: `feat→Features`, `fix→Bug Fixes`, `perf→Performance`, `refactor→Refactoring`, `docs→Documentation`, `test→Tests`, `ci→CI`, `build→Build`, `chore→Chores`. Unrecognized prefixes go under `Other`.
- Format per entry: `- YYYY-MM-DD: <subject> (<short-hash>)`
- **`--check`**: doesn't write; exits 1 if the file would change. CI-friendly stale detection.
- **`--since REV`**: only commits after REV.
- Auto-resolves repo: `$DOTFILES_REPO_DIR` > git toplevel from cwd > script's parent.
- Alias **`cl`** added in `.zsh/aliases.zsh`.

The included `CHANGELOG.md` was generated from the full history (since the 2024-11-01 initial commit), 133 lines.

## Bug avoided during dev

Initial implementation used `--pretty=format:` which doesn't terminate the last commit with a newline → `while read` skipped the oldest entry silently. Switched to `--pretty=tformat:` (always newline-terminated). Tests caught this on the regen check.

## Notes

- **Conflict warning**: this PR adds a "Repo maintenance" alias block in the same region as PR #10 (which adds `dch`). When both merge, expect a trivial conflict — both aliases should coexist.
- Not wired into CI yet. To enforce CHANGELOG freshness, add a CI step running `./scripts/changelog-gen.sh --check`. Left as a follow-up decision.

## Test plan

- [x] `~/.local/bin/bats tests/changelog-gen.bats` → 11/11
- [x] Full suite green
- [x] Manual: `./scripts/changelog-gen.sh && ./scripts/changelog-gen.sh --check` → idempotent
- [x] `~/.local/bin/shellcheck scripts/changelog-gen.sh` → clean