### PR TITLE
fix(ghostty): translate config comments to English (English-only rule)

### DIFF
--- a/terminal/ghostty/config
+++ b/terminal/ghostty/config
@@ -1,8 +1,8 @@
-# Font (Nerd Font para iconos de opencode / claude-code)
+# Font (Nerd Font for opencode / claude-code glyphs)
 font-family = JetBrainsMono Nerd Font Mono
 font-size = 12
 
-# Tema (lista completa: `ghostty +list-themes`)
+# Theme (full list: `ghostty +list-themes`)
 theme = Catppuccin Mocha
 
 # UX
@@ -11,7 +11,7 @@ window-padding-x = 8
 window-padding-y = 8
 mouse-hide-while-typing = true
 
-# Confirmación al cerrar si hay procesos vivos (evita matar sesiones tmux por error)
+# Confirm before close if live processes exist (prevents accidental tmux session kills)
 confirm-close-surface = true
 
-# Shell se autodetecta desde $SHELL — no override
+# Shell autodetected from $SHELL — no override


### PR DESCRIPTION
## Summary

Audit hit on the dotfiles English-only rule (origin: vault-language correction 2026-05-09). Four Spanish comments in `terminal/ghostty/config` rewritten to English. Semantics preserved.

## Findings (from audit)

| Line | Before | After |
|---|---|---|
| 1 | `# Font (Nerd Font para iconos de opencode / claude-code)` | `# Font (Nerd Font for opencode / claude-code glyphs)` |
| 5 | `# Tema (lista completa: ...)` | `# Theme (full list: ...)` |
| 14 | `# Confirmación al cerrar si hay procesos vivos (evita matar sesiones tmux por error)` | `# Confirm before close if live processes exist (prevents accidental tmux session kills)` |
| 17 | `# Shell se autodetecta desde $SHELL — no override` | `# Shell autodetected from $SHELL — no override` |

## Rule context

All tooling-layer content (code, settings, comments, docs) in English. Spanish reserved for genuinely Spanish-targeted artifacts (e.g. client-specific docs). Origin rule lives in `~/.claude/projects/.../memory/feedback_vault_language.md`.

## Why a separate PR

`fix` scope is distinct from the `feat` work in #53 (gitleaks) and #54 (session-start hooks). Per atomic-PR rule, file overlap is zero — keeping diffs reviewable.

## Out of scope (flagged for awareness)

`specs/archive/AI-011-opencode-bootstrap/proposal.md` (~25 lines Spanish) was archived 2026-05-16, AFTER the English-only correction landed. The lesson didn't catch the spec-authoring workflow. No action in this PR — archive content is frozen — but worth deciding separately whether to back-translate or accept as historical.

## Test plan

- [x] `terminal/ghostty/config` syntax unchanged (only comment lines edited)
- [x] dotfiles' own pre-commit hooks (validate-commit-msg + dotfiles-test + gitleaks) pass — verified by this commit going through the hook stack