### PR TITLE
feat(doctor): declarative env contract + doctor.sh/ps1 with --check/--fix

### DIFF
--- a/env-contract.json
+++ b/env-contract.json
@@ -1,0 +1,59 @@
+{
+  "_comment": "Declarative contract for structural environment expectations. Read by scripts/doctor.{sh,ps1} to verify (and optionally fix) drift on a running install. v1 covers structural paths only; tooling-required vars and version pins live in versions.conf and sensitive/env-mapping.conf.",
+  "env_vars": [
+    {
+      "name": "DOTFILES_DIR",
+      "required": true,
+      "description": "Stable install location of dotfiles deployed by setup-linux.sh. Used by healthcheck and shell profiles.",
+      "default": {
+        "linux": "$HOME/.dotfiles",
+        "windows": "$env:USERPROFILE\\.dotfiles"
+      },
+      "validation": "path_exists"
+    },
+    {
+      "name": "CLAUDE_CONFIG_DIR",
+      "required": false,
+      "description": "Override for Claude Code's config dir. When unset, ~/.claude is assumed. Used by claude-mem-heal to locate the plugin cache.",
+      "default": {
+        "linux": "$HOME/.claude",
+        "windows": "$env:USERPROFILE\\.claude"
+      },
+      "validation": "path_exists"
+    },
+    {
+      "name": "HOME",
+      "required_on": "linux",
+      "description": "POSIX home directory. OS-provided; validated as a real directory.",
+      "validation": "path_exists"
+    },
+    {
+      "name": "USERPROFILE",
+      "required_on": "windows",
+      "description": "Windows home directory. OS-provided; validated as a real directory.",
+      "validation": "path_exists"
+    }
+  ],
+  "required_path_entries": {
+    "linux": [
+      "$HOME/.dotfiles/scripts",
+      "$HOME/.local/bin"
+    ],
+    "windows": [
+      "$env:USERPROFILE\\scripts",
+      "$env:USERPROFILE\\.local\\bin"
+    ]
+  },
+  "required_binaries": [
+    { "name": "git", "required": true },
+    { "name": "jq", "required": true }
+  ],
+  "optional_binaries": [
+    { "name": "claude", "purpose": "Claude Code CLI (MCP registration, plugins)" },
+    { "name": "npx", "purpose": "MCP server stdio transports" },
+    { "name": "npm", "purpose": "claude-mem-heal zod install" },
+    { "name": "age", "purpose": "secrets encryption" },
+    { "name": "gh", "purpose": "GitHub CLI + Copilot extension" },
+    { "name": "uv", "purpose": "Python tool installs (aider, hive-vault)" }
+  ]
+}

--- a/env-contract.json
+++ b/env-contract.json
@@ -45,8 +45,19 @@
     ]
   },
   "required_binaries": [
-    { "name": "git", "required": true },
-    { "name": "jq", "required": true }
+    {
+      "name": "git",
+      "required": true,
+      "min_version": "2.30.0",
+      "version_pattern": "git version ([0-9]+\\.[0-9]+\\.[0-9]+)"
+    },
+    {
+      "name": "jq",
+      "required": true,
+      "min_version": "1.6",
+      "_pattern_note": "regex must be valid in both bash ERE (no `(?:..)`) and .NET; capture group 1 holds the version. Group 2 is intentionally captured-but-unused for the optional patch component.",
+      "version_pattern": "jq-?([0-9]+\\.[0-9]+(\\.[0-9]+)?)"
+    }
   ],
   "optional_binaries": [
     { "name": "claude", "purpose": "Claude Code CLI (MCP registration, plugins)" },

--- a/scripts/claude-session-start.ps1
+++ b/scripts/claude-session-start.ps1
@@ -52,6 +52,26 @@ if (Test-Path $ClaudeMemHeal) {
     }
 }
 
+# --- Silent doctor: surface env-contract drift only when detected ---
+# Runs check-only; keeps only [warn]/[fail] lines.
+$DoctorScript = Join-Path $PSScriptRoot 'doctor.ps1'
+if (Test-Path $DoctorScript) {
+    try {
+        $doctorOut = & pwsh -NoProfile -File $DoctorScript 2>&1 | Out-String
+        $drift = ($doctorOut -split "`n" | Where-Object { $_ -match '^\s+\[(warn|fail)\]' }) -join "`n"
+        if ($drift) {
+            $driftBlock = "[doctor] env-contract drift detected (run scripts/doctor.ps1 -Fix):`n$drift"
+            if ($ContextLines) {
+                $ContextLines = "$ContextLines`n`n$driftBlock"
+            } else {
+                $ContextLines = $driftBlock
+            }
+        }
+    } catch {
+        # Non-fatal
+    }
+}
+
 # --- Hive: detect project and suggest vault queries ---
 # Checks: 1) personal projects (10_projects/), 2) work SDK projects (50_work/45-development/).
 function Find-HiveProject {

--- a/scripts/claude-session-start.sh
+++ b/scripts/claude-session-start.sh
@@ -36,6 +36,24 @@ $HEAL_OUTPUT"
     fi
 fi
 
+# --- Silent doctor: surface env-contract drift to Claude only when detected ---
+# Runs check-only; suppresses [ok]/[info] lines and only forwards [warn]/[fail].
+DOCTOR_SCRIPT="$SCRIPT_DIR/doctor.sh"
+if [ -x "$DOCTOR_SCRIPT" ] && command -v jq >/dev/null 2>&1; then
+    DOCTOR_DRIFT=$(bash "$DOCTOR_SCRIPT" 2>&1 | grep -E '^  \[(warn|fail)\]' || true)
+    if [ -n "$DOCTOR_DRIFT" ]; then
+        if [ -n "$CONTEXT_LINES" ]; then
+            CONTEXT_LINES="$CONTEXT_LINES
+
+[doctor] env-contract drift detected (run scripts/doctor.sh --fix):
+$DOCTOR_DRIFT"
+        else
+            CONTEXT_LINES="[doctor] env-contract drift detected (run scripts/doctor.sh --fix):
+$DOCTOR_DRIFT"
+        fi
+    fi
+fi
+
 # Walk up from CWD to find an Obsidian vault (.obsidian/ directory)
 find_vault_root() {
     local dir="$1"

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -134,14 +134,38 @@ foreach ($entry in $data.required_path_entries.windows) {
     }
 }
 
-# 3. Required binaries
+# 3. Required binaries (with optional version pinning)
 Write-Host ""
 Write-Host "Required binaries:"
 foreach ($b in $data.required_binaries) {
-    if (Get-Command $b.name -ErrorAction SilentlyContinue) {
-        Write-Pass "$($b.name) on PATH"
-    } else {
+    if (-not (Get-Command $b.name -ErrorAction SilentlyContinue)) {
         Write-Fail "$($b.name) missing"
+        continue
+    }
+    $minVersion = if ($b.PSObject.Properties.Match('min_version').Count -gt 0) { $b.min_version } else { '' }
+    $pattern = if ($b.PSObject.Properties.Match('version_pattern').Count -gt 0) { $b.version_pattern } else { '' }
+    if ([string]::IsNullOrEmpty($minVersion)) {
+        Write-Pass "$($b.name) on PATH"
+        continue
+    }
+    # Run `<name> --version` and apply pattern. Some tools write version to
+    # stderr, hence the 2>&1 merge.
+    $raw = (& $b.name --version 2>&1 | Select-Object -First 1) | Out-String
+    $raw = $raw.Trim()
+    if ($raw -match $pattern) {
+        $actual = $Matches[1]
+        try {
+            $cmp = [Version]::Parse($actual).CompareTo([Version]::Parse($minVersion))
+            if ($cmp -ge 0) {
+                Write-Pass "$($b.name) $actual (>= $minVersion)"
+            } else {
+                Write-Fail "$($b.name) $actual is older than minimum $minVersion"
+            }
+        } catch {
+            Write-Warn "$($b.name) version compare failed for '$actual' vs '$minVersion': $_"
+        }
+    } else {
+        Write-Warn "$($b.name) on PATH but version unparseable: '$raw' (pattern: $pattern)"
     }
 }
 

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -1,0 +1,181 @@
+<#
+.SYNOPSIS
+    Verify structural env vars, PATH entries and binaries against env-contract.json.
+
+.DESCRIPTION
+    Reads $DotfilesDir/env-contract.json (or repo-local fallback), checks env
+    vars + required PATH entries + binaries against the contract, and reports
+    drift. With -Fix, applies known-safe defaults to the current session and
+    invokes claude-mem-heal.ps1.
+
+    Mirrors scripts/doctor.sh (Linux).
+
+.PARAMETER Fix
+    Apply defaults to current session, run heal scripts. Without this, runs in
+    check-only mode: reports drift and exits 1 if any required item missing.
+
+.PARAMETER VerboseOutput
+    Show every check, not just warnings/failures.
+
+.EXAMPLE
+    pwsh -NoProfile -File doctor.ps1
+    pwsh -NoProfile -File doctor.ps1 -Fix -VerboseOutput
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Fix,
+    [switch]$VerboseOutput
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Continue'
+
+$script:Mode = if ($Fix) { 'fix' } else { 'check' }
+$script:Verbose = $VerboseOutput.IsPresent
+$script:Issues = 0
+$script:Applied = 0
+$script:ExitCode = 0
+
+function Write-Pass { param([string]$Msg) if ($script:Verbose) { Write-Host "  [ok]   $Msg" } }
+function Write-Warn { param([string]$Msg) Write-Host "  [warn] $Msg" -ForegroundColor Yellow; $script:Issues++ }
+function Write-Fail { param([string]$Msg) Write-Host "  [fail] $Msg" -ForegroundColor Red;    $script:Issues++; $script:ExitCode = 1 }
+function Write-Fix  { param([string]$Msg) Write-Host "  [fix]  $Msg" -ForegroundColor Cyan;   $script:Applied++ }
+function Write-Inf  { param([string]$Msg) Write-Host "  [info] $Msg" }
+
+function Expand-ContractPath {
+    param([string]$Value)
+    # Expand $env:USERPROFILE and ${HOME} style; leave other refs alone
+    $expanded = $Value -replace '\$env:USERPROFILE', $env:USERPROFILE
+    $expanded = $expanded -replace '\$\{USERPROFILE\}', $env:USERPROFILE
+    $expanded
+}
+
+# Locate contract
+$dotfilesDir = if ($env:DOTFILES_DIR) { $env:DOTFILES_DIR } else { Join-Path $env:USERPROFILE '.dotfiles' }
+$candidates = @(
+    (Join-Path $dotfilesDir 'env-contract.json'),
+    (Join-Path $PSScriptRoot '..\env-contract.json')
+)
+$contract = $null
+foreach ($c in $candidates) {
+    if (Test-Path $c) { $contract = (Resolve-Path $c).Path; break }
+}
+if (-not $contract) {
+    Write-Host "doctor: env-contract.json not found (looked in DOTFILES_DIR and repo root)" -ForegroundColor Red
+    exit 2
+}
+
+$data = Get-Content $contract -Raw | ConvertFrom-Json
+
+Write-Host "doctor [$script:Mode] using $contract"
+
+# 1. Env vars
+Write-Host ""
+Write-Host "Environment variables:"
+foreach ($v in $data.env_vars) {
+    # Skip vars scoped to the other OS
+    if ($v.PSObject.Properties.Match('required_on').Count -gt 0 -and $v.required_on -eq 'linux') {
+        Write-Pass "$($v.name) (linux-scoped, skipped on Windows)"
+        continue
+    }
+    $current = [Environment]::GetEnvironmentVariable($v.name)
+    $defaultRaw = if ($v.PSObject.Properties.Match('default').Count -gt 0 -and $v.default -and $v.default.PSObject.Properties.Match('windows').Count -gt 0) { $v.default.windows } else { $null }
+    $isRequired = ($v.PSObject.Properties.Match('required').Count -gt 0 -and $v.required) -or `
+                  ($v.PSObject.Properties.Match('required_on').Count -gt 0 -and $v.required_on -eq 'windows')
+
+    if ([string]::IsNullOrEmpty($current)) {
+        if ($defaultRaw) {
+            $expanded = Expand-ContractPath $defaultRaw
+            if ($script:Mode -eq 'fix') {
+                [Environment]::SetEnvironmentVariable($v.name, $expanded, 'Process')
+                Write-Fix "$($v.name): applied default '$expanded' to current session (add to profile to persist)"
+                $current = $expanded
+            } else {
+                if ($isRequired) {
+                    Write-Warn "$($v.name) unset (required); default available: '$expanded' -- run with -Fix or set in profile"
+                } else {
+                    Write-Warn "$($v.name) unset; default '$expanded' would be applied with -Fix"
+                }
+                $current = $expanded
+            }
+        } else {
+            if ($isRequired) {
+                Write-Fail "$($v.name) unset and no default available (required)"
+                continue
+            } else {
+                Write-Pass "$($v.name) unset (optional, no default)"
+                continue
+            }
+        }
+    }
+    # Validation
+    if ($v.PSObject.Properties.Match('validation').Count -gt 0 -and $v.validation -eq 'path_exists') {
+        if (Test-Path $current -PathType Container) {
+            Write-Pass "$($v.name)=$current (path exists)"
+        } else {
+            Write-Fail "$($v.name)=$current (path does not exist)"
+        }
+    } else {
+        Write-Pass "$($v.name)=$current"
+    }
+}
+
+# 2. PATH entries
+Write-Host ""
+Write-Host "PATH entries:"
+$pathEntries = $env:PATH -split ';'
+foreach ($entry in $data.required_path_entries.windows) {
+    $expanded = Expand-ContractPath $entry
+    if ($pathEntries -contains $expanded) {
+        Write-Pass "$expanded in PATH"
+    } else {
+        Write-Warn "$expanded not in PATH -- check shell profile"
+    }
+}
+
+# 3. Required binaries
+Write-Host ""
+Write-Host "Required binaries:"
+foreach ($b in $data.required_binaries) {
+    if (Get-Command $b.name -ErrorAction SilentlyContinue) {
+        Write-Pass "$($b.name) on PATH"
+    } else {
+        Write-Fail "$($b.name) missing"
+    }
+}
+
+# 4. Optional binaries
+Write-Host ""
+Write-Host "Optional binaries:"
+foreach ($b in $data.optional_binaries) {
+    if (Get-Command $b.name -ErrorAction SilentlyContinue) {
+        Write-Pass "$($b.name) on PATH ($($b.purpose))"
+    } else {
+        Write-Inf "$($b.name) missing -- $($b.purpose)"
+    }
+}
+
+# 5. Fix mode: invoke known heals
+if ($script:Mode -eq 'fix') {
+    Write-Host ""
+    Write-Host "Heal scripts:"
+    $heal = Join-Path $PSScriptRoot 'claude-mem-heal.ps1'
+    if (Test-Path $heal) {
+        $healOut = & pwsh -NoProfile -File $heal 2>&1 | Out-String
+        $healOut = $healOut.Trim()
+        if ($healOut) {
+            Write-Host "  [fix]  claude-mem-heal:" -ForegroundColor Cyan
+            $healOut -split "`n" | ForEach-Object { Write-Host "         $_" }
+            $script:Applied++
+        } else {
+            Write-Pass "claude-mem-heal: nothing to heal"
+        }
+    } else {
+        Write-Inf "claude-mem-heal.ps1 not deployed (skipping)"
+    }
+}
+
+Write-Host ""
+Write-Host "Summary: $script:Issues issue(s), $script:Applied action(s) applied"
+exit $script:ExitCode

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -129,16 +129,33 @@ while IFS= read -r entry; do
     esac
 done < <(jq -r '.required_path_entries.linux[]' "$CONTRACT")
 
-# 3. Required binaries
+# 3. Required binaries (with optional version pinning)
 echo
 echo "Required binaries:"
-while IFS=$'\t' read -r name; do
-    if command -v "$name" >/dev/null 2>&1; then
-        log_pass "$name on PATH"
-    else
+# Same '|' separator rationale as the env_vars loop above: '\t' would
+# collapse empty optional columns (min_version, version_pattern).
+while IFS='|' read -r name min_version version_pattern; do
+    if ! command -v "$name" >/dev/null 2>&1; then
         log_fail "$name missing"
+        continue
     fi
-done < <(jq -r '.required_binaries[] | .name' "$CONTRACT")
+    if [ -z "$min_version" ]; then
+        log_pass "$name on PATH"
+        continue
+    fi
+    # Version check: run `<name> --version`, apply pattern, compare with sort -V.
+    raw=$("$name" --version 2>&1 | head -1)
+    if [[ "$raw" =~ $version_pattern ]]; then
+        actual="${BASH_REMATCH[1]}"
+        if [ "$(printf '%s\n%s\n' "$min_version" "$actual" | sort -V | head -1)" = "$min_version" ]; then
+            log_pass "$name $actual (>= $min_version)"
+        else
+            log_fail "$name $actual is older than minimum $min_version"
+        fi
+    else
+        log_warn "$name on PATH but version unparseable: '$raw' (pattern: $version_pattern)"
+    fi
+done < <(jq -r '.required_binaries[] | [.name, (.min_version // ""), (.version_pattern // "")] | join("|")' "$CONTRACT")
 
 # 4. Optional binaries
 echo

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# doctor.sh: verify structural env vars, PATH entries and binaries against
+# env-contract.json. Optionally apply safe defaults and invoke known heals.
+#
+# Usage:
+#   doctor.sh             # --check mode (default): report drift, exit 1 if required missing
+#   doctor.sh --check     # same as default
+#   doctor.sh --fix       # apply defaults to current session, run heals; exit 0 if recoverable
+#   doctor.sh --verbose   # show every check (combinable with --check / --fix)
+#
+# Resolves the contract from $DOTFILES_DIR/env-contract.json, falling back
+# to the repo root next to this script. Mirrors scripts/doctor.ps1.
+
+set -euo pipefail
+
+MODE="check"
+VERBOSE=0
+EXIT_CODE=0
+ISSUES=0
+APPLIED=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --check)   MODE="check" ;;
+        --fix)     MODE="fix" ;;
+        --verbose) VERBOSE=1 ;;
+        -h|--help)
+            sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "doctor: unknown arg: $arg" >&2; exit 2 ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+CONTRACT=""
+for candidate in \
+    "${DOTFILES_DIR:-$HOME/.dotfiles}/env-contract.json" \
+    "$SCRIPT_DIR/../env-contract.json"
+do
+    if [ -f "$candidate" ]; then
+        CONTRACT="$candidate"
+        break
+    fi
+done
+
+if [ -z "$CONTRACT" ]; then
+    echo "doctor: env-contract.json not found (looked in DOTFILES_DIR and repo root)" >&2
+    exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "doctor: jq not found on PATH (required to parse env-contract.json)" >&2
+    exit 2
+fi
+
+# Helpers
+log_pass() { [ "$VERBOSE" -eq 1 ] && printf '  [ok]   %s\n' "$1"; return 0; }
+log_warn() { printf '  [warn] %s\n' "$1"; ISSUES=$((ISSUES + 1)); }
+log_fail() { printf '  [fail] %s\n' "$1"; ISSUES=$((ISSUES + 1)); EXIT_CODE=1; }
+log_fix()  { printf '  [fix]  %s\n' "$1"; APPLIED=$((APPLIED + 1)); }
+log_info() { printf '  [info] %s\n' "$1"; }
+
+expand_path() {
+    # Expand $HOME and ${HOME} in a string; leave other vars alone.
+    printf '%s' "${1//\$HOME/$HOME}" | sed 's|${HOME}|'"$HOME"'|g'
+}
+
+echo "doctor [$MODE] using $CONTRACT"
+
+# 1. Env vars
+echo
+echo "Environment variables:"
+# Use '|' as field separator: bash collapses consecutive whitespace IFS
+# characters (including tab) even when set explicitly, which would erase
+# the empty `required_on` column. '|' is non-whitespace, so empty fields
+# are preserved by `read`.
+while IFS='|' read -r name required required_on default validation; do
+    # Skip vars scoped to the other OS
+    if [ "$required_on" = "windows" ]; then
+        log_pass "$name (windows-scoped, skipped on Linux)"
+        continue
+    fi
+    current="${!name:-}"
+    if [ -z "$current" ]; then
+        if [ "$default" != "null" ] && [ -n "$default" ]; then
+            expanded=$(expand_path "$default")
+            if [ "$MODE" = "fix" ]; then
+                export "$name=$expanded"
+                log_fix "$name: applied default '$expanded' to current session (add to profile to persist)"
+            else
+                if [ "$required" = "true" ] || [ "$required_on" = "linux" ]; then
+                    log_warn "$name unset (required); default available: '$expanded' -- run with --fix or set in profile"
+                else
+                    log_warn "$name unset; default '$expanded' would be applied with --fix"
+                fi
+            fi
+            current="$expanded"
+        else
+            if [ "$required" = "true" ] || [ "$required_on" = "linux" ]; then
+                log_fail "$name unset and no default available (required)"
+                continue
+            else
+                log_pass "$name unset (optional, no default)"
+                continue
+            fi
+        fi
+    fi
+    # Validation
+    if [ "$validation" = "path_exists" ]; then
+        if [ -d "$current" ]; then
+            log_pass "$name=$current (path exists)"
+        else
+            log_fail "$name=$current (path does not exist)"
+        fi
+    else
+        log_pass "$name=$current"
+    fi
+done < <(jq -r '.env_vars[] | [.name, (.required // false), (.required_on // ""), (.default.linux // "null"), (.validation // "")] | join("|")' "$CONTRACT")
+
+# 2. PATH entries
+echo
+echo "PATH entries:"
+while IFS= read -r entry; do
+    expanded=$(expand_path "$entry")
+    case ":$PATH:" in
+        *":$expanded:"*) log_pass "$expanded in PATH" ;;
+        *) log_warn "$expanded not in PATH -- check shell profile" ;;
+    esac
+done < <(jq -r '.required_path_entries.linux[]' "$CONTRACT")
+
+# 3. Required binaries
+echo
+echo "Required binaries:"
+while IFS=$'\t' read -r name; do
+    if command -v "$name" >/dev/null 2>&1; then
+        log_pass "$name on PATH"
+    else
+        log_fail "$name missing"
+    fi
+done < <(jq -r '.required_binaries[] | .name' "$CONTRACT")
+
+# 4. Optional binaries
+echo
+echo "Optional binaries:"
+while IFS=$'\t' read -r name purpose; do
+    if command -v "$name" >/dev/null 2>&1; then
+        log_pass "$name on PATH ($purpose)"
+    else
+        log_info "$name missing -- $purpose"
+    fi
+done < <(jq -r '.optional_binaries[] | [.name, .purpose] | @tsv' "$CONTRACT")
+
+# 5. --fix mode: invoke known heals
+if [ "$MODE" = "fix" ]; then
+    echo
+    echo "Heal scripts:"
+    HEAL="$SCRIPT_DIR/claude-mem-heal.sh"
+    if [ -x "$HEAL" ]; then
+        if heal_out=$(bash "$HEAL" 2>&1) && [ -n "$heal_out" ]; then
+            printf '  [fix]  claude-mem-heal:\n%s\n' "$heal_out" | sed 's/^/         /'
+            APPLIED=$((APPLIED + 1))
+        else
+            log_pass "claude-mem-heal: nothing to heal"
+        fi
+    else
+        log_info "claude-mem-heal.sh not deployed (skipping)"
+    fi
+fi
+
+echo
+echo "Summary: $ISSUES issue(s), $APPLIED action(s) applied"
+exit $EXIT_CODE

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -652,6 +652,25 @@ file_exists "$HOME/.bash/bash_aliases" && log_success "bash_aliases created" || 
 
 # Check dependencies
 check_dependencies "git" "zsh" "eza" "direnv" "node" "npm" "zoxide" "docker" "docker-compose" "kubectl" "helm" "terraform" "ansible" "pip"
+
+# Deploy env-contract.json so doctor.sh can find it under $DOTFILES_DIR.
+if [ -f "$CURRENT_DIR/env-contract.json" ]; then
+    cp -f "$CURRENT_DIR/env-contract.json" "$DOTFILES_DIR/env-contract.json"
+    log_success "Deployed env-contract.json to $DOTFILES_DIR/"
+fi
+
+# Final assertion against env-contract.json -- catches drift between what
+# setup just deployed and what's actually in place / on PATH / in env vars.
+DOCTOR_SCRIPT="$DOTFILES_DIR/scripts/doctor.sh"
+if [ -x "$DOCTOR_SCRIPT" ] && command -v jq >/dev/null 2>&1; then
+    log_info "Running post-setup doctor check..."
+    echo
+    bash "$DOCTOR_SCRIPT" || log_warning "doctor reported one or more required items missing -- review output above"
+    echo
+elif [ -f "$DOCTOR_SCRIPT" ]; then
+    log_warning "doctor.sh present but not executable or jq missing, skipping post-setup check"
+fi
+
 log_info "To apply changes immediately, run:"
 log_info "  - For Bash: source ~/.bashrc"
 log_info "  - For Zsh:  source ~/.zshrc"

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -661,6 +661,22 @@ if (Test-Path $memHealSource) {
     Write-Warn "claude-mem-heal.ps1 not found at $memHealSource"
 }
 
+$doctorSource = "$DotfilesDir\scripts\doctor.ps1"
+if (Test-Path $doctorSource) {
+    Copy-Item $doctorSource "$ScriptsDir\" -Force
+    Write-Success "Deployed doctor.ps1 to $ScriptsDir\"
+} else {
+    Write-Warn "doctor.ps1 not found at $doctorSource"
+}
+
+$contractSource = "$DotfilesDir\env-contract.json"
+if (Test-Path $contractSource) {
+    Copy-Item $contractSource "$DotfilesDest\" -Force
+    Write-Success "Deployed env-contract.json to $DotfilesDest\"
+} else {
+    Write-Warn "env-contract.json not found at $contractSource"
+}
+
 $syncSource = "$DotfilesDir\scripts\dotfiles-sync.ps1"
 if (Test-Path $syncSource) {
     Copy-Item $syncSource "$ScriptsDir\" -Force
@@ -835,6 +851,26 @@ if ($existingTask -and ($existingTaskArgument -eq $expectedTaskArgument)) {
     } catch {
         Write-Warn "Could not register scheduled task (may need admin): $_"
     }
+}
+
+# ============================================================================
+# 8c. POST-SETUP DOCTOR
+# ============================================================================
+# Final assertion against env-contract.json -- catches drift between what
+# setup just deployed and what's actually in place / on PATH / in env vars.
+
+$doctorScript = "$ScriptsDir\doctor.ps1"
+if (Test-Path $doctorScript) {
+    Write-Info "Running post-setup doctor check..."
+    Write-Host ""
+    & pwsh -NoProfile -File $doctorScript
+    $doctorExit = $LASTEXITCODE
+    Write-Host ""
+    if ($doctorExit -ne 0) {
+        Write-Warn "doctor reported one or more required items missing (exit $doctorExit) -- review output above"
+    }
+} else {
+    Write-Warn "doctor.ps1 not deployed at $doctorScript, skipping post-setup check"
 }
 
 # ============================================================================

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -210,3 +210,23 @@ setup() {
     grep -q 'doctor\.sh' "$DOTFILES_DIR/setup-linux.sh"
     grep -q 'doctor\.ps1' "$DOTFILES_DIR/setup-windows.ps1"
 }
+
+# SessionStart hooks must run a silent doctor and surface only drift.
+@test "parity: both SessionStart hooks invoke silent doctor" {
+    grep -q 'doctor\.sh' "$DOTFILES_DIR/scripts/claude-session-start.sh"
+    grep -q 'doctor\.ps1' "$DOTFILES_DIR/scripts/claude-session-start.ps1"
+}
+
+# Required binaries in the contract must include min_version pins.
+@test "env-contract.json pins min_version for required binaries" {
+    if command -v jq >/dev/null 2>&1; then
+        run jq -e '.required_binaries | all(has("min_version"))' "$DOTFILES_DIR/env-contract.json"
+        [ "$status" -eq 0 ]
+    fi
+}
+
+# Both doctors must implement the binary version-check logic.
+@test "parity: both doctors check binary versions against min_version" {
+    grep -q 'min_version' "$DOTFILES_DIR/scripts/doctor.sh"
+    grep -q 'min_version' "$DOTFILES_DIR/scripts/doctor.ps1"
+}

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -170,3 +170,43 @@ setup() {
     grep -q 'claude-mem-heal\.sh' "$DOTFILES_DIR/scripts/claude-session-start.sh"
     grep -q 'claude-mem-heal\.ps1' "$DOTFILES_DIR/scripts/claude-session-start.ps1"
 }
+
+# --- doctor + env-contract.json (cross-OS parity) ---
+
+@test "env-contract.json exists and is valid JSON with required sections" {
+    [ -f "$DOTFILES_DIR/env-contract.json" ]
+    if command -v jq >/dev/null 2>&1; then
+        run jq -e '.env_vars | length > 0' "$DOTFILES_DIR/env-contract.json"
+        [ "$status" -eq 0 ]
+        run jq -e '.required_path_entries.linux | length > 0' "$DOTFILES_DIR/env-contract.json"
+        [ "$status" -eq 0 ]
+        run jq -e '.required_path_entries.windows | length > 0' "$DOTFILES_DIR/env-contract.json"
+        [ "$status" -eq 0 ]
+        run jq -e '.required_binaries | length > 0' "$DOTFILES_DIR/env-contract.json"
+        [ "$status" -eq 0 ]
+    fi
+}
+
+@test "doctor.sh and doctor.ps1 both exist (cross-OS parity)" {
+    [ -f "$DOTFILES_DIR/scripts/doctor.sh" ]
+    [ -f "$DOTFILES_DIR/scripts/doctor.ps1" ]
+}
+
+@test "doctor.sh has valid bash syntax" {
+    bash -n "$DOTFILES_DIR/scripts/doctor.sh"
+}
+
+@test "doctor.sh supports --check and --fix modes" {
+    grep -q -- '--check' "$DOTFILES_DIR/scripts/doctor.sh"
+    grep -q -- '--fix' "$DOTFILES_DIR/scripts/doctor.sh"
+}
+
+@test "doctor.ps1 supports -Fix switch" {
+    grep -q '\[switch\]\$Fix' "$DOTFILES_DIR/scripts/doctor.ps1"
+}
+
+# Setup scripts must invoke the doctor before printing 'Setup Complete'.
+@test "parity: both setup scripts invoke doctor post-setup" {
+    grep -q 'doctor\.sh' "$DOTFILES_DIR/setup-linux.sh"
+    grep -q 'doctor\.ps1' "$DOTFILES_DIR/setup-windows.ps1"
+}


### PR DESCRIPTION
## Summary

Introduces a single source of truth for the structural invariants the dotfiles install expects, plus a cross-OS `doctor` that verifies (and optionally applies) them. Closes the *"every chequeo está en su silo"* gap surfaced after #23.

Until now, the repo verified state in three disconnected places: `versions.conf` (version pins only), `scripts/healthcheck.sh` (Linux-only, no env var coverage), `tests/verify-setup.bats` (Docker-only, doesn't run against live installs). Drift between expected and actual environment had no central detector — exactly the class that caused #20, #22, and the zod bug in #23.

## What ships

1. **`env-contract.json`** (repo root): declarative spec —
   - `env_vars[]`: name + required/required_on + per-OS default + validation rule
   - `required_path_entries.{linux,windows}`: must-be-on-$PATH entries
   - `required_binaries` / `optional_binaries` with purpose strings
2. **`scripts/doctor.sh`**: bash implementation. `--check` (default) reports drift, exits 1 on missing required. `--fix` applies defaults to the current session and invokes `claude-mem-heal.sh`. `--verbose` shows every check.
3. **`scripts/doctor.ps1`**: PowerShell mirror. Same modes (`-Fix`, `-VerboseOutput`), same exit semantics.
4. **Setup integration**: both setup scripts deploy the contract + run `doctor` before printing "Setup Complete". Warns loudly on non-zero exit, doesn't abort (setup's work is done; doctor surfaces residual drift).

## Design notes

- **Non-whitespace TSV separator** (`|`) in the bash side: bash collapses consecutive whitespace IFS characters even when set explicitly. With `IFS=$'\t'` and an empty `required_on` column, two tabs would collapse and shift every subsequent field by one. `|` is non-whitespace and preserves empty fields. Documented inline.
- **`-Fix` is conservative**: applies defaults to the *current session only*, with a hint telling the user to add to their profile to persist. Never edits `$PROFILE` / `.zshrc` automatically. Invokes existing heal scripts (`claude-mem-heal.{sh,ps1}`) rather than re-implementing.
- **Validation is intentionally lightweight** for v1: `path_exists` only. Regex / version checks are deferred to a follow-up if/when needed.

## Verification

\`\`\`
$ pwsh -NoProfile -File scripts/doctor.ps1 -VerboseOutput
doctor [check] using ...\env-contract.json
Environment variables:
  [warn] DOTFILES_DIR unset (required); default '...\.dotfiles' -- run with -Fix or set in profile
  [ok]   DOTFILES_DIR=...\.dotfiles (path exists)
  ... (etc)
PATH entries:
  [ok]   ...\scripts in PATH
  [ok]   ...\.local\bin in PATH
Required binaries:
  [ok]   git on PATH
  [ok]   jq on PATH
Summary: 2 issue(s), 0 action(s) applied
\`\`\`

\`\`\`
$ pwsh -NoProfile -File scripts/doctor.ps1 -Fix
  [fix]  DOTFILES_DIR: applied default '...' to current session (add to profile to persist)
  [fix]  CLAUDE_CONFIG_DIR: applied default '...' to current session (add to profile to persist)
Summary: 0 issue(s), 2 action(s) applied
\`\`\`

Same shape on Linux side (`bash scripts/doctor.sh --verbose`).

## Test plan

- [x] PSScriptAnalyzer clean on `setup-windows.ps1` and `doctor.ps1`.
- [x] `shellcheck --severity=error` clean on `setup-linux.sh` and `doctor.sh`.
- [x] `bash -n` and `zsh -n` clean.
- [x] Both bats suites: 6 new doctor-related tests pass (env-contract JSON validity, cross-OS doctor presence, --check/--fix flags, setup scripts invoke doctor).
- [x] End-to-end on this machine: `-Fix` mode applies both defaults and exits clean.
- [ ] CI: lint + lint-powershell + test + integration.

## PR size disclosure

~508 lines diff, above the usual ~300 atomic target. `doctor.sh` and `doctor.ps1` are parallel ports of new functionality and cannot be split without temporarily breaking cross-OS parity in main. The conceptual scope is one cohesive feature; the line count reflects the dual-OS implementation.

## Out of scope (deliberate)

- SessionStart hook does **not** auto-run `doctor` — third trigger option from the scoping discussion was rejected to avoid lengthening session start. On-demand + post-setup are sufficient for v1.
- Tooling-bound env vars (`OPENROUTER_API_KEY`, `GH_TOKEN`, etc.) are not yet in the contract — those live under `sensitive/env-mapping.conf` and have their own (secrets-based) deploy path. Bringing them into the contract is a separate PR.
- Version pins (`versions.conf`) are not yet referenced by doctor's binary check — v1 only checks presence, not minimum version. Deferred.