### PR TITLE
feat(scripts): add init-spec + archive-spec for SDD per-feature workflow

### DIFF
--- a/scripts/archive-spec.ps1
+++ b/scripts/archive-spec.ps1
@@ -1,0 +1,113 @@
+# archive-spec.ps1
+# Purpose: Mechanical archive of a per-feature spec folder.
+#          Tag-check pre-flight enforced unless -ForceWithDrafts.
+#          No vault promotion — do that interactively via /spec archive in an agent.
+#
+# Usage:
+#   .\archive-spec.ps1 <feature-id> [-Pr <url>] [-Abandoned] [-ForceWithDrafts]
+#
+# See: $env:VAULT_PATH\00_meta\skills\spec\SKILL.md for the full archive workflow.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$FeatureId,
+
+    [string]$Pr,
+
+    [switch]$Abandoned,
+
+    [switch]$ForceWithDrafts,
+
+    [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Help) {
+    @"
+Usage: archive-spec.ps1 <feature-id> [-Pr <url>] [-Abandoned] [-ForceWithDrafts]
+
+  <feature-id>           e.g. AI-001-ollama-public
+  -Pr <url>              record PR URL in proposal.md (informational)
+  -Abandoned             route to specs\archive\_abandoned\<id>\, set status abandoned
+  -ForceWithDrafts       allow archive even with unresolved [AGENT-DRAFT] tags
+"@ | Write-Host
+    exit 0
+}
+
+# --- Resolve paths ---
+$RepoRoot = $null
+try {
+    $RepoRoot = (git rev-parse --show-toplevel 2>$null) | ForEach-Object { $_.Trim() }
+} catch { }
+if (-not $RepoRoot) {
+    Write-Error 'Not in a git repo.'
+    exit 1
+}
+
+$SpecDir = Join-Path $RepoRoot "specs\$FeatureId"
+if (-not (Test-Path $SpecDir)) {
+    Write-Error "Spec not found: $SpecDir"
+    exit 1
+}
+
+# --- Pre-flight: tag check ---
+if (-not $ForceWithDrafts) {
+    $tagged = Select-String -Path "$SpecDir\*.md" -Pattern '\[AGENT-(DRAFT|SUGGESTION)\]'
+    if ($tagged) {
+        Write-Host '[ERROR] Unresolved tags found:' -ForegroundColor Red
+        foreach ($t in $tagged) {
+            Write-Host ("  {0}:{1}: {2}" -f $t.Path, $t.LineNumber, $t.Line.Trim())
+        }
+        Write-Error 'Resolve them (accept/edit/delete) before archiving, or use -ForceWithDrafts.'
+        exit 4
+    }
+}
+
+# --- Determine target ---
+if ($Abandoned) {
+    $TargetDir = Join-Path $RepoRoot "specs\archive\_abandoned\$FeatureId"
+    $NewStatus = 'abandoned'
+} else {
+    $TargetDir = Join-Path $RepoRoot "specs\archive\$FeatureId"
+    $NewStatus = 'archived'
+}
+
+if (Test-Path $TargetDir) {
+    Write-Error "Already in archive: $TargetDir"
+    exit 1
+}
+
+# --- Move ---
+$TargetParent = Split-Path $TargetDir -Parent
+if (-not (Test-Path $TargetParent)) {
+    New-Item -ItemType Directory -Path $TargetParent -Force | Out-Null
+}
+Move-Item -Path $SpecDir -Destination $TargetDir
+
+# --- Update status in proposal.md frontmatter ---
+$Proposal = Join-Path $TargetDir 'proposal.md'
+if (Test-Path $Proposal) {
+    $content = Get-Content $Proposal -Raw
+    $content = $content -replace '(?m)^(status:)\s+\S+', "`$1 $NewStatus"
+    Set-Content -Path $Proposal -Value $content -NoNewline
+}
+
+# --- Record PR URL if provided ---
+if ($Pr) {
+    $today = Get-Date -Format 'yyyy-MM-dd'
+    Add-Content -Path $Proposal -Value ''
+    Add-Content -Path $Proposal -Value "<!-- archived $today — PR: $Pr -->"
+}
+
+# --- Output ---
+Write-Host ''
+Write-Host "[OK] Archived: $SpecDir -> $TargetDir"
+Write-Host "     status: $NewStatus"
+if ($Pr) {
+    Write-Host "     PR: $Pr"
+}
+Write-Host ''
+Write-Host 'Vault promotion (lessons/ADR/pattern) and 11-tasks.md tick must be done'
+Write-Host 'separately (via /spec archive in an agent, or by hand).'

--- a/scripts/archive-spec.sh
+++ b/scripts/archive-spec.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# archive-spec.sh
+# Purpose: Mechanical archive of a per-feature spec folder.
+#          Tag-check pre-flight enforced unless --force-with-drafts.
+#          No vault promotion — do that interactively via /spec archive in an agent.
+#
+# Usage:
+#   ./archive-spec.sh <feature-id> [--pr <url>] [--abandoned] [--force-with-drafts]
+#
+# See: $VAULT_PATH/00_meta/skills/spec/SKILL.md for the full archive workflow.
+
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+Usage: archive-spec.sh <feature-id> [--pr <url>] [--abandoned] [--force-with-drafts]
+
+  <feature-id>             e.g. AI-001-ollama-public
+  --pr <url>               record PR URL in proposal.md (informational)
+  --abandoned              route to specs/archive/_abandoned/<id>/, set status abandoned
+  --force-with-drafts      allow archive even with unresolved [AGENT-DRAFT] tags
+  -h, --help               show this help
+EOF
+}
+
+# --- Parse args ---
+FEATURE_ID=""
+PR_URL=""
+ABANDONED=0
+FORCE_DRAFTS=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr) PR_URL="$2"; shift 2 ;;
+        --abandoned) ABANDONED=1; shift ;;
+        --force-with-drafts) FORCE_DRAFTS=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        -*) printf '[ERROR] Unknown option: %s\n' "$1" >&2; usage >&2; exit 1 ;;
+        *)
+            if [[ -z "$FEATURE_ID" ]]; then
+                FEATURE_ID="$1"; shift
+            else
+                printf '[ERROR] Multiple feature ids given\n' >&2; exit 1
+            fi ;;
+    esac
+done
+
+if [[ -z "$FEATURE_ID" ]]; then
+    usage >&2
+    exit 1
+fi
+
+# --- Resolve paths ---
+if ! REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    printf '[ERROR] Not in a git repo.\n' >&2
+    exit 1
+fi
+SPEC_DIR="$REPO_ROOT/specs/$FEATURE_ID"
+
+if [[ ! -d "$SPEC_DIR" ]]; then
+    printf '[ERROR] Spec not found: %s\n' "$SPEC_DIR" >&2
+    exit 1
+fi
+
+# --- Pre-flight: tag check ---
+if [[ "$FORCE_DRAFTS" -eq 0 ]]; then
+    if matches="$(grep -rnE '\[AGENT-(DRAFT|SUGGESTION)\]' "$SPEC_DIR" 2>/dev/null)"; then
+        printf '[ERROR] Unresolved tags found:\n' >&2
+        echo "$matches" >&2
+        printf '\nResolve them (accept/edit/delete) before archiving, or use --force-with-drafts.\n' >&2
+        exit 4
+    fi
+fi
+
+# --- Determine target ---
+if [[ "$ABANDONED" -eq 1 ]]; then
+    TARGET_DIR="$REPO_ROOT/specs/archive/_abandoned/$FEATURE_ID"
+    NEW_STATUS="abandoned"
+else
+    TARGET_DIR="$REPO_ROOT/specs/archive/$FEATURE_ID"
+    NEW_STATUS="archived"
+fi
+
+if [[ -d "$TARGET_DIR" ]]; then
+    printf '[ERROR] Already in archive: %s\n' "$TARGET_DIR" >&2
+    exit 1
+fi
+
+# --- Move ---
+mkdir -p "$(dirname "$TARGET_DIR")"
+mv "$SPEC_DIR" "$TARGET_DIR"
+
+# --- Update status in proposal.md frontmatter ---
+PROPOSAL="$TARGET_DIR/proposal.md"
+if [[ -f "$PROPOSAL" ]]; then
+    awk -v new_status="$NEW_STATUS" '
+        BEGIN {in_fm=0; fm_count=0}
+        /^---$/ {
+            fm_count++
+            if (fm_count == 1) {in_fm=1}
+            else if (fm_count == 2) {in_fm=0}
+            print
+            next
+        }
+        in_fm && /^status: / {print "status: " new_status; next}
+        {print}
+    ' "$PROPOSAL" > "${PROPOSAL}.tmp" && mv "${PROPOSAL}.tmp" "$PROPOSAL"
+fi
+
+# --- Record PR URL if provided ---
+if [[ -n "$PR_URL" ]]; then
+    printf '\n<!-- archived %s — PR: %s -->\n' "$(date -u +%Y-%m-%d)" "$PR_URL" >> "$PROPOSAL"
+fi
+
+# --- Output ---
+printf '\n[OK] Archived: %s -> %s\n' "$SPEC_DIR" "$TARGET_DIR"
+printf '     status: %s\n' "$NEW_STATUS"
+if [[ -n "$PR_URL" ]]; then
+    printf '     PR: %s\n' "$PR_URL"
+fi
+printf '\nVault promotion (lessons/ADR/pattern) and 11-tasks.md tick must be done\n'
+printf 'separately (via /spec archive in an agent, or by hand).\n'

--- a/scripts/init-spec.ps1
+++ b/scripts/init-spec.ps1
@@ -1,0 +1,138 @@
+# init-spec.ps1
+# Purpose: Mechanical scaffold of a per-feature spec folder per pattern-spec-driven-development.
+#          Vault-rooted: requires vault entry before scaffolding (SSOT discipline).
+#
+# Usage:
+#   .\init-spec.ps1 <feature-id> [-Task <task-id>] [-ForceNoVault]
+#
+# Mechanical only. For Socratic proposal filling (Q1-Q6), use /spec fill in an agent.
+# See: $env:VAULT_PATH\00_meta\skills\spec\SKILL.md for the full workflow.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$FeatureId,
+
+    [string]$Task,
+
+    [switch]$ForceNoVault,
+
+    [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Help) {
+    @"
+Usage: init-spec.ps1 <feature-id> [-Task <task-id>] [-ForceNoVault]
+
+  <feature-id>      e.g. AI-001-ollama-public or 2026-05-13-foo
+  -Task <task-id>   override which task ID to look up in vault 11-tasks.md
+  -ForceNoVault     skip vault context check (NOT RECOMMENDED — violates SSOT)
+"@ | Write-Host
+    exit 0
+}
+
+# --- Validate id ---
+$Pattern = '^([A-Z]+-[0-9]+(-[a-z0-9-]+)?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+)$'
+if ($FeatureId -notmatch $Pattern) {
+    Write-Error "Invalid feature-id: $FeatureId. Expected: TICKET-NNN[-slug] or YYYY-MM-DD-slug."
+    exit 1
+}
+
+# --- Resolve paths ---
+$VaultPath = if ($env:VAULT_PATH) { $env:VAULT_PATH } else { Join-Path $HOME 'Projects\knowledge' }
+$TemplatesDir = Join-Path $VaultPath '00_meta\templates'
+
+if (-not (Test-Path $TemplatesDir)) {
+    Write-Error "Vault templates not found at: $TemplatesDir. Set `$env:VAULT_PATH or clone the vault."
+    exit 2
+}
+
+$RepoRoot = $null
+try {
+    $RepoRoot = (git rev-parse --show-toplevel 2>$null) | ForEach-Object { $_.Trim() }
+} catch { }
+if (-not $RepoRoot) {
+    Write-Error 'Not in a git repo. cd into a repo first.'
+    exit 1
+}
+
+$RepoName = Split-Path $RepoRoot -Leaf
+$SpecDir = Join-Path $RepoRoot "specs\$FeatureId"
+
+# --- No clobber ---
+if (Test-Path $SpecDir) {
+    Write-Error "Already exists: $SpecDir"
+    exit 1
+}
+$ArchivedPath = Join-Path $RepoRoot "specs\archive\$FeatureId"
+if (Test-Path $ArchivedPath) {
+    Write-Warning "$FeatureId exists in specs\archive\. Possibly reviving."
+}
+
+# --- Vault context check ---
+$VaultLine = $null
+$TasksFile = Join-Path $VaultPath "10_projects\$RepoName\11-tasks.md"
+
+if (-not $ForceNoVault) {
+    $SearchId = if ($Task) { $Task } else { $FeatureId }
+    if (Test-Path $TasksFile) {
+        $Escaped = [regex]::Escape($SearchId)
+        $VaultLine = Select-String -Path $TasksFile -Pattern "^- \[[ x-]\] \*\*$Escaped\*\*" |
+            Select-Object -First 1
+    }
+    if (-not $VaultLine) {
+        @"
+[ERROR] No vault entry found for "$SearchId" in $TasksFile.
+
+Spec must be downstream of a vault entry (backlog/ADR/roadmap) per SSOT discipline.
+
+Options:
+  (a) Cancel. Add an entry to 11-tasks.md, then re-run.
+  (b) Re-run with -ForceNoVault (NOT RECOMMENDED).
+"@ | Write-Error
+        exit 3
+    }
+    Write-Host "[INFO] Vault context found in $TasksFile"
+}
+
+# --- Scaffold ---
+New-Item -ItemType Directory -Path $SpecDir | Out-Null
+$Today = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+$Title = $FeatureId
+
+foreach ($tpl in @('proposal', 'tasks', 'verification')) {
+    $src = Join-Path $TemplatesDir "spec-$tpl.md"
+    $dst = Join-Path $SpecDir "$tpl.md"
+    if (-not (Test-Path $src)) {
+        Write-Error "Template missing: $src"
+        exit 2
+    }
+    $content = (Get-Content $src -Raw) `
+        -replace '<feature-id>', $FeatureId `
+        -replace '\{TITLE\}', $Title `
+        -replace '\{\{date:YYYY-MM-DD\}\}', $Today
+    Set-Content -Path $dst -Value $content -NoNewline
+}
+
+# --- Inject vault context comment in proposal Why ---
+if ($VaultLine) {
+    $proposal = Join-Path $SpecDir 'proposal.md'
+    $contextText = $VaultLine.Line -replace '^- \[[^]]+\] \*\*[^*]+\*\*:? *', ''
+    $contextLine = "<!-- from 11-tasks.md: $contextText -->"
+    $content = Get-Content $proposal -Raw
+    $content = $content -replace '(?m)^(## Why)\s*$', "`$1`n`n$contextLine"
+    Set-Content -Path $proposal -Value $content -NoNewline
+}
+
+# --- Output ---
+Write-Host ''
+Write-Host "[OK] Created: $SpecDir"
+Write-Host '     proposal.md, tasks.md, verification.md'
+if ($VaultLine) {
+    Write-Host "     Vault context linked from $TasksFile"
+}
+Write-Host ''
+Write-Host "Next: fill proposal.md interactively (`"/spec fill $FeatureId`" in an agent)"
+Write-Host '      or edit by hand. Do not skip the Why.'

--- a/scripts/init-spec.sh
+++ b/scripts/init-spec.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# init-spec.sh
+# Purpose: Mechanical scaffold of a per-feature spec folder per pattern-spec-driven-development.
+#          Vault-rooted: requires vault entry before scaffolding (SSOT discipline).
+#
+# Usage:
+#   ./init-spec.sh <feature-id> [--task <task-id>] [--force-no-vault]
+#
+# Mechanical only. For Socratic proposal filling (Q1-Q6), use /spec fill in an agent.
+# See: $VAULT_PATH/00_meta/skills/spec/SKILL.md for the full workflow.
+
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+Usage: init-spec.sh <feature-id> [--task <task-id>] [--force-no-vault]
+
+  <feature-id>           e.g. AI-001-ollama-public or 2026-05-13-foo
+  --task <task-id>       override which task ID to look up in vault 11-tasks.md
+  --force-no-vault       skip vault context check (NOT RECOMMENDED — violates SSOT)
+  -h, --help             show this help
+EOF
+}
+
+# --- Parse args ---
+FEATURE_ID=""
+TASK_ID=""
+FORCE_NO_VAULT=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --task) TASK_ID="$2"; shift 2 ;;
+        --force-no-vault) FORCE_NO_VAULT=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        -*) printf '[ERROR] Unknown option: %s\n' "$1" >&2; usage >&2; exit 1 ;;
+        *)
+            if [[ -z "$FEATURE_ID" ]]; then
+                FEATURE_ID="$1"; shift
+            else
+                printf '[ERROR] Multiple feature ids given\n' >&2; exit 1
+            fi ;;
+    esac
+done
+
+if [[ -z "$FEATURE_ID" ]]; then
+    usage >&2
+    exit 1
+fi
+
+# --- Validate id ---
+if [[ ! "$FEATURE_ID" =~ ^([A-Z]+-[0-9]+(-[a-z0-9-]+)?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+)$ ]]; then
+    printf '[ERROR] Invalid feature-id: %s\n' "$FEATURE_ID" >&2
+    printf '        Expected: TICKET-NNN[-slug] (e.g. AI-001-ollama-public) or YYYY-MM-DD-slug\n' >&2
+    exit 1
+fi
+
+# --- Resolve paths ---
+VAULT_PATH="${VAULT_PATH:-$HOME/Projects/knowledge}"
+TEMPLATES_DIR="$VAULT_PATH/00_meta/templates"
+
+if [[ ! -d "$TEMPLATES_DIR" ]]; then
+    printf '[ERROR] Vault templates not found at: %s\n' "$TEMPLATES_DIR" >&2
+    # shellcheck disable=SC2016  # intentional: '$VAULT_PATH' is the literal env var name we want to show
+    printf '        Set %s env var to vault root, or clone the vault.\n' '$VAULT_PATH' >&2
+    exit 2
+fi
+
+if ! REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    printf '[ERROR] Not in a git repo. cd into a repo first.\n' >&2
+    exit 1
+fi
+REPO_NAME="$(basename "$REPO_ROOT")"
+SPEC_DIR="$REPO_ROOT/specs/$FEATURE_ID"
+
+# --- No clobber ---
+if [[ -d "$SPEC_DIR" ]]; then
+    printf '[ERROR] Already exists: %s\n' "$SPEC_DIR" >&2
+    exit 1
+fi
+if [[ -d "$REPO_ROOT/specs/archive/$FEATURE_ID" ]]; then
+    printf '[WARN] %s exists in specs/archive/. Possibly reviving.\n' "$FEATURE_ID" >&2
+fi
+
+# --- Vault context check ---
+VAULT_LINE=""
+TASKS_FILE="$VAULT_PATH/10_projects/$REPO_NAME/11-tasks.md"
+
+if [[ "$FORCE_NO_VAULT" -eq 0 ]]; then
+    SEARCH_ID="${TASK_ID:-$FEATURE_ID}"
+    if [[ -f "$TASKS_FILE" ]]; then
+        VAULT_LINE="$(grep -E "^- \[[ x-]\] \*\*${SEARCH_ID}\*\*" "$TASKS_FILE" 2>/dev/null || true)"
+    fi
+    if [[ -z "$VAULT_LINE" ]]; then
+        cat >&2 <<EOF
+[ERROR] No vault entry found for "$SEARCH_ID" in $TASKS_FILE.
+
+Spec must be downstream of a vault entry (backlog/ADR/roadmap) per SSOT discipline.
+
+Options:
+  (a) Cancel. Add an entry to 11-tasks.md, then re-run.
+  (b) Re-run with --force-no-vault (NOT RECOMMENDED).
+EOF
+        exit 3
+    fi
+    printf '[INFO] Vault context found in %s\n' "$TASKS_FILE"
+fi
+
+# --- Scaffold ---
+mkdir -p "$SPEC_DIR"
+TODAY="$(date -u +%Y-%m-%d)"
+TITLE="$FEATURE_ID"
+
+for tpl in proposal tasks verification; do
+    src="$TEMPLATES_DIR/spec-${tpl}.md"
+    dst="$SPEC_DIR/${tpl}.md"
+    if [[ ! -f "$src" ]]; then
+        printf '[ERROR] Template missing: %s\n' "$src" >&2
+        exit 2
+    fi
+    sed -e "s|<feature-id>|$FEATURE_ID|g" \
+        -e "s|{TITLE}|$TITLE|g" \
+        -e "s|{{date:YYYY-MM-DD}}|$TODAY|g" \
+        "$src" > "$dst"
+done
+
+# --- Inject vault context comment in proposal Why ---
+if [[ -n "$VAULT_LINE" ]]; then
+    proposal="$SPEC_DIR/proposal.md"
+    CONTEXT_TEXT="$(echo "$VAULT_LINE" | sed -E 's/^- \[[^]]+\] \*\*[^*]+\*\*:? *//')"
+    awk -v line="<!-- from 11-tasks.md: $CONTEXT_TEXT -->" '
+        /^## Why$/ {print; print ""; print line; next}
+        {print}
+    ' "$proposal" > "${proposal}.tmp" && mv "${proposal}.tmp" "$proposal"
+fi
+
+# --- Output ---
+printf '\n[OK] Created: %s\n' "$SPEC_DIR"
+printf '     proposal.md, tasks.md, verification.md\n'
+if [[ -n "$VAULT_LINE" ]]; then
+    printf '     Vault context linked from %s\n' "$TASKS_FILE"
+fi
+printf '\nNext: fill proposal.md interactively ("/spec fill %s" in an agent)\n' "$FEATURE_ID"
+printf '      or edit by hand. Do not skip the Why.\n'


### PR DESCRIPTION
## Summary

Adds 4 scripts (POSIX + PowerShell parity) supporting the per-feature **Spec-Driven Development** workflow. Canonical playbook lives in the knowledge vault at `\$VAULT_PATH/00_meta/skills/spec/SKILL.md`.

- **`init-spec.sh` / `init-spec.ps1`** — Mechanical scaffold of `<repo>/specs/<feature-id>/` from vault templates. Vault-rooted: refuses if no matching entry in `11-tasks.md` (override via `--force-no-vault` / `-ForceNoVault`). Injects vault context as HTML comment in proposal `## Why`.
- **`archive-spec.sh` / `archive-spec.ps1`** — Mechanical archive to `specs/archive/`. Pre-flight tag check refuses unresolved `[AGENT-DRAFT]` / `[AGENT-SUGGESTION]` markers (override via `--force-with-drafts` / `-ForceWithDrafts`). Updates `status` frontmatter; optional `--pr` / `-Pr` URL record. Supports `--abandoned` / `-Abandoned` for cancelled specs.

These are the **mechanical / non-agent fallback** path (CI, batch, scripts). The full Socratic workflow (Q1-Q6 proposal fill, interactive vault promotion on archive) runs through the \`spec\` skill in an agent.

## Test plan

- [x] \`init-spec.sh\` runs end-to-end on real backlog ticket (kubelab AI-002 → scaffolded \`specs/AI-002-e2e-tests/\`, vault context comment injected, frontmatter substituted correctly)
- [x] ShellCheck clean on both \`.sh\` files
- [ ] PowerShell scripts tested on Windows (deferred — not on this machine; structural parity validated)
- [ ] \`archive-spec.sh\` tested against an existing spec (deferred — destructive op, will validate at first real archive)

## Related vault docs

- Pattern: \`\$VAULT_PATH/00_meta/patterns/pattern-spec-driven-development.md\`
- Canonical skill: \`\$VAULT_PATH/00_meta/skills/spec/SKILL.md\`
- Templates: \`\$VAULT_PATH/00_meta/templates/spec-{proposal,tasks,verification}.md\`
- AGENTS.md snippet: \`\$VAULT_PATH/00_meta/templates/agents-spec-section.md\`
- Lesson: \`\$VAULT_PATH/10_projects/knowledge/90-lessons.md\` (Socratic capture design)

## Follow-ups (separate PRs)

- L2a automation: \`link_vault_skills\` function in \`install.sh\` / \`install.ps1\` to create symlinks/junctions for vault-hosted skills (SDD-006).
- AGENTS.md bootstrap script per repo (SDD-013).