### PR TITLE
refactor(claude-md): compact MCP Server Usage Rules to bullets + links

### DIFF
--- a/ai/claude/CLAUDE.md
+++ b/ai/claude/CLAUDE.md
@@ -160,72 +160,52 @@ When creating or placing a vault file, query `00_meta/patterns/workflow-protocol
 
 ### Context7 (Library Documentation)
 
-**Auto-invoke when:** Writing or debugging code that uses third-party libraries/frameworks.
+**When:** Writing or debugging code with third-party libraries/frameworks (even well-known ones — training data may be stale).
 
-* Use `resolve-library-id` first to get the Context7 ID, then `query` for docs.
-* Always specify the library version in prompts (e.g., "Next.js 14", "Go 1.26").
-* Prefer Context7 over WebSearch for API/library documentation — it returns version-accurate, hallucination-free results.
-* Skip for stdlib or well-known patterns already in this CLAUDE.md.
+* `resolve-library-id` first → then `query-docs` with the resolved ID.
+* Always specify the library version in the prompt.
+
+For tool flow detail, anti-patterns and pairing rules, query `00_meta/patterns/pattern-mcp-context7.md`.
 
 ### Sequential Thinking (Complex Reasoning)
 
-**Auto-invoke when:** The Socratic Guardrail triggers (High Cognitive Load tasks).
+**When:** The Socratic Guardrail triggers (architectural decisions, multi-step debugging, schema design, concurrency, trade-off analysis).
 
-* Use for: architectural decisions, multi-step debugging, schema design, concurrency reasoning, trade-off analysis.
-* Structure as: describe problem → generate hypotheses → verify each → branch alternatives → commit to best option.
-* Do NOT use for: boilerplate, single-file edits, syntax fixes, CSS changes.
-* Pairs well with Context7: use Sequential Thinking to plan, Context7 to validate API choices.
+* Structure as: problem → hypotheses → verify → branch → commit.
+* Skip for boilerplate, single-file edits, syntax fixes, CSS.
+
+For full reasoning structure and pairing with Context7, query `00_meta/patterns/pattern-mcp-sequential-thinking.md`.
 
 ### Hive (Obsidian Vault Operations)
 
-**Auto-invoke for any read/search/write against the vault.** Hive saves tokens
-by returning excerpts (not full files) and offloading work server-side.
+**When:** Any read/search/write against the vault. Hive returns excerpts (5–10× cheaper than `grep`+`Read`) and auto-commits writes as `vault: patch …`.
 
-* `vault_search` over `grep`+`Read` (5–10× cheaper, returns excerpts).
-* `vault_query(section=context|tasks|lessons|roadmap)` over `Read` of whole files.
-* `vault_patch` / `vault_write` over `Edit`/`Write` — auto-commits as `vault: patch …`.
+* `vault_search` over `grep`+`Read`; `vault_query` over `Read` of whole files.
+* `vault_patch` / `vault_write` over `Edit`/`Write` — do NOT also create a manual git commit (Hive already committed).
 * `capture_lesson` over manual `90-lessons.md` writes.
-* `vault_health` over Bash + `vault-validate.py`.
-* `delegate_task` for bulk summaries — keeps main context lean.
-* `vault_list` before `ls`/`find` to browse structure.
+* Native `Read`/`Edit`/`Write`/`grep` remain correct for code repos and configs outside the vault.
 
-Native `Read`/`Edit`/`Write`/`grep` remain correct for code repos, scripts,
-configs — anything outside the vault. Vault auto-commits are intentional;
-do NOT also create a manual git commit for vault edits.
-
-See `00_meta/patterns/pattern-hive-first-vault-access.md` for full rationale.
+For the full tool list and edge cases, query `00_meta/patterns/pattern-hive-first-vault-access.md`.
 
 ### claude-mem (Conversation Memory & Cross-Session Recall)
 
-**Active by default in every session, every project, every machine.** Captures observations automatically via session hooks — no explicit writes needed during routine work. claude-mem stores conversation flow; the vault stores crystallized knowledge. They are complementary, not interchangeable.
+**Active by default in every session.** Captures observations automatically via session hooks — conversation flow → claude-mem, crystallized knowledge → vault. Never duplicate across both.
 
-* `/mem-search "query"` — find solutions/decisions from past sessions ("did we solve this before?").
-* `/timeline-report` — narrative history of a project from accumulated observations.
-* `/knowledge-agent` — build a topic-focused brain from observations.
-* `/how-it-works` — explain what claude-mem is doing if asked.
+* `/mem-search "query"` — find solutions from past sessions.
+* `/timeline-report`, `/knowledge-agent`, `/how-it-works` — narrative history, topic brains, self-explanation.
+* **Do NOT** write strategic decisions, lessons or ADRs to claude-mem — those go to vault via `capture_lesson` / `vault_write`.
+* Default `worker` runtime blocks manual writes (`observation_add`, `memory_add`); hook capture works regardless. Set `CLAUDE_MEM_RUNTIME=server-beta` in `~/.claude/settings.json` to enable manual writes.
 
-**Do NOT write strategic decisions, lessons, or ADRs to claude-mem.** Those go to vault via `capture_lesson` / `vault_write`. See `pattern-decision-persistence.md` — claude-mem is a conversation log, not a source of truth.
-
-**Default protocol:** BOTH claude-mem AND vault active simultaneously. claude-mem records as you work; vault gets explicit writes for crystallization. See `00_meta/patterns/pattern-dual-memory.md` for full rationale.
-
-**Runtime note:** In Claude Code's default `worker` runtime, manual writes (`observation_add`, `memory_add`) are blocked. Automatic hook capture works regardless — observations from each session appear in the next session start. Slash commands above are read-only and always available. To enable manual writes in parallel to vault, set `CLAUDE_MEM_RUNTIME=server-beta` in `~/.claude/settings.json` (affects all projects). Default worker mode is sufficient for the dual-memory protocol.
+For the full dual-memory protocol, query `00_meta/patterns/pattern-dual-memory.md`.
 
 ### Obsidian CLI (Vault Graph Queries)
 
-**Available via:** `obs-cli.sh <command>` (Linux) / `obs-cli.ps1 <command>` (Windows).
-Requires Obsidian GUI running. Falls back with exit 2 if GUI is down.
-Set `OBS_VAULT` env var to override default vault (default: `knowledge`).
+**When:** Graph queries Hive cannot answer (orphans, backlinks, dead-ends, unresolved links, bulk tag rename).
 
-**Unique commands (not covered by Hive MCP):**
-* `backlinks file="path/to/note.md"` — notes linking to a given file
-* `orphans` — files with no incoming links
-* `dead-ends` — files with no outgoing links
-* `unresolved` — broken wikilinks
-* `tags` / `tags:rename old=X new=Y` — list or bulk-rename tags
-* `eval "expression"` — execute JS against Obsidian internal API
+* `obs-cli.sh <cmd>` (Linux) / `obs-cli.ps1 <cmd>` (Windows). Requires Obsidian GUI; exits 2 if GUI down.
+* For file CRUD or text search, use Hive instead (headless, always available).
 
-**When to use:** Vault maintenance, graph analysis, bulk tag operations.
-**When NOT to use:** File CRUD and search — use Hive MCP instead (headless, always available).
+For the full command list and `vault-health.sh` integration, query `00_meta/patterns/pattern-obsidian-cli.md`.
 
 ## Response Protocol
 


### PR DESCRIPTION
## Summary

Compact the **5 MCP Server Usage Rules** subsections from 8-15 lines of detail each to **1-line trigger + 2-4 critical bullets + pointer-trigger** to dedicated vault patterns:

| Server | Dedicated pattern | Status |
|---|---|---|
| Context7 | `pattern-mcp-context7.md` | Created in PR-1 (vault `2026c05`) |
| Sequential Thinking | `pattern-mcp-sequential-thinking.md` | Created in PR-1 |
| Hive | `pattern-hive-first-vault-access.md` | Pre-existing |
| claude-mem | `pattern-dual-memory.md` | Pre-existing |
| Obsidian CLI | `pattern-obsidian-cli.md` | Created in PR-1 |

Net: **+25 / -45 lines**.

## What stays eager (and why)

The bullets that remain in CLAUDE.md are the ones that affect **tool-call decisions in real time** — Claude must apply them moment-to-moment without time to fetch a pattern first:

- `vault_search` over `grep`+`Read` (cost-per-call discipline)
- Do NOT also create a manual git commit after a Hive write (double-commit risk)
- Worker runtime blocks manual claude-mem writes (failure mode)
- Native `Read`/`Edit` is correct for code repos outside the vault (fallback rule)
- `obs-cli.sh` requires GUI, exits 2 if down (failure mode)

Everything else (full tool tables, anti-pattern catalogs, pairing rules) is on-demand.

## Stacking

This PR is **stacked on #28** (PR-3, base branch `refactor/claude-md-trim-loop-vault-structure`). Merge order: #27 → #28 → this PR.

## Cumulative impact across PR-2/3/4

| | Before | After | Δ |
|---|---|---|---|
| `ai/claude/CLAUDE.md` | 391 lines | **249 lines** | -36% |
| Tokens eager-loaded per session | ~5500 | ~3500 | ~-2000 tok / session |

## Context

Final PR of vault task **SDD-014a** placement audit:

- ✅ PR-1 (vault, commit `2026c05`): 3 new MCP usage patterns + index updates.
- ✅ PR-2 (#27): delete byte-for-byte duplicates (Technical Standards + Architecture Patterns).
- ✅ PR-3 (#28): trim Neural Hive Loop phases + Vault Structure.
- 🟡 **PR-4 (this PR):** compact 5 MCP Server Usage subsections.

Once all 4 PRs merge, SDD-014a closes and SDD-014b (Socratic rewrites of 4 generative skills: writing-plans, audit, crystallize, prd-to-issues) becomes unblocked.

## Test plan

- [x] After #28 merges, rebase this branch on main and verify clean diff
- [ ] `setup-linux.sh` deploys updated `~/.claude/CLAUDE.md` cleanly
- [ ] Open a fresh Claude Code session and run `/mem-search "test"` — verify the slash command still works
- [ ] Ask Claude to update a vault file — verify it uses `vault_patch` (Hive) instead of `Edit` (no eager-rule regression)
- [ ] Run `vault_query(project="_meta", path="patterns/pattern-mcp-context7.md")` — verify the pattern is reachable