### PR TITLE
fix(scripts): claude-mem-heal Windows parity (zod/v3 plugin bug)

### DIFF
--- a/scripts/claude-mem-heal.ps1
+++ b/scripts/claude-mem-heal.ps1
@@ -1,0 +1,163 @@
+<#
+.SYNOPSIS
+    Idempotently repair the thedotmack/claude-mem plugin cache when the
+    published artifact ships broken (v12.7.4, v13.0.0+).
+
+.DESCRIPTION
+    Two known issues this script papers over:
+
+      1. .mcp.json embeds shell parameter expansion (${_R%/}) that Claude
+         Code's MCP loader misreads as an env-var name. See upstream
+         issue #2385. Rewrite the file to the simpler v10.6.3 form.
+
+      2. v13.0.0+ declares "zod": "^4.3.6" in package.json but the
+         published bun.lock and node_modules/ omit it, so
+         worker-service.cjs crashes with
+         "Cannot find module 'zod/v3'". Install zod in place with
+         --ignore-scripts so other native deps (tree-sitter) do not
+         trigger MSBuild on Windows.
+
+    Both upstream errors revert on /plugin update, so this is invoked
+    from claude-session-start.ps1 to self-heal at session start.
+
+    Mirrors scripts/claude-mem-heal.sh (Linux).
+
+.NOTES
+    Behaviour: silent on healthy installs (exit 0, no output). Prints one
+    line per heal action taken so the SessionStart hook can surface it.
+    Always exits 0 -- never blocks session start on transient failures.
+
+.PARAMETER Verbose
+    When passed, always logs what was checked.
+
+.EXAMPLE
+    pwsh -NoProfile -File claude-mem-heal.ps1
+    pwsh -NoProfile -File claude-mem-heal.ps1 -VerboseOutput
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$VerboseOutput
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Continue'
+
+# Promote param to script-scope so PSScriptAnalyzer sees the reference
+# explicitly; downstream functions read it via $script:VerboseOutput.
+$script:VerboseOutput = $VerboseOutput.IsPresent
+
+$ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $env:USERPROFILE '.claude' }
+$CacheRoot = Join-Path $ClaudeDir 'plugins\cache\thedotmack\claude-mem'
+$MarketplaceDir = Join-Path $ClaudeDir 'plugins\marketplaces\thedotmack\plugin'
+
+function Write-HealLog {
+    param([string]$Message)
+    Write-Output "[claude-mem-heal] $Message"
+}
+
+function Write-HealVerbose {
+    param([string]$Message)
+    if ($script:VerboseOutput) { Write-HealLog $Message }
+}
+
+# Replace a broken .mcp.json with the v10.6.3 form. Idempotent: only
+# rewrites if the file contains the offending ${_R%/} pattern.
+function Repair-McpJson {
+    param([string]$Target)
+
+    if (-not (Test-Path $Target)) {
+        Write-HealVerbose "no .mcp.json at $Target"
+        return
+    }
+
+    $content = Get-Content $Target -Raw -ErrorAction SilentlyContinue
+    if (-not $content -or ($content -notmatch '\$\{_R%/\}')) {
+        Write-HealVerbose ".mcp.json already healthy: $Target"
+        return
+    }
+
+    $healthy = @'
+{
+  "mcpServers": {
+    "mcp-search": {
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/scripts/mcp-server.cjs"
+      ]
+    }
+  }
+}
+'@
+    Set-Content -Path $Target -Value $healthy -Encoding UTF8 -NoNewline
+    Write-HealLog "patched .mcp.json: $Target"
+}
+
+# Install the zod runtime dep if package.json declares it but it isn't
+# installed. Idempotent: skips when node_modules/zod exists.
+# --ignore-scripts is mandatory on Windows: other deps (tree-sitter)
+# trigger node-gyp + MSBuild on postinstall and fail on machines without
+# the C++ build toolchain. We only need zod's pure-JS files.
+function Repair-ZodDep {
+    param([string]$PluginDir)
+
+    $pkg = Join-Path $PluginDir 'package.json'
+    if (-not (Test-Path $pkg)) {
+        Write-HealVerbose "no package.json at $PluginDir"
+        return
+    }
+
+    $pkgContent = Get-Content $pkg -Raw -ErrorAction SilentlyContinue
+    if (-not $pkgContent -or ($pkgContent -notmatch '"zod"')) {
+        Write-HealVerbose "no zod dep in $pkg"
+        return
+    }
+
+    $zodDir = Join-Path $PluginDir 'node_modules\zod'
+    if (Test-Path $zodDir) {
+        Write-HealVerbose "zod present in $PluginDir"
+        return
+    }
+
+    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+        Write-HealLog "ERROR: zod missing in $PluginDir but npm not on PATH -- skipping"
+        return
+    }
+
+    Push-Location $PluginDir
+    try {
+        $npmArgs = @('install', '--no-save', '--no-package-lock', '--no-audit', '--no-fund', '--ignore-scripts', 'zod@^4.3.6')
+        if (-not $script:VerboseOutput) { $npmArgs += '--silent' }
+        $null = & npm @npmArgs 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-HealLog "installed missing zod dep in $PluginDir"
+        } else {
+            Write-HealLog "ERROR: npm install zod failed in $PluginDir (exit $LASTEXITCODE)"
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+function Repair-PluginDir {
+    param([string]$Dir)
+
+    if (-not (Test-Path $Dir -PathType Container)) { return }
+    Repair-McpJson -Target (Join-Path $Dir '.mcp.json')
+    Repair-ZodDep -PluginDir $Dir
+}
+
+# Heal every cached version (so a rolled-back /plugin doesn't surprise us)
+# plus the marketplace copy used as fallback by the discovery logic.
+if (Test-Path $CacheRoot -PathType Container) {
+    foreach ($versionDir in (Get-ChildItem $CacheRoot -Directory -ErrorAction SilentlyContinue)) {
+        Repair-PluginDir -Dir $versionDir.FullName
+    }
+} else {
+    Write-HealVerbose "no cache dir at $CacheRoot"
+}
+
+Repair-PluginDir -Dir $MarketplaceDir
+
+exit 0

--- a/scripts/claude-mem-heal.sh
+++ b/scripts/claude-mem-heal.sh
@@ -80,13 +80,17 @@ heal_zod() {
     fi
 
     # Use a subshell so we don't leak the cd. Suppress output unless verbose.
+    # --ignore-scripts is mandatory: other deps in the plugin (e.g.
+    # tree-sitter) trigger node-gyp on postinstall and fail on machines
+    # without a C++ build toolchain (Windows MSBuild, Linux build-essential).
+    # We only need zod's pure-JS files; no postinstall is required for it.
     if [ "$VERBOSE" -eq 1 ]; then
-        ( cd "$plugin_dir" && npm install --no-save --no-package-lock --no-audit --no-fund zod@^4.3.6 ) || {
+        ( cd "$plugin_dir" && npm install --no-save --no-package-lock --no-audit --no-fund --ignore-scripts zod@^4.3.6 ) || {
             log "ERROR: npm install zod failed in $plugin_dir"
             return 0
         }
     else
-        ( cd "$plugin_dir" && npm install --no-save --no-package-lock --no-audit --no-fund --silent zod@^4.3.6 >/dev/null 2>&1 ) || {
+        ( cd "$plugin_dir" && npm install --no-save --no-package-lock --no-audit --no-fund --ignore-scripts --silent zod@^4.3.6 >/dev/null 2>&1 ) || {
             log "ERROR: npm install zod failed in $plugin_dir"
             return 0
         }

--- a/scripts/claude-session-start.ps1
+++ b/scripts/claude-session-start.ps1
@@ -36,6 +36,22 @@ if (-not $CWD) {
 $KnowledgeVault = Join-Path $env:USERPROFILE 'Projects\knowledge'
 $ContextLines = ''
 
+# --- Self-heal claude-mem plugin if marketplace shipped broken artifacts ---
+# Patches .mcp.json (${_R%/} regression, upstream #2385) and installs the
+# missing zod runtime dep. Silent on healthy installs. Mirrors the bash side.
+$ClaudeMemHeal = Join-Path $PSScriptRoot 'claude-mem-heal.ps1'
+if (Test-Path $ClaudeMemHeal) {
+    try {
+        $healOutput = & pwsh -NoProfile -File $ClaudeMemHeal 2>&1 | Out-String
+        $healOutput = $healOutput.Trim()
+        if ($healOutput) {
+            $ContextLines = "[claude-mem] self-healed plugin install:`n$healOutput"
+        }
+    } catch {
+        # Non-fatal -- session continues even if heal fails
+    }
+}
+
 # --- Hive: detect project and suggest vault queries ---
 # Checks: 1) personal projects (10_projects/), 2) work SDK projects (50_work/45-development/).
 function Find-HiveProject {

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -653,6 +653,14 @@ if (Test-Path $sessionStartSource) {
     Write-Warn "claude-session-start.ps1 not found at $sessionStartSource"
 }
 
+$memHealSource = "$DotfilesDir\scripts\claude-mem-heal.ps1"
+if (Test-Path $memHealSource) {
+    Copy-Item $memHealSource "$ScriptsDir\" -Force
+    Write-Success "Deployed claude-mem-heal.ps1 to $ScriptsDir\"
+} else {
+    Write-Warn "claude-mem-heal.ps1 not found at $memHealSource"
+}
+
 $syncSource = "$DotfilesDir\scripts\dotfiles-sync.ps1"
 if (Test-Path $syncSource) {
     Copy-Item $syncSource "$ScriptsDir\" -Force

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -149,3 +149,24 @@ setup() {
     grep -q 'mcp-servers\.json' "$DOTFILES_DIR/setup-linux.sh"
     grep -q 'mcp-servers\.json' "$DOTFILES_DIR/setup-windows.ps1"
 }
+
+# --- claude-mem-heal cross-OS parity ---
+
+@test "claude-mem-heal.ps1 exists alongside the bash version" {
+    [ -f "$DOTFILES_DIR/scripts/claude-mem-heal.sh" ]
+    [ -f "$DOTFILES_DIR/scripts/claude-mem-heal.ps1" ]
+}
+
+# Both heal scripts must use --ignore-scripts to avoid triggering native
+# postinstalls (tree-sitter -> node-gyp -> MSBuild on Windows, build-essential
+# on Linux). Only zod's pure-JS files are needed.
+@test "claude-mem-heal scripts both use --ignore-scripts on npm install" {
+    grep -q -- '--ignore-scripts' "$DOTFILES_DIR/scripts/claude-mem-heal.sh"
+    grep -q -- '--ignore-scripts' "$DOTFILES_DIR/scripts/claude-mem-heal.ps1"
+}
+
+# Both SessionStart hooks must invoke the heal at session start.
+@test "parity: both SessionStart hooks invoke claude-mem-heal" {
+    grep -q 'claude-mem-heal\.sh' "$DOTFILES_DIR/scripts/claude-session-start.sh"
+    grep -q 'claude-mem-heal\.ps1' "$DOTFILES_DIR/scripts/claude-session-start.ps1"
+}

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -68,6 +68,10 @@ setup() {
     grep -q 'claude-session-start.ps1' "$PS1_SCRIPT"
 }
 
+@test "setup-windows.ps1 deploys claude-mem-heal.ps1" {
+    grep -q 'claude-mem-heal.ps1' "$PS1_SCRIPT"
+}
+
 @test "setup-windows.ps1 deploys dotfiles-sync.ps1" {
     grep -q 'dotfiles-sync.ps1' "$PS1_SCRIPT"
 }


### PR DESCRIPTION
## Summary

`scripts/claude-mem-heal.sh` was Linux-only, so Windows users hit the upstream `thedotmack/claude-mem` v13.0.0+ packaging bug on every session start and stayed broken across plugin updates.

**Upstream bug:** `package.json` declares `"zod": "^4.3.6"` but the published artifact omits `node_modules/zod`. `worker-service.cjs` then crashes with `Cannot find module 'zod/v3'`. Symptom seen on this machine:

\`\`\`
SessionStart:startup hook error
Failed with non-blocking status code: error: Cannot find module 'zod/v3' from
'C:\Users\<u>\.claude\plugins\cache\thedotmack\claude-mem\13.2.0\scripts\worker-service.cjs'
\`\`\`

The Linux heal `scripts/claude-mem-heal.sh` already patched this transparently from `claude-session-start.sh`. Windows had no equivalent.

## Changes

- **`scripts/claude-mem-heal.ps1`** (new) — faithful PS1 port of the bash heal. Iterates every cached version under `~/.claude/plugins/cache/thedotmack/claude-mem/` plus the marketplace fallback, patches broken `.mcp.json` (upstream issue #2385), and `npm install`s zod when missing. Silent on healthy installs, one log line per action otherwise. Always exits 0.
- **`scripts/claude-session-start.ps1`** — invokes the heal at session start and folds its output into the hook's `additionalContext`. Mirrors the bash hook pattern.
- **`setup-windows.ps1`** — deploys `claude-mem-heal.ps1` to `~/scripts/` alongside `claude-session-start.ps1`.
- **`scripts/claude-mem-heal.sh`** — adds `--ignore-scripts` to the `npm install` call. Required on Windows (`tree-sitter` → `node-gyp` → MSBuild fails without the C++ toolchain); robustness win on Linux machines without `build-essential`. `zod` is pure JS, no postinstall needed.
- **Tests** — cross-OS parity assertions: both heal scripts exist, both use `--ignore-scripts`, both session-start hooks invoke the heal.

## Verification on this machine

Local test of the new heal script with `-VerboseOutput`:

\`\`\`
[claude-mem-heal] .mcp.json already healthy: ...\10.6.3\.mcp.json
[claude-mem-heal] no zod dep in ...\10.6.3\package.json
[claude-mem-heal] .mcp.json already healthy: ...\13.2.0\.mcp.json
[claude-mem-heal] zod present in ...\13.2.0
[claude-mem-heal] .mcp.json already healthy: ...\marketplaces\thedotmack\plugin\.mcp.json
[claude-mem-heal] installed missing zod dep in ...\marketplaces\thedotmack\plugin
\`\`\`

→ Found and healed the marketplace dir that was *also* silently broken. Re-run is silent (idempotent).

## Test plan

- [x] PSScriptAnalyzer clean on `setup-windows.ps1` and `claude-mem-heal.ps1` (pre-existing warnings on `claude-session-start.ps1` and `init-project.ps1` not in scope; CI only scans `setup-windows.ps1` and a few others, none affected).
- [x] `shellcheck --severity=error` clean on `claude-mem-heal.sh` and `setup-linux.sh`.
- [x] Both bats suites: 77 tests, all new heal-parity tests pass.
- [x] End-to-end on this machine: `pwsh -NoProfile -File claude-mem-heal.ps1 -VerboseOutput` healed the marketplace dir; second run silent.
- [x] CI: lint + lint-powershell + test + integration.

## Out of scope

- The integration Docker image doesn't run `claude-mem` (it's not in the plugin install list for the test container). The bash heal still gets `bash -n` / shellcheck coverage but no functional invocation test. The grep-based bats tests are the contract here.
- PSScriptAnalyzer warnings on `claude-session-start.ps1` (`$Input` automatic var, plural `Test-RepoSpecs`, BOM) are pre-existing and out of scope.