### PR TITLE
fix(WIN-001): deploy healthcheck.ps1 in setup-windows.ps1

### DIFF
--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -860,6 +860,17 @@ if (Test-Path $doctorSource) {
     Write-Warn "doctor.ps1 not found at $doctorSource"
 }
 
+# WIN-001 follow-up: PR #71 added the post-setup invocation in section 8d but
+# omitted the deploy. Without this Copy-Item, $ScriptsDir\healthcheck.ps1 never
+# exists and section 8d silently warns "not deployed, skipping" on every run.
+$healthcheckSource = "$DotfilesDir\scripts\healthcheck.ps1"
+if (Test-Path $healthcheckSource) {
+    Copy-Item $healthcheckSource "$ScriptsDir\" -Force
+    Write-Success "Deployed healthcheck.ps1 to $ScriptsDir\"
+} else {
+    Write-Warn "healthcheck.ps1 not found at $healthcheckSource"
+}
+
 $contractSource = "$DotfilesDir\env-contract.json"
 if (Test-Path $contractSource) {
     Copy-Item $contractSource "$DotfilesDest\" -Force


### PR DESCRIPTION
## Summary

- PR #71 (WIN-001) added the post-setup auto-invocation of `healthcheck.ps1` in `setup-windows.ps1` section 8d but never deployed the script itself to `$ScriptsDir`. Every setup run ended with `[WARNING] healthcheck.ps1 not deployed... skipping post-setup check`.
- Add the missing `Copy-Item` right after the `doctor.ps1` deploy (section 7), mirroring the idempotent pattern used for every other script.
- Net: +11 lines. No behaviour change beyond closing the WIN-001 wiring end-to-end.

## Why this slipped past PR #71

The PR was reviewed and tested on a machine where `healthcheck.ps1` already lived at `$ScriptsDir` from prior manual placement, so the section 8d wiring appeared to work. On a fresh machine — or on mine after a clean re-run — the warning surfaced.

## Test plan

- [x] Static parse of `setup-windows.ps1` is clean (`[Parser]::ParseFile`)
- [x] `git diff` confirms a single 11-line addition mirroring the doctor.ps1 deploy idiom
- [ ] After merge, re-run `setup-windows.ps1` on the daily-driver Windows machine; expect `[SUCCESS] Deployed healthcheck.ps1 to $ScriptsDir\` followed by section 8d running healthcheck instead of skipping it.

## Out of scope

- WIN-001b (mirror auto-wire in `setup-linux.sh`) — already tracked in vault, pending UX validation
- WIN-002 full clean-VM sweep — separate ticket
- OpenCode Windows install — its own runbook, tracked separately