### PR TITLE
refactor(claude-md): add Hive failure-mode fallback rule

### DIFF
--- a/ai/claude/CLAUDE.md
+++ b/ai/claude/CLAUDE.md
@@ -184,8 +184,9 @@ For full reasoning structure and pairing with Context7, query `00_meta/patterns/
 * `vault_patch` / `vault_write` over `Edit`/`Write` — do NOT also create a manual git commit (Hive already committed).
 * `capture_lesson` over manual `90-lessons.md` writes.
 * Native `Read`/`Edit`/`Write`/`grep` remain correct for code repos and configs outside the vault.
+* **If Hive hangs or exceeds ~10-20s (queries) / ~30s (writes):** abandon the call and fall back to native `Read`/`Edit`/`Write`/`grep` against the vault path. Use manual `git add` + `git commit -m "vault: …"` in fallback mode. Do NOT retry Hive in the same session — the server may be wedged.
 
-For the full tool list and edge cases, query `00_meta/patterns/pattern-hive-first-vault-access.md`.
+For the full tool list, edge cases, and failure-mode protocol, query `00_meta/patterns/pattern-hive-first-vault-access.md`.
 
 ### claude-mem (Conversation Memory & Cross-Session Recall)
 


### PR DESCRIPTION
## Summary

Add an eager-loaded fallback rule to the Hive (Obsidian Vault Operations) subsection in the global CLAUDE.md:

> **If Hive hangs or exceeds ~10-20s (queries) / ~30s (writes):** abandon the call and fall back to native \`Read\`/\`Edit\`/\`Write\`/\`grep\` against the vault path. Use manual \`git add\` + \`git commit -m \"vault: …\"\` in fallback mode. Do NOT retry Hive in the same session — the server may be wedged.

## Why

User feedback (2026-05-15): the session must never block indefinitely waiting for Hive. Hive-first is the default, not a mandate — when it's slow, the work must continue via filesystem. This rule needs to be **eager-loaded** because Claude can't fetch the pattern from the vault if the vault is precisely what's hanging.

## Three coordinated changes

| Layer | Where | Status |
|---|---|---|
| Auto-memory (per-session) | \`~/.claude/projects/-home-manu-Projects-knowledge/memory/feedback_hive_first.md\` | ✅ Vault commit \`4f85cec\` |
| Canonical pattern (all agents) | \`00_meta/patterns/pattern-hive-first-vault-access.md\` (new "Failure mode and fallback" section) | ✅ Vault commit \`8c20416\` |
| **Eager rule (Claude Code, every session)** | \`ai/claude/CLAUDE.md\` Hive subsection | 🟡 **This PR** |

## Stacking

Stacked on **#30** (the cascade PR for PR-3 + PR-4). Once #30 merges to main, this PR's diff vs main will collapse to **+6 / -2** lines.

## Test plan

- [ ] After #30 merges, rebase this branch to main; verify diff is just the Hive fallback bullet
- [ ] Open a fresh Claude Code session, intentionally cause a Hive call to hang (e.g., disable hive MCP), confirm Claude falls back to native \`Read\` instead of blocking
- [ ] Vault patterns reachable via \`vault_query\` once Hive is back online (no breakage)