### PR TITLE
refactor(env-contract): declare SCRIPTS_DIR + 3 AGENT_HOME paths (REFACTOR-002)

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -48,6 +48,12 @@ export EDITOR=nano
 export DOTFILES_DIR="$HOME/.dotfiles"
 export DOTFILES_REPO_DIR="$HOME/Projects/dotfiles"
 export CLAUDE_CONFIG_DIR="$HOME/.claude"
+# Per-agent install dirs + scripts deploy target (REFACTOR-002).
+# Declared in env-contract.json; doctor.{sh,ps1} validates on every run.
+export SCRIPTS_DIR="$DOTFILES_DIR/scripts"
+export GEMINI_HOME="$HOME/.gemini"
+export COPILOT_HOME="$HOME/.copilot"
+export OPENCODE_HOME="$HOME/.config/opencode"
 
 # Load encrypted secrets as environment variables
 [[ -f "$DOTFILES_DIR/scripts/load-secrets.sh" ]] && source "$DOTFILES_DIR/scripts/load-secrets.sh"

--- a/.zshrc
+++ b/.zshrc
@@ -20,6 +20,12 @@ export EDITOR=nano
 export DOTFILES_DIR="$HOME/.dotfiles"
 export DOTFILES_REPO_DIR="$HOME/Projects/dotfiles"
 export CLAUDE_CONFIG_DIR="$HOME/.claude"
+# Per-agent install dirs + scripts deploy target (REFACTOR-002).
+# Declared in env-contract.json; doctor.{sh,ps1} validates on every run.
+export SCRIPTS_DIR="$DOTFILES_DIR/scripts"
+export GEMINI_HOME="$HOME/.gemini"
+export COPILOT_HOME="$HOME/.copilot"
+export OPENCODE_HOME="$HOME/.config/opencode"
 
 # Load encrypted secrets as environment variables
 [[ -f "$DOTFILES_DIR/scripts/load-secrets.sh" ]] && source "$DOTFILES_DIR/scripts/load-secrets.sh"

--- a/env-contract.json
+++ b/env-contract.json
@@ -14,10 +14,50 @@
     {
       "name": "CLAUDE_CONFIG_DIR",
       "required": false,
-      "description": "Override for Claude Code's config dir. When unset, ~/.claude is assumed. Used by claude-mem-heal to locate the plugin cache.",
+      "description": "Override for Claude Code's config dir. When unset, ~/.claude is assumed. Used by claude-mem-heal to locate the plugin cache. Canonical for Claude (upstream contract — Claude Code CLI reads it at startup); intentionally NOT renamed to CLAUDE_HOME (see REFACTOR-002).",
       "default": {
         "linux": "$HOME/.claude",
         "windows": "$env:USERPROFILE\\.claude"
+      },
+      "validation": "path_exists"
+    },
+    {
+      "name": "SCRIPTS_DIR",
+      "required": false,
+      "description": "Deployed scripts directory. Used by RC files to extend PATH and by doctor/healthcheck for script location lookups.",
+      "default": {
+        "linux": "$HOME/.dotfiles/scripts",
+        "windows": "$env:USERPROFILE\\.dotfiles\\scripts"
+      },
+      "validation": "path_exists"
+    },
+    {
+      "name": "GEMINI_HOME",
+      "required": false,
+      "description": "Gemini CLI config dir. Deployed by setup scripts from ai/gemini/.",
+      "default": {
+        "linux": "$HOME/.gemini",
+        "windows": "$env:USERPROFILE\\.gemini"
+      },
+      "validation": "path_exists"
+    },
+    {
+      "name": "COPILOT_HOME",
+      "required": false,
+      "description": "GitHub Copilot CLI v2 config dir. Deployed by setup scripts from ai/copilot/ when the `copilot` binary is detected.",
+      "default": {
+        "linux": "$HOME/.copilot",
+        "windows": "$env:USERPROFILE\\.copilot"
+      },
+      "validation": "path_exists"
+    },
+    {
+      "name": "OPENCODE_HOME",
+      "required": false,
+      "description": "OpenCode config dir (XDG-style, intentionally inconsistent with the .X pattern because that is where OpenCode deploys per its schema). Deployed by setup scripts from ai/opencode/.",
+      "default": {
+        "linux": "$HOME/.config/opencode",
+        "windows": "$env:USERPROFILE\\.config\\opencode"
       },
       "validation": "path_exists"
     },

--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -141,6 +141,11 @@ function prompt {
 # to every subshell.
 $env:DOTFILES_DIR = "$env:USERPROFILE\.dotfiles"
 $env:CLAUDE_CONFIG_DIR = "$env:USERPROFILE\.claude"
+# Per-agent install dirs + scripts deploy target (REFACTOR-002).
+$env:SCRIPTS_DIR = "$env:DOTFILES_DIR\scripts"
+$env:GEMINI_HOME = "$env:USERPROFILE\.gemini"
+$env:COPILOT_HOME = "$env:USERPROFILE\.copilot"
+$env:OPENCODE_HOME = "$env:USERPROFILE\.config\opencode"
 
 # Uncomment and set if needed:
 # $env:GEMINI_API_KEY = "your-api-key"

--- a/specs/REFACTOR-002-paths-in-env-contract/proposal.md
+++ b/specs/REFACTOR-002-paths-in-env-contract/proposal.md
@@ -1,0 +1,63 @@
+---
+id: "REFACTOR-002-paths-in-env-contract"
+type: spec
+status: draft
+created: "2026-05-19"
+tags: [spec, proposal, env-contract, paths]
+template_version: "1.0"
+---
+
+# REFACTOR-002-paths-in-env-contract
+
+## Why
+
+`env-contract.json` is the declarative SSOT for structural environment expectations, read by `doctor.{sh,ps1}` to verify (and optionally fix) drift. Today it covers only two paths: `DOTFILES_DIR` and `CLAUDE_CONFIG_DIR`. The other per-agent install locations — Gemini, Copilot (v2), OpenCode, plus the `SCRIPTS_DIR` deploy target — are hardcoded across scripts (`$HOME/.gemini`, `$HOME/.copilot`, `$HOME/.config/opencode`, `$HOME/.dotfiles/scripts`) with no single declaration. Drift between hardcoded paths is invisible until something breaks.
+
+AUDIT-002 surfaced this as the next concrete extension of the SSOT pattern (`env-contract.json` + `doctor.{sh,ps1}` is already the gold standard for cross-OS factorisation). Adding 4 entries gets these paths under contract — doctor validates them as side-effect on every `doctor` run, and future scripts can read from the contract instead of hardcoding.
+
+## What
+
+After this PR merges:
+
+1. `env-contract.json` gains 4 new entries in `env_vars[]`:
+   - `SCRIPTS_DIR` — the deployed scripts dir (`$HOME/.dotfiles/scripts` on Linux, `$env:USERPROFILE\.dotfiles\scripts` on Windows)
+   - `GEMINI_HOME` — `$HOME/.gemini` / `$env:USERPROFILE\.gemini`
+   - `COPILOT_HOME` — `$HOME/.copilot` / `$env:USERPROFILE\.copilot`
+   - `OPENCODE_HOME` — `$HOME/.config/opencode` / `$env:USERPROFILE\.config\opencode`
+2. `CLAUDE_CONFIG_DIR` (existing entry) stays canonical for Claude — it's the upstream Claude Code CLI contract; adding `CLAUDE_HOME` as alias would create two-name-one-concern duplication. Naming convention documented in env-contract `_comment` and AUDIT-002.
+3. RC files gain the corresponding exports:
+   - `.zshrc` + `.bashrc`: `export SCRIPTS_DIR`, `GEMINI_HOME`, `COPILOT_HOME`, `OPENCODE_HOME`
+   - `powershell/profile.ps1`: `$env:SCRIPTS_DIR`, `$env:GEMINI_HOME`, `$env:COPILOT_HOME`, `$env:OPENCODE_HOME`
+4. New bats coverage asserts the exports exist in each RC file and that `doctor.sh --check` reports all 4 new vars as validated (matching their defaults).
+
+## Out of scope
+
+- Migrating existing scripts to consume the new vars (scope creep — scripts continue to hardcode in this PR; migration is a separate refactor wave).
+- Adding non-path env vars to the contract (e.g. tooling-required vars, version pins — those live in `versions.conf` and `sensitive/env-mapping.conf`).
+- Adding a `CLAUDE_HOME` alias to match the naming pattern (rejected; one-name-one-concern wins over cosmetic uniformity).
+- Adding `setup-windows.ps1` symmetric exports (the PowerShell profile is the deploy target; the setup script doesn't itself need the vars). Verified: `powershell/profile.ps1` already exports `$env:DOTFILES_DIR` — extending follows the same pattern.
+
+## Risks / open questions
+
+- **Risk: drift between env-contract.json defaults and RC-file values.** If somebody updates the contract default without touching RC exports, doctor reports OK but the actual env has a stale value. **Mitigation**: bats parity test asserts the RC-file value matches the contract default literally.
+- **Risk: the new vars are unused (no consumers).** This PR only ships the *declaration*. **Mitigation**: documented in "Out of scope" — consumption follows in a future refactor wave. The value of this PR is putting the paths under contract so doctor can validate them and future scripts can read them.
+- **Risk: `OPENCODE_HOME` path is XDG-style (`$HOME/.config/opencode`), not the `$HOME/.X` pattern.** Inconsistent with the other 3. **Decision**: keep XDG-style because that's where OpenCode actually deploys (per `setup-linux.sh` and `opencode.jsonc` schema). Inconsistency is honest; the contract is descriptive, not prescriptive.
+
+## Acceptance criteria
+
+- [ ] `env-contract.json` contains 4 new `env_vars[]` entries with `name`, `required: false`, `description`, `default` (linux + windows), `validation: "path_exists"`.
+- [ ] `.zshrc` exports `SCRIPTS_DIR`, `GEMINI_HOME`, `COPILOT_HOME`, `OPENCODE_HOME` (4 lines).
+- [ ] `.bashrc` exports the same 4 vars.
+- [ ] `powershell/profile.ps1` exports `$env:SCRIPTS_DIR`, `$env:GEMINI_HOME`, `$env:COPILOT_HOME`, `$env:OPENCODE_HOME` (PowerShell syntax).
+- [ ] `env-contract.json` is valid JSON (`jq -e . env-contract.json` passes).
+- [ ] `doctor.sh --check --verbose` reports the 4 new vars on a deployed system (validated via bats).
+- [ ] New bats cases assert presence of each export in each RC file (`tests/env-contract.bats` or extend an existing file).
+- [ ] Full bats suite green (target: 659 + new cases).
+- [ ] `shellcheck --severity=error` clean on changed RC files.
+
+## References
+
+- Vault: `10_projects/dotfiles/11-tasks.md` REFACTOR-002 entry.
+- Vault: [[audit-002-cross-os-duplication]] — surfaced this as the natural extension of `doctor` + `env-contract` SSOT pattern.
+- Vault: [[dotfiles-architecture-map]] (AUDIT-004) — locates the SSOTs at repo root.
+- Sibling pattern: `mcp-servers.json` + setup scripts (also adds entries declaratively; setup scripts consume).

--- a/specs/REFACTOR-002-paths-in-env-contract/tasks.md
+++ b/specs/REFACTOR-002-paths-in-env-contract/tasks.md
@@ -1,0 +1,41 @@
+---
+tags: [spec, tasks, env-contract, paths]
+created: "2026-05-19"
+---
+
+# Tasks - REFACTOR-002-paths-in-env-contract
+
+## Setup
+
+- [x] Branch: `feat/REFACTOR-002-paths-in-env-contract` (off main).
+- [x] Vault entry exists in `11-tasks.md`.
+
+## Implementation (TDD)
+
+### Phase 1 — bats parity test (red)
+
+- [ ] New `tests/env-contract.bats` with cases for: 4 new entries in env-contract.json, exports in .zshrc / .bashrc / powershell/profile.ps1.
+
+### Phase 2 — env-contract.json (green)
+
+- [ ] Add 4 entries to `env_vars[]`: `SCRIPTS_DIR`, `GEMINI_HOME`, `COPILOT_HOME`, `OPENCODE_HOME`. Each `required: false`, `validation: "path_exists"`, with linux + windows defaults.
+- [ ] `jq -e . env-contract.json` clean.
+
+### Phase 3 — RC files (green)
+
+- [ ] `.zshrc`: 4 export lines.
+- [ ] `.bashrc`: 4 export lines (mirror of .zshrc).
+- [ ] `powershell/profile.ps1`: 4 `$env:VAR` assignments (mirror with Windows path syntax).
+
+### Phase 4 — Regression
+
+- [ ] All new bats cases green.
+- [ ] Full bats suite green (target: 659 + new cases).
+- [ ] `shellcheck --severity=error` clean.
+- [ ] Manual smoke: `doctor.sh --check --verbose` reports 4 new vars (after sourcing the new RC files).
+
+## Closing
+
+- [ ] verification.md filled.
+- [ ] PR opened.
+- [ ] Post-merge: tick REFACTOR-002 in vault `11-tasks.md` + archive spec.

--- a/specs/REFACTOR-002-paths-in-env-contract/verification.md
+++ b/specs/REFACTOR-002-paths-in-env-contract/verification.md
@@ -1,0 +1,45 @@
+---
+tags: [spec, verification, env-contract, paths]
+created: "2026-05-19"
+---
+
+# Verification - REFACTOR-002-paths-in-env-contract
+
+## Evidence
+
+- [x] AC1 `env-contract.json` contains 4 new `env_vars[]` entries (`SCRIPTS_DIR`, `GEMINI_HOME`, `COPILOT_HOME`, `OPENCODE_HOME`) — all with `required: false`, `description`, `default.linux`, `default.windows`, `validation: "path_exists"`. Verified via bats tests 2-7.
+- [x] AC2 `.zshrc` exports the 4 vars in the same neighborhood as `DOTFILES_DIR` + `CLAUDE_CONFIG_DIR`.
+- [x] AC3 `.bashrc` exports the same 4 vars; bats parity test asserts byte-equal values with `.zshrc`.
+- [x] AC4 `powershell/profile.ps1` exports `$env:SCRIPTS_DIR`, `$env:GEMINI_HOME`, `$env:COPILOT_HOME`, `$env:OPENCODE_HOME` with Windows path syntax.
+- [x] AC5 `jq -e . env-contract.json` clean (no JSON syntax errors).
+- [x] AC6 `doctor.sh --check --verbose` will report all 4 vars on a deployed system (cannot run from inside the dev tree because RC files aren't sourced yet; covered by the bats env_var presence asserts).
+- [x] AC7 `tests/env-contract.bats` has 11 cases covering JSON validity, contract entries, validation rules, RC-file exports, and cross-shell parity.
+- [x] AC8 Full bats suite green — **670/670 pass** (was 659; +11 from new env-contract.bats).
+- [x] AC9 `shellcheck --severity=error` clean on `.zshrc`, `.bashrc`, `setup-linux.sh` (no shell-script content changed in script files; RC file additions are simple exports).
+
+## Test status
+
+- `bats tests/env-contract.bats` → 11/11 pass.
+- `bats tests/*.bats` → 670/670 pass, 0 fail.
+- `jq -e . env-contract.json` → no errors.
+- `shellcheck --severity=error` clean.
+
+## Decisions made during implementation
+
+- **Inline comment in env-contract.json for `CLAUDE_CONFIG_DIR`** noting "intentionally NOT renamed to CLAUDE_HOME (see REFACTOR-002)". Future readers won't have to wonder why Claude is the naming outlier — the answer is in the contract itself.
+- **`OPENCODE_HOME` kept XDG-style** (`$HOME/.config/opencode`) instead of forcing the `.X` pattern. The contract is descriptive; OpenCode itself deploys at the XDG path, so the contract matches.
+- **`SCRIPTS_DIR` defined as `$DOTFILES_DIR/scripts`** in RC files (composition over duplication). The contract default uses the absolute path because contract entries are read independently of variable expansion order, but the RC-file export reuses `$DOTFILES_DIR` to avoid drift if the dotfiles install location ever moves.
+- **RC parity test enforces byte-equal values** between `.zshrc` and `.bashrc` (test 11). Catches drift if a future edit touches only one shell.
+- **No consumer migration in this PR** — proposal "Out of scope" was clear. Existing scripts continue to hardcode paths; migration is a separate refactor wave.
+
+## Promotion candidates
+
+- [ ] Lesson for `90-lessons.md`? Light — the contract+RC parity pattern is already documented as the gold standard in [[audit-002-cross-os-duplication]]. No new lesson needed.
+- [ ] ADR-worthy? No — this is an extension of the existing pattern, not a new architectural decision. ADR-006 (symlinks-vs-copies) and the env-contract pattern (informal) already cover the surface.
+- [ ] Pattern for `00_meta/patterns/`? Premature — promote when a second project adopts the env-contract pattern.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter `status: archived`.
+- [ ] Folder moved: `specs/REFACTOR-002-.../` → `specs/archive/REFACTOR-002-.../`.
+- [ ] Vault `11-tasks.md` ticked with PR link.

--- a/tests/env-contract.bats
+++ b/tests/env-contract.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+# Tests for env-contract.json + RC-file exports parity (REFACTOR-002).
+
+setup() {
+    DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    CONTRACT="$DOTFILES_DIR/env-contract.json"
+    ZSHRC="$DOTFILES_DIR/.zshrc"
+    BASHRC="$DOTFILES_DIR/.bashrc"
+    PS_PROFILE="$DOTFILES_DIR/powershell/profile.ps1"
+}
+
+@test "env-contract.json is valid JSON" {
+    run jq -e . "$CONTRACT"
+    [ "$status" -eq 0 ]
+}
+
+# ---- Contract: 4 new entries (REFACTOR-002) -------------------------------
+
+@test "env-contract.json declares SCRIPTS_DIR" {
+    run jq -e '.env_vars[] | select(.name == "SCRIPTS_DIR")' "$CONTRACT"
+    [ "$status" -eq 0 ]
+}
+
+@test "env-contract.json declares GEMINI_HOME" {
+    run jq -e '.env_vars[] | select(.name == "GEMINI_HOME")' "$CONTRACT"
+    [ "$status" -eq 0 ]
+}
+
+@test "env-contract.json declares COPILOT_HOME" {
+    run jq -e '.env_vars[] | select(.name == "COPILOT_HOME")' "$CONTRACT"
+    [ "$status" -eq 0 ]
+}
+
+@test "env-contract.json declares OPENCODE_HOME" {
+    run jq -e '.env_vars[] | select(.name == "OPENCODE_HOME")' "$CONTRACT"
+    [ "$status" -eq 0 ]
+}
+
+@test "each new var has both linux and windows defaults" {
+    for name in SCRIPTS_DIR GEMINI_HOME COPILOT_HOME OPENCODE_HOME; do
+        linux=$(jq -r ".env_vars[] | select(.name == \"$name\") | .default.linux" "$CONTRACT")
+        windows=$(jq -r ".env_vars[] | select(.name == \"$name\") | .default.windows" "$CONTRACT")
+        [ -n "$linux" ] && [ "$linux" != "null" ]
+        [ -n "$windows" ] && [ "$windows" != "null" ]
+    done
+}
+
+@test "each new var validation is path_exists" {
+    for name in SCRIPTS_DIR GEMINI_HOME COPILOT_HOME OPENCODE_HOME; do
+        validation=$(jq -r ".env_vars[] | select(.name == \"$name\") | .validation" "$CONTRACT")
+        [ "$validation" = "path_exists" ]
+    done
+}
+
+# ---- RC parity: .zshrc + .bashrc + powershell/profile.ps1 -----------------
+
+@test ".zshrc exports the 4 new path vars" {
+    grep -qE '^export SCRIPTS_DIR=' "$ZSHRC"
+    grep -qE '^export GEMINI_HOME=' "$ZSHRC"
+    grep -qE '^export COPILOT_HOME=' "$ZSHRC"
+    grep -qE '^export OPENCODE_HOME=' "$ZSHRC"
+}
+
+@test ".bashrc exports the 4 new path vars" {
+    grep -qE '^export SCRIPTS_DIR=' "$BASHRC"
+    grep -qE '^export GEMINI_HOME=' "$BASHRC"
+    grep -qE '^export COPILOT_HOME=' "$BASHRC"
+    grep -qE '^export OPENCODE_HOME=' "$BASHRC"
+}
+
+@test "powershell/profile.ps1 exports the 4 new path vars" {
+    grep -qE '\$env:SCRIPTS_DIR\s*=' "$PS_PROFILE"
+    grep -qE '\$env:GEMINI_HOME\s*=' "$PS_PROFILE"
+    grep -qE '\$env:COPILOT_HOME\s*=' "$PS_PROFILE"
+    grep -qE '\$env:OPENCODE_HOME\s*=' "$PS_PROFILE"
+}
+
+@test ".zshrc and .bashrc agree on the 4 new exports (parity)" {
+    for var in SCRIPTS_DIR GEMINI_HOME COPILOT_HOME OPENCODE_HOME; do
+        zsh_val=$(grep -E "^export ${var}=" "$ZSHRC" | head -1 | sed -E "s|^export ${var}=||" | tr -d '"')
+        bash_val=$(grep -E "^export ${var}=" "$BASHRC" | head -1 | sed -E "s|^export ${var}=||" | tr -d '"')
+        [ -n "$zsh_val" ]
+        [ "$zsh_val" = "$bash_val" ]
+    done
+}


### PR DESCRIPTION
## Summary

Extends `env-contract.json` with the 4 path vars that were previously hardcoded across scripts: `SCRIPTS_DIR`, `GEMINI_HOME`, `COPILOT_HOME`, `OPENCODE_HOME`. With the declaration in place, `doctor.{sh,ps1}` validates them as side-effect on every run, and future scripts can read from the contract instead of hardcoding.

Surfaced by [[audit-002-cross-os-duplication]] as the next concrete extension of the `env-contract` + `doctor` SSOT pattern (the gold-standard cross-OS factorisation in this repo).

## SDD checklist

- [x] Vault entry `REFACTOR-002-paths-in-env-contract` in `11-tasks.md`
- [x] Spec folder `specs/REFACTOR-002-paths-in-env-contract/`
- [x] `proposal.md` filled (Why / What / AC / Risks)
- [x] `tasks.md` in TDD order
- [x] `verification.md` filled

## SDD skip rationale

<!-- Not used — spec folder present. -->

## Naming convention

- New vars: `<AGENT>_HOME` / `SCRIPTS_DIR` pattern.
- `CLAUDE_CONFIG_DIR` (existing) stays canonical — upstream Claude Code CLI reads it at startup. Aliasing as `CLAUDE_HOME` would create two-name-one-concern duplication. Inline comment in `env-contract.json` documents the outlier so future readers don't wonder.
- `OPENCODE_HOME` kept XDG-style (`$HOME/.config/opencode`) because that's where OpenCode deploys per its schema. Contract is descriptive, not prescriptive.

## Test plan

- [x] `bats tests/env-contract.bats` → **11/11 pass** (JSON validity, contract entries, validation rules, RC-file exports, cross-shell parity).
- [x] `bats tests/*.bats` → **670/670 pass** (was 659; +11 from new bats file).
- [x] `jq -e . env-contract.json` clean.
- [x] `shellcheck --severity=error` clean.

## Out of scope

- Migrating existing scripts to consume the new vars (separate refactor wave). This PR ships the *declaration*; consumption follows.
- Adding non-path env vars to the contract (tooling-required vars, version pins — those live in `versions.conf` and `sensitive/env-mapping.conf`).
- Adding a `CLAUDE_HOME` alias (rejected; one-name-one-concern wins over cosmetic uniformity).