### PR TITLE
fix(setup): idempotent claude plugin install (stops .claude.json truncation)

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -457,9 +457,22 @@ else
     log_warning "Claude Code CLI, npx, or jq not found, skipping MCP server registration"
 fi
 
-# Claude Code plugins (requires claude CLI)
+# Claude Code plugins (requires claude CLI).
+# Idempotent: cache the installed-plugins list ONCE before the loop and skip
+# entries already present. CRITICAL: every `claude plugin install` call
+# writes to ~/.claude/.claude.json. The CLI's deserialize-modify-serialize
+# cycle does NOT preserve fields outside its internal struct — subscription
+# metadata (`organizationType: claude_max`, `organizationRateLimitTier`),
+# the `projects` map, and onboarding flags get silently dropped. Re-running
+# `plugin install` for plugins that are already installed is the trigger
+# for `.claude.json` truncation (75k -> 1.5k), which makes Claude Code
+# prompt for re-authentication in every project (subscription state lost).
+# Same idempotence pattern as MCP registration (line 447).
 if command -v claude >/dev/null 2>&1; then
     log_info "Installing Claude Code plugins..."
+    installed_plugins=$(claude plugin list 2>/dev/null || true)
+    plugins_added=0
+    plugins_skipped=0
     for plugin in \
         "claude-mem@thedotmack" \
         "code-simplifier@claude-plugins-official" \
@@ -473,9 +486,15 @@ if command -v claude >/dev/null 2>&1; then
         "code-review@claude-plugins-official" \
         "commit-commands@claude-plugins-official" \
         "pr-review-toolkit@claude-plugins-official"; do
-        claude plugin install "$plugin" >/dev/null 2>&1 || true
+        if printf '%s' "$installed_plugins" | grep -qF "$plugin"; then
+            plugins_skipped=$((plugins_skipped + 1))
+        else
+            if claude plugin install "$plugin" >/dev/null 2>&1; then
+                plugins_added=$((plugins_added + 1))
+            fi
+        fi
     done
-    log_success "Claude Code plugins installed"
+    log_success "Claude Code plugins ready ($plugins_added added, $plugins_skipped already present)"
 else
     log_warning "Claude Code CLI not found, skipping plugin installation"
 fi

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -221,7 +221,15 @@ if (-not ($claudeCmd -and $npxCmd)) {
     }
 }
 
-# Claude Code plugins (requires claude CLI)
+# Claude Code plugins (requires claude CLI).
+# Idempotent: cache the installed-plugins list ONCE before the loop and skip
+# entries already present. CRITICAL: every `claude plugin install` writes to
+# %USERPROFILE%\.claude\.claude.json. The CLI does NOT preserve all fields
+# on rewrite — subscription metadata (organizationType, organizationRateLimitTier),
+# the projects map, and onboarding flags get silently dropped. Re-running
+# install for already-installed plugins triggers silent .claude.json truncation
+# and forces re-authentication in every project. Same idempotence pattern as
+# MCP registration above.
 if ($claudeCmd) {
     Write-Info "Installing Claude Code plugins..."
     $plugins = @(
@@ -238,14 +246,22 @@ if ($claudeCmd) {
         "commit-commands@claude-plugins-official",
         "pr-review-toolkit@claude-plugins-official"
     )
+    $installedPlugins = try { (& claude plugin list 2>$null) -join "`n" } catch { "" }
+    $pluginsAdded = 0
+    $pluginsSkipped = 0
     foreach ($plugin in $plugins) {
+        if ($installedPlugins -match [regex]::Escape($plugin)) {
+            $pluginsSkipped++
+            continue
+        }
         try {
             & claude plugin install $plugin 2>$null | Out-Null
+            $pluginsAdded++
         } catch {
             # Silently continue if a plugin fails
         }
     }
-    Write-Success "Claude Code plugins installed"
+    Write-Success "Claude Code plugins ready ($pluginsAdded added, $pluginsSkipped already present)"
 } else {
     Write-Warn "Claude Code CLI not found, skipping plugin installation"
 }

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -234,7 +234,7 @@ if (-not ($claudeCmd -and $npxCmd)) {
 # Idempotent: cache the installed-plugins list ONCE before the loop and skip
 # entries already present. CRITICAL: every `claude plugin install` writes to
 # %USERPROFILE%\.claude\.claude.json. The CLI does NOT preserve all fields
-# on rewrite — subscription metadata (organizationType, organizationRateLimitTier),
+# on rewrite -- subscription metadata (organizationType, organizationRateLimitTier),
 # the projects map, and onboarding flags get silently dropped. Re-running
 # install for already-installed plugins triggers silent .claude.json truncation
 # and forces re-authentication in every project. Same idempotence pattern as


### PR DESCRIPTION
## Summary

Every \`claude plugin install\` call writes to \`~/.claude/.claude.json\`. The Claude Code CLI's deserialize-modify-serialize cycle **silently strips fields** that aren't in its internal struct — including \`oauthAccount.organizationType\` (the subscription marker), \`organizationRateLimitTier\`, the per-project \`projects\` map, onboarding flags, install metadata, and ~50 other fields.

Re-running setup with the prior unconditional install loop **truncates \`.claude.json\` from ~75 KB to ~1.5 KB every time**, which makes Claude Code believe the user has no subscription and prompts for re-authentication in every project.

Mirror the idempotence pattern already used for MCP registration (line 447): cache \`claude plugin list\` once, skip plugins already present.

## Evidence

Observed 2026-05-15 after a routine \`setup-linux.sh\` run:

| File | Size | Keys | \`organizationType\` |
|---|---|---|---|
| Live \`.claude.json\` post-setup | 1467 B | 8 | (missing) |
| Pre-setup backup at \`~/.claude/backups/.claude.json.backup.1778900735198\` | 75475 B | 60 | \`claude_max\` |

Recovered via \`cp\` from the backup. Symptom (re-auth in every project) resolved immediately on restore.

## Why this is upstream-driven but our trigger is fixable

The deserialize-strip behaviour is a bug in the \`claude\` CLI binary itself. We cannot patch it. But we **own the trigger** — the unconditional plugin install loop in \`setup-linux.sh\` / \`setup-windows.ps1\`. Adding the same idempotence check we already use for MCPs makes re-runs of setup a no-op when plugins are already installed.

If Anthropic later fixes the CLI to preserve unknown fields, this wrapper stays correct (now-idempotent vs always-idempotent — same outcome).

## Diff

\`\`\`
setup-linux.sh    | 25 ++++++++++++++++++++++---
setup-windows.ps1 | 20 ++++++++++++++++++--
2 files changed, 40 insertions(+), 5 deletions(-)
\`\`\`

- **bash**: cache \`installed_plugins=\$(claude plugin list 2>/dev/null || true)\` once, then \`grep -qF\` per loop iteration.
- **PowerShell**: cache \`\$installedPlugins\` once via \`-join\`, then \`-match [regex]::Escape(...)\` per iteration.
- Counts and final log line ("\`N added, M already present\`") match the MCP block style.

## Relationship to #32

Unrelated to **#32** (skill-sync symlink-follow bug). Both PRs fix different data-loss bugs in setup scripts:

- **#32**: \`rm -rf <symlink-with-trailing-slash>\` follows the symlink → vault SKILL.md content deleted.
- **This PR**: \`claude plugin install\` unconditional → \`.claude.json\` subscription metadata stripped.

Different sections of \`setup-linux.sh\` (line ~304 vs line ~460). No conflict. Can merge in any order.

## Test plan

- [ ] Run \`./setup-linux.sh\` once → \`~/.claude/.claude.json\` size stays at restored ~75 KB
- [ ] Run \`./setup-linux.sh\` twice in a row → second run logs \`"12 already present, 0 added"\` and file size unchanged
- [ ] \`jq '.oauthAccount.organizationType' ~/.claude/.claude.json\` returns \`"claude_max"\` after both runs
- [ ] Open Claude Code in any project → no re-auth prompt
- [ ] Equivalent verification on Windows via \`setup-windows.ps1\`

## Follow-up (out of scope, separate concern)

- **Defensive monitor**: add a check to \`vault-health.sh\` or \`claude-session-start.sh\` that flags if \`~/.claude/.claude.json\` size drops below a threshold (e.g. 10 KB). Catches recurrence even if a different trigger fires.
- **Upstream report**: file an issue with Anthropic re: \`claude plugin install\` not preserving unknown fields on rewrite of \`.claude.json\`. (Out of scope for dotfiles.)