### PR TITLE
feat(scripts): add init-repo-agents bootstrap for AGENTS.md (SDD-013)

### DIFF
--- a/scripts/init-repo-agents.ps1
+++ b/scripts/init-repo-agents.ps1
@@ -1,0 +1,117 @@
+<#
+.SYNOPSIS
+    Bootstrap AGENTS.md in a repo with Spec-Driven Development snippet from vault.
+
+.DESCRIPTION
+    Idempotent - re-running is safe (skips if section already present).
+    See: $VaultPath/00_meta/templates/agents-spec-section.md for the snippet source.
+
+.PARAMETER Repo
+    Target repo root (default: current git repo)
+
+.PARAMETER Force
+    Overwrite existing SDD section in AGENTS.md
+
+.NOTES
+    VAULT_PATH (env)  vault root (default: $env:USERPROFILE\Projects\knowledge)
+#>
+param(
+    [string]$Repo,
+    [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# --- Resolve target repo ---
+if (-not $Repo) {
+    try {
+        $Repo = (& git rev-parse --show-toplevel 2>$null) -replace "`r`n|`r|`n", ''
+    } catch {
+        $Repo = ''
+    }
+    if (-not $Repo) {
+        Write-Error 'Not in a git repo. Use -Repo <path> or cd into a repo.'
+        exit 1
+    }
+}
+
+if (-not (Test-Path $Repo -PathType Container)) {
+    Write-Error "Repo not found: $Repo"
+    exit 1
+}
+
+# --- Resolve vault snippet ---
+$VaultPath = if ($env:VAULT_PATH) { $env:VAULT_PATH } else { Join-Path $env:USERPROFILE 'Projects\knowledge' }
+$SnippetSrc = Join-Path $VaultPath '00_meta\templates\agents-spec-section.md'
+
+if (-not (Test-Path $SnippetSrc -PathType Leaf)) {
+    Write-Error "Snippet template not found: $SnippetSrc. Set VAULT_PATH env var or clone vault."
+    exit 2
+}
+
+# --- Extract snippet content (between markers, exclusive) ---
+$lines = Get-Content $SnippetSrc
+$inside = $false
+$snippet = New-Object System.Collections.Generic.List[string]
+foreach ($line in $lines) {
+    if ($line -eq '## --- BEGIN SNIPPET ---') { $inside = $true; continue }
+    if ($line -eq '## --- END SNIPPET ---')   { $inside = $false; continue }
+    if ($inside) { $snippet.Add($line) }
+}
+
+if ($snippet.Count -eq 0) {
+    Write-Error "BEGIN/END SNIPPET markers not found in $SnippetSrc"
+    exit 2
+}
+
+$snippetText = $snippet -join "`n"
+
+# --- Target AGENTS.md ---
+$AgentsFile = Join-Path $Repo 'AGENTS.md'
+
+# --- Idempotency / force ---
+if (Test-Path $AgentsFile -PathType Leaf) {
+    $existing = Get-Content $AgentsFile
+    $hasSection = @($existing | Where-Object { $_ -eq '## Spec-Driven Development' }).Count -gt 0
+
+    if ($hasSection -and -not $Force) {
+        Write-Host "[OK] Spec-Driven Development section already present in $AgentsFile"
+        Write-Host '     Re-run with -Force to overwrite.'
+        exit 0
+    }
+
+    if ($hasSection -and $Force) {
+        $output = New-Object System.Collections.Generic.List[string]
+        $skip = $false
+        foreach ($line in $existing) {
+            if ($line -eq '## Spec-Driven Development') {
+                $skip = $true
+                $output.Add($snippetText)
+                continue
+            }
+            if ($skip -and $line -match '^## ' -and $line -ne '## Spec-Driven Development') {
+                $skip = $false
+            }
+            if (-not $skip) { $output.Add($line) }
+        }
+        Set-Content -Path $AgentsFile -Value ($output -join "`n") -Encoding UTF8
+        Write-Host "[OK] Replaced Spec-Driven Development section in $AgentsFile"
+        exit 0
+    }
+
+    # Append with leading blank line separation
+    Add-Content -Path $AgentsFile -Value "`n$snippetText" -Encoding UTF8
+    Write-Host "[OK] Appended Spec-Driven Development section to $AgentsFile"
+} else {
+    # Create new with minimal header
+    $content = @"
+# AGENTS.md
+
+> Instructions for AI coding agents (Claude Code, Copilot, Cursor, Codex) operating in this repo.
+
+$snippetText
+"@
+    Set-Content -Path $AgentsFile -Value $content -Encoding UTF8
+    Write-Host "[OK] Created $AgentsFile with Spec-Driven Development section"
+}

--- a/scripts/init-repo-agents.sh
+++ b/scripts/init-repo-agents.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# init-repo-agents.sh
+# Purpose: Bootstrap AGENTS.md in a repo with the Spec-Driven Development snippet from the vault.
+#          Idempotent — re-running is safe (skips if section already present).
+#
+# Usage:
+#   ./init-repo-agents.sh [--repo <path>] [--force]
+#
+# See: $VAULT_PATH/00_meta/templates/agents-spec-section.md for the snippet source.
+
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+Usage: init-repo-agents.sh [--repo <path>] [--force]
+
+  --repo <path>    target repo root (default: current git repo)
+  --force          overwrite existing SDD section in AGENTS.md
+  -h, --help       show this help
+
+VAULT_PATH (env)   vault root (default: \$HOME/Projects/knowledge)
+EOF
+}
+
+# --- Parse args ---
+TARGET_REPO=""
+FORCE=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) TARGET_REPO="$2"; shift 2 ;;
+        --force) FORCE=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) printf '[ERROR] Unknown option: %s\n' "$1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+# --- Resolve target repo ---
+if [[ -z "$TARGET_REPO" ]]; then
+    if ! TARGET_REPO="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+        printf '[ERROR] Not in a git repo. Use --repo <path> or cd into a repo.\n' >&2
+        exit 1
+    fi
+fi
+
+if [[ ! -d "$TARGET_REPO" ]]; then
+    printf '[ERROR] Repo not found: %s\n' "$TARGET_REPO" >&2
+    exit 1
+fi
+
+# --- Resolve vault snippet ---
+VAULT_PATH="${VAULT_PATH:-$HOME/Projects/knowledge}"
+SNIPPET_SRC="$VAULT_PATH/00_meta/templates/agents-spec-section.md"
+
+if [[ ! -f "$SNIPPET_SRC" ]]; then
+    printf '[ERROR] Snippet template not found: %s\n' "$SNIPPET_SRC" >&2
+    # shellcheck disable=SC2016
+    printf '        Set %s env var to vault root, or clone the vault.\n' '$VAULT_PATH' >&2
+    exit 2
+fi
+
+# --- Extract snippet content (between markers, exclusive) ---
+SNIPPET="$(awk '
+    /^## --- BEGIN SNIPPET ---$/ {flag=1; next}
+    /^## --- END SNIPPET ---$/   {flag=0; next}
+    flag {print}
+' "$SNIPPET_SRC")"
+
+if [[ -z "$SNIPPET" ]]; then
+    printf '[ERROR] BEGIN/END SNIPPET markers not found in %s\n' "$SNIPPET_SRC" >&2
+    exit 2
+fi
+
+# --- Target AGENTS.md ---
+AGENTS_FILE="$TARGET_REPO/AGENTS.md"
+
+# --- Idempotency / force ---
+if [[ -f "$AGENTS_FILE" ]] && grep -q '^## Spec-Driven Development$' "$AGENTS_FILE"; then
+    if [[ "$FORCE" -eq 0 ]]; then
+        printf '[OK] Spec-Driven Development section already present in %s\n' "$AGENTS_FILE"
+        printf '     Re-run with --force to overwrite.\n'
+        exit 0
+    fi
+    # Replace existing section (from heading until next ^## or EOF)
+    awk -v snippet="$SNIPPET" '
+        /^## Spec-Driven Development$/ {skip=1; print snippet; next}
+        skip && /^## / && !/^## Spec-Driven Development$/ {skip=0}
+        !skip {print}
+    ' "$AGENTS_FILE" > "${AGENTS_FILE}.tmp" && mv "${AGENTS_FILE}.tmp" "$AGENTS_FILE"
+    printf '[OK] Replaced Spec-Driven Development section in %s\n' "$AGENTS_FILE"
+    exit 0
+fi
+
+# --- Append or create ---
+if [[ -f "$AGENTS_FILE" ]]; then
+    # Append with leading blank line separation
+    {
+        printf '\n'
+        printf '%s\n' "$SNIPPET"
+    } >> "$AGENTS_FILE"
+    printf '[OK] Appended Spec-Driven Development section to %s\n' "$AGENTS_FILE"
+else
+    # Create new with minimal header
+    cat > "$AGENTS_FILE" <<EOF
+# AGENTS.md
+
+> Instructions for AI coding agents (Claude Code, Copilot, Cursor, Codex) operating in this repo.
+
+$SNIPPET
+EOF
+    printf '[OK] Created %s with Spec-Driven Development section\n' "$AGENTS_FILE"
+fi


### PR DESCRIPTION
## Summary

- `init-repo-agents.sh` (POSIX bash) and `.ps1` (PowerShell, ASCII clean) insert the Spec-Driven Development snippet from the vault template into any repo's `AGENTS.md`, so all agents (Claude Code, Copilot, Cursor, Codex) discover the canonical workflow at `$VAULT_PATH/00_meta/skills/spec/SKILL.md`.
- Idempotent by design: skips silently if the section is already present. `--force` / `-Force` replaces in place without duplication.
- Closes the manual copy-paste gap that the snippet template called out in its "Bootstrap automation" note.

## Behavior matrix

| Target state | Action |
|---|---|
| No AGENTS.md | Creates with minimal header + snippet |
| AGENTS.md exists, no SDD section | Appends snippet (preserves prior content) |
| AGENTS.md exists, SDD section present | Skip silently (idempotent) |
| Above + `--force` / `-Force` | Replace section in place |

## Test plan

- [x] shellcheck clean on the `.sh`
- [x] Test scenario 1: fresh repo → creates AGENTS.md with single SDD section
- [x] Test scenario 2: existing AGENTS.md without SDD → appends, prior content preserved
- [x] Test scenario 3: re-run on already-installed → no-op (line count unchanged)
- [x] Test scenario 4: `--force` on installed → replaces, still single section
- [ ] PSScriptAnalyzer (validated by CI — pwsh not in local dev env)

## Notes

- Vault snippet template (`_meta/templates/agents-spec-section.md`) patched to point users at the script (was "future helper script" placeholder before this PR).
- Tracks knowledge backlog item `SDD-013`.