### PR TITLE
fix(setup-windows): use AGENTS.md pointer marker for CLAUDE/GEMINI verify

### DIFF
--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -139,10 +139,10 @@ if (Test-Path $claudeSource) {
 $claudeMdSource = "$DotfilesDir\ai\claude\CLAUDE.md"
 if (Test-Path $claudeMdSource) {
     Copy-Item $claudeMdSource "$ClaudeHome\" -Force
-    if (Select-String -Path "$ClaudeHome\CLAUDE.md" -Pattern "CORE PRINCIPLE" -Quiet) {
-        Write-Success "CLAUDE.md deployed successfully (verified)"
+    if (Select-String -Path "$ClaudeHome\CLAUDE.md" -Pattern 'First, read `AGENTS.md`' -SimpleMatch -Quiet) {
+        Write-Success "CLAUDE.md deployed successfully (verified pointer to AGENTS.md)"
     } else {
-        Write-Err "CLAUDE.md deployment failed verification"
+        Write-Err "CLAUDE.md deployment failed verification (expected pointer to AGENTS.md)"
     }
 } else {
     Write-Warn "CLAUDE.md not found at $claudeMdSource"
@@ -463,10 +463,10 @@ if (Test-Path $geminiSource) {
 $geminiMdSource = "$DotfilesDir\ai\gemini\GEMINI.md"
 if (Test-Path $geminiMdSource) {
     Copy-Item $geminiMdSource "$GeminiHome\" -Force
-    if (Select-String -Path "$GeminiHome\GEMINI.md" -Pattern "CORE PRINCIPLE" -Quiet) {
-        Write-Success "GEMINI.md deployed successfully (verified)"
+    if (Select-String -Path "$GeminiHome\GEMINI.md" -Pattern 'First, read `AGENTS.md`' -SimpleMatch -Quiet) {
+        Write-Success "GEMINI.md deployed successfully (verified pointer to AGENTS.md)"
     } else {
-        Write-Err "GEMINI.md deployment failed verification"
+        Write-Err "GEMINI.md deployment failed verification (expected pointer to AGENTS.md)"
     }
 } else {
     Write-Warn "GEMINI.md not found at $geminiMdSource"

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -222,6 +222,29 @@ setup() {
     grep -q 'ajeetdsouza.zoxide' "$PS1_SCRIPT"
 }
 
+# --- Cross-platform parity: AI config deploy verification ---
+# AI-013 refactored CLAUDE.md/GEMINI.md/copilot-instructions.md to pointer-style
+# files starting with 'First, read `AGENTS.md`'. The old marker 'CORE PRINCIPLE'
+# no longer exists in any deployed file. setup-linux.sh was updated; this guard
+# keeps setup-windows.ps1 in lockstep (regression class: BUG-001 + BUG-002).
+
+@test "parity: both scripts verify CLAUDE.md deploy with AGENTS.md pointer marker" {
+    grep -qF "grep -q 'First, read \`AGENTS.md\`' \"\$HOME/.claude/CLAUDE.md\"" "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF "Select-String -Path \"\$ClaudeHome\\CLAUDE.md\" -Pattern 'First, read \`AGENTS.md\`'" "$PS1_SCRIPT"
+}
+
+@test "parity: both scripts verify GEMINI.md deploy with AGENTS.md pointer marker" {
+    grep -qF "grep -q 'First, read \`AGENTS.md\`' \"\$HOME/.gemini/GEMINI.md\"" "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF "Select-String -Path \"\$GeminiHome\\GEMINI.md\" -Pattern 'First, read \`AGENTS.md\`'" "$PS1_SCRIPT"
+}
+
+@test "setup-windows.ps1 has no stale 'CORE PRINCIPLE' verify-pattern references" {
+    # AGENTS.md itself may mention 'CORE PRINCIPLE' as documentation text -- that
+    # is fine. The bug is using it as a Select-String -Pattern, which post-AI-013
+    # never matches the deployed file and emits a spurious [ERROR] every run.
+    ! grep -qF -- '-Pattern "CORE PRINCIPLE"' "$PS1_SCRIPT"
+}
+
 # --- PSScriptAnalyzer ---
 
 @test "setup-windows.ps1 passes PSScriptAnalyzer (if pwsh available)" {


### PR DESCRIPTION
## Summary

- Replace stale `"CORE PRINCIPLE"` verify pattern (lines 142, 466) with `'First, read \`AGENTS.md\`'` using `-SimpleMatch`.
- Mirrors the fix already applied to Copilot verification in #40 (BUG-001) — closes the cross-OS parity gap (`setup-linux.sh` already uses this marker for all three AI configs at lines 297/335/514).
- Adds three bats parity asserts in `tests/setup-windows.bats` as regression guard.

## Why

After AI-013 refactored `CLAUDE.md`/`GEMINI.md`/`copilot-instructions.md` to pointer-style files delegating to the canonical `AGENTS.md`, the legacy `CORE PRINCIPLE` string no longer exists in any deployed file. `setup-windows.ps1` was emitting two spurious `[ERROR]` lines on every run despite the actual `Copy-Item` succeeding — the verify post-check was lying.

Found empirically on 2026-05-18 during the WIN-003 SessionStart hook self-heal validation (#21).

## Test plan

- [x] Three new bats asserts simulated manually with `grep -qF` (red bar pre-fix, green bar post-fix)
- [x] PowerShell smoke: `Select-String -Pattern 'First, read \`AGENTS.md\`' -SimpleMatch` matches both deployed files; legacy `CORE PRINCIPLE` matches neither
- [x] PSScriptAnalyzer clean on `setup-windows.ps1` (Severity Error+Warning)
- [ ] CI: `tests/setup-windows.bats` + PSScriptAnalyzer job green
- [ ] Optional: re-run `pwsh -NoProfile -ExecutionPolicy Bypass -File setup-windows.ps1` on the affected machine, confirm two `[ERROR]` lines disappear from output