### PR TITLE
feat(scripts): vault working-tree integrity check at session start (SDD-017)

### DIFF
--- a/scripts/claude-session-start.ps1
+++ b/scripts/claude-session-start.ps1
@@ -200,6 +200,36 @@ function Ensure-MemoryJunction {
 
 Ensure-MemoryJunction
 
+function Test-VaultIntegrity {
+    param([string]$VaultPath)
+
+    # GUI-independent check: detect files deleted from working tree but still in HEAD.
+    # Triggered by 2026-05-13 incident - SKILL.md vanished from disk, git status showed D.
+    # Pattern '^.D ' matches Y-column=D (unstaged delete), NOT X-column=D (intentional git rm).
+    if (-not (Test-Path (Join-Path $VaultPath '.git'))) { return }
+
+    try {
+        $deletedLines = @(& git -C $VaultPath status --short 2>$null | Where-Object { $_ -match '^.D ' })
+    } catch {
+        return
+    }
+
+    if ($deletedLines.Count -gt 0) {
+        $count = $deletedLines.Count
+        $list = ($deletedLines | ForEach-Object { "        $_" }) -join "`n"
+        $script:ContextLines += @"
+
+Vault integrity: $count file(s) deleted from working tree but still in HEAD - likely sync/watcher race
+$list
+        Recovery: cd $VaultPath; git checkout -- <file>
+"@
+    }
+}
+
+if ($VaultRoot) {
+    Test-VaultIntegrity -VaultPath $VaultRoot
+}
+
 function Test-KnowledgeHealth {
     $encoded = Get-EncodedProjectPath -Path $CWD
     $memoryFile = Join-Path $env:USERPROFILE ".claude\projects\$encoded\memory\MEMORY.md"

--- a/scripts/claude-session-start.sh
+++ b/scripts/claude-session-start.sh
@@ -141,8 +141,17 @@ if [ -x "$VAULT_HEALTH" ]; then
     HEALTH_EXIT=${HEALTH_EXIT:-0}
 
     if [ "$HEALTH_EXIT" -eq 2 ]; then
-        CONTEXT_LINES="$CONTEXT_LINES
+        # GUI down: GUI-dependent checks skipped, but integrity check (git-based) ran anyway.
+        # Scan HEALTH_OUTPUT for any FAIL lines so integrity alerts still surface.
+        INTEGRITY_FAILS=$(echo "$HEALTH_OUTPUT" | sed 's/\x1b\[[0-9;]*m//g' | grep 'FAIL' || echo "")
+        if [ -n "$INTEGRITY_FAILS" ]; then
+            CONTEXT_LINES="$CONTEXT_LINES
+Obsidian GUI not running — GUI-dependent checks skipped. Integrity issues found:
+$INTEGRITY_FAILS"
+        else
+            CONTEXT_LINES="$CONTEXT_LINES
 Obsidian GUI not running — vault health skipped. Run 'vault-health.sh' manually when GUI is up."
+        fi
     elif [ "$HEALTH_EXIT" -eq 0 ]; then
         CONTEXT_LINES="$CONTEXT_LINES
 Vault health: ALL CHECKS PASSED"

--- a/scripts/vault-health.sh
+++ b/scripts/vault-health.sh
@@ -81,7 +81,29 @@ echo "========================================"
 echo "Vault: $VAULT_NAME ($VAULT_DIR)"
 
 # ==================================================
-section "1/5" "Vault Connectivity"
+section "1/6" "Working Tree Integrity"
+
+# GUI-independent check: detect files deleted from working tree but still in HEAD.
+# Triggered by 2026-05-13 incident — SKILL.md vanished from disk, git status showed `D`.
+# Pattern `^.D ` matches Y-column=D (unstaged delete), NOT X-column=D (intentional `git rm`).
+if [ ! -d "$VAULT_DIR" ]; then
+    skip "Working tree integrity" "vault dir not found"
+elif [ ! -d "$VAULT_DIR/.git" ]; then
+    skip "Working tree integrity" "vault is not a git repo"
+else
+    DELETED_LINES=$(git -C "$VAULT_DIR" status --short 2>/dev/null | grep '^.D ' || true)
+    if [ -z "$DELETED_LINES" ]; then
+        pass "Working tree clean — no files deleted from disk"
+    else
+        DELETED_COUNT=$(printf '%s\n' "$DELETED_LINES" | wc -l | tr -d ' ')
+        fail "$DELETED_COUNT file(s) deleted from working tree but still in HEAD — likely sync/watcher race"
+        printf '%s\n' "$DELETED_LINES" | sed 's|^|        |'
+        printf '        Recovery: cd %s && git checkout -- <file>\n' "$VAULT_DIR"
+    fi
+fi
+
+# ==================================================
+section "2/6" "Vault Connectivity"
 
 if ! command_exists obsidian; then
     log_error "Obsidian CLI not found in PATH"
@@ -105,7 +127,7 @@ else
 fi
 
 # ==================================================
-section "2/5" "Orphans & Dead-Ends"
+section "3/6" "Orphans & Dead-Ends"
 
 ORPHAN_OUTPUT=$(obsidian_cmd orphans --vault "$VAULT_NAME" 2>/dev/null || true)
 ORPHAN_COUNT=$(echo "$ORPHAN_OUTPUT" | grep -c '[^[:space:]]' 2>/dev/null || echo "0")
@@ -148,7 +170,7 @@ if [ "$VERBOSE" = true ]; then
 fi
 
 # ==================================================
-section "3/5" "Unresolved Links"
+section "4/6" "Unresolved Links"
 
 UNRESOLVED_OUTPUT=$(obsidian_cmd unresolved --vault "$VAULT_NAME" 2>/dev/null || true)
 UNRESOLVED_COUNT=$(echo "$UNRESOLVED_OUTPUT" | grep -c '[^[:space:]]' 2>/dev/null || echo "0")
@@ -168,7 +190,7 @@ if [ "$VERBOSE" = true ] && [ "$UNRESOLVED_COUNT" -gt 0 ]; then
 fi
 
 # ==================================================
-section "4/5" "Frontmatter Coverage"
+section "5/6" "Frontmatter Coverage"
 
 check_frontmatter_field() {
     local field="$1"
@@ -198,7 +220,7 @@ else
 fi
 
 # ==================================================
-section "5/5" "Tag Hygiene"
+section "6/6" "Tag Hygiene"
 
 TAG_OUTPUT=$(obsidian_cmd tags --vault "$VAULT_NAME" 2>/dev/null || true)
 TAG_COUNT=$(echo "$TAG_OUTPUT" | grep -c '[^[:space:]]' 2>/dev/null || echo "0")


### PR DESCRIPTION
## Summary

- New **Section 1/6 "Working Tree Integrity"** in `vault-health.sh` runs `git status --short` on the vault and surfaces any file with `^.D ` (Y-column=D, unstaged delete). Pattern deliberately excludes `git rm` deletions (X-column=D). Existing sections renumbered 2-6.
- `claude-session-start.sh` patched: when Obsidian GUI is down (`HEALTH_EXIT=2`), the hook now still scans captured output for `FAIL` lines so integrity alerts surface — the integrity check is git-based and GUI-independent.
- `claude-session-start.ps1` adds standalone `Test-VaultIntegrity` (Windows has no `vault-health.ps1`).

## Why

Closes the loop from the **2026-05-13 incident**: `00_meta/skills/spec/SKILL.md` appeared `D` in `git status` at session close — recovered with `git checkout`, root cause undetermined (likely sync/watcher race). Until this PR, the only detection mechanism was manually running `cd $VAULT_PATH && git status` at every session start.

## Behavior

| State | Output |
|---|---|
| Clean vault | `PASS: Working tree clean — no files deleted from disk` |
| 1+ unstaged deletes | `FAIL: N file(s) deleted from working tree but still in HEAD — likely sync/watcher race` + file list + recovery hint |
| Vault not a git repo | `SKIP: vault is not a git repo` |
| Obsidian GUI down | GUI-dependent checks skipped, integrity FAIL still surfaces |

Recovery hint included in output: `cd <vault> && git checkout -- <file>`. Auto-recovery deliberately not attempted (SessionStart hooks are non-interactive).

## Test plan

- [x] shellcheck clean on both `.sh` files
- [x] Manual run on clean vault → Section 1 PASS
- [x] Simulated `D` entry in throwaway repo → Section 1 FAIL with file list + recovery hint
- [x] End-to-end hook test with mock JSON input → FAIL surfaces in `additionalContext`
- [ ] PSScriptAnalyzer on `.ps1` (validated by CI — pwsh not in local dev env)

## Notes

- Tracks knowledge backlog item `SDD-017`.
- Should be merged independently of #16 (different concerns: SDD-013 = distribution, SDD-017 = robustness).