### PR TITLE
feat(scripts): opt-in shell startup profiling

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,5 +1,13 @@
 # ~/.bashrc: executed by bash(1) for non-login shells.
 
+# Optional startup profiling. Enable with: DOTFILES_PROFILE=1 bash -i -c exit
+# Bash has no built-in profiler — emit timestamped xtrace to a tmp file.
+if [[ -n "${DOTFILES_PROFILE:-}" ]]; then
+    PS4='+ $EPOCHREALTIME ${BASH_SOURCE}:${LINENO}: '
+    exec 3>&2 2>"/tmp/bashrc-profile.$$.log"
+    set -x
+fi
+
 # ==========================
 #    INTERACTIVE CHECK
 # ==========================
@@ -121,3 +129,10 @@ if [ -f /usr/share/bash-completion/bash_completion ]; then
     . /usr/share/bash-completion/bash_completion
 fi
 complete -o nospace -C /usr/bin/terraform terraform
+
+# Stop xtrace and surface the profile log path if profiling was enabled
+if [[ -n "${DOTFILES_PROFILE:-}" ]]; then
+    set +x
+    exec 2>&3 3>&-
+    echo "bashrc profile written to /tmp/bashrc-profile.$$.log"
+fi

--- a/.zshrc
+++ b/.zshrc
@@ -1,3 +1,7 @@
+# Optional startup profiling. Enable with: DOTFILES_PROFILE=1 zsh -i -c exit
+# Pairs with the zprof dump at the bottom of this file.
+[[ -n "${DOTFILES_PROFILE:-}" ]] && zmodload zsh/zprof
+
 # ==========================
 #       OH MY ZSH SETUP
 # ==========================
@@ -102,3 +106,6 @@ command -v zoxide >/dev/null && eval "$(zoxide init zsh)"
 # Terraform Autocomplete
 autoload -U +X bashcompinit && bashcompinit
 complete -o nospace -C /usr/bin/terraform terraform
+
+# Dump zprof results at end of startup if profiling is enabled
+[[ -n "${DOTFILES_PROFILE:-}" ]] && zprof | head -25

--- a/scripts/shell-profile.sh
+++ b/scripts/shell-profile.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# shell-profile.sh: measure shell startup time and (optionally) per-function detail.
+#
+# Time-only mode (default): runs the chosen shell N times, reports min/median/max
+# of total interactive startup. Cheap, repeatable.
+#
+# Detail mode (--detail): activates DOTFILES_PROFILE=1, which the rc files
+# enable per-function profiling via zsh's zprof (or bash xtrace). Gives a
+# breakdown of which sourced file/function consumed time.
+#
+# Usage: ./scripts/shell-profile.sh [--shell zsh|bash] [--detail] [--runs N]
+# Exit:  0 on success, 2 on usage error
+
+set -euo pipefail
+
+SHELL_CHOICE="zsh"
+DETAIL=false
+RUNS=5
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --shell)  SHELL_CHOICE="$2"; shift 2 ;;
+        --detail) DETAIL=true; shift ;;
+        --runs)   RUNS="$2"; shift 2 ;;
+        --help|-h)
+            cat <<'EOF'
+Usage: shell-profile.sh [--shell zsh|bash] [--detail] [--runs N]
+
+Time-only mode (default): time RUNS interactive shells, report stats.
+Detail mode (--detail):   one shell with DOTFILES_PROFILE=1, dump profile.
+
+Options:
+  --shell zsh|bash   Which shell to profile (default: zsh)
+  --detail           Enable per-function profiling via DOTFILES_PROFILE=1
+  --runs N           Number of warm-up + measurement runs (default: 5)
+EOF
+            exit 0
+            ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+case "$SHELL_CHOICE" in
+    zsh|bash) ;;
+    *) echo "Error: --shell must be zsh or bash, got: $SHELL_CHOICE" >&2; exit 2 ;;
+esac
+
+if ! command -v "$SHELL_CHOICE" >/dev/null 2>&1; then
+    echo "Error: $SHELL_CHOICE not in PATH" >&2
+    exit 2
+fi
+
+if $DETAIL; then
+    echo "=== Detail profile: $SHELL_CHOICE (DOTFILES_PROFILE=1) ==="
+    echo ""
+    DOTFILES_PROFILE=1 "$SHELL_CHOICE" -i -c exit
+    exit 0
+fi
+
+# Time-only mode: collect RUNS measurements (in seconds, with decimals) and report stats.
+echo "Profiling $SHELL_CHOICE startup ($RUNS runs)..."
+echo ""
+
+samples=""
+for _ in $(seq 1 "$RUNS"); do
+    # `time` writes to stderr in `real Xm Y.YYYs` format; capture and convert to seconds.
+    raw=$( { time "$SHELL_CHOICE" -i -c exit ; } 2>&1 | awk '/^real/ {print $2}')
+    # Format: "0m0.234s" → 0.234
+    seconds=$(printf '%s' "$raw" | awk -F'[ms]' '{ printf "%.3f", $1 * 60 + $2 }')
+    printf '  run: %ss\n' "$seconds"
+    samples+="$seconds"$'\n'
+done
+
+# Stats: sort, pick min/median/max, mean.
+echo ""
+printf '%s' "$samples" | sort -n | awk -v runs="$RUNS" '
+    { values[NR] = $1; sum += $1 }
+    END {
+        min = values[1]
+        max = values[NR]
+        median = (NR % 2 == 1) ? values[(NR + 1) / 2] : (values[NR/2] + values[NR/2 + 1]) / 2
+        mean = sum / NR
+        printf "  min:    %.3fs\n", min
+        printf "  median: %.3fs\n", median
+        printf "  mean:   %.3fs\n", mean
+        printf "  max:    %.3fs\n", max
+    }
+'
+
+echo ""
+echo "Tip: re-run with --detail for a per-function breakdown."

--- a/tests/shell-profile.bats
+++ b/tests/shell-profile.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+# Tests for scripts/shell-profile.sh — shell startup profiling
+
+setup() {
+    SCRIPTS_DIR="$BATS_TEST_DIRNAME/../scripts"
+    REPO_ROOT="$BATS_TEST_DIRNAME/.."
+}
+
+@test "shell-profile.sh --help shows usage" {
+    run "$SCRIPTS_DIR/shell-profile.sh" --help
+    [[ $status -eq 0 ]]
+    [[ "$output" == *"Usage"* ]]
+    [[ "$output" == *"--detail"* ]]
+    [[ "$output" == *"--runs"* ]]
+}
+
+@test "shell-profile.sh rejects unknown args" {
+    run "$SCRIPTS_DIR/shell-profile.sh" --bogus
+    [[ $status -eq 2 ]]
+    [[ "$output" == *"Unknown"* ]]
+}
+
+@test "shell-profile.sh rejects unsupported shell" {
+    run "$SCRIPTS_DIR/shell-profile.sh" --shell fish
+    [[ $status -eq 2 ]]
+    [[ "$output" == *"--shell must be zsh or bash"* ]]
+}
+
+@test "shell-profile.sh rejects shell not in PATH" {
+    run "$SCRIPTS_DIR/shell-profile.sh" --shell bash --runs 1
+    # bash is in PATH so this should succeed; smoke check the path
+    [[ $status -eq 0 ]]
+}
+
+@test "shell-profile.sh time-only mode reports min/median/mean/max" {
+    run "$SCRIPTS_DIR/shell-profile.sh" --shell bash --runs 3
+    [[ $status -eq 0 ]]
+    [[ "$output" == *"min:"* ]]
+    [[ "$output" == *"median:"* ]]
+    [[ "$output" == *"mean:"* ]]
+    [[ "$output" == *"max:"* ]]
+}
+
+@test "shell-profile.sh time-only mode runs the requested number of iterations" {
+    run "$SCRIPTS_DIR/shell-profile.sh" --shell bash --runs 4
+    [[ $status -eq 0 ]]
+    # Count "run:" lines (each iteration prints one)
+    local run_count
+    run_count=$(printf '%s' "$output" | grep -c "^  run:" || true)
+    [[ "$run_count" -eq 4 ]]
+}
+
+@test ".bashrc has DOTFILES_PROFILE opt-in hook" {
+    grep -q 'DOTFILES_PROFILE' "$REPO_ROOT/.bashrc"
+    grep -q 'set -x' "$REPO_ROOT/.bashrc"
+    grep -q 'set +x' "$REPO_ROOT/.bashrc"
+}
+
+@test ".zshrc has DOTFILES_PROFILE opt-in hook with zprof" {
+    grep -q 'DOTFILES_PROFILE' "$REPO_ROOT/.zshrc"
+    grep -q 'zmodload zsh/zprof' "$REPO_ROOT/.zshrc"
+    grep -q 'zprof' "$REPO_ROOT/.zshrc"
+}
+
+@test ".zshrc and .bashrc remain valid syntax with profile hook" {
+    bash -n "$REPO_ROOT/.bashrc"
+    zsh -n "$REPO_ROOT/.zshrc"
+}
+
+@test ".bashrc profile hook is no-op when DOTFILES_PROFILE is unset" {
+    # Source bashrc without DOTFILES_PROFILE; should not enable xtrace.
+    run bash -c 'unset DOTFILES_PROFILE; source "$1"; [[ "$-" != *x* ]] && echo "no_xtrace"' \
+        -- "$REPO_ROOT/.bashrc"
+    [[ "$output" == *"no_xtrace"* ]]
+}


### PR DESCRIPTION
Closes the dotfiles backlog item "Shell startup profiling" (P2 in vault).

## What it does

`scripts/shell-profile.sh` measures interactive shell startup time, two modes:

| Mode | Output |
|---|---|
| **Time-only** (default) | Runs N shells (default 5), reports min/median/mean/max in seconds |
| **`--detail`** | Sets `DOTFILES_PROFILE=1`, rc files dump per-function profile via zsh `zprof` (or bash `xtrace` to `/tmp/bashrc-profile.PID.log`) |

Opt-in by design — the rc-file hooks are no-ops unless `DOTFILES_PROFILE` is set, so there's zero overhead in normal use.

## Demo (real numbers from this branch)

```
$ ./scripts/shell-profile.sh --shell bash --runs 3
Profiling bash startup (3 runs)...

  run: 0.308s
  run: 0.240s
  run: 0.258s

  min:    0.240s
  median: 0.258s
  mean:   0.269s
  max:    0.308s
```

## Implementation notes

- Stats computed in awk — no Python/jq dependency.
- `.zshrc` uses `zsh/zprof` (built-in), the canonical zsh way.
- `.bashrc` uses `set -x` with timestamped `PS4` (bash has no built-in profiler). Output goes to a tmp log so it doesn't pollute the interactive session.
- No alias added — `--detail` is invoked rarely; `./scripts/shell-profile.sh` is fine.

## Test plan

- [x] `~/.local/bin/bats tests/shell-profile.bats` → 10/10
- [x] Full suite green
- [x] `~/.local/bin/shellcheck scripts/shell-profile.sh` → clean
- [x] Manual: hook is no-op when `DOTFILES_PROFILE` unset (covered by test #10)
- [ ] Post-merge smoke: `./setup-linux.sh` to deploy new rc files, then `./scripts/shell-profile.sh --shell zsh --detail` to see real zprof output for your live shell