### PR TITLE
feat(aliases): add oclog for live opencode log tailing

### DIFF
--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -33,6 +33,7 @@ alias cl="changelog-gen.sh"                       # Regenerate CHANGELOG.md from
 
 # OpenCode (primary AI coding agent — replaces aider)
 alias oc="opencode"                                                                       # TUI: opencode Go subscription
+alias oclog='tail -F "$(ls -t ~/.local/share/opencode/log/*.log | head -1)" | grep --line-buffered -vE "file\.watcher\.updated|bus type=message\.part\.delta"'  # live tail of newest opencode log, filtered
 
 # tmux session management
 alias tx='tmux new -A -s'         # attach-or-create by name: tx dotfiles

--- a/tests/aliases.bats
+++ b/tests/aliases.bats
@@ -38,6 +38,13 @@ setup() {
     grep -q '^alias oc="opencode"' "$ALIASES_FILE"
 }
 
+@test "aliases.zsh defines oclog alias for live opencode log tailing" {
+    # Surfaced 2026-05-17 during AI-011-validation -- visibility into
+    # opencode TUI while it shows "thinking..." for a long time.
+    grep -q "^alias oclog='tail -F" "$ALIASES_FILE"
+    grep -q 'opencode/log' "$ALIASES_FILE"
+}
+
 @test "aliases.zsh no longer defines aider tier aliases (sunset)" {
     ! grep -qE '^alias (ai|aic|aia)=' "$ALIASES_FILE"
 }


### PR DESCRIPTION
## Summary

Surfaced during AI-011-validation (2026-05-17). The opencode TUI shows "thinking..." for tens of seconds with no indication whether the model is streaming, hung mid-tool-call, or waiting on a congested upstream provider. The fastest way to know is to tail the newest log file in a parallel Ghostty split/tab.

Adds the alias to `.zsh/aliases.zsh` next to `oc` so it deploys via `setup-linux.sh` on every shell.

```bash
alias oclog='tail -F "$(ls -t ~/.local/share/opencode/log/*.log | head -1)" \
    | grep --line-buffered -vE "file\.watcher\.updated|bus type=message\.part\.delta"'
```

The filter strips two very chatty event types so signal/noise stays workable:
- `file.watcher.updated` — inotify events, dozens per second on any active repo
- `bus type=message.part.delta` — per-token publish events during streaming

Useful signals you DO see after filtering: `service=llm ... stream` (request sent), `service=tool.registry started/completed` (tool execution), `ERROR` lines, snapshot timings.

## Workflow

Open Ghostty, `Ctrl+Shift+E` to split, in one pane `oc`, in the other `oclog`. Documented under "Live log tailing" in the runbook `40-runbooks/guide-opencode-go-setup.md`.

## Test plan

- [x] `bats tests/aliases.bats` — 24/24 green (new test #8 asserts oclog present and points at opencode/log path)
- [x] `bash -n .zsh/aliases.zsh` + `zsh -n .zsh/aliases.zsh` clean
- [ ] Manual: re-source `.zshrc` after merge, run `oclog` in a split while `oc` runs in another — confirm filtered live log streams

## Cross-links

- Runbook source for the pattern: `~/Projects/knowledge/10_projects/dotfiles/40-runbooks/guide-opencode-go-setup.md` section "Live log tailing"
- Related closed: BUG-001 (PR #40), AI-011 (PR #39)