### PR TITLE
fix(setup): stop deleting vault content via symlink follow in skill sync

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -301,11 +301,20 @@ ensure_directory "$HOME/.claude"
 ensure_directory "$HOME/.claude/skills"
 cp -rf "$CURRENT_DIR/ai/claude/"* "$HOME/.claude/" 2>/dev/null || true
 cp -f "$CURRENT_DIR/scripts/init-project.sh" "$HOME/.claude/" 2>/dev/null || true
-# Sync Claude skills: remove stale skill directories not in source
+# Sync Claude skills: remove stale skill directories not in source.
+# CRITICAL: For symlinks (vault-hosted skills, see link_vault_skills below),
+# unlink only — never rm -rf through a symlink with trailing slash, which
+# POSIX rm follows and would delete vault content. The vault-skills loop
+# below re-creates the symlink if the source still exists.
 for target_dir in "$HOME/.claude/skills/"*/; do
-    [ -d "$target_dir" ] || continue
-    skill_name=$(basename "$target_dir")
-    [ -d "$CURRENT_DIR/ai/skills/$skill_name" ] || rm -rf "$target_dir"
+    target_path="${target_dir%/}"
+    [ -e "$target_path" ] || [ -L "$target_path" ] || continue
+    skill_name=$(basename "$target_path")
+    if [ -L "$target_path" ]; then
+        unlink "$target_path"
+    elif [ ! -d "$CURRENT_DIR/ai/skills/$skill_name" ]; then
+        rm -rf "$target_path"
+    fi
 done
 # Copy skill directories (each skill has its own dir with SKILL.md)
 for skill_dir in "$CURRENT_DIR/ai/skills/"*/; do

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -151,11 +151,20 @@ if (Test-Path $claudeMdSource) {
 # Sync skills: remove stale skill directories not in source, then copy current
 $skillsSource = "$DotfilesDir\ai\skills"
 if (Test-Path $skillsSource) {
-    # Remove stale skills from target that no longer exist in source
+    # Remove stale skills from target that no longer exist in source.
+    # CRITICAL: Junction directories (vault-hosted skills, see vault-skills loop
+    # later in this script) must be detected via the ReparsePoint attribute and
+    # removed with .Delete() only. Remove-Item -Recurse -Force on a junction in
+    # Windows PowerShell 5.1 historically follows the link and deletes the target
+    # contents. The vault-skills loop below re-creates the junction if still valid.
     $existingSkills = Get-ChildItem "$ClaudeHome\skills" -Directory -ErrorAction SilentlyContinue
     foreach ($existing in $existingSkills) {
         if (-not (Test-Path "$skillsSource\$($existing.Name)")) {
-            Remove-Item $existing.FullName -Recurse -Force
+            if ($existing.Attributes -band [IO.FileAttributes]::ReparsePoint) {
+                $existing.Delete()
+            } else {
+                Remove-Item $existing.FullName -Recurse -Force
+            }
         }
     }
     # Copy current skills


### PR DESCRIPTION
## Summary

The skill-sync prune loops in both \`setup-linux.sh\` and \`setup-windows.ps1\` were silently **deleting vault SKILL.md content** every time the user ran the setup script. This PR makes the prune loops symlink/junction-aware.

## Symptom

Vault commits like:
\`\`\`
a8c27d9  vault backup: 2026-05-15 19:02:16
  00_meta/skills/spec/SKILL.md               | 200 ------------------
  00_meta/skills/enrich-us/SKILL.md          |  85 ------------
  00_meta/skills/adversarial-review/SKILL.md | 126 ------------------
  3 files changed, 411 deletions(-)
\`\`\`

These appear immediately after running \`setup-linux.sh\` and are auto-committed by the Obsidian-git plugin shortly after. **Second recurrence**: same incident first observed 2026-05-13 (observation #17225 in claude-mem) — recovered then, root cause not identified at the time.

## Root cause

Bash (\`setup-linux.sh\` line 305):
\`\`\`bash
for target_dir in "$HOME/.claude/skills/"*/; do
    [ -d "$target_dir" ] || continue
    skill_name=\$(basename "\$target_dir")
    [ -d "\$CURRENT_DIR/ai/skills/\$skill_name" ] || rm -rf "\$target_dir"
done
\`\`\`

1. Glob \`*/\` expands symlinks-to-directories WITH a trailing slash (e.g. \`~/.claude/skills/spec/\`).
2. The check \`[ -d "\$CURRENT_DIR/ai/skills/\$name" ]\` fails for vault-hosted skills (\`spec\`, \`enrich-us\`, \`adversarial-review\`) because they live in \`\$VAULT_ROOT/00_meta/skills\`, not dotfiles. They were added by **SDD-006** (\`link_vault_skills\` block, lines 587-614) AFTER the prune loop was coded.
3. \`rm -rf "\$target_dir"\` runs as \`rm -rf <symlink-with-trailing-slash>\` — **POSIX \`rm -rf\` follows the symlink** when the path has a trailing slash, and deletes the target directory's contents.
4. The \`link_vault_skills\` block right after re-creates the symlink, but the vault content is already gone.
5. The Obsidian-git plugin's next auto-backup commits the deletion to vault history.

PowerShell (\`setup-windows.ps1\` line 158): \`Remove-Item -Recurse -Force\` on a junction directory has the same data-loss behavior on Windows PowerShell 5.1.

## Fix

**bash**: strip trailing slash from the loop variable, test \`[ -L ]\` first, use \`unlink\` for symlinks (cheap, never follows), \`rm -rf\` only for true directories with missing dotfiles source.

**PowerShell**: detect \`ReparsePoint\` attribute via \`\$existing.Attributes -band [IO.FileAttributes]::ReparsePoint\`, call \`\$existing.Delete()\` (junction-only removal) for those, \`Remove-Item\` only for regular directories.

The \`link_vault_skills\` / vault-skills-loop blocks later in each script re-create the symlink/junction afterwards if the vault source still exists, so the prune step remains correctly idempotent.

## Verification

- [ ] On Linux: \`./setup-linux.sh\` runs cleanly; \`ls -la ~/.claude/skills/\` shows the 3 vault skills as live symlinks (\`spec\`, \`enrich-us\`, \`adversarial-review\`); \`ls ~/Projects/knowledge/00_meta/skills/spec/SKILL.md\` exists and is non-empty.
- [ ] On Windows: \`./setup-windows.ps1\` runs cleanly; vault \`00_meta/skills/*/SKILL.md\` content intact.
- [ ] No new \`vault backup\` commits in the vault history show SKILL.md deletions after re-running setup.

## Related

- Vault recovery commit: \`fcf7d76\` (\`vault: restore 3 SKILL.md files from silent-delete recurrence\`)
- Vault lesson capture: \`99f08e8\` (\`vault: capture lesson on setup-script skill sync data loss\`)
- Original incident: 2026-05-13 (observation #17225)
- Pattern affected: \`pattern-spec-driven-development\` (vault-hosted skills are its delivery mechanism via SDD-006)

## Follow-up (not in this PR)

**SDD-017b**: the session-start vault integrity check (\`vault-health.sh\` Section 1) only catches working-tree \`D\` entries. By the time a session opens, Obsidian-git has already auto-committed the deletion. Add a check that compares HEAD against a baseline of "files that must exist" (e.g., every \`00_meta/skills/*/SKILL.md\`) and flags missing canonical files. Tracked separately.