### PR TITLE
refactor(claude-md): replace duplicated standards with vault pointers

### DIFF
--- a/ai/claude/CLAUDE.md
+++ b/ai/claude/CLAUDE.md
@@ -75,93 +75,11 @@ Senior Principal Software Architect & Technical Mentor. 20+ years production exp
 
 ## Technical Standards
 
-### Python (3.12+)
-
-| Requirement | Tool/Pattern |
-|-------------|--------------|
-| Type hints | `mypy --strict` |
-| Data models | Pydantic v2 |
-| Dependencies| Poetry or uv |
-| Formatting | Ruff |
-| Testing | pytest + pytest-cov |
-| CLI | Typer + Rich |
-| Async HTTP | httpx (not requests) |
-
-### Go (1.26+)
-
-| Requirement | Pattern |
-|-------------|---------|
-| Error handling| `if err != nil` with context wrapping |
-| Context | Propagate `context.Context` in all I/O |
-| Testing | Table-driven tests with `t.Run` |
-| Generics | Prefer over `interface{}` |
-| HTTP | stdlib `net/http` or Chi |
-
-### TypeScript (ESNext)
-
-| Requirement | Pattern |
-|-------------|---------|
-| Strict mode | `strict: true` in tsconfig |
-| Runtime validation| Zod |
-| Async | `async/await` exclusively |
-| Variables | `const` default, no `var`, no `==` |
-
-### Java (21+ LTS)
-
-| Requirement | Pattern |
-|-------------|---------|
-| Version | JDK 21+ (LTS) strict |
-| Build Tool | Gradle (Kotlin DSL) or Maven |
-| Null Safety | `Optional<T>`, never return `null` |
-| Concurrency | Virtual Threads (Project Loom) |
-| Testing | JUnit 5 + AssertJ + Mockito |
-| Style | Google Java Format / Spotless |
-| Records | Use `record` for DTOs |
-
-### Astro (Frontend)
-
-| Requirement | Pattern |
-|-------------|---------|
-| Architecture| Islands Architecture (Zero JS default) |
-| Interactivity| `client:visible` or `client:idle` |
-| Components | `.astro` preferred over React/Vue |
-| Content | Content Collections + Zod |
-| State | Nano Stores |
-
-### Matlab (Scientific)
-
-| Requirement | Pattern |
-|-------------|---------|
-| Performance | Vectorization over Loops (Strict) |
-| Linting | `checkcode` / MLint clean |
-| Variables | `camelCase`, descriptive names |
-| Output | Always suppress with `;` |
-| Testing | MATLAB Unit Test Framework |
+When writing or reviewing code, query `00_meta/patterns/language-standards.md` for the per-language toolchain and conventions (Python 3.12+, Go 1.26+, TypeScript ESNext, Java 21+, Astro, Matlab).
 
 ## Architecture Patterns
 
-### Microservices (Go/Rust)
-
-```text
-/cmd           # Entry points (main.go)
-/internal      # Private packages
-/pkg           # Public libraries
-/api           # OpenAPI/gRPC specs
-/deployments   # K8s manifests, Helm charts
-
-```
-
-### Monolith (Python/Node)
-
-```text
-/src
-  /domain      # Pure business logic (no I/O)
-  /application # Use cases, orchestration
-  /infra       # DB, external APIs, adapters
-  /api         # HTTP handlers, routes
-/tests         # Mirror src structure
-
-```
+When scaffolding a new project or reviewing service layout, query `00_meta/patterns/architecture.md` for canonical directory structures (microservices Go/Rust, monolith Python/Node).
 
 ## Security (Immediate Flags)
 


### PR DESCRIPTION
## Summary

- Replace `## Technical Standards` (Python/Go/TS/Java/Astro/Matlab tables) — byte-for-byte duplicate of `00_meta/patterns/language-standards.md` in vault — with a one-line pointer-trigger.
- Replace `## Architecture Patterns` (microservices/monolith directory trees) — byte-for-byte duplicate of `00_meta/patterns/architecture.md` in vault — with a one-line pointer-trigger.

Net: **+2 / -84 lines**. Pattern Catalog index in CLAUDE.md still surfaces both patterns for discovery (Standing Order #5: "Consult patterns before architectural decisions").

## Why

The two sections violated **Standing Order #2** (`Code lives in git. Knowledge lives in the vault. Never duplicate across both.`). Beyond the SSOT issue, they were eager-loaded into every Claude session despite being relevant to <10% of sessions (only when actually writing/reviewing code in one of those languages, or scaffolding a new service). Recovers ~700 tokens per session in the common case.

The new pointers tell Claude **WHEN** to consult each pattern, not just where it lives — preventing the trigger-content gap risk:

```markdown
## Technical Standards

When writing or reviewing code, query \`00_meta/patterns/language-standards.md\` for the per-language toolchain and conventions (Python 3.12+, Go 1.26+, TypeScript ESNext, Java 21+, Astro, Matlab).
```

## Context

Part of vault task **SDD-014a** (placement audit of dotfiles `CLAUDE.md` → vault patterns), PR-2 of 4 sequential atomic PRs:

- **PR-1** (vault, already merged as commit `2026c05`): created 3 new MCP usage patterns + index updates.
- **PR-2** (this PR): delete pure duplicates from CLAUDE.md, replace with pointers.
- PR-3 (next): trim Neural Hive Protocol Phase 1/2/3 + Vault Structure & Standards (already covered by `workflow-protocol.md` + `ai-protocol.md`).
- PR-4 (last): compact the 5 MCP Server Usage Rules subsections to 4 bullets each + link to the dedicated patterns.

Total expected reduction across the 4 PRs: ~50% (391 → ~190 lines in CLAUDE.md).

## Test plan

- [x] `setup-linux.sh` runs cleanly and deploys updated `~/.claude/CLAUDE.md`
- [x] Open a fresh Claude Code session — verify no parsing errors / no missing-section warnings
- [x] Ask Claude a Python question — verify it triggers a vault query for `language-standards.md` (or applies the standards from memory; either is acceptable)
- [x] `vault_query(project="_meta", path="patterns/language-standards.md")` returns the canonical content
- [x] `vault_query(project="_meta", path="patterns/architecture.md")` returns the canonical content