### PR TITLE
feat(aliases): add qq/qf one-shot opencode wrappers (cross-shell)

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -113,6 +113,19 @@ function gp() {
     gemini -i "$(cat "$prompt_file")"$'\n\n'"$*"
 }
 
+# qq / qf: one-shot opencode wrappers. Mirrors .zsh/aliases.zsh for bash users.
+# Bash leaves `foo?` literal when no match exists (no zsh-style nomatch error),
+# so no `noglob` wrapper is needed here.
+#   qq -> qwen3.6-plus     (multilingual, ES-friendly, balanced)
+#   qf -> deepseek-v4-flash (faster, never-rate-limited per opencode-go docs)
+_qq_call() {
+    local model="$1" name="$2"; shift 2
+    [ $# -eq 0 ] && { printf 'usage: %s <consulta libre>\n' "$name" >&2; return 1; }
+    opencode run -m "$model" "$*"
+}
+qq() { _qq_call opencode-go/qwen3.6-plus qq "$@"; }
+qf() { _qq_call opencode-go/deepseek-v4-flash qf "$@"; }
+
 # Claude Code - use slash commands inside session:
 #   claude
 #   > /audit src/auth.py

--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -35,6 +35,20 @@ alias cl="changelog-gen.sh"                       # Regenerate CHANGELOG.md from
 alias oc="opencode"                                                                       # TUI: opencode Go subscription
 alias oclog='tail -F "$(ls -t ~/.local/share/opencode/log/*.log | head -1)" | grep --line-buffered -vE "file\.watcher\.updated|bus type=message\.part\.delta"'  # live tail of newest opencode log, filtered
 
+# qq / qf: cross-platform one-shot quick-question wrappers. Each invocation is
+# a fresh session; for follow-ups use `opencode run -c` directly or the TUI.
+#   qq -> qwen3.6-plus     (multilingual, ES-friendly, balanced)
+#   qf -> deepseek-v4-flash (faster, never-rate-limited per opencode-go docs)
+# Aliases are wrapped in `noglob` so `qq por que tardas tanto?` works without
+# quotes -- zsh would otherwise try to glob-expand the trailing `?`.
+_qq_call() {
+  local model="$1" name="$2"; shift 2
+  [ $# -eq 0 ] && { printf 'usage: %s <consulta libre>\n' "$name" >&2; return 1; }
+  opencode run -m "$model" "$*"
+}
+alias qq='noglob _qq_call opencode-go/qwen3.6-plus qq'
+alias qf='noglob _qq_call opencode-go/deepseek-v4-flash qf'
+
 # GitHub Copilot CLI v2 (BUG-003: standalone agentic CLI, replaces ghcs/ghce wrappers)
 # cop  -> interactive agent (tool use requires confirmation, safe default)
 # cops -> single-shot non-interactive prompt with --allow-all-tools (required by CLI for -p mode)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ claude                               # Start Claude Code session
 > /audit src/auth.py                 # Use skills via slash commands
 gp audit "$(cat src/main.py)"       # Gemini prompt function
 oc                                   # OpenCode TUI (Go subscription, DeepSeek V4 Pro default)
+qq por que tardas tanto?             # one-shot question (no quotes needed in zsh) -> qwen3.6-plus (ES-friendly)
+qf explain the C10k problem         # one-shot question -> deepseek-v4-flash (faster, technical)
 ```
 
 ### Sync

--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -16,6 +16,27 @@ Set-Alias -Name g -Value gemini
 # block is a no-op and `oc` reports "command not found" as expected.)
 if (Get-Command opencode -ErrorAction SilentlyContinue) {
     Set-Alias -Name oc -Value opencode
+
+    # qq / qf: one-shot quick-question wrappers. Mirrors .zsh/aliases.zsh and
+    # .bashrc. One-shot: each call is a fresh session.
+    #   qq -> qwen3.6-plus     (multilingual, ES-friendly, balanced)
+    #   qf -> deepseek-v4-flash (faster, never-rate-limited per opencode-go docs)
+    # Note: '??' is the null-coalescing operator in PowerShell 7+, so the
+    # name 'qq' is the cross-platform compromise (works in bash, zsh, pwsh).
+    function qq {
+        if ($args.Count -eq 0) {
+            Write-Error 'usage: qq <consulta libre>'
+            return
+        }
+        opencode run -m opencode-go/qwen3.6-plus ($args -join ' ')
+    }
+    function qf {
+        if ($args.Count -eq 0) {
+            Write-Error 'usage: qf <consulta libre>'
+            return
+        }
+        opencode run -m opencode-go/deepseek-v4-flash ($args -join ' ')
+    }
 }
 
 # ============================================================================

--- a/tests/aliases.bats
+++ b/tests/aliases.bats
@@ -64,6 +64,29 @@ setup() {
     grep -qF -- '--allow-all-tools' "$ALIASES_FILE"
 }
 
+# --- qq / qf: cross-platform quick-question wrappers ---
+# Names are "qq"/"qf" (not "??"/"?f") because PowerShell 7+ reserves "??" as
+# the null-coalescing operator; this is the cross-platform compromise.
+# zsh aliases use `noglob` so `qq por que tardas tanto?` works without quotes.
+
+@test "aliases.zsh defines qq alias pinning qwen3.6-plus via noglob" {
+    grep -qE "^alias qq='noglob _qq_call opencode-go/qwen3.6-plus" "$ALIASES_FILE"
+}
+
+@test "aliases.zsh defines qf alias pinning deepseek-v4-flash via noglob" {
+    grep -qE "^alias qf='noglob _qq_call opencode-go/deepseek-v4-flash" "$ALIASES_FILE"
+}
+
+@test "aliases.zsh _qq_call helper invokes opencode run" {
+    grep -qE '^_qq_call\(\)' "$ALIASES_FILE"
+    grep -qF 'opencode run' "$ALIASES_FILE"
+}
+
+@test "aliases.zsh _qq_call prints usage when called with no args" {
+    # Single usage string parameterized by the alias name ($name).
+    grep -qF 'usage: %s' "$ALIASES_FILE"
+}
+
 @test "aliases.zsh no longer defines ghcs/ghce (renamed in BUG-003)" {
     # Anchor to start-of-line + alias/function definition forms only -- comments
     # mentioning the old names (e.g. "replaces ghcs/ghce wrappers") are fine.
@@ -135,6 +158,27 @@ setup() {
     grep -qE 'Set-Alias -Name cop -Value copilot' "$ps_file"
     grep -qE '^cops\(\)' "$ALIASES_FILE"
     grep -qE 'function cops' "$ps_file"
+}
+
+@test "parity: qq + qf wrappers exist in aliases.zsh, .bashrc, and profile.ps1" {
+    ps_file="$DOTFILES_DIR/powershell/profile.ps1"
+    bashrc_file="$DOTFILES_DIR/.bashrc"
+    # zsh: aliases wrapping noglob _qq_call
+    grep -qE "^alias qq='noglob _qq_call" "$ALIASES_FILE"
+    grep -qE "^alias qf='noglob _qq_call" "$ALIASES_FILE"
+    # bash: functions delegating to _qq_call
+    grep -qE '^qq\(\)' "$bashrc_file"
+    grep -qE '^qf\(\)' "$bashrc_file"
+    # PowerShell: standalone functions
+    grep -qE 'function qq' "$ps_file"
+    grep -qE 'function qf' "$ps_file"
+    # All three name the same models so behavior matches across shells.
+    grep -qF 'opencode-go/qwen3.6-plus' "$ALIASES_FILE"
+    grep -qF 'opencode-go/qwen3.6-plus' "$bashrc_file"
+    grep -qF 'opencode-go/qwen3.6-plus' "$ps_file"
+    grep -qF 'opencode-go/deepseek-v4-flash' "$ALIASES_FILE"
+    grep -qF 'opencode-go/deepseek-v4-flash' "$bashrc_file"
+    grep -qF 'opencode-go/deepseek-v4-flash' "$ps_file"
 }
 
 @test "parity: ghcs/ghce removed from both aliases.zsh and profile.ps1" {


### PR DESCRIPTION
## Summary

Two quick-question CLI wrappers around `opencode run`, pinned to specific models in the OpenCode Go catalog:

| Alias | Model | Why |
|---|---|---|
| `qq` | `opencode-go/qwen3.6-plus` | Multilingual (ES-friendly), balanced |
| `qf` | `opencode-go/deepseek-v4-flash` | ~97 tok/s, **never-rate-limited** per opencode-go docs |

Each call starts a fresh session — for follow-ups use `opencode run -c` directly or the TUI. Tested live: both models respond, with characteristically different output styles (qwen confident-first-guess, deepseek-flash disambiguates).

## Design notes

- **Name is `qq`, not `??`** — PowerShell 7+ reserves `??` as the null-coalescing operator. `qq` is the cross-platform compromise that works in bash, zsh, and pwsh.
- **zsh aliases wrapped in `noglob`** so `qq por que tardas tanto?` works literal, without quotes. (zsh's default `nomatch` would otherwise erroring out on the trailing `?`.) Bash and PowerShell don't need this — their default behavior is already permissive enough.
- **Helper `_qq_call`** factors out the usage check + opencode invocation so the two aliases stay one-liners.

## Test plan

- [x] `bats tests/aliases.bats` — 34/34 pass including 3 new cases (qq + qf + parity)
- [x] `bash -n` / `zsh -n` clean on all touched files
- [x] ASCII-clean on `.ps1` (per `pattern-powershell-ascii-only`)
- [x] Live smoke test in zsh: both aliases respond, with and without quotes (`qq que es un p-tree`, `qf que es un p-tree`)
- [ ] Windows verification deferred to next Windows session (CI `lint-powershell` job will catch syntax issues)