### PR TITLE
fix(BUG-001): correct Copilot verification + gate on extension presence

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -2,6 +2,11 @@
 
 # setup-linux.sh: Install dotfiles and set up environment
 # Usage: ./setup-linux.sh
+#
+# Philosophy: opportunistic configuration. The script attempts to set up
+# every supported tool and warns when something is not available, rather
+# than requiring opt-in flags. Heavy / disk-intensive installs (e.g.
+# future Ollama, Ghostty) may add explicit flags case by case.
 
 set -euo pipefail
 
@@ -424,26 +429,33 @@ else
     log_warning "opencode binary not reachable at $OPENCODE_BINARY after install — agent unavailable"
 fi
 
-# GitHub Copilot CLI (requires gh)
+# GitHub Copilot CLI (detect-and-act: deploy config only when the extension
+# is actually installed; the script does NOT auto-install the extension on
+# Linux — gh is widely used for PR/issue management without Copilot intent.
+# To enable: gh extension install github/gh-copilot, then re-run setup).
+# Verification string updated for AI-013 pointer-style copilot-instructions.md.
 if command -v gh >/dev/null 2>&1; then
-    log_info "Installing GitHub Copilot CLI extension..."
-    gh extension install github/gh-copilot 2>/dev/null || true
-    ensure_directory "$HOME/.copilot"
-    cp -rf "$CURRENT_DIR/ai/copilot/"* "$HOME/.copilot/" 2>/dev/null || true
-    if [ -f "$HOME/.copilot/copilot-instructions.md" ] && grep -q "Engineering Discipline" "$HOME/.copilot/copilot-instructions.md"; then
-        log_success "Copilot instructions deployed successfully (verified)"
+    if gh extension list 2>/dev/null | grep -q "github/gh-copilot"; then
+        log_info "GitHub Copilot CLI extension detected, deploying configuration..."
+        ensure_directory "$HOME/.copilot"
+        cp -rf "$CURRENT_DIR/ai/copilot/"* "$HOME/.copilot/" 2>/dev/null || true
+        if [ -f "$HOME/.copilot/copilot-instructions.md" ] && grep -q 'First, read `AGENTS.md`' "$HOME/.copilot/copilot-instructions.md"; then
+            log_success "copilot-instructions.md deployed successfully (verified pointer to AGENTS.md)"
+        else
+            log_warning "copilot-instructions.md deployment failed verification (expected pointer to AGENTS.md)"
+        fi
+        log_success "GitHub Copilot CLI configured"
+
+        # Aliases
+        log_info "Adding Copilot aliases to .zshrc/.bashrc..."
+        COPILOT_SUGGEST='eval "$(gh copilot alias -- bash)"'
+        [ -f "$HOME/.zshrc" ] && ensure_line_in_file "$HOME/.zshrc" "$COPILOT_SUGGEST"
+        [ -f "$HOME/.bashrc" ] && ensure_line_in_file "$HOME/.bashrc" "$COPILOT_SUGGEST"
     else
-        echo "❌ Error: Copilot instructions deployment failed verification"
+        log_info "GitHub Copilot CLI extension not installed, skipping Copilot config (install with: gh extension install github/gh-copilot)"
     fi
-    log_success "GitHub Copilot CLI configured"
-    
-    # Aliases
-    log_info "Adding Copilot aliases to .zshrc/.bashrc..."
-    COPILOT_SUGGEST='eval "$(gh copilot alias -- bash)"'
-    [ -f "$HOME/.zshrc" ] && ensure_line_in_file "$HOME/.zshrc" "$COPILOT_SUGGEST"
-    [ -f "$HOME/.bashrc" ] && ensure_line_in_file "$HOME/.bashrc" "$COPILOT_SUGGEST"
 else
-    log_warning "GitHub CLI (gh) not found, skipping Copilot installation"
+    log_warning "GitHub CLI (gh) not found, skipping Copilot setup"
 fi
 
 # Register MCP servers (requires Claude Code CLI, Node.js, jq)

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -792,32 +792,43 @@ if (Test-Path $ClaudeSettings) {
 
 Write-Info "Setting up GitHub Copilot CLI..."
 
+# Detect-and-act: deploy config only when gh AND the gh-copilot extension
+# are actually installed. The script does NOT auto-install the extension --
+# gh is widely used for PR/issue management on machines that do not want
+# Copilot. To enable: gh extension install github/gh-copilot, then re-run.
+# Verification string updated for AI-013 pointer-style copilot-instructions.md.
 $ghCmd = Get-Command gh -ErrorAction SilentlyContinue
 if ($ghCmd) {
-    Write-Info "Installing GitHub Copilot CLI extension..."
+    $copilotInstalled = $false
     try {
-        & gh extension install github/gh-copilot 2>$null
+        $extensions = & gh extension list 2>$null
+        $copilotInstalled = ($extensions -match 'github/gh-copilot')
     } catch {
-        # Extension may already be installed
+        $copilotInstalled = $false
     }
 
-    $CopilotHome = "$env:USERPROFILE\.copilot"
-    Ensure-Directory $CopilotHome
+    if ($copilotInstalled) {
+        Write-Info "GitHub Copilot CLI extension detected, deploying configuration..."
+        $CopilotHome = "$env:USERPROFILE\.copilot"
+        Ensure-Directory $CopilotHome
 
-    $copilotSource = "$DotfilesDir\ai\copilot"
-    if (Test-Path $copilotSource) {
-        Copy-Item "$copilotSource\*" "$CopilotHome\" -Recurse -Force -ErrorAction SilentlyContinue
-        if ((Test-Path "$CopilotHome\copilot-instructions.md") -and
-            (Select-String -Path "$CopilotHome\copilot-instructions.md" -Pattern "Engineering Discipline" -Quiet)) {
-            Write-Success "Copilot instructions deployed successfully (verified)"
-        } else {
-            Write-Err "Copilot instructions deployment failed verification"
+        $copilotSource = "$DotfilesDir\ai\copilot"
+        if (Test-Path $copilotSource) {
+            Copy-Item "$copilotSource\*" "$CopilotHome\" -Recurse -Force -ErrorAction SilentlyContinue
+            if ((Test-Path "$CopilotHome\copilot-instructions.md") -and
+                (Select-String -Path "$CopilotHome\copilot-instructions.md" -Pattern 'First, read `AGENTS.md`' -SimpleMatch -Quiet)) {
+                Write-Success "copilot-instructions.md deployed successfully (verified pointer to AGENTS.md)"
+            } else {
+                Write-Warn "copilot-instructions.md deployment failed verification (expected pointer to AGENTS.md)"
+            }
         }
-    }
 
-    Write-Success "GitHub Copilot CLI configured (aliases ghcs/ghce in profile.ps1)"
+        Write-Success "GitHub Copilot CLI configured (aliases ghcs/ghce in profile.ps1)"
+    } else {
+        Write-Info "GitHub Copilot CLI extension not installed, skipping Copilot config (install with: gh extension install github/gh-copilot)"
+    }
 } else {
-    Write-Warn "GitHub CLI (gh) not found, skipping Copilot installation"
+    Write-Warn "GitHub CLI (gh) not found, skipping Copilot setup"
 }
 
 # Weekly vault maintenance scheduled task (Sundays 10:07 AM)

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -285,8 +285,13 @@ setup() {
 # Section 10: Graceful skips (optional tools not present)
 # =============================================================================
 
-@test "copilot directory created (gh installed)" {
-    [ -d "$HOME/.copilot" ]
+@test "copilot config NOT deployed when gh-copilot extension is absent" {
+    # Post-BUG-001 (PR #40): setup-linux.sh uses detect-and-act. The
+    # gh-copilot extension is no longer auto-installed; ~/.copilot is created
+    # only if the extension is genuinely present. In the integration container
+    # gh is installed (as a dev tool) but gh-copilot is not, so the directory
+    # should NOT exist — confirming the skip path is silent and correct.
+    [ ! -d "$HOME/.copilot" ]
 }
 
 @test "no MCP servers registered (claude CLI absent)" {


### PR DESCRIPTION
## Summary

Surfaced 2026-05-17 during AI-011-validation runtime. The setup-linux.sh output printed a contradictory pair on every run:

\`\`\`
[INFO] Installing GitHub Copilot CLI extension...
❌ Error: Copilot instructions deployment failed verification
[SUCCESS] GitHub Copilot CLI configured
\`\`\`

Two underlying issues, fixed together (same code block, same scope):

### 1. Stale verification assertion

The check grepped for the literal \`"Engineering Discipline"\` in the deployed \`copilot-instructions.md\`, but that string no longer exists — AI-013 (May 2026) refactored \`ai/copilot/copilot-instructions.md\` to a pointer-style ≤70-line shim that delegates to canonical \`AGENTS.md\` at repo root. The deploy succeeds, but the assertion fails on every run.

Replaced with the same pattern that the already-working Claude/Gemini deploys use:

\`\`\`bash
grep -q 'First, read \\\`AGENTS.md\\\`' "$HOME/.copilot/copilot-instructions.md"
\`\`\`

### 2. Gating on \`gh\` is the wrong signal

\`gh\` (GitHub CLI) is widely used for PR/issue management on machines that have zero interest in Copilot. The old logic ran the entire Copilot block any time \`gh\` was installed, including the \`gh extension install github/gh-copilot\` line — installing the extension as a side effect of running setup.

Switched to **detect-and-act**: deploy the Copilot config only if the \`gh-copilot\` extension is actually present (\`gh extension list | grep github/gh-copilot\`). No more auto-installs. If absent, skip the block with an info-level log that includes the install one-liner.

This keeps the project's general philosophy of "try every supported tool opportunistically and warn on missing pieces" — without making the user own a surprise extension install.

## Files changed

- \`setup-linux.sh\` (lines 427-450 reshape, plus header comment trim)
- \`setup-windows.ps1\` (lines 793-821 mirror — gh extension list parsed in PowerShell, same assertion via \`Select-String -SimpleMatch\`)

## Test plan

- [x] \`bash -n setup-linux.sh\` + \`zsh -n setup-linux.sh\` clean
- [x] \`shellcheck setup-linux.sh\` — only pre-existing INFO warnings (lines 696, 713, 724) untouched by this PR
- [x] \`bats tests/setup-linux.bats tests/setup-windows.bats\` — 90/90 green
- [x] Non-ASCII check on \`setup-windows.ps1\` — PSScriptAnalyzer \`PSUseBOMForUnicodeEncodedFile\` rule respected, all ASCII
- [ ] Manual: re-run \`./setup-linux.sh\` post-merge → confirm \`copilot-instructions.md deployed successfully (verified pointer to AGENTS.md)\` line and no \`❌\` (extension already present on local machine — branch validated)
- [ ] Manual (Windows): when WIN-002 runs, confirm same line and behavior

## Cross-links

- Spec: closes \`BUG-001-copilot-instructions-verify-error\` in vault \`10_projects/dotfiles/11-tasks.md\`
- Predecessor: AI-013 pointer-style refactor (folded into AI-011 PR #34)
- Related: WIN-002-windows-smoke-sweep — empirical Windows-side verification of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)