### PR TITLE
fix(tmux): pass truecolor through to ghostty

### DIFF
--- a/tests/tmux.bats
+++ b/tests/tmux.bats
@@ -41,3 +41,7 @@ setup() {
 @test "tmux.conf pipes mouse-drag-end selection to system clipboard" {
     grep -qE "^bind -T copy-mode-vi MouseDragEnd1Pane .*copy-pipe-and-cancel .*xclip" "$CONFIG_FILE"
 }
+
+@test "tmux.conf enables truecolor passthrough for ghostty" {
+    grep -qE 'xterm-ghostty:Tc' "$CONFIG_FILE"
+}

--- a/tmux.conf
+++ b/tmux.conf
@@ -8,9 +8,9 @@ set -g history-limit 50000
 set -sg escape-time 10
 set -g focus-events on
 
-# True color (works in alacritty/kitty/wezterm/gnome-terminal)
+# True color (works in alacritty/kitty/wezterm/gnome-terminal/ghostty)
 set -g default-terminal "tmux-256color"
-set -ga terminal-overrides ",*256col*:Tc"
+set -ga terminal-overrides ",*256col*:Tc,xterm-ghostty:Tc"
 
 # Copy mode: vi keys (matches nvim/vim)
 setw -g mode-keys vi


### PR DESCRIPTION
## Summary

- Add explicit `xterm-ghostty:Tc` entry to tmux `terminal-overrides`
- Without it, 24-bit colour stops at the terminal boundary when running tmux inside Ghostty (default `TERM=xterm-ghostty` does not match the existing `*256col*` glob), and tmux falls back to 256 colour
- Inert under any other terminal — pure additive change

## Context

Prep work for spec `TERM-001-ghostty-bootstrap` (separate, not yet scaffolded). Shipping the tmux fix now as an atomic 1-line change so the moment Ghostty lands locally, truecolor works without re-deploying tmux.conf.

## Test plan

- [x] `bats tests/tmux.bats` — all 8 tests pass (new test 8 asserts `xterm-ghostty:Tc` presence)
- [x] `tmux -f tmux.conf -L test new-session -d 'true'` parses cleanly (covered by test 2)
- [ ] Manual: open tmux inside Ghostty (once installed), confirm `$COLORTERM=truecolor` and a 24-bit colour test prints a smooth gradient (deferred to TERM-001)