### PR TITLE
chore(specs): retroactive archive for BUG-003 (PR #48)

### DIFF
--- a/specs/archive/BUG-003-copilot-cli-v2-detection/proposal.md
+++ b/specs/archive/BUG-003-copilot-cli-v2-detection/proposal.md
@@ -1,0 +1,59 @@
+---
+id: "BUG-003-copilot-cli-v2-detection"
+type: spec
+status: archived
+created: "2026-05-18"
+archived: "2026-05-18"
+tags: [spec, proposal, bug, copilot, detect-and-act]
+template_version: "1.0"
+---
+
+# BUG-003-copilot-cli-v2-detection
+
+> **Retroactive spec.** PR #48 (commit `63b0716`) shipped before this spec folder was created — a deviation from `pattern-spec-driven-development.md` that directly triggered SDD-001 (PR #49). This document captures what was done, post-hoc, per the pattern's emergency-hotfix retroactive clause (line 121-122). Audit trail honesty over after-the-fact fiction.
+
+## Why
+
+Empirical discovery on the admin Windows machine 2026-05-18 while validating BUG-001 (#40): GitHub Copilot ships TWO different products under the same conceptual name:
+
+1. **Legacy (v1, ~2023-2024)** — `gh extension install github/gh-copilot`. Wrapper around suggest/explain API.
+2. **New (v2, 2025+)** — standalone `copilot` binary, winget `GitHub.Copilot`. Agentic interface (closer to Claude Code).
+
+`dotfiles` setup scripts only detected v1 (`gh extension list | grep github/gh-copilot`). On machines with v2 installed and operative, the script logged `extension not installed, skipping` and never deployed `~/.copilot/copilot-instructions.md`. The AI-013 pointer-style refactor was functionally inert on those machines. Compounded by GitHub's own confusing CLI: trying to install the legacy extension on a machine with v2 yields `"copilot" matches the name of a built-in command or alias`.
+
+## What
+
+Seven-file diff (134/63 lines) across the dotfiles repo:
+
+1. `setup-windows.ps1`: detect via `Get-Command copilot` instead of `gh extension list`; add `GitHub.Copilot` to the winget dev-tools auto-install array; refresh PATH after the winget loop so newly-installed binaries are visible to subsequent setup blocks (load-bearing for the Copilot deploy block).
+2. `setup-linux.sh`: same detection swap via `command -v copilot`; no auto-install (Linux distros vary); idempotent `sed -i` cleanup of the stale `eval "$(gh copilot alias -- bash)"` line from `.zshrc`/`.bashrc` (the subcommand does not exist in v2 and errors silently on every shell startup).
+3. `powershell/profile.ps1` + `.zsh/aliases.zsh`: rename `ghcs`/`ghce` → `cop`/`cops`. Old aliases wrapped `gh copilot suggest|explain` which do not exist in v2. Same names with different semantics would be a cognitive trap (`ghcs "delete logs"` v1 = suggest a command; v2 = the agent might execute `rm`).
+4. `env-contract.json`: add `copilot` to `optional_binaries`; update `gh` purpose to reflect that Copilot is no longer a `gh` extension.
+5. `tests/setup-windows.bats` + `tests/aliases.bats`: 9 new parity asserts locking the new detection path + alias rename + absence of legacy references.
+
+## Out of scope (deferred)
+
+- AWS Copilot CLI (`Amazon.CopilotCLI`) name collision — both install as `copilot`. If both present, `Get-Command` resolves to whichever is first on PATH. Documented as inline comment; <1% population. BUG-004 if it surfaces.
+- Linux auto-install of `copilot` — distros vary (snap, apt, curl, brew). The detect-and-act info message points to docs.
+- `copilot init` repo integration vs our `init-repo-agents.{sh,ps1}` — needs its own spec when relevant.
+- v2 skills / MCP / hooks audit — opened as `AI-017` (skills surface) and `AI-018` (MCP deploy from `mcp-servers.json` SSOT), both pending. ADR-010 re-audit (matrix update) follows AI-017 + AI-018.
+
+## Acceptance criteria (all green at archive)
+
+- [x] Setup logs `[INFO] GitHub Copilot CLI already installed` (winget recognises v1.0.48) on the admin machine
+- [x] After PATH refresh, `Get-Command copilot` resolves to the WinGet packages path
+- [x] `[SUCCESS] copilot-instructions.md deployed successfully (verified pointer to AGENTS.md)` line appears
+- [x] `[SUCCESS] GitHub Copilot CLI configured (aliases cop/cops in profile.ps1)` line appears (no `ghcs`/`ghce` references in any log line)
+- [x] BUG-002 (#47) verify-strings regression-free in the same setup run (CLAUDE.md + GEMINI.md both green)
+- [x] WIN-003 self-heal idempotent no-op when hook already correct
+- [x] CI 5/5 green on PR #48: GitGuardian, integration, lint, lint-powershell, test (bats)
+
+## References
+
+- PR: [#48](https://github.com/mlorentedev/dotfiles/pull/48) (`fix(setup,aliases): detect new standalone Copilot CLI v2 (BUG-003)`)
+- Sibling PR: [#47](https://github.com/mlorentedev/dotfiles/pull/47) (BUG-002, same audit session)
+- Triggered: SDD-001 (PR #49) — the audit found this PR bypassed SDD discipline, leading to the discipline gate work
+- Vault entry: `10_projects/dotfiles/11-tasks.md` "BUG-003-copilot-cli-v2-detection"
+- Lesson: `10_projects/dotfiles/90-lessons.md` 2026-05-18 entry "detect-and-act scripts go silently inert when upstream products change their surface"
+- Troubleshooting: `10_projects/dotfiles/50-troubleshooting/copilot-cli-v1-vs-v2-detection.md`
+- ADR-010 (pending update): cross-agent harness parity matrix — v2 changes several Copilot column cells

--- a/specs/archive/BUG-003-copilot-cli-v2-detection/tasks.md
+++ b/specs/archive/BUG-003-copilot-cli-v2-detection/tasks.md
@@ -1,0 +1,60 @@
+---
+tags: [spec, tasks, archived]
+created: "2026-05-18"
+archived: "2026-05-18"
+---
+
+# Tasks - BUG-003-copilot-cli-v2-detection
+
+> Retroactive checklist. All items completed in PR #48 (commit `63b0716`) before this folder was created. Reverse-engineered from the merged diff for audit-trail consistency.
+
+## Setup (post-hoc)
+
+- [x] Branch created from main: `fix/BUG-003-copilot-cli-v2-detection`
+- [ ] ~~Vault entry in 11-tasks.md added BEFORE branch~~ — SKIPPED at the time (the discipline violation that triggered SDD-001). Added post-merge as part of vault hygiene catchup, same 2026-05-18 session.
+- [ ] ~~Spec folder scaffolded via init-spec.ps1 BEFORE coding~~ — SKIPPED at the time (this folder created retroactively).
+- [x] User empirically confirmed (a) `copilot --version` returns "GitHub Copilot CLI 1.0.48"; (b) `~/.copilot/` has skills/, mcp-config.json, settings.json, permissions-config.json, copilot-instructions.md; (c) `gh extension install github/gh-copilot` errors with "matches built-in alias"; (d) `winget search copilot` resolves the new product as `GitHub.Copilot` (Moniker: copilot).
+
+## Implementation (TDD order, as executed)
+
+### Tests first (bats parity asserts)
+
+- [x] `tests/setup-windows.bats`: new asserts — detects via `Get-Command copilot` (not `gh extension list`); winget tool array contains `GitHub.Copilot`; no `github/gh-copilot` literal references remain; parity with `setup-linux.sh` on `command -v copilot`
+- [x] `tests/aliases.bats`: new asserts — `cop`/`cops` defined in both `.zsh/aliases.zsh` and `powershell/profile.ps1`; ghcs/ghce removed (anchored to definition forms only, not comments); cross-OS parity
+
+### Cross-OS detection
+
+- [x] `setup-windows.ps1`: replace `gh extension list | match 'github/gh-copilot'` block with `Get-Command copilot`. Add `@{ Name = "GitHub Copilot CLI"; Cmd = "copilot"; Id = "GitHub.Copilot" }` to the winget tools array. After the winget loop, refresh PATH: `$env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [Environment]::GetEnvironmentVariable("PATH", "User")` so the new binary is visible to the subsequent Copilot block (otherwise Get-Command misses it until next shell start).
+- [x] `setup-linux.sh`: replace `gh extension list | grep -q "github/gh-copilot"` with `command -v copilot`. No auto-install (distros vary). Idempotent `sed -i` cleanup of stale `eval "$(gh copilot alias -- bash)"` from `.zshrc`/`.bashrc` if present (the subcommand does not exist in v2; would error silently every shell startup).
+
+### Aliases rename
+
+- [x] `powershell/profile.ps1`: drop `ghcs`/`ghce` functions. Add `Set-Alias -Name cop -Value copilot` + `function cops { copilot -p "$args" --allow-all-tools -s }`. Comment block explaining the breaking-change rationale (v2 has no `suggest`/`explain` subcommands; same names + different semantics = cognitive trap).
+- [x] `.zsh/aliases.zsh`: same. Add `alias cop="copilot"` + `cops() { copilot -p "$*" --allow-all-tools -s; }`.
+
+### Contract update
+
+- [x] `env-contract.json`: add `{ "name": "copilot", "purpose": "GitHub Copilot CLI (agentic assistant; winget GitHub.Copilot on Windows, manual install on Linux)" }` to `optional_binaries`. Update `gh` purpose to "GitHub CLI (PR/issue management; Copilot CLI is the standalone `copilot` binary, not a gh extension since BUG-003)".
+
+### Local verification
+
+- [x] PSScriptAnalyzer (Error+Warning) on `setup-windows.ps1` and `powershell/profile.ps1` → clean
+- [x] `bash -n setup-linux.sh && bash -n .zsh/aliases.zsh` → clean
+- [x] `jq empty env-contract.json` → valid
+- [x] Simulated bats grep-by-grep for all 9 new asserts → green
+- [x] Empirical smoke on admin Windows: `pwsh -NoProfile -ExecutionPolicy Bypass -File setup-windows.ps1` → `[SUCCESS] copilot-instructions.md deployed successfully (verified pointer to AGENTS.md)` + `[SUCCESS] GitHub Copilot CLI configured (aliases cop/cops in profile.ps1)`
+
+## Closing
+
+- [x] All acceptance criteria from `proposal.md` (retroactive) marked green
+- [x] PR #48 description references this work; commit message convention `fix(setup,aliases): detect new standalone Copilot CLI v2 (BUG-003)`
+- [x] PR #48 merged 2026-05-18 (commit `49bb58e` merge of `63b0716`); branch deleted
+- [x] Follow-up specs opened: AI-017 (Copilot skills port), AI-018 (Copilot MCP deploy), ADR-010 update
+- [x] Spec folder created retroactively at `specs/archive/BUG-003-copilot-cli-v2-detection/` (this PR, `chore/BUG-003-retro-spec`)
+
+## Decisions (post-hoc)
+
+- **Aliases renamed (breaking change) rather than kept as ghcs/ghce with new internals**: user explicitly chose Option C of three (Socratic exchange captured in session transcript). Rationale: v2 has no `suggest`/`explain` subcommands; keeping the same alias names with different semantics ("`ghcs "delete logs"` v1 = print suggestion; v2 = agent might run rm") would be a cognitive trap. Breaking-change documented in commit body.
+- **Auto-install via winget enabled** for Windows: user explicitly opted in (Option A of multi-select). Trade-off: less friction on new machines vs adds a winget dep at setup time. The dev-tools winget block already handles 5 other tools so the pattern was familiar.
+- **No Linux auto-install**: distros vary too much (snap vs apt vs curl vs brew). Detect-and-act only; install URL in the info message.
+- **AWS Copilot collision NOT defensively handled**: <1% population (almost no one has both AWS Copilot CLI and GitHub Copilot CLI). Documented inline as comment + verification.md note. BUG-004 if it surfaces.

--- a/specs/archive/BUG-003-copilot-cli-v2-detection/verification.md
+++ b/specs/archive/BUG-003-copilot-cli-v2-detection/verification.md
@@ -1,0 +1,57 @@
+---
+tags: [spec, verification, archived]
+created: "2026-05-18"
+archived: "2026-05-18"
+---
+
+# Verification - BUG-003-copilot-cli-v2-detection
+
+> Retroactive evidence file. Captures empirical results from PR #48 (merged 2026-05-18, commit `49bb58e`).
+
+## Evidence
+
+Each acceptance criterion from `proposal.md` mapped to its concrete proof.
+
+- [x] **Setup logs "GitHub Copilot CLI already installed"** → captured 2026-05-18 in user's PowerShell after `pwsh -NoProfile -ExecutionPolicy Bypass -File setup-windows.ps1`. Exact line: `[INFO] GitHub Copilot CLI already installed`. winget version reported: v1.0.48.
+- [x] **PATH refresh exposes `copilot.exe` to subsequent block** → setup output: `[INFO] GitHub Copilot CLI detected at C:\Users\mlorente\AppData\Local\Microsoft\WinGet\Packages\GitHub.Copilot_Microsoft.Winget.Source_8wekyb3d8bbwe\copilot.exe, deploying configuration...`
+- [x] **`copilot-instructions.md` verified pointer** → `[SUCCESS] copilot-instructions.md deployed successfully (verified pointer to AGENTS.md)`
+- [x] **Aliases cop/cops in profile.ps1, no ghcs/ghce references** → `[SUCCESS] GitHub Copilot CLI configured (aliases cop/cops in profile.ps1)`. Grep on the deployed `~/.claude/CLAUDE.md` + profile.ps1 → zero matches for `ghcs|ghce` definitions (only comment references in the deprecation note).
+- [x] **BUG-002 regression-free** → same setup run output: `[SUCCESS] CLAUDE.md deployed successfully (verified pointer to AGENTS.md)` + `[SUCCESS] GEMINI.md deployed successfully (verified pointer to AGENTS.md)`. The two `[ERROR]` lines that triggered BUG-002 are gone.
+- [x] **WIN-003 self-heal idempotent no-op** → `[INFO] SessionStart hook already correctly configured, skipping`. Re-running setup on a healed machine does not re-fix.
+- [x] **CI 5/5 green on PR #48** → confirmed at `gh pr checks 48`: GitGuardian (pass 1s), integration (pass 40s), lint (pass 10s), lint-powershell (pass 34s), test/bats (pass 1m15s).
+
+## Test status
+
+- **CI on PR #48**: 5/5 green. Run URL: `https://github.com/mlorentedev/dotfiles/actions/runs/26048101176`.
+- **Bats simulation (local, no bats binary on Windows)**: 9 new asserts across `tests/setup-windows.bats` + `tests/aliases.bats` validated by grep-by-grep emulation. 100% green.
+- **Manual smoke (admin Windows machine, 2026-05-18)**: full setup re-run + filtered output produced the expected lines (above). Captured in session transcript.
+- **PSScriptAnalyzer**: clean on `setup-windows.ps1` and `powershell/profile.ps1` (Severity Error+Warning).
+- **bash -n + jq empty**: clean on `setup-linux.sh`, `.zsh/aliases.zsh`, `env-contract.json`.
+- **No regressions**: verified that BUG-002 (#47) verify-strings still pass and WIN-003 (#21) hook self-heal still idempotent — same setup run.
+
+## Decisions made during implementation
+
+- **Aliases rename `ghcs`/`ghce` → `cop`/`cops`**: explicit user choice (Option C of three Socratic options). Documented in PR body + commit body. Breaking change accepted as the lesser evil vs cognitive trap of same-name-different-semantics.
+- **Auto-install via winget (Windows only)**: explicit user opt-in. Existing winget block already handled 5 tools, pattern familiar.
+- **Linux: detect-and-act, no auto-install**: distros vary too much; info message points to upstream docs.
+- **AWS Copilot CLI collision not handled defensively**: <1% population, inline comment only.
+- **`-SimpleMatch` on `Select-String -Pattern 'First, read \`AGENTS.md\`'`**: pattern with literal backticks; `-SimpleMatch` is the established convention from BUG-001 PR #40 (Copilot side). Re-applied for CLAUDE.md and GEMINI.md verify checks (which became BUG-002 in a sibling PR).
+- **Stale `eval "$(gh copilot alias -- bash)"` cleanup in setup-linux.sh**: pre-existing line added by older setup runs; with v2 the `alias` subcommand does not exist, so the line errors silently on every shell startup. Idempotent `sed -i` removes it on the next setup run. Zero-cost on clean machines.
+
+## Promotion candidates (all executed in same session)
+
+- [x] **Lesson** → `10_projects/dotfiles/90-lessons.md` 2026-05-18 entry "detect-and-act scripts go silently inert when upstream products change their surface". Captured 3-layer mitigation (detect on binary not extension; quarterly upstream audit cadence; annotate detect-and-act blocks with last-validated-date).
+- [x] **Troubleshooting** → `10_projects/dotfiles/50-troubleshooting/copilot-cli-v1-vs-v2-detection.md`. Symptom + root cause + resolution + cross-refs.
+- [ ] **ADR** → not yet executed. Open as follow-up: ADR-010 (`30-architecture/adr-010-agent-harness-parity`) needs re-audit because v2 changes 3-4 cells of the Copilot column (`~/.copilot/skills/` exists; `~/.copilot/mcp-config.json` exists; permissions surface exists). Pending AI-017 + AI-018 empirical audits.
+- [ ] **New pattern** → `00_meta/patterns/pattern-detect-and-act-upstream-audit.md` candidate if the lesson recurs in a 3rd project (recurrence rule: 2 = workaround, 3 = pattern). Currently 2 instances (this bug and the original BUG-001 + claude-mem heal pattern); under threshold.
+
+## Archive checklist
+
+- [x] `proposal.md` frontmatter set to `status: archived`
+- [x] Folder created directly at `specs/archive/BUG-003-copilot-cli-v2-detection/` (retroactive — no `specs/<id>/` to move from)
+- [x] Backlog entry in vault `10_projects/dotfiles/11-tasks.md` ticked with PR #48 link (added 2026-05-18 in same session; pending user commit in vault repo)
+- [x] Promotions: lesson + troubleshooting captured; ADR + pattern deferred with explicit rationale above
+
+## Audit-trail note
+
+This spec folder was created AFTER the PR merged, violating step-order of `pattern-spec-driven-development.md`. The violation directly triggered SDD-001 (PR #49) — the 5-layer enforcement stack that now makes this kind of slip much less likely. So while the retroactive nature is an embarrassment, the audit trail is honest and the fix-forward is in place.


### PR DESCRIPTION
## Summary

Documentation-only PR. Creates `specs/archive/BUG-003-copilot-cli-v2-detection/` with the standard 3-file spec set (proposal + tasks + verification) post-hoc for an already-merged PR.

## Why retroactive

PR #48 (Copilot CLI v2 detection) shipped without a per-feature spec folder despite the change meeting all SDD trigger criteria: 134/63 line diff, public contract change (alias rename `ghcs`/`ghce` → `cop`/`cops`), new winget dep (`GitHub.Copilot`), multiple Socratic Guardrail pauses during design. The deviation directly triggered SDD-001 (PR #49) — the 5-layer enforcement stack that makes this kind of slip much less likely going forward.

Per `pattern-spec-driven-development.md` line 121-122 (emergency hotfix retroactive clause), the spec is created AFTER the fact for audit trail consistency. The `verification.md` "Audit-trail note" documents the retroactive nature explicitly — no after-the-fact fiction.

## Why this PR itself does NOT need a spec scaffold

Per the new SDD Discipline Gate (now in `AGENTS.md` post #49):

| Trigger | This PR |
|---------|---------|
| ~50-300 LOC of production diff | ❌ — 176 lines of pure documentation in `specs/archive/` |
| Public contract change | ❌ |
| New/removed dep | ❌ |
| First step of multi-PR sequence | ❌ |
| Socratic Guardrail warranted | ❌ — mechanical retro-fill from existing artifacts |

And the pattern's explicit skip criteria (line 80): "documentation-only changes" → skip SDD scaffold.

## Cross-references

- BUG-003 PR: #48 (merged, commit `49bb58e`)
- SDD-001 PR: #49 (merged, commit `331730b`) — the enforcement stack triggered by this deviation
- Vault entry: `10_projects/dotfiles/11-tasks.md` BUG-003-copilot-cli-v2-detection (already added in vault hygiene catchup this session)
- Lesson: `10_projects/dotfiles/90-lessons.md` 2026-05-18 entry on detect-and-act upstream drift
- Troubleshooting: `10_projects/dotfiles/50-troubleshooting/copilot-cli-v1-vs-v2-detection.md`

## Test plan

- [ ] CI: lint + integration + lint-powershell + test + GitGuardian — should all pass trivially (no code change, just markdown under `specs/archive/`)