### PR TITLE
feat(setup): auto-link vault-hosted skills into ~/.claude/skills/

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -539,6 +539,41 @@ if [ -d "$VAULT_ROOT" ]; then
     done
 fi
 
+# Deploy vault-hosted skill symlinks (vault → Claude Code)
+# Vault skills live in $VAULT_ROOT/00_meta/skills/<name>/SKILL.md per pattern-spec-driven-development.
+# Symlink each into ~/.claude/skills/ for Claude Code discovery. Idempotent.
+VAULT_SKILLS_DIR="$VAULT_ROOT/00_meta/skills"
+if [ -d "$VAULT_SKILLS_DIR" ]; then
+    log_info "Linking vault-hosted skills to Claude Code..."
+    for skill_dir in "$VAULT_SKILLS_DIR"/*/; do
+        [ -d "$skill_dir" ] || continue
+        skill_source="${skill_dir%/}"
+        skill_name=$(basename "$skill_source")
+        target="$HOME/.claude/skills/$skill_name"
+
+        if [ -L "$target" ]; then
+            current_target=$(readlink "$target")
+            if [ "$current_target" != "$skill_source" ]; then
+                rm "$target"
+                ln -s "$skill_source" "$target"
+                log_success "Re-linked vault skill: $skill_name"
+            fi
+        elif [ -d "$target" ] && [ -n "$(ls -A "$target" 2>/dev/null)" ]; then
+            log_warning "$skill_name exists at $target — backing up"
+            mv "$target" "${target}.bak.$(date +%s)"
+            ln -s "$skill_source" "$target"
+            log_success "Linked vault skill: $skill_name"
+        elif [ -d "$target" ]; then
+            rmdir "$target" 2>/dev/null || true
+            ln -s "$skill_source" "$target"
+            log_success "Linked vault skill: $skill_name"
+        else
+            ln -s "$skill_source" "$target"
+            log_success "Linked vault skill: $skill_name"
+        fi
+    done
+fi
+
 # Add project-init alias (AI-agnostic naming)
 PROJECT_INIT_LINE='alias project-init="$HOME/.claude/init-project.sh"'
 [ -f "$HOME/.zshrc" ] && ensure_line_in_file "$HOME/.zshrc" "$PROJECT_INIT_LINE" 2>/dev/null || true

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -327,7 +327,7 @@ if (Test-Path $VaultSkillsDir) {
                 cmd /c rmdir $target 2>&1 | Out-Null
             } elseif ((Get-ChildItem $target -ErrorAction SilentlyContinue).Count -gt 0) {
                 $backup = "$target.bak.$(Get-Date -Format 'yyyyMMddHHmmss')"
-                Write-Warn "$skillName exists at $target — backing up to $backup"
+                Write-Warn "$skillName exists at $target - backing up to $backup"
                 Rename-Item $target $backup
             } else {
                 Remove-Item $target -Recurse -Force -ErrorAction SilentlyContinue

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -310,6 +310,35 @@ if (Test-Path $VaultRoot) {
     }
 }
 
+# Deploy vault-hosted skill junctions (vault -> Claude Code)
+# Vault skills live in $VaultRoot\00_meta\skills\<name>\SKILL.md per pattern-spec-driven-development.
+# Junction each into $env:USERPROFILE\.claude\skills\ for Claude Code discovery. Idempotent.
+$VaultSkillsDir = Join-Path $VaultRoot "00_meta\skills"
+if (Test-Path $VaultSkillsDir) {
+    Write-Info "Linking vault-hosted skills to Claude Code..."
+    Get-ChildItem -Path $VaultSkillsDir -Directory -ErrorAction SilentlyContinue | ForEach-Object {
+        $skillSource = $_.FullName
+        $skillName = $_.Name
+        $target = Join-Path $ClaudeHome "skills\$skillName"
+
+        if (Test-Path $target) {
+            $item = Get-Item $target -Force
+            if ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) {
+                cmd /c rmdir $target 2>&1 | Out-Null
+            } elseif ((Get-ChildItem $target -ErrorAction SilentlyContinue).Count -gt 0) {
+                $backup = "$target.bak.$(Get-Date -Format 'yyyyMMddHHmmss')"
+                Write-Warn "$skillName exists at $target — backing up to $backup"
+                Rename-Item $target $backup
+            } else {
+                Remove-Item $target -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        New-Item -ItemType Junction -Path $target -Target $skillSource -Force | Out-Null
+        Write-Success "Linked vault skill: $skillName"
+    }
+}
+
 # ============================================================================
 # 2b. DEPLOY AIDER CONFIGURATION
 # ============================================================================


### PR DESCRIPTION
## Summary

Adds idempotent deployment of vault-hosted skills to \`~/.claude/skills/\` (Linux symlinks + Windows junctions). Closes the cross-machine gap revealed when adopting the \`/spec\` skill: today vault skills must be manually linked on each machine.

Each \`\$VAULT_PATH/00_meta/skills/<name>/\` becomes \`~/.claude/skills/<name>\`. Follows the same pattern as the existing auto-memory deployment.

Handles:
- No target → creates link
- Empty target dir → removes + creates link
- Real dir with files → backs up to \`<target>.bak.<timestamp>\` + creates link
- Symlink/junction with wrong target → re-points

## Test plan

- [x] Manual symlink already exists for vault \`spec\` skill on Ubuntu primary. Running the new function should be idempotent (detect correct symlink, no-op).
- [x] Linux: shellcheck clean for added 35-line block (pre-existing info-level findings in other parts of setup-linux.sh are unchanged, not introduced by this PR).
- [ ] Windows tested manually on next Windows session.
- [ ] Fresh-machine test: clone vault + clone dotfiles + run setup → \`/spec\` available in Claude Code without manual steps.

## Related

- Companion to #13 (POSIX + PS1 scripts for the spec workflow). Independent: this PR works on its own; #13 works on its own.
- Vault SSOT: \`\$VAULT_PATH/00_meta/skills/spec/SKILL.md\`.
- Tracked in vault: SDD-006 in \`10_projects/knowledge/11-tasks.md\`.