### PR TITLE
fix(WIN-002): tighten healthcheck.ps1 to Windows install reality

### DIFF
--- a/scripts/healthcheck.ps1
+++ b/scripts/healthcheck.ps1
@@ -120,9 +120,13 @@ Write-Host "Checking from: $script:DotfilesDir"
 # ==================================================
 # 1/12 Core Tools in PATH
 # ==================================================
+# Required = installed by setup-windows.ps1 (winget array) + the bootstrap
+# prerequisites git/pwsh. Workflow-dependent tools (node/npm/docker/kubectl/
+# terraform/direnv) moved to section 6 (Optional) because dotfiles does not
+# deploy them on Windows -- they're user choice per task.
 Write-Section '1/12' 'Core Tools in PATH'
 
-$coreTools = @('git', 'pwsh', 'curl', 'jq', 'eza', 'direnv', 'node', 'npm', 'zoxide', 'docker', 'kubectl', 'terraform')
+$coreTools = @('git', 'pwsh', 'curl', 'jq', 'eza', 'gh', 'zoxide')
 foreach ($tool in $coreTools) {
     if (Test-Command $tool) {
         Write-Pass "$tool found"
@@ -165,28 +169,37 @@ if ($env:MINIKUBE_HOME -and (Test-Path -LiteralPath $env:MINIKUBE_HOME -PathType
 # ==================================================
 # 3/12 Version Match (versions.conf)
 # ==================================================
+# Linux deploys language toolchains under $APPS_HOME/{jdk-VERSION,go-VERSION,...}
+# and pins versions via versions.conf. Windows installs language toolchains via
+# winget into user-chosen paths and does NOT use $APPS_HOME. So this section is
+# only meaningful when $env:APPS_HOME is explicitly set; otherwise SKIP the
+# whole block (a single line, not 5 individual SKIPs).
 Write-Section '3/12' 'Version Match (versions.conf)'
 
-$appsHome = if ($env:APPS_HOME) { $env:APPS_HOME } else { Join-Path $env:USERPROFILE 'Applications' }
+if (-not $env:APPS_HOME) {
+    Write-Skip 'version match' '$env:APPS_HOME not set (Windows uses winget, not $APPS_HOME -- skip section)'
+} else {
+    $appsHome = $env:APPS_HOME
 
-function Test-VersionMatch {
-    param([string]$Name, [string]$Expected, [string]$DirPath)
-    if (-not $Expected) {
-        Write-Skip "$Name version" 'not set in versions.conf'
-        return
+    function Test-VersionMatch {
+        param([string]$Name, [string]$Expected, [string]$DirPath)
+        if (-not $Expected) {
+            Write-Skip "$Name version" 'not set in versions.conf'
+            return
+        }
+        if (Test-Path -LiteralPath $DirPath -PathType Container) {
+            Write-Pass "$Name version $Expected (directory exists)"
+        } else {
+            Write-Fail "$Name expected version $Expected but directory missing: $DirPath"
+        }
     }
-    if (Test-Path -LiteralPath $DirPath -PathType Container) {
-        Write-Pass "$Name version $Expected (directory exists)"
-    } else {
-        Write-Fail "$Name expected version $Expected but directory missing: $DirPath"
-    }
+
+    Test-VersionMatch 'Java'     $script:Versions['JAVA_VERSION']     (Join-Path $appsHome "jdk-$($script:Versions['JAVA_VERSION'])")
+    Test-VersionMatch 'Maven'    $script:Versions['MAVEN_VERSION']    (Join-Path $appsHome "apache-maven-$($script:Versions['MAVEN_VERSION'])")
+    Test-VersionMatch 'Python'   $script:Versions['PYTHON_VERSION']   (Join-Path $appsHome "python-$($script:Versions['PYTHON_VERSION'])")
+    Test-VersionMatch 'Minikube' $script:Versions['MINIKUBE_VERSION'] (Join-Path $appsHome "minikube-$($script:Versions['MINIKUBE_VERSION'])")
+    Test-VersionMatch 'Go'       $script:Versions['GO_VERSION']       (Join-Path $appsHome "go-$($script:Versions['GO_VERSION'])")
 }
-
-Test-VersionMatch 'Java'     $script:Versions['JAVA_VERSION']     (Join-Path $appsHome "jdk-$($script:Versions['JAVA_VERSION'])")
-Test-VersionMatch 'Maven'    $script:Versions['MAVEN_VERSION']    (Join-Path $appsHome "apache-maven-$($script:Versions['MAVEN_VERSION'])")
-Test-VersionMatch 'Python'   $script:Versions['PYTHON_VERSION']   (Join-Path $appsHome "python-$($script:Versions['PYTHON_VERSION'])")
-Test-VersionMatch 'Minikube' $script:Versions['MINIKUBE_VERSION'] (Join-Path $appsHome "minikube-$($script:Versions['MINIKUBE_VERSION'])")
-Test-VersionMatch 'Go'       $script:Versions['GO_VERSION']       (Join-Path $appsHome "go-$($script:Versions['GO_VERSION'])")
 
 # ==================================================
 # 4/12 Key Files / Junctions
@@ -228,10 +241,15 @@ if (Test-Path -LiteralPath $marketplaceReal -PathType Container) {
 # ==================================================
 # 5/12 Environment Variables
 # ==================================================
+# DOTFILES_DIR is the only Windows-required env var (set by powershell/profile.ps1).
+# APPS_HOME + language _HOME vars are Linux-deploy-pattern vars; on Windows they
+# are optional (user may set them per workflow) -- SKIP if unset, not FAIL.
 Write-Section '5/12' 'Environment Variables'
 
-$envVars = @('DOTFILES_DIR', 'APPS_HOME', 'JAVA_HOME', 'MAVEN_HOME', 'PYTHON_HOME', 'GO_HOME', 'MINIKUBE_HOME')
-foreach ($v in $envVars) {
+$requiredVars = @('DOTFILES_DIR')
+$optionalVars = @('APPS_HOME', 'JAVA_HOME', 'MAVEN_HOME', 'PYTHON_HOME', 'GO_HOME', 'MINIKUBE_HOME')
+
+foreach ($v in $requiredVars) {
     $val = [Environment]::GetEnvironmentVariable($v)
     if ($val) {
         Write-Pass "$v is set"
@@ -240,12 +258,27 @@ foreach ($v in $envVars) {
     }
 }
 
+foreach ($v in $optionalVars) {
+    $val = [Environment]::GetEnvironmentVariable($v)
+    if ($val) {
+        Write-Pass "$v is set"
+    } else {
+        Write-Skip $v 'optional on Windows (Linux-deploy var)'
+    }
+}
+
 # ==================================================
 # 6/12 Optional Tools
 # ==================================================
 Write-Section '6/12' 'Optional Tools'
 
-$optionalTools = @('age', 'gh', 'claude', 'gemini', 'bats', 'helm', 'ansible', 'pip', 'copilot', 'opencode', 'uv')
+$optionalTools = @(
+    'age', 'claude', 'gemini', 'bats', 'helm', 'ansible', 'pip', 'copilot', 'opencode', 'uv',
+    # Workflow-dependent tools moved here from sec 1 (Windows doesn't deploy
+    # them by default; they're user choice per workflow). Linux's sec 1 keeps
+    # them required because setup-linux.sh installs the standard dev set.
+    'node', 'npm', 'docker', 'kubectl', 'terraform', 'direnv'
+)
 foreach ($tool in $optionalTools) {
     if (Test-Command $tool) {
         Write-Pass "$tool found"

--- a/specs/WIN-002-windows-smoke-sweep/proposal.md
+++ b/specs/WIN-002-windows-smoke-sweep/proposal.md
@@ -1,0 +1,63 @@
+---
+id: "WIN-002-windows-smoke-sweep"
+type: spec
+status: implementing # this PR ships partial closure; full clean-machine sweep remains
+created: "2026-05-21"
+tags: [spec, proposal, windows, smoke-sweep, healthcheck]
+template_version: "1.0"
+---
+
+# WIN-002-windows-smoke-sweep
+
+> Multi-PR umbrella for the Windows post-setup smoke sweep. **This PR ships partial closure**: tightens `scripts/healthcheck.ps1` so the FAILs it emits reflect what `setup-windows.ps1` actually deploys, not the Linux-deploy expectations. Full WIN-002 closure (clean admin Windows machine sweep, BUG-N tickets per finding) is tracked by subsequent work in the same spec.
+
+## Why
+
+<!-- from 11-tasks.md: Run `setup-windows.ps1` + `healthcheck.ps1` on a clean admin Windows machine, log every fail as inline BUG-N entries, fix trivial ones in place. Closes when healthcheck reports 0 fails. -->
+
+After WIN-001 (PR #71) merged, the first empirical `healthcheck.ps1` run on this Windows machine reported 17 FAILs. Closer inspection revealed **most of them are not bugs in `healthcheck.ps1` itself** — they're a scope mismatch between what `healthcheck.sh` checks on Linux (where setup deploys a full dev toolchain via `$APPS_HOME`) and what `setup-windows.ps1` actually installs on Windows (a much narrower winget list: age, eza, jq, gh, zoxide, copilot). The healthcheck was ported 1:1 to PowerShell but never re-scoped to Windows install reality, so it flags as FAIL many tools and env vars that dotfiles never promised to deploy on Windows.
+
+Result: a fresh `setup-windows.ps1 + healthcheck.ps1` run looks alarming ("18+ FAILs!") when in fact the install is doing exactly what was designed. This breaks the canary value of healthcheck — if users learn to ignore healthcheck FAILs because most are false, they'll miss real ones (the kind WIN-002 was supposed to surface in the first place).
+
+## What
+
+Three observable behavior changes after this PR:
+
+1. **Section 1 (Core Tools in PATH)** now lists only the tools `setup-windows.ps1` actually installs via winget plus the bootstrap prerequisites: `git, pwsh, curl, jq, eza, gh, zoxide`. Workflow-dependent tools (`node, npm, docker, kubectl, terraform, direnv`) move to section 6 (Optional Tools) — present means PASS, absent means SKIP (not FAIL).
+2. **Section 3 (Version Match)** gates the entire body on `$env:APPS_HOME` being explicitly set. On Linux that's set by `setup-linux.sh`; on Windows it's not (language toolchains come from winget, not `$APPS_HOME/jdk-VERSION` dirs). When `$env:APPS_HOME` is unset, the section emits a single SKIP line explaining the rationale, instead of 5 individual FAILs for absent `jdk-21.0.4/`, `apache-maven-3.9.4/`, etc.
+3. **Section 5 (Environment Variables)** splits the var list into REQUIRED (currently only `DOTFILES_DIR`, set by `powershell/profile.ps1`) and OPTIONAL (`APPS_HOME, JAVA_HOME, MAVEN_HOME, PYTHON_HOME, GO_HOME, MINIKUBE_HOME`). Optional vars emit SKIP when unset (with explanation), not FAIL.
+
+**Empirical result on local Windows after the change**: from 60 PASSED / 17 FAILED / 15 SKIPPED → 60 PASSED / 2 FAILED / 26 SKIPPED. The 2 remaining FAILs are legitimate: `Obsidian CLI not in PATH` (real `setup-windows.ps1` gap — see BUG-013 below) and `Linter lintOnSave disabled` (user-side Obsidian config drift — same cross-OS check as Linux, behavior matches healthcheck.sh).
+
+## Out of scope (deferred to subsequent WIN-002 PRs)
+
+- **Full clean-machine sweep.** Running `setup-windows.ps1` end-to-end on a **fresh** Windows VM (no pre-existing tools, no pre-existing config) and logging every FAIL inline. This needs a separate session on a clean machine; this PR works from the daily-driver Windows install.
+- **BUG-013-obsidian-cli-windows-parity** (to be opened in vault): `setup-windows.ps1` does not install the Obsidian CLI (`@vorillaz/obsidian-cli` via npm) the way `setup-linux.sh` does. Surfaced by the remaining `FAIL: Obsidian CLI not in PATH` and confirmed against `setup-windows.ps1` (no npm install block for it).
+- **Linter lintOnSave drift fix.** The `FAIL: Linter lintOnSave disabled` is the same check Linux's healthcheck performs and is a user-side state finding (Obsidian config in vault, not in dotfiles). Cross-OS parity says keep the FAIL; user resolves by toggling lintOnSave in Obsidian linter plugin. No script change needed.
+
+## Risks / open questions
+
+**Risk: removing tools from sec 1 hides real install regressions.** Mitigation: the moved tools (node/npm/docker/kubectl/terraform/direnv) all go to sec 6 (Optional Tools), still checked, just with SKIP semantics instead of FAIL. A user who needs Docker and finds it missing still sees the SKIP line — same diagnostic value, less alarm.
+
+**Risk: cross-OS healthcheck divergence.** Mitigation: this is OS-conditional behavior inside a single script, not a fork. `healthcheck.sh` keeps its broader Linux contract (because setup-linux.sh genuinely installs that toolchain); `healthcheck.ps1` reflects Windows install reality. The 12-section numbering parity is preserved (bats parity asserts still pass).
+
+**Open question (resolved): should `gh` be required or optional?** `setup-windows.ps1` installs `gh` via winget. Decision: required (in sec 1 list). Same logic as the other 5 winget-installed tools.
+
+## Acceptance criteria
+
+- [x] `scripts/healthcheck.ps1` sec 1 core list reduced to `git, pwsh, curl, jq, eza, gh, zoxide`
+- [x] Moved tools (`node, npm, docker, kubectl, terraform, direnv`) appear in sec 6 optional list
+- [x] `scripts/healthcheck.ps1` sec 3 gates entire body on `$env:APPS_HOME`; emits single SKIP line when unset
+- [x] `scripts/healthcheck.ps1` sec 5 distinguishes required vs optional env vars; optional unset → SKIP not FAIL
+- [x] PSScriptAnalyzer clean (Error+Warning)
+- [x] PowerShell parse clean
+- [x] Empirical: on this Windows machine, healthcheck FAIL count drops from 17 → 2 (Obsidian CLI gap + Linter lintOnSave drift, both deferred per Out of Scope)
+- [ ] CI bats suite still green (no asserts on the moved tool lists; structural greps unaffected)
+- [ ] Vault entry BUG-013-obsidian-cli-windows-parity opened (P2, ~20 LOC fix for follow-up)
+
+## References
+
+- Vault: `10_projects/dotfiles/11-tasks.md` "WIN-002-windows-smoke-sweep" backlog entry
+- Sibling: WIN-001-healthcheck-ps1 (PR #71) — the artifact this PR scopes
+- Discovered: BUG-013-obsidian-cli-windows-parity (opened in same session)
+- Reference: `setup-windows.ps1` lines 262-269 (the canonical winget array — source of truth for what Windows core tools are)

--- a/specs/WIN-002-windows-smoke-sweep/tasks.md
+++ b/specs/WIN-002-windows-smoke-sweep/tasks.md
@@ -1,0 +1,55 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-05-13"
+---
+
+# Tasks - WIN-002-windows-smoke-sweep
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+
+## Setup
+
+- [ ] Branch created from main: `feat/WIN-002-windows-smoke-sweep`
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+> Replace these with the actual steps for this feature. Keep them small (one commit each) and in TDD order.
+
+- [ ] Write failing test for <behavior 1>
+- [ ] Implement <module/function> to make it pass
+- [ ] Refactor for clarity (extract, rename, dedupe)
+- [ ] Write failing test for <behavior 2>
+- [ ] Implement to make it pass
+- [ ] ...
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
+- [ ] Type checks pass
+- [ ] Lint passes
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
+
+Minimal `features.json` skeleton (drop into `<repo>/specs/WIN-002-windows-smoke-sweep/features.json`):
+
+```json
+[
+  {
+    "id": "WIN-002-windows-smoke-sweep-f1",
+    "behavior": "<one-line copy of an acceptance criterion>",
+    "verification": "<single shell command; exit 0 means pass>",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/WIN-002-windows-smoke-sweep/verification.md
+++ b/specs/WIN-002-windows-smoke-sweep/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-05-13"
+---
+
+# Verification - WIN-002-windows-smoke-sweep
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for `<area>/90-lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for `<area>/30-architecture/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/WIN-002-windows-smoke-sweep/` -> `specs/archive/WIN-002-windows-smoke-sweep/`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
## Summary

After WIN-001 (PR #71) merged, the first empirical `healthcheck.ps1` run on the daily-driver Windows machine reported 17 FAILs. Most were not bugs but a scope mismatch: the script was ported 1:1 from `healthcheck.sh` and inherits Linux-deploy assumptions, while `setup-windows.ps1` installs a much narrower winget set and does not set `$APPS_HOME` or language `_HOME` vars.

## Changes

- **Sec 1 (Core Tools)**: reduced to `{git, pwsh, curl, jq, eza, gh, zoxide}` — bootstrap prerequisites + the winget install array from `setup-windows.ps1` lines 262-269. Workflow-dependent tools (`node, npm, docker, kubectl, terraform, direnv`) moved to sec 6 (Optional Tools) with SKIP semantics.
- **Sec 3 (Version Match)**: gated on `$env:APPS_HOME` being set. Single SKIP line with rationale when unset, instead of 5 individual FAILs.
- **Sec 5 (Env Vars)**: split into REQUIRED (`DOTFILES_DIR`) + OPTIONAL (`APPS_HOME` + 5 language `_HOME` vars). Optional unset = SKIP, not FAIL.

## Empirical result on local Windows

`60 PASSED / 17 FAILED / 15 SKIPPED` → `60 PASSED / 2 FAILED / 26 SKIPPED`.

Remaining 2 FAILs are legitimate:
- `Obsidian CLI not in PATH` — to be opened as BUG-013 (`setup-windows.ps1` doesn't install `@vorillaz/obsidian-cli` the way `setup-linux.sh` does).
- `Linter lintOnSave disabled` — user-side Obsidian config drift; same check `healthcheck.sh` runs on Linux. Cross-OS parity says keep the FAIL.

## Test plan

- [x] PSScriptAnalyzer clean
- [x] PowerShell parse clean
- [ ] CI bats suite green (existing asserts unaffected — no assert on tool list contents; structural greps only)
- [ ] CI spec-gate green (`specs/WIN-002-windows-smoke-sweep/` folder present)

## Spec status

`specs/WIN-002-windows-smoke-sweep/` is `status: implementing` — this PR ships **partial closure** (healthcheck scope tightening). Full WIN-002 closure (clean admin Windows machine sweep, BUG-N tickets per finding) remains open as subsequent work in the same spec.