### PR TITLE
feat(claude-md): add claude-mem MCP rules + dual-memory protocol pointer

### DIFF
--- a/ai/claude/CLAUDE.md
+++ b/ai/claude/CLAUDE.md
@@ -316,6 +316,21 @@ do NOT also create a manual git commit for vault edits.
 
 See `00_meta/patterns/pattern-hive-first-vault-access.md` for full rationale.
 
+### claude-mem (Conversation Memory & Cross-Session Recall)
+
+**Active by default in every session, every project, every machine.** Captures observations automatically via session hooks — no explicit writes needed during routine work. claude-mem stores conversation flow; the vault stores crystallized knowledge. They are complementary, not interchangeable.
+
+* `/mem-search "query"` — find solutions/decisions from past sessions ("did we solve this before?").
+* `/timeline-report` — narrative history of a project from accumulated observations.
+* `/knowledge-agent` — build a topic-focused brain from observations.
+* `/how-it-works` — explain what claude-mem is doing if asked.
+
+**Do NOT write strategic decisions, lessons, or ADRs to claude-mem.** Those go to vault via `capture_lesson` / `vault_write`. See `pattern-decision-persistence.md` — claude-mem is a conversation log, not a source of truth.
+
+**Default protocol:** BOTH claude-mem AND vault active simultaneously. claude-mem records as you work; vault gets explicit writes for crystallization. See `00_meta/patterns/pattern-dual-memory.md` for full rationale.
+
+**Runtime note:** In Claude Code's default `worker` runtime, manual writes (`observation_add`, `memory_add`) are blocked. Automatic hook capture works regardless — observations from each session appear in the next session start. Slash commands above are read-only and always available. To enable manual writes in parallel to vault, set `CLAUDE_MEM_RUNTIME=server-beta` in `~/.claude/settings.json` (affects all projects). Default worker mode is sufficient for the dual-memory protocol.
+
 ### Obsidian CLI (Vault Graph Queries)
 
 **Available via:** `obs-cli.sh <command>` (Linux) / `obs-cli.ps1 <command>` (Windows).


### PR DESCRIPTION
## Summary

Documents claude-mem under MCP Server Usage Rules in canonical Claude instructions. Previously CLAUDE.md mentioned Hive (vault operations) under MCP rules but had no explicit guidance for claude-mem — leaving ambiguity about whether the plugin should be invoked actively or just rely on hooks.

New \`claude-mem\` subsection establishes:

- **Both claude-mem AND vault default-active** in every session, project, machine.
- **claude-mem** captures conversation flow automatically via session hooks (no manual writes during routine work).
- **Read-only slash commands** are the explicit-invocation path: \`/mem-search\`, \`/timeline-report\`, \`/knowledge-agent\`, \`/how-it-works\`.
- **Strategic decisions / lessons / ADRs** go to vault, NOT claude-mem (per \`pattern-decision-persistence.md\`).
- **Runtime constraint documented**: default \`worker\` mode blocks manual writes (\`observation_add\`, \`memory_add\`); hook capture works regardless. Verified empirically — the \`observation_add\` tool description self-declares "Server-beta runtime only". \`CLAUDE_MEM_RUNTIME=server-beta\` in settings.json unlocks manual writes if ever needed (not required for the dual-memory protocol).

Canonical rationale lives in vault: \`\$VAULT_PATH/00_meta/patterns/pattern-dual-memory.md\` (created in same session). CLAUDE.md references it.

## Test plan

- [x] CLAUDE.md edit verified — \`claude-mem\` section sits between Hive and Obsidian CLI sections.
- [x] Vault pattern \`pattern-dual-memory.md\` created with full rationale (principle / when to use each / both simultaneous / anti-patterns / cross-OS / runtime constraint / origin).
- [x] MEMORY.md handoff updated with pointer to pattern.
- [x] Runtime constraint verified empirically: \`observation_add\` tool schema declares "Server-beta runtime only".
- [ ] Verify pattern referenced in Pattern Catalog of CLAUDE.md (Workflow category) — deferred to next CLAUDE.md edit (optional, minor).

## Related

- Vault pattern (canonical): \`\$VAULT_PATH/00_meta/patterns/pattern-dual-memory.md\`
- Companion PRs in same session: #13 (init-spec/archive-spec scripts, MERGED), #14 (setup auto-link vault skills, CI green).
- Origin: 2026-05-13 SDD-building session. User flagged the need to make dual-memory the universal default.