### PR TITLE
fix(copilot): sync .github/copilot-instructions.md + bats parity (SDD-005)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 > **First, read [`AGENTS.md`](../AGENTS.md) at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Copilot-specific extensions on top.
 >
-> If `AGENTS.md` is missing, default to the canonical version at `~/Projects/dotfiles/AGENTS.md` (Linux/macOS) or `%USERPROFILE%\Projects\dotfiles\AGENTS.md` (Windows).
+> If `AGENTS.md` is missing from the current repo, default to the canonical version at `~/Projects/dotfiles/AGENTS.md` (Linux/macOS) or `%USERPROFILE%\Projects\dotfiles\AGENTS.md` (Windows).
 
 ## Role & Goal (Copilot framing)
 
@@ -31,3 +31,9 @@
 * **FAE tickets:** `50_work/tickets/`.
 
 Full vault hierarchy and frontmatter law live in `AGENTS.md` § Vault Structure & Standards.
+
+## Model Tier (per AGENTS.md "Model Selection")
+
+- **Top / Mid / Low:** TBD — concrete model identifiers pending AI-017 (skills port) and AI-018 (MCP deploy) audits on a Windows admin machine where `copilot` v2 is installed. Until then, follow AGENTS.md tier semantics and use whatever default the v2 CLI provides.
+
+When AI-017/AI-018 close, replace this block with the literal model IDs.

--- a/specs/SDD-005-github-copilot-instructions-sync/proposal.md
+++ b/specs/SDD-005-github-copilot-instructions-sync/proposal.md
@@ -1,0 +1,53 @@
+---
+id: "SDD-005-github-copilot-instructions-sync"
+type: spec
+status: draft
+created: "2026-05-19"
+tags: [spec, proposal, copilot, docs-drift]
+template_version: "1.0"
+---
+
+# SDD-005-github-copilot-instructions-sync
+
+## Why
+
+AUDIT-003 detected real drift between `ai/copilot/copilot-instructions.md` (deployed user-global to `~/.copilot/`) and `.github/copilot-instructions.md` (repo-local, read by GitHub Copilot for this repo). PR #60 (AI-019) added a "Model Tier" subsection to the first file but missed the second. As a result, GitHub Copilot operating inside this dotfiles repo currently does NOT see the model-tier policy that every other agent reads — the cross-agent rule is partially broken.
+
+Same drift class as BUG-001 (#40) and BUG-002 (#47): files that must move together silently diverge when an editor touches only one. CI has no enforcement, so the next AI-019-style edit will likely re-introduce the same drift.
+
+## What
+
+After this PR merges:
+
+1. `.github/copilot-instructions.md` contains the same load-bearing content as `ai/copilot/copilot-instructions.md`. Specifically: same H2 section headers (Role & Goal, Execution Preferences, Interaction Style, Quick Reference, Model Tier), same Model Tier wording, same vault paths.
+2. **Both files are byte-equivalent in content**, except for the pointer banner (`> First, read AGENTS.md...`). The `.github/` version preserves its markdown link form `[`AGENTS.md`](../AGENTS.md)` because GitHub renders it as a clickable link; the `ai/copilot/` version stays plain because it deploys to `~/.copilot/` where the relative link would not resolve.
+3. A new bats parity test in `tests/docs-drift.bats` asserts: stripping the leading `>` blockquote lines from both files yields byte-identical output. CI fails on future drift.
+
+## Out of scope
+
+- Build-time generation of `.github/copilot-instructions.md` from `ai/copilot/...` (a pre-commit hook or `setup-linux.sh` step). Bats parity check is sufficient enforcement; generation adds complexity without proportional benefit.
+- Reformatting `ai/copilot/copilot-instructions.md` (the canonical-ish source). The drift fix flows from canonical to drifted, not the other way.
+- Auditing other cross-file sync relationships (e.g. setup-linux.sh ↔ setup-windows.ps1 verification strings). Those have their own bats coverage; not in scope here.
+
+## Risks / open questions
+
+- **Risk: future contributors edit only one file again.** Mitigation is the bats parity test — CI fails loud, no merge.
+- **Risk: legitimate future divergence** (e.g. a GitHub-repo-specific guideline that does NOT belong in user-global Copilot config). Then the parity test becomes incorrect. **Decision rule**: if divergence is intentional, the spec for that change must update the parity test simultaneously. The test is enforcement, not absolute truth.
+- **Open**: which file is "canonical"? **Decision**: `ai/copilot/copilot-instructions.md` is canonical for content; `.github/` is the deploy mirror with one allowed difference (pointer link form). This matches the existing flow (setup-windows + setup-linux deploy `ai/copilot/` → `~/.copilot/`, but `.github/` is repo-local and not deployed by setup).
+- **Risk: pointer-banner stripping is fragile.** A future contributor might add a non-blockquote pointer line that the bats `sed '/^> /d'` filter would miss. Mitigation: use `## ` headers as anchors and compare section-by-section instead of stripping. **Final approach**: compare both files with the pointer banner block stripped — simpler and tied to the actual difference.
+
+## Acceptance criteria
+
+- [ ] `.github/copilot-instructions.md` contains a `## Model Tier (per AGENTS.md "Model Selection")` section with the same Top/Mid/Low TBD wording as `ai/copilot/copilot-instructions.md`.
+- [ ] `.github/copilot-instructions.md` pointer-banner fallback line matches `ai/copilot/copilot-instructions.md` wording ("If `AGENTS.md` is missing **from the current repo**, default to..."). Only the markdown-link form of the AGENTS.md reference may differ.
+- [ ] New file `tests/docs-drift.bats` exists with at least one parity test that fails when content (excluding the pointer banner block) drifts.
+- [ ] Bats parity test passes on the synced state.
+- [ ] Full existing bats suite remains green (no regression). Target: 645 + new cases.
+- [ ] No edits to `ai/copilot/copilot-instructions.md` (it is canonical for this PR — the drift is one-directional).
+
+## References
+
+- Vault: `10_projects/dotfiles/11-tasks.md` SDD-005 entry.
+- Vault: [[audit-003-docs-drift]] — the audit that detected this drift.
+- Sibling drift class: BUG-001 PR [#40](https://github.com/mlorentedev/dotfiles/pull/40), BUG-002 PR [#47](https://github.com/mlorentedev/dotfiles/pull/47).
+- Source of the partial sync: PR [#60](https://github.com/mlorentedev/dotfiles/pull/60) (AI-019 added Model Tier to `ai/copilot/` only).

--- a/specs/SDD-005-github-copilot-instructions-sync/tasks.md
+++ b/specs/SDD-005-github-copilot-instructions-sync/tasks.md
@@ -1,0 +1,36 @@
+---
+tags: [spec, tasks, copilot, docs-drift]
+created: "2026-05-19"
+---
+
+# Tasks - SDD-005-github-copilot-instructions-sync
+
+## Setup
+
+- [x] Branch: `feat/SDD-005-github-copilot-instructions-sync` (off main).
+- [x] Vault entry exists in `11-tasks.md`.
+
+## Implementation (TDD)
+
+### Phase 1 — Parity test (red)
+
+- [ ] Create `tests/docs-drift.bats` with parity case: strip blockquote lines (`^> `) from both files, compare with `cmp -s`. Expect FAIL pre-fix.
+
+### Phase 2 — Sync content (green)
+
+- [ ] Edit `.github/copilot-instructions.md`:
+  - Re-align fallback line wording to include "from the current repo"
+  - Append "## Model Tier (per AGENTS.md "Model Selection")" section with the same TBD wording as `ai/copilot/copilot-instructions.md`
+- [ ] Re-run parity test → expect PASS.
+
+### Phase 3 — Full regression
+
+- [ ] `bats tests/*.bats` → must remain green (target 645 + new cases).
+- [ ] Manual sanity: `diff` the two files, confirm only the pointer-banner pointer-reference line (markdown link form vs plain) differs.
+
+## Closing
+
+- [ ] Every AC ticked.
+- [ ] `verification.md` filled.
+- [ ] PR opened referencing this spec folder.
+- [ ] Post-merge: tick SDD-005 in vault `11-tasks.md` and archive spec folder.

--- a/specs/SDD-005-github-copilot-instructions-sync/verification.md
+++ b/specs/SDD-005-github-copilot-instructions-sync/verification.md
@@ -1,0 +1,40 @@
+---
+tags: [spec, verification, copilot, docs-drift]
+created: "2026-05-19"
+---
+
+# Verification - SDD-005-github-copilot-instructions-sync
+
+## Evidence
+
+- [x] AC1 `.github/copilot-instructions.md` has `## Model Tier (per AGENTS.md "Model Selection")` section with TBD wording matching `ai/copilot/copilot-instructions.md`.
+- [x] AC2 Pointer-banner fallback line aligned to include "from the current repo" wording. Only the AGENTS.md reference form differs (linked vs plain) — by design per file deploy context.
+- [x] AC3 `tests/docs-drift.bats` exists with parity test (`copilot-instructions: ai/copilot/ and .github/ match outside pointer banner`).
+- [x] AC4 Parity test passes on the synced state.
+- [x] AC5 Full bats suite green: **650/650 pass** (was 645 pre-PR; 5 new docs-drift cases added).
+- [x] AC6 `ai/copilot/copilot-instructions.md` untouched (canonical source for this PR).
+
+## Test status
+
+- `bats tests/docs-drift.bats` → 5/5 pass.
+- `bats tests/*.bats` → 650/650 pass.
+- Manual `diff`: only the pointer-banner reference form differs (markdown link `[`AGENTS.md`](../AGENTS.md)` vs plain `` `AGENTS.md` ``). All other content byte-identical.
+
+## Decisions made during implementation
+
+- **Parity rule by blockquote stripping, not section-by-section.** The bats test strips lines beginning with `> ` and `cmp -s` the rest. Simpler and tied to the actual difference (banner). Section-by-section would require maintaining a list of expected headers — more code, same coverage.
+- **Cosmetic fallback alignment included** even though the bats test ignores blockquote lines. The 15-character diff was trivial to fix; leaving it would have left a small invisible inconsistency for the next reader.
+- **No `--no-verify` skip; pre-commit hooks ran clean.** gitleaks + dotfiles-test (full bats) passed at commit time.
+
+## Promotion candidates
+
+- [ ] Lesson for `90-lessons.md`? **Yes** — "Files that must move together silently diverge unless CI asserts parity. When AI-013-style pointer refactors split content across mirror files, ship a bats parity test in the SAME PR." Recurring pattern (BUG-001, BUG-002, AI-019). Captures generic prevention.
+- [ ] ADR-worthy? No — this is operational tooling for an existing decision (cross-agent docs structure already decided in ADR-009).
+- [ ] Pattern for `00_meta/patterns/`? **Maybe** — "Pattern: bats parity assertions for mirror files." Defer until a third project hits it.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter `status: archived`.
+- [ ] Folder moved: `specs/SDD-005-.../` → `specs/archive/SDD-005-.../`.
+- [ ] Vault `11-tasks.md` ticked with PR link.
+- [ ] Lesson promoted to `dotfiles/90-lessons.md`.

--- a/tests/docs-drift.bats
+++ b/tests/docs-drift.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# Tests for cross-file docs sync (SDD-005).
+# Catches the drift class that hit BUG-001, BUG-002, and AI-019 → AUDIT-003.
+
+setup() {
+    DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    AI_COPILOT="$DOTFILES_DIR/ai/copilot/copilot-instructions.md"
+    GH_COPILOT="$DOTFILES_DIR/.github/copilot-instructions.md"
+    SCRATCH="$BATS_TMPDIR/sdd-005"
+    mkdir -p "$SCRATCH"
+}
+
+teardown() {
+    rm -rf "$SCRATCH"
+}
+
+@test "ai/copilot/copilot-instructions.md exists" {
+    [ -f "$AI_COPILOT" ]
+}
+
+@test ".github/copilot-instructions.md exists" {
+    [ -f "$GH_COPILOT" ]
+}
+
+# Parity rule (SDD-005): the two copilot-instructions files MUST contain the
+# same content modulo the pointer banner. The pointer banner is a leading
+# blockquote (lines beginning with `> `) that legitimately differs because
+# .github/ uses a markdown link to ../AGENTS.md while ai/copilot/ uses a plain
+# backticked reference (different deploy contexts). Everything outside the
+# blockquote MUST be byte-identical.
+@test "copilot-instructions: ai/copilot/ and .github/ match outside pointer banner" {
+    sed -E '/^> /d' "$AI_COPILOT" > "$SCRATCH/ai.txt"
+    sed -E '/^> /d' "$GH_COPILOT" > "$SCRATCH/gh.txt"
+    if ! cmp -s "$SCRATCH/ai.txt" "$SCRATCH/gh.txt"; then
+        echo "DRIFT: ai/copilot/ and .github/copilot-instructions.md differ outside the pointer banner."
+        echo "Run 'diff' on the two files; sync ai/copilot/ -> .github/ (excluding the > blockquote)."
+        diff "$SCRATCH/ai.txt" "$SCRATCH/gh.txt" >&2 || true
+        return 1
+    fi
+}
+
+@test "copilot-instructions: both files contain '## Model Tier' section header" {
+    grep -q '^## Model Tier' "$AI_COPILOT"
+    grep -q '^## Model Tier' "$GH_COPILOT"
+}
+
+@test "copilot-instructions: both reference AGENTS.md in their pointer banner" {
+    grep -qE '^> .*AGENTS\.md' "$AI_COPILOT"
+    grep -qE '^> .*AGENTS\.md' "$GH_COPILOT"
+}


### PR DESCRIPTION
## Summary

Closes a real drift detected by AUDIT-003: PR #60 (AI-019) added a "Model Tier" subsection to `ai/copilot/copilot-instructions.md` but missed `.github/copilot-instructions.md`. GitHub Copilot reading the dotfiles repo did NOT see the model-tier policy that every other agent reads.

Same drift class as BUG-001 (#40) and BUG-002 (#47) — mirror files that must move together silently diverge when an editor touches only one.

## SDD checklist

- [x] Vault entry exists (`SDD-005-github-copilot-instructions-sync` in `11-tasks.md`)
- [x] Spec folder `specs/SDD-005-github-copilot-instructions-sync/` in this PR
- [x] `proposal.md` filled (Why / What / AC / Risks)
- [x] `tasks.md` in TDD order
- [x] `verification.md` filled with evidence

## SDD skip rationale

<!-- Not used — spec folder present. -->

## Test plan

- [x] `bats tests/*.bats` → **650/650 pass** (was 645; +5 from new `tests/docs-drift.bats`)
- [x] `bats tests/docs-drift.bats` → 5/5 green:
  - both files exist
  - parity outside pointer banner
  - both contain `## Model Tier` header
  - both reference AGENTS.md in banner
- [x] Manual `diff`: only the pointer-banner reference form differs (markdown link vs plain — by design per file deploy context)

## Out of scope

- Build-time generation of `.github/copilot-instructions.md` from `ai/copilot/...` (a pre-commit hook). Bats parity check is sufficient enforcement; generation adds complexity without proportional benefit.
- Reformatting `ai/copilot/copilot-instructions.md` (canonical source). Drift flows canonical → mirror, not back.

## Promotion candidate

The verification.md flags a lesson worth promoting to `90-lessons.md`:

> Files that must move together silently diverge unless CI asserts parity. When AI-013-style pointer refactors split content across mirror files, ship a bats parity test in the SAME PR.

Three repeats so far (BUG-001 / BUG-002 / AI-019). Generic prevention rule.

## Companion audit artifact

`30-architecture/audit-003-docs-drift.md` (vault) is the audit that surfaced this finding.