### PR TITLE
fix: remove broken github@claude-plugins-official from deploy (BUG-007)

### DIFF
--- a/ai/claude/settings.json
+++ b/ai/claude/settings.json
@@ -30,7 +30,6 @@
     "explanatory-output-style@claude-plugins-official": true,
     "learning-output-style@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
-    "github@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -643,7 +643,6 @@ if command -v claude >/dev/null 2>&1; then
     for plugin in \
         "claude-mem@thedotmack" \
         "code-simplifier@claude-plugins-official" \
-        "github@claude-plugins-official" \
         "gopls-lsp@claude-plugins-official" \
         "security-guidance@claude-plugins-official" \
         "claude-md-management@claude-plugins-official" \

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -412,7 +412,6 @@ if ($claudeCmd) {
     $plugins = @(
         "claude-mem@thedotmack",
         "code-simplifier@claude-plugins-official",
-        "github@claude-plugins-official",
         "gopls-lsp@claude-plugins-official",
         "security-guidance@claude-plugins-official",
         "claude-md-management@claude-plugins-official",

--- a/specs/BUG-007-remove-github-plugin-broken/proposal.md
+++ b/specs/BUG-007-remove-github-plugin-broken/proposal.md
@@ -1,0 +1,50 @@
+---
+id: "BUG-007-remove-github-plugin-broken"
+type: spec
+status: draft
+created: "2026-05-19"
+tags: [spec, proposal, claude-plugins, removal]
+template_version: "1.0"
+---
+
+# BUG-007-remove-github-plugin-broken
+
+## Why
+
+The user reports `github@claude-plugins-official` is no longer useful and does not work. Every dotfiles setup run currently includes this plugin in the `enabledPlugins` list, triggering a `claude plugin install` call for a broken dependency. Removing it cleans the deploy contract.
+
+## What
+
+Remove every reference to `github@claude-plugins-official` across the repo:
+
+- `ai/claude/settings.json` (template `enabledPlugins`)
+- `setup-linux.sh` (plugin install loop)
+- `setup-windows.ps1` (plugin install loop)
+- `tests/claude-settings-template.bats` (positive assertion at line 86)
+
+Add an **inverse bats assertion** that fails CI if the plugin is ever re-added to the template (incident → guard pattern from SDD-006).
+
+## Out of scope
+
+- Removing other plugins.
+- Auditing the remaining 13 plugins.
+- Touching archived spec documents that mention the plugin (`specs/archive/SDD-002-settings-portability/proposal.md`) — archive is frozen historical record.
+
+## Risks / open questions
+
+- **Risk: user's existing `~/.claude/settings.json` still has the plugin enabled** post-setup (since `merge_claude_settings` preserves user values for keys outside the dotfiles-owned subset, but `enabledPlugins` IS in the subset). **Mitigation**: per SDD-002 design, `enabledPlugins` is dotfiles-owned → next setup run will overwrite with the new list (sans github). User may want to manually `claude plugin uninstall` for cleanup; documented in PR body.
+- **Risk: someone re-adds the plugin in a future PR.** **Mitigation**: inverse bats assertion is the guard.
+
+## Acceptance criteria
+
+- [ ] Zero matches for `github@claude-plugins-official` in `ai/claude/settings.json`, `setup-linux.sh`, `setup-windows.ps1`.
+- [ ] `tests/claude-settings-template.bats` has an **inverse assertion**: `! jq -e '.enabledPlugins["github@claude-plugins-official"]'`.
+- [ ] The previously-existing positive assertion (line 86) is removed or replaced with a different sample plugin.
+- [ ] Full bats suite green (target: 670 + new = 671 or unchanged if the inverse replaces the positive).
+- [ ] `jq -e . ai/claude/settings.json` clean.
+
+## References
+
+- Vault: `10_projects/dotfiles/11-tasks.md` BUG-007 entry.
+- Vault lesson: [[90-lessons]] "Incident → guard pattern (red-team thyself)" — applied here as the inverse assertion.
+- Trigger: user statement 2026-05-19 "el plugin de github habria que quitarlo de claude code, no nos sirve mas y no funciona".

--- a/specs/BUG-007-remove-github-plugin-broken/tasks.md
+++ b/specs/BUG-007-remove-github-plugin-broken/tasks.md
@@ -1,0 +1,27 @@
+---
+tags: [spec, tasks, claude-plugins, removal]
+created: "2026-05-19"
+---
+
+# Tasks - BUG-007-remove-github-plugin-broken
+
+## Setup
+
+- [x] Branch: `fix/BUG-007-remove-github-plugin-broken` (off main).
+- [x] Vault entry in `11-tasks.md`.
+
+## Implementation
+
+- [ ] Remove plugin entry from `ai/claude/settings.json` (line 33).
+- [ ] Remove plugin from `setup-linux.sh` plugin install loop (line 646).
+- [ ] Remove plugin from `setup-windows.ps1` plugin install loop (line 415).
+- [ ] In `tests/claude-settings-template.bats`: replace the positive assertion at line 86 with an inverse assertion that fails CI if the plugin is re-added. Keep the sample size at 5 by adding a different plugin (e.g. `feature-dev`).
+- [ ] `jq -e . ai/claude/settings.json` clean.
+- [ ] Full bats suite green.
+- [ ] `shellcheck --severity=error` clean on touched scripts.
+
+## Closing
+
+- [ ] verification.md filled.
+- [ ] PR opened with note for user: existing `~/.claude/settings.json` will be overwritten by next setup run; user may want to `claude plugin uninstall github@claude-plugins-official` manually for clean state.
+- [ ] Post-merge: tick BUG-007 in vault + archive spec.

--- a/specs/BUG-007-remove-github-plugin-broken/verification.md
+++ b/specs/BUG-007-remove-github-plugin-broken/verification.md
@@ -1,0 +1,49 @@
+---
+tags: [spec, verification, claude-plugins, removal]
+created: "2026-05-19"
+---
+
+# Verification - BUG-007-remove-github-plugin-broken
+
+## Evidence
+
+- [x] AC1 Zero matches for `github@claude-plugins-official` in `ai/claude/settings.json`, `setup-linux.sh`, `setup-windows.ps1`. Confirmed via `grep -nE` (returns no hits).
+- [x] AC2 `tests/claude-settings-template.bats` has 3 inverse assertions (BUG-007 guards): template lookup must fail, setup-linux.sh grep must miss, setup-windows.ps1 grep must miss.
+- [x] AC3 Positive sample list rebalanced: `github` removed from the 5-plugin sample, replaced with `feature-dev` (also widely used). Sample size preserved at 5.
+- [x] AC4 Plugin count assertion updated from 14 to 13 (the only place a count is hardcoded). Comment updated to flag the pre/post-BUG-007 state.
+- [x] AC5 Full bats suite: **673/673 pass** (was 670; +3 net from inverse guards).
+- [x] AC6 `jq -e . ai/claude/settings.json` clean.
+- [x] AC7 `shellcheck --severity=error setup-linux.sh` clean.
+
+## Test status
+
+- `bats tests/claude-settings-template.bats` → all green (including new inverse asserts).
+- `bats tests/*.bats` → 673/673 pass, 0 fail.
+- Manual cross-check: `grep -rn "github@claude-plugins-official" .` returns only the inverse-assertion lines in the bats file and references in archived specs (`specs/archive/SDD-002-settings-portability/proposal.md`) — which are correctly left untouched.
+
+## Decisions made during implementation
+
+- **Sample plugin swap rather than shrink.** Removing `github` from the 5-plugin sample would have left only 4 — weaker test. Adding `feature-dev` keeps the assertion strength while reflecting the new state. Comment documents the swap.
+- **Triple inverse assertion (template + 2 setup scripts) instead of just template.** Each surface can drift independently; checking all three catches any re-add path. Direct application of the SDD-006 incident → guard lesson.
+- **Plugin count down-tick from 14 → 13.** The count is hardcoded in only one place (line 74). Updating it locks the new contract; a future re-add would require BOTH adding the plugin AND bumping the count — two simultaneous edits is a higher bar than one.
+- **No removal from `specs/archive/SDD-002-settings-portability/proposal.md`** (which mentions "14 plugins"). Archive is frozen historical record; rewriting it would distort the audit trail. The current count assertion (13) and the prose explanation in the inverse-assert comment carry the truth forward.
+
+## Post-merge user action
+
+The user's existing `~/.claude/settings.json` may still have `github@claude-plugins-official` enabled (from prior setup runs). Per SDD-002 merge policy, `enabledPlugins` is dotfiles-owned → the **next `setup-linux.sh` run will overwrite the list** without the github entry, but the plugin will remain installed on disk under `~/.claude/plugins/`. For full cleanup:
+
+```bash
+claude plugin uninstall github@claude-plugins-official
+```
+
+## Promotion candidates
+
+- [ ] Lesson for `90-lessons.md`? Already captured — SDD-006's "Incident → guard pattern" lesson. This PR is a textbook application: bug encountered → inverse assertion added in the same diff.
+- [ ] ADR-worthy? No — operational removal, not architecture.
+- [ ] Pattern for `00_meta/patterns/`? Premature.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter `status: archived`.
+- [ ] Folder moved: `specs/BUG-007-.../` → `specs/archive/BUG-007-.../`.
+- [ ] Vault `11-tasks.md` ticked with PR link.

--- a/tests/claude-settings-template.bats
+++ b/tests/claude-settings-template.bats
@@ -68,10 +68,10 @@ setup() {
     [[ "$status" -ne 0 ]]
 }
 
-# --- enabledPlugins: 14 universal plugins, all true ---
+# --- enabledPlugins: 13 universal plugins, all true (was 14 pre-BUG-007) ---
 
-@test "template enabledPlugins has exactly 14 universal plugins" {
-    [[ "$(jq '.enabledPlugins | length' "$SETTINGS_TEMPLATE")" == "14" ]]
+@test "template enabledPlugins has exactly 13 universal plugins" {
+    [[ "$(jq '.enabledPlugins | length' "$SETTINGS_TEMPLATE")" == "13" ]]
 }
 
 @test "template enabledPlugins values all set to true" {
@@ -79,13 +79,32 @@ setup() {
 }
 
 @test "template enabledPlugins includes core plugins from the existing user setup" {
-    # Sample the 5 most-used: code-review, commit-commands, github, pr-review-toolkit, claude-md-management.
-    # Asserting a sample catches accidental removal while keeping the test list maintainable.
+    # Sample 5 representative plugins. Asserting a sample catches accidental
+    # removal while keeping the test list maintainable. (`github` was on this
+    # list pre-BUG-007; replaced with `feature-dev` which is also widely used.)
     jq -e '.enabledPlugins["code-review@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
     jq -e '.enabledPlugins["commit-commands@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
-    jq -e '.enabledPlugins["github@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
+    jq -e '.enabledPlugins["feature-dev@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
     jq -e '.enabledPlugins["pr-review-toolkit@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
     jq -e '.enabledPlugins["claude-md-management@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
+}
+
+# Inverse assertion (BUG-007, incident → guard pattern from SDD-006):
+# `github@claude-plugins-official` is broken/unused and was removed. CI MUST
+# fail if it ever returns to the template (accidental re-add, copy-paste
+# from old docs, etc.). The setup scripts' plugin install loop is checked
+# below as a cross-OS parity guard.
+@test "template enabledPlugins must NOT include github (BUG-007 removed)" {
+    run jq -e '.enabledPlugins["github@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
+    [ "$status" -ne 0 ]
+}
+
+@test "setup-linux.sh plugin install loop must NOT include github (BUG-007 removed)" {
+    ! grep -qE '"github@claude-plugins-official"' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-windows.ps1 plugin install loop must NOT include github (BUG-007 removed)" {
+    ! grep -qE '"github@claude-plugins-official"' "$DOTFILES_DIR/setup-windows.ps1"
 }
 
 # --- Negative assertions: user/machine-specific keys MUST NOT be in template ---


### PR DESCRIPTION
## Summary

User reported `github@claude-plugins-official` is no longer useful and does not work. Every dotfiles setup run was install-ing a broken dependency. Removed from all 4 surfaces:

- `ai/claude/settings.json`: dropped `enabledPlugins` entry (13 plugins now, was 14).
- `setup-linux.sh`: removed from plugin install loop.
- `setup-windows.ps1`: removed from plugin install loop.
- `tests/claude-settings-template.bats`: **inverse assertions added** per the SDD-006 incident-to-guard lesson — CI fails if the plugin returns to template OR to either setup script.

## SDD checklist

- [x] Vault entry `BUG-007-remove-github-plugin-broken` in `11-tasks.md`
- [x] Spec folder `specs/BUG-007-remove-github-plugin-broken/`
- [x] `proposal.md` filled (Why / What / AC / Risks)
- [x] `tasks.md` in TDD order
- [x] `verification.md` filled

## SDD skip rationale

<!-- Not used — spec folder present. -->

## Test plan

- [x] `bats tests/*.bats` → **673/673 pass** (was 670; +3 net from inverse guards).
- [x] `bats tests/claude-settings-template.bats` covers: positive sample (5 plugins, `github` swapped for `feature-dev`), inverse template assertion, inverse setup-linux assertion, inverse setup-windows assertion, plugin count 14→13.
- [x] `jq -e . ai/claude/settings.json` clean.
- [x] `shellcheck --severity=error setup-linux.sh` clean.
- [x] Manual grep cross-check: `github@claude-plugins-official` appears only in the inverse-assertion lines and in archived spec docs (intentionally untouched — frozen history).

## Notable decisions

- **Triple inverse guard** (template + linux + windows) instead of single. Each surface can drift independently; checking all three catches any re-add path. Direct application of SDD-006 incident → guard.
- **Plugin count down-tick** locks the new contract. A future re-add would require BOTH adding the entry AND bumping the count — two simultaneous edits is a higher bar than one.
- **Sample swap** in the positive 5-plugin sample (github → feature-dev) preserves assertion strength.

## Post-merge user action (optional, cleanup)

Existing `~/.claude/settings.json` may still have the plugin enabled from prior setup runs. Per SDD-002 merge policy, `enabledPlugins` is dotfiles-owned, so the next `setup-linux.sh` run will overwrite the list without `github`. The on-disk plugin folder under `~/.claude/plugins/` remains until manually uninstalled:

```
claude plugin uninstall github@claude-plugins-official
```