### PR TITLE
feat(scripts): SessionStart hook surfaces repo specs/ state (SDD-016)

### DIFF
--- a/scripts/claude-session-start.ps1
+++ b/scripts/claude-session-start.ps1
@@ -98,9 +98,57 @@ function Find-WorkSdkProject {
     }
 }
 
+# --- Spec-Driven Development: detect repo specs/ and surface in-flight work ---
+# Counts active vs archived specs under $RepoPath/specs/ and flags any spec
+# containing unresolved [AGENT-DRAFT] or [AGENT-SUGGESTION] tags.
+# Discovery without proactive nag - silent if no specs/.
+function Test-RepoSpecs {
+    param([string]$RepoPath)
+
+    $specsDir = Join-Path $RepoPath 'specs'
+    if (-not (Test-Path $specsDir -PathType Container)) { return }
+
+    $activeCount = 0
+    $draftsSpecs = New-Object System.Collections.Generic.List[string]
+
+    foreach ($d in (Get-ChildItem $specsDir -Directory -ErrorAction SilentlyContinue)) {
+        if ($d.Name -eq 'archive') { continue }
+        $activeCount++
+        $hasTags = $false
+        $files = Get-ChildItem $d.FullName -File -Recurse -ErrorAction SilentlyContinue
+        foreach ($f in $files) {
+            $content = Get-Content $f.FullName -Raw -ErrorAction SilentlyContinue
+            if ($content -match '\[AGENT-DRAFT\]|\[AGENT-SUGGESTION\]') {
+                $hasTags = $true
+                break
+            }
+        }
+        if ($hasTags) { $draftsSpecs.Add($d.Name) }
+    }
+
+    $archiveCount = 0
+    $archiveDir = Join-Path $specsDir 'archive'
+    if (Test-Path $archiveDir -PathType Container) {
+        $archiveCount = @(Get-ChildItem $archiveDir -Directory -ErrorAction SilentlyContinue).Count
+    }
+
+    if ($activeCount -eq 0 -and $archiveCount -eq 0) { return }
+
+    $msg = "[specs] $activeCount active, $archiveCount archived"
+    if ($draftsSpecs.Count -gt 0) {
+        $msg += " - $($draftsSpecs.Count) with unresolved [AGENT-DRAFT]/[AGENT-SUGGESTION] tags:"
+        foreach ($name in $draftsSpecs) {
+            $msg += "`n  - $name"
+        }
+    }
+
+    $script:ContextLines += "`n$msg"
+}
+
 # Check if CWD is a git repo
 if (Test-Path (Join-Path $CWD '.git')) {
     Find-HiveProject -Path $CWD
+    Test-RepoSpecs -RepoPath $CWD
 }
 
 # --- Walk up to find Obsidian vault ---

--- a/scripts/claude-session-start.sh
+++ b/scripts/claude-session-start.sh
@@ -115,8 +115,58 @@ find_work_sdk_project() {
     done
 }
 
+# --- Spec-Driven Development: detect repo specs/ and surface in-flight work ---
+# Counts active vs archived specs under $CWD/specs/ and flags any spec
+# containing unresolved [AGENT-DRAFT] or [AGENT-SUGGESTION] tags.
+# Discovery without proactive nag — silent if no specs/.
+detect_repo_specs() {
+    local specs_dir d name active_count archive_count drafts_specs draft_count msg
+    specs_dir="$CWD/specs"
+    [ -d "$specs_dir" ] || return 0
+
+    active_count=0
+    drafts_specs=""
+    for d in "$specs_dir"/*/; do
+        [ -d "$d" ] || continue
+        name=$(basename "$d")
+        [ "$name" = "archive" ] && continue
+        active_count=$((active_count + 1))
+        if grep -rlE '\[AGENT-DRAFT\]|\[AGENT-SUGGESTION\]' "$d" >/dev/null 2>&1; then
+            drafts_specs="$drafts_specs $name"
+        fi
+    done
+
+    archive_count=0
+    if [ -d "$specs_dir/archive" ]; then
+        for d in "$specs_dir/archive"/*/; do
+            [ -d "$d" ] || continue
+            archive_count=$((archive_count + 1))
+        done
+    fi
+
+    # Silent if entirely empty
+    if [ "$active_count" -eq 0 ] && [ "$archive_count" -eq 0 ]; then
+        return 0
+    fi
+
+    msg="[specs] $active_count active, $archive_count archived"
+    if [ -n "$drafts_specs" ]; then
+        drafts_specs="${drafts_specs# }"
+        draft_count=$(printf '%s' "$drafts_specs" | wc -w | tr -d ' ')
+        msg="$msg — $draft_count with unresolved [AGENT-DRAFT]/[AGENT-SUGGESTION] tags:"
+        for name in $drafts_specs; do
+            msg="$msg
+  - $name"
+        done
+    fi
+
+    CONTEXT_LINES="$CONTEXT_LINES
+$msg"
+}
+
 if [ -d "$CWD/.git" ]; then
     detect_hive_project
+    detect_repo_specs
 fi
 
 if [ -z "$VAULT_ROOT" ] && [ -z "$CONTEXT_LINES" ]; then


### PR DESCRIPTION
## Summary

When the session starts inside a git repo containing `specs/`, the hook now emits a one-line summary in `additionalContext`:

```
[specs] 4 active, 2 archived
```

If any active spec contains unresolved `[AGENT-DRAFT]` or `[AGENT-SUGGESTION]` markers (written by the SDD `spec` skill when Socratic Q&A is skipped or its suggestions are not yet accepted), the line extends:

```
[specs] 4 active, 2 archived — 1 with unresolved [AGENT-DRAFT]/[AGENT-SUGGESTION] tags:
  - AI-001-ollama-public
```

## Why

Closes the cross-session **"I forgot I had AI-001 in flight"** gap. Until now, in-flight specs and unresolved AGENT-DRAFT placeholders were invisible at session resume — easy to skip past a spec waiting on human review.

## Behavior

| State | Output |
|---|---|
| No `specs/` directory | Silent (nothing emitted) |
| `specs/` exists, empty + no archive | Silent |
| Active specs, no drafts | `[specs] N active, M archived` |
| Active specs with drafts | Above + tag list with spec IDs |
| `specs/archive/` present | Counted, not scanned for tags (archived ≠ in-flight) |

## Test plan

- [x] shellcheck clean
- [x] kubelab real-world (4 active, 0 archived, 0 drafts) → `[specs] 4 active, 0 archived` (no draft line)
- [x] Throwaway repo without `specs/` → silent (no `[specs]` line in output)
- [x] Simulated: 2 active (one with `[AGENT-DRAFT]` in proposal + `[AGENT-SUGGESTION]` in tasks) + 1 archived → `[specs] 2 active, 1 archived — 1 with unresolved tags: AI-001` (deduplicated per-spec, not per-tag)
- [ ] PSScriptAnalyzer on `.ps1` (validated by CI)

## Notes

- Discovery without proactive nag: never emits when there's nothing to say.
- Tag scan is per-spec via `grep -rl` (Linux) / recursive `Get-Content -match` (Windows). Acceptable for spec dir size (<100 files per spec).
- Tracks knowledge backlog item `SDD-016`. Last of the 3-task SDD bundle (013/016/017) from this sprint.