### PR TITLE
fix(setup): idempotent MCP registration + self-healing scheduled task

### DIFF
--- a/mcp-servers.json
+++ b/mcp-servers.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "Single source of truth for Claude Code MCP servers registered by setup-linux.sh and setup-windows.ps1. Add new servers here; both setup scripts pick them up automatically. Args is a space-separated string of arguments passed after `--` to `claude mcp add`.",
+  "servers": [
+    {
+      "name": "drawio",
+      "transport": "stdio",
+      "args": "npx -y @drawio/mcp"
+    },
+    {
+      "name": "socket",
+      "transport": "http",
+      "args": "https://mcp.socket.dev/"
+    },
+    {
+      "name": "sequential-thinking",
+      "transport": "stdio",
+      "args": "npx -y @modelcontextprotocol/server-sequential-thinking"
+    },
+    {
+      "name": "context7",
+      "transport": "http",
+      "args": "https://mcp.context7.com/mcp"
+    },
+    {
+      "name": "hive",
+      "transport": "stdio",
+      "args": "uvx hive-vault",
+      "prerequisite_binary": "uv",
+      "prerequisite_command": "uv tool install --upgrade hive-vault"
+    }
+  ]
+}

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -404,21 +404,55 @@ else
     log_warning "GitHub CLI (gh) not found, skipping Copilot installation"
 fi
 
-# Register MCP servers (requires Claude Code CLI and Node.js)
-if command -v claude >/dev/null 2>&1 && command -v npx >/dev/null 2>&1; then
-    log_info "Registering Claude Code MCP servers..."
-    claude mcp add --transport stdio drawio --scope user -- npx -y @drawio/mcp 2>/dev/null || true
-    claude mcp add --transport http socket --scope user -- https://mcp.socket.dev/ 2>/dev/null || true
-    claude mcp add --transport stdio sequential-thinking --scope user -- npx -y @modelcontextprotocol/server-sequential-thinking 2>/dev/null || true
-    claude mcp add --transport http context7 --scope user -- https://mcp.context7.com/mcp 2>/dev/null || true
-    # Hive vault server (pypi.org/project/hive-vault)
-    if command -v uv >/dev/null 2>&1; then
-        uv tool install --upgrade hive-vault 2>/dev/null || true
-        claude mcp add --transport stdio hive --scope user -- uvx hive-vault 2>/dev/null || true
+# Register MCP servers (requires Claude Code CLI, Node.js, jq)
+# Idempotent: server list lives in mcp-servers.json (SSOT shared with Windows);
+# `claude mcp get` is used to skip already-registered entries, and `add` errors
+# are surfaced rather than swallowed.
+MCP_CONFIG="$DOTFILES_DIR/mcp-servers.json"
+if command -v claude >/dev/null 2>&1 && command -v npx >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+    if [ ! -f "$MCP_CONFIG" ]; then
+        log_warning "mcp-servers.json not found at $MCP_CONFIG, skipping MCP registration"
+    else
+        log_info "Registering Claude Code MCP servers from $MCP_CONFIG..."
+        mcp_added=0
+        mcp_skipped=0
+        mcp_failed=0
+        while IFS=$'\t' read -r mcp_name mcp_transport mcp_args mcp_prereq_bin mcp_prereq_cmd; do
+            # Check prerequisite binary, run prerequisite command if specified
+            if [ -n "$mcp_prereq_bin" ]; then
+                if ! command -v "$mcp_prereq_bin" >/dev/null 2>&1; then
+                    log_warning "MCP $mcp_name: prerequisite '$mcp_prereq_bin' not found, skipping"
+                    mcp_failed=$((mcp_failed + 1))
+                    continue
+                fi
+                if [ -n "$mcp_prereq_cmd" ]; then
+                    # shellcheck disable=SC2086
+                    if ! $mcp_prereq_cmd >/dev/null 2>&1; then
+                        log_warning "MCP $mcp_name: prerequisite command failed: $mcp_prereq_cmd"
+                    fi
+                fi
+            fi
+            # Idempotence: skip if `claude mcp get` already knows this name
+            if claude mcp get "$mcp_name" >/dev/null 2>&1; then
+                log_info "MCP $mcp_name already registered, skipping"
+                mcp_skipped=$((mcp_skipped + 1))
+                continue
+            fi
+            # Word-split args intentionally; entries in mcp-servers.json are
+            # tokenized for `claude mcp add` argv after `--`.
+            # shellcheck disable=SC2086
+            if mcp_err=$(claude mcp add --transport "$mcp_transport" "$mcp_name" --scope user -- $mcp_args 2>&1); then
+                log_success "Registered MCP $mcp_name"
+                mcp_added=$((mcp_added + 1))
+            else
+                log_warning "Failed to register MCP $mcp_name: $mcp_err"
+                mcp_failed=$((mcp_failed + 1))
+            fi
+        done < <(jq -r '.servers[] | [.name, .transport, .args, (.prerequisite_binary // ""), (.prerequisite_command // "")] | @tsv' "$MCP_CONFIG")
+        log_success "MCP servers: $mcp_added added, $mcp_skipped already present, $mcp_failed failed"
     fi
-    log_success "MCP servers registered"
 else
-    log_warning "Claude Code CLI or npx not found, skipping MCP server registration"
+    log_warning "Claude Code CLI, npx, or jq not found, skipping MCP server registration"
 fi
 
 # Claude Code plugins (requires claude CLI)

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -168,28 +168,57 @@ if (Test-Path $skillsSource) {
     Write-Success "Synced skills to $ClaudeHome\skills\"
 }
 
-# Register MCP servers (requires Claude Code CLI and Node.js)
+# Register MCP servers (requires Claude Code CLI, Node.js)
+# Idempotent: server list lives in mcp-servers.json (SSOT shared with Linux);
+# `claude mcp get` is used to skip already-registered entries, and `add` errors
+# are surfaced rather than swallowed.
+$mcpConfig = "$DotfilesDir\mcp-servers.json"
 $claudeCmd = Get-Command claude -ErrorAction SilentlyContinue
 $npxCmd = Get-Command npx -ErrorAction SilentlyContinue
-if ($claudeCmd -and $npxCmd) {
-    Write-Info "Registering Claude Code MCP servers..."
+if (-not ($claudeCmd -and $npxCmd)) {
+    Write-Warn "Claude Code CLI or npx not found, skipping MCP server registration"
+} elseif (-not (Test-Path $mcpConfig)) {
+    Write-Warn "mcp-servers.json not found at $mcpConfig, skipping MCP registration"
+} else {
+    Write-Info "Registering Claude Code MCP servers from $mcpConfig..."
+    $mcpAdded = 0
+    $mcpSkipped = 0
+    $mcpFailed = 0
     try {
-        & claude mcp add --transport stdio drawio --scope user -- npx -y @drawio/mcp 2>$null
-        & claude mcp add --transport http socket --scope user -- https://mcp.socket.dev/ 2>$null
-        & claude mcp add --transport stdio sequential-thinking --scope user -- npx -y @modelcontextprotocol/server-sequential-thinking 2>$null
-        & claude mcp add --transport http context7 --scope user -- https://mcp.context7.com/mcp 2>$null
-        # Hive vault server (pypi.org/project/hive-vault)
-        $uvCmd = Get-Command uv -ErrorAction SilentlyContinue
-        if ($uvCmd) {
-            & uv tool install --upgrade hive-vault 2>$null
-            & claude mcp add --transport stdio hive --scope user -- uvx hive-vault 2>$null
+        $servers = (Get-Content $mcpConfig -Raw | ConvertFrom-Json).servers
+        foreach ($srv in $servers) {
+            if ($srv.prerequisite_binary) {
+                $prereqCmd = Get-Command $srv.prerequisite_binary -ErrorAction SilentlyContinue
+                if (-not $prereqCmd) {
+                    Write-Warn "MCP $($srv.name): prerequisite '$($srv.prerequisite_binary)' not found, skipping"
+                    $mcpFailed++
+                    continue
+                }
+                if ($srv.prerequisite_command) {
+                    $prereqParts = $srv.prerequisite_command -split '\s+'
+                    & $prereqParts[0] @($prereqParts[1..($prereqParts.Length - 1)]) 2>&1 | Out-Null
+                }
+            }
+            $null = & claude mcp get $srv.name 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                Write-Info "MCP $($srv.name) already registered, skipping"
+                $mcpSkipped++
+                continue
+            }
+            $argParts = $srv.args -split '\s+'
+            $mcpErr = & claude mcp add --transport $srv.transport $srv.name --scope user -- @argParts 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                Write-Success "Registered MCP $($srv.name)"
+                $mcpAdded++
+            } else {
+                Write-Warn "Failed to register MCP $($srv.name): $mcpErr"
+                $mcpFailed++
+            }
         }
-        Write-Success "MCP servers registered"
+        Write-Success "MCP servers: $mcpAdded added, $mcpSkipped already present, $mcpFailed failed"
     } catch {
         Write-Warn "Failed to register MCP servers: $_"
     }
-} else {
-    Write-Warn "Claude Code CLI or npx not found, skipping MCP server registration"
 }
 
 # Claude Code plugins (requires claude CLI)
@@ -768,23 +797,36 @@ if ($ghCmd) {
     Write-Warn "GitHub CLI (gh) not found, skipping Copilot installation"
 }
 
-# Weekly vault maintenance scheduled task (Sundays 10:00 AM)
+# Weekly vault maintenance scheduled task (Sundays 10:07 AM)
+# Self-healing: compare existing action arguments against expected and rewrite
+# when they diverge -- guards against stale tasks pointing at moved/renamed scripts.
 Write-Info "Setting up weekly vault maintenance task..."
 $taskName = "DotfilesVaultMaintenance"
+$expectedTaskScript = "$DotfilesDir\scripts\vault-maintenance-weekly.ps1"
+$expectedTaskArgument = "-NoProfile -ExecutionPolicy Bypass -File `"$expectedTaskScript`""
 $existingTask = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
-if (-not $existingTask) {
+$existingTaskArgument = $null
+if ($existingTask -and $existingTask.Actions -and $existingTask.Actions[0]) {
+    $existingTaskArgument = $existingTask.Actions[0].Arguments
+}
+if ($existingTask -and ($existingTaskArgument -eq $expectedTaskArgument)) {
+    Write-Info "Weekly vault maintenance task already correctly configured, skipping"
+} else {
+    if ($existingTask) {
+        Write-Info "Weekly vault maintenance task arguments drifted ('$existingTaskArgument' != expected); re-registering"
+    }
     try {
-        $action = New-ScheduledTaskAction -Execute "powershell.exe" `
-            -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$DotfilesDir\scripts\vault-maintenance-weekly.ps1`""
+        $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument $expectedTaskArgument
         $trigger = New-ScheduledTaskTrigger -Weekly -DaysOfWeek Sunday -At "10:07AM"
         Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger `
             -Description "Weekly vault maintenance - knowledge crystallization and health checks" -Force | Out-Null
         Write-Success "Installed weekly vault maintenance task (Sundays 10:07)"
+        if (-not (Test-Path $expectedTaskScript)) {
+            Write-Warn "Task registered but target script does not exist: $expectedTaskScript"
+        }
     } catch {
         Write-Warn "Could not register scheduled task (may need admin): $_"
     }
-} else {
-    Write-Info "Weekly vault maintenance task already installed"
 }
 
 # ============================================================================

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -122,3 +122,30 @@ setup() {
     grep -q 'EXISTING_HOOK_COMMAND' "$DOTFILES_DIR/setup-linux.sh"
     grep -qE '\[ "\$EXISTING_HOOK_COMMAND" = "\$EXPECTED_HOOK_COMMAND" \]' "$DOTFILES_DIR/setup-linux.sh"
 }
+
+# --- MCP server registration (SSOT + idempotence) ---
+
+@test "mcp-servers.json exists and is valid JSON with at least one server" {
+    [ -f "$DOTFILES_DIR/mcp-servers.json" ]
+    if command -v jq >/dev/null 2>&1; then
+        run jq -e '.servers | length > 0' "$DOTFILES_DIR/mcp-servers.json"
+        [ "$status" -eq 0 ]
+    fi
+}
+
+# MCP server list must live in mcp-servers.json, not hardcoded in setup-linux.sh.
+@test "setup-linux.sh MCP registration reads from mcp-servers.json" {
+    grep -q 'mcp-servers\.json' "$DOTFILES_DIR/setup-linux.sh"
+    ! grep -qE 'claude mcp add --transport (stdio|http) (drawio|socket|context7|sequential-thinking|hive)' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+# MCP registration must check existence before adding, not blindly retry.
+@test "setup-linux.sh MCP registration checks existence with claude mcp get" {
+    grep -q 'claude mcp get' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+# Both setup scripts must read the same SSOT.
+@test "parity: both setup scripts source mcp-servers.json" {
+    grep -q 'mcp-servers\.json' "$DOTFILES_DIR/setup-linux.sh"
+    grep -q 'mcp-servers\.json' "$DOTFILES_DIR/setup-windows.ps1"
+}

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -106,6 +106,28 @@ setup() {
     grep -Eq '\$existingHookCommand\s+-eq\s+\$expectedHookCommand' "$PS1_SCRIPT"
 }
 
+# --- Scheduled task self-heal (same class as #20) ---
+
+# DotfilesVaultMaintenance task must reconcile arguments, not skip when present;
+# otherwise a stale task pointing at a moved/renamed script stays broken forever.
+@test "setup-windows.ps1 vault maintenance task self-heals on argument drift" {
+    grep -q '\$expectedTaskArgument' "$PS1_SCRIPT"
+    grep -Eq '\$existingTaskArgument\s+-eq\s+\$expectedTaskArgument' "$PS1_SCRIPT"
+}
+
+# --- MCP server registration (SSOT + idempotence) ---
+
+# MCP server list must live in mcp-servers.json, not hardcoded in the setup script.
+@test "setup-windows.ps1 MCP registration reads from mcp-servers.json" {
+    grep -q 'mcp-servers\.json' "$PS1_SCRIPT"
+    ! grep -Eq 'claude mcp add --transport (stdio|http) (drawio|socket|context7|sequential-thinking|hive)' "$PS1_SCRIPT"
+}
+
+# MCP registration must check existence before adding, not blindly retry.
+@test "setup-windows.ps1 MCP registration checks existence with claude mcp get" {
+    grep -q 'claude mcp get' "$PS1_SCRIPT"
+}
+
 @test "setup-windows.ps1 deploys SSH config" {
     grep -q 'Setting up SSH config' "$PS1_SCRIPT"
 }


### PR DESCRIPTION
## Summary

Follow-up to #21. Closes the three idempotence smells documented in the pattern audit (`pattern-setup-script-idempotence` → "Smells in this repo, audited 2026-05-15") — same class of bug as #20, none of them bitten yet, all primed to bite on the next path/script change.

### 1. Self-healing scheduled task (Windows)

`DotfilesVaultMaintenance` was registered with `if (-not $existingTask) { register }`. A task left over from an older `$DotfilesDir`, a moved script, or a renamed argument list would stay broken forever.

Now: compare existing `Actions[0].Arguments` against the expected argument string. If they match, no-op. If they differ (or no task exists), `Register-ScheduledTask -Force`. Post-deploy assertion warns when the target script doesn't actually exist.

### 2. MCP server registration idempotence (both OSes)

Five hardcoded `claude mcp add ... 2>/dev/null || true` lines per OS, with all stderr silenced. No way to tell if registration succeeded; re-runs depended on whatever `claude mcp add` does on duplicates (it returns exit 1 with "already exists" — silently masked by `|| true`).

Now: loop over `mcp-servers.json`, `claude mcp get NAME` to detect existing entries, `claude mcp add` only for missing ones. Errors from `add` are captured and surfaced (`log_warning "Failed to register MCP $name: $err"`), with an `added / already present / failed` summary at the end.

### 3. MCP server list as SSOT

`mcp-servers.json` (new, at repo root) replaces the duplicate 5-line list in both setup scripts. Adding a server is now a one-place edit. Bash side parses with `jq`, PowerShell side with `ConvertFrom-Json`. Both have these dependencies already.

Schema:
\`\`\`json
{
  "servers": [
    { "name": "drawio", "transport": "stdio", "args": "npx -y @drawio/mcp" },
    { "name": "hive", "transport": "stdio", "args": "uvx hive-vault",
      "prerequisite_binary": "uv",
      "prerequisite_command": "uv tool install --upgrade hive-vault" }
  ]
}
\`\`\`

## Diff size

191 insertions / 34 deletions across 5 files. Atomic per project policy.

## Test plan

- [x] `PSScriptAnalyzer -Severity Error,Warning` clean on `setup-windows.ps1`.
- [x] `shellcheck --severity=error` clean on `setup-linux.sh`.
- [x] `bash -n` and `zsh -n` clean on `setup-linux.sh` (LF-stripped working copy).
- [x] `bats tests/setup-windows.bats` — 47 pass (2 skipped: pwsh not in local WSL); new tests for scheduled-task self-heal, MCP-from-JSON, `claude mcp get` check.
- [x] `bats tests/setup-linux.bats` — new tests 23–26 pass: JSON validity, MCP-from-JSON, `claude mcp get`, parity-both-OS-source-SSOT. (Pre-existing 1–2 still fail locally on Windows CRLF working tree; CI sees LF.)
- [x] Dry-run of the bash MCP loop with a mocked `claude` confirms all 5 servers parse and dispatch with correct argv.
- [x] CI: lint + lint-powershell + test + integration.

## Out of scope (intentional)

- Plugin install list is also duplicated between OSes; same SSOT-extraction pattern would apply. Defer to a follow-up PR — that list is more volatile than MCP servers and deserves its own discussion.
- The integration test in `tests/Dockerfile.integration` doesn't install `claude` CLI, so the new MCP block is skipped by the `command -v claude` guard. Wiring `claude` into the integration image is a separate concern; the bats grep-tests are the contract here.