### PR TITLE
feat(BUG-014): register thedotmack marketplace before plugin install (cross-OS)

### DIFF
--- a/scripts/healthcheck.ps1
+++ b/scripts/healthcheck.ps1
@@ -225,12 +225,33 @@ Test-DeployedFile (Join-Path $env:USERPROFILE '.claude\CLAUDE.md')  'CLAUDE.md'
 Test-DeployedFile (Join-Path $env:USERPROFILE '.gemini\GEMINI.md')  'GEMINI.md'
 Test-DeployedFile (Join-Path $env:USERPROFILE '.ssh\config')        'SSH config'
 
-# BUG-012 marketplace junction (claude-mem plugin discovery compat)
+# BUG-014 canonical install-state assertion (primary).
+# The BUG-012 junction check below validates a proxy artifact (filesystem
+# junction) and PASSes even when the plugin is never registered in
+# installed_plugins.json. This primary check closes that false-positive class
+# by grepping the canonical install record.
+$installedPluginsJson = Join-Path $env:USERPROFILE '.claude\plugins\installed_plugins.json'
+if (Test-Path -LiteralPath $installedPluginsJson) {
+    if (Select-String -Path $installedPluginsJson -SimpleMatch 'claude-mem@thedotmack' -Quiet) {
+        Write-Pass 'claude-mem@thedotmack installed (BUG-014 canonical check)'
+    } else {
+        Write-Fail "claude-mem@thedotmack NOT in installed_plugins.json -- re-run setup-windows.ps1 (BUG-014)"
+    }
+} else {
+    Write-Skip 'claude-mem install state' 'installed_plugins.json missing (Claude Code never ran)'
+}
+
+# BUG-012 marketplace junction (claude-mem plugin discovery compat) -- SECONDARY
+# diagnostic. Different failure class than BUG-014: install OK in
+# installed_plugins.json but plugin hooks still break because the legacy
+# junction is missing (UserPromptSubmit fails). Kept after BUG-014 so a true
+# install miss surfaces as FAIL on the primary check; this only flags the
+# narrower discovery-path issue.
 $marketplaceLegacy = Join-Path $env:USERPROFILE '.claude\plugins\marketplaces\thedotmack'
 $marketplaceReal   = Join-Path $env:USERPROFILE '.claude\plugins\marketplaces\thedotmack-claude-mem'
 if (Test-Path -LiteralPath $marketplaceReal -PathType Container) {
     if (Test-Path -LiteralPath $marketplaceLegacy) {
-        Write-Pass 'claude-mem marketplace legacy junction present (BUG-012)'
+        Write-Pass 'claude-mem marketplace legacy junction present (BUG-012 secondary)'
     } else {
         Write-Fail "claude-mem marketplace legacy junction missing: $marketplaceLegacy (run claude-mem-heal.ps1)"
     }

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -168,6 +168,22 @@ check_symlink "$HOME/.zsh/aliases.zsh" ".zsh/aliases.zsh"
 check_symlink "$HOME/.zsh/functions.zsh" ".zsh/functions.zsh"
 check_symlink "$HOME/.ssh/config" ".ssh/config"
 
+# BUG-014 canonical install-state assertion (placed in sec 4 for cross-OS
+# parity with healthcheck.ps1). Greps the canonical install record; PASS only
+# when claude-mem is actually registered. Closes the false-positive class
+# where the marketplace dir exists on disk but the plugin was never installed
+# (e.g. after a .claude.json truncation event before BUG-004's snapshot guard).
+installed_plugins_json="$HOME/.claude/plugins/installed_plugins.json"
+if [ -f "$installed_plugins_json" ]; then
+    if grep -qF 'claude-mem@thedotmack' "$installed_plugins_json"; then
+        pass "claude-mem@thedotmack installed (BUG-014 canonical check)"
+    else
+        fail "claude-mem@thedotmack NOT in installed_plugins.json -- re-run setup-linux.sh (BUG-014)"
+    fi
+else
+    skip "claude-mem install state -- installed_plugins.json missing (Claude Code never ran)"
+fi
+
 # ==================================================
 section "5/12" "Environment Variables"
 

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -649,6 +649,17 @@ fi
 # also wrapped because it goes through the same #59870 path.
 if command -v claude >/dev/null 2>&1; then
     log_info "Installing Claude Code plugins..."
+    # BUG-014: register the `thedotmack` marketplace BEFORE the plugin install
+    # loop. Without this, `claude plugin install claude-mem@thedotmack` cannot
+    # resolve `@thedotmack` (only `claude-plugins-official` is registered by
+    # default) and fails silently inside the loop's `|| true`. The CLI is
+    # idempotent ("Marketplace 'thedotmack' already on disk" + exit 0 on
+    # re-run), so we call it unconditionally. Wrapped per BUG-011 — every
+    # `claude` CLI invocation in setup must be snapshot-guarded.
+    _snap=$(snapshot_claude_json)
+    claude plugin marketplace add thedotmack/claude-mem >/dev/null 2>&1 || true
+    restore_claude_json_if_truncated "$_snap"
+
     # BUG-011: wrap the read-only `claude plugin list` pre-fetch with the
     # snapshot guard -- the CLI still rewrites .claude.json on any invocation.
     _snap=$(snapshot_claude_json)

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -442,13 +442,13 @@ if ($claudeCmd) {
     # `@thedotmack` (only `claude-plugins-official` is registered by default)
     # and fails silently inside the loop's try/catch. The CLI is idempotent
     # ("Marketplace 'thedotmack' already on disk" + exit 0 on re-run), so we
-    # call it unconditionally. Wrapped per BUG-011 — every `claude` CLI
+    # call it unconditionally. Wrapped per BUG-011 -- every `claude` CLI
     # invocation in setup must be snapshot-guarded.
     Backup-AndRestoreClaudeJson -Action {
         try {
             & claude plugin marketplace add thedotmack/claude-mem 2>$null | Out-Null
         } catch {
-            # Network failure or transient CLI issue — let the install loop fail
+            # Network failure or transient CLI issue -- let the install loop fail
             # loud-but-recoverable rather than blocking the rest of setup.
         }
     }

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -437,6 +437,22 @@ if ($claudeCmd) {
         "commit-commands@claude-plugins-official",
         "pr-review-toolkit@claude-plugins-official"
     )
+    # BUG-014: register the `thedotmack` marketplace BEFORE the install loop.
+    # Without this, `claude plugin install claude-mem@thedotmack` cannot resolve
+    # `@thedotmack` (only `claude-plugins-official` is registered by default)
+    # and fails silently inside the loop's try/catch. The CLI is idempotent
+    # ("Marketplace 'thedotmack' already on disk" + exit 0 on re-run), so we
+    # call it unconditionally. Wrapped per BUG-011 — every `claude` CLI
+    # invocation in setup must be snapshot-guarded.
+    Backup-AndRestoreClaudeJson -Action {
+        try {
+            & claude plugin marketplace add thedotmack/claude-mem 2>$null | Out-Null
+        } catch {
+            # Network failure or transient CLI issue — let the install loop fail
+            # loud-but-recoverable rather than blocking the rest of setup.
+        }
+    }
+
     # BUG-011: wrap the read-only `claude plugin list` pre-fetch with the
     # snapshot guard -- the CLI still rewrites .claude.json on any invocation.
     $installedPlugins = Backup-AndRestoreClaudeJson -Action {

--- a/specs/BUG-014-claude-mem-marketplace-register/proposal.md
+++ b/specs/BUG-014-claude-mem-marketplace-register/proposal.md
@@ -1,0 +1,62 @@
+---
+id: "BUG-014-claude-mem-marketplace-register"
+type: spec
+status: implementing
+created: "2026-05-21"
+tags: [spec, proposal, claude-mem, plugin-discovery, cross-os-parity]
+template_version: "1.0"
+---
+
+# BUG-014-claude-mem-marketplace-register
+
+## Why
+
+`setup-{linux.sh,windows.ps1}` list `claude-mem@thedotmack` in the plugin install loop but **neither script ever registers the `thedotmack` marketplace first**. On a fresh machine `claude plugin marketplace list` shows only `claude-plugins-official` (the bundled default), so `claude plugin install claude-mem@thedotmack` cannot resolve `@thedotmack` and fails silently inside the wide `try{} catch{}` (`setup-windows.ps1:456-462`, `setup-linux.sh` plugin loop). Result: `installed_plugins.json` never contains `claude-mem@thedotmack`, the session-start hook does not fire, `/mem-search` is unavailable. The global `~/.claude/CLAUDE.md` declares claude-mem "Active by default in every session" — the install gap silently breaks that contract.
+
+Empirically reproduced on Windows daily-driver 2026-05-21: 15-plugin install record contained zero `@thedotmack` entries. `claude plugin marketplace add thedotmack/claude-mem` followed by `claude plugin install claude-mem@thedotmack` succeeded (exit 0 both, idempotent on re-run, no `.claude.json` truncation under BUG-004 snapshot guard) and restored claude-mem in the next session. The fix command is upstream-supported and stable; setup scripts just never call it.
+
+BUG-012 (PR #70) created a legacy junction filesystem-side but did not address marketplace registration. `claude-mem-heal.{sh,ps1}` only patches existing installs; it cannot bootstrap a marketplace. Healthcheck `[4/12] PASS: claude-mem marketplace legacy junction present (BUG-012)` is a **false positive** — it checks a proxy artifact (filesystem junction) instead of the canonical state (`installed_plugins.json` membership).
+
+## What
+
+1. **Both setup scripts** insert one new step BEFORE the existing plugin install loop: invoke `claude plugin marketplace add thedotmack/claude-mem`, wrapped with the existing `Backup-AndRestoreClaudeJson` / `backup_and_restore_claude_json` BUG-004/BUG-011 snapshot guard. The CLI is idempotent (exit 0 + `'thedotmack' already on disk` message on re-run), so no pre-check needed.
+2. **Both healthcheck scripts** sec 4 add a **new** assertion: `claude-mem@thedotmack` is present in `~/.claude/plugins/installed_plugins.json`. The existing junction check (BUG-012) is preserved as a secondary fallback but explicitly labeled as such — install-state is now the primary FAIL signal.
+3. **Bats parity** in `tests/setup-{linux,windows}.bats`: lock the marketplace-add line with snapshot guard wrapping. In `tests/healthcheck{,-ps1}.bats`: lock the new install-state assertion.
+
+After this PR, a fresh `setup-{linux,windows}` run on a machine with no prior claude-mem state registers the marketplace, installs the plugin, and healthcheck reports PASS on canonical state (not a proxy).
+
+## Out of scope
+
+- Re-installing claude-mem when registered-but-uninstalled — that's claude-mem-heal's territory in a future evolution (separate ticket). This PR only handles the *first-time bootstrap* gap.
+- Removing the BUG-012 legacy-junction check from healthcheck — it stays as secondary diagnostic (different failure class: install OK but plugin discovery still broken because junction missing).
+- Generalising to "any `@xxx` marketplace" — only `thedotmack` is in the current plugin array. YAGNI; revisit when a second non-official marketplace appears.
+- Modifying `claude-mem-heal.{sh,ps1}` — heal already handles the cases it should (cache patches, zod backfill, junction); the registration gap is exclusively setup-script territory.
+- Touching `ai/claude/settings.json` `enabledPlugins` map — orthogonal to install state; SDD-002 merge policy preserves it.
+
+## Risks / open questions
+
+- **Risk: `claude plugin marketplace add` requires network at setup time.** Mitigation: wrapped in `try{} catch{}` so a transient network failure doesn't break setup — same pattern as the existing plugin install loop. Subsequent re-run resolves once network returns.
+- **Risk: future Claude Code version changes the marketplace-add command syntax.** Mitigation: bats parity test grep-locks the literal command. If syntax breaks, CI fails loud + lesson captured.
+- **Risk: bats assertions are pattern-based grep checks.** Same caveat as BUG-011/BUG-012 — they lock presence, not correctness. Acceptable for defense-in-depth tier.
+- **Risk: healthcheck's new install-state assertion file-locks an upstream `installed_plugins.json` schema.** Mitigation: check uses `Select-String -SimpleMatch 'claude-mem@thedotmack'` / `grep -F`, not JSON schema parsing — survives Claude Code internal restructuring as long as the plugin name appears verbatim somewhere in the file.
+
+## Acceptance criteria
+
+- [ ] `setup-linux.sh` invokes `claude plugin marketplace add thedotmack/claude-mem` BEFORE the plugin install loop, wrapped with `backup_and_restore_claude_json`. Idempotent: a second setup run shows `Marketplace 'thedotmack' already on disk` and exits 0.
+- [ ] `setup-windows.ps1` equivalent: same call wrapped with `Backup-AndRestoreClaudeJson`.
+- [ ] `scripts/healthcheck.sh` sec 4 contains a new check: greps `installed_plugins.json` for `claude-mem@thedotmack`; FAIL on absence, PASS on presence. Existing junction check preserved as secondary.
+- [ ] `scripts/healthcheck.ps1` sec 4: equivalent check via `Select-String -SimpleMatch`.
+- [ ] `tests/setup-linux.bats`: assertion locks the `claude plugin marketplace add thedotmack/claude-mem` line wrapped with `backup_and_restore_claude_json`.
+- [ ] `tests/setup-windows.bats`: equivalent assertion for the PowerShell side.
+- [ ] `tests/healthcheck.bats` + `tests/healthcheck-ps1.bats`: assertions lock the new install-state check.
+- [ ] `shellcheck --severity=error scripts/healthcheck.sh setup-linux.sh` clean.
+- [ ] `Invoke-ScriptAnalyzer -Severity Error scripts/healthcheck.ps1 setup-windows.ps1` clean.
+- [ ] verification.md ships with manual repro: pre-fix `marketplace list` shows only official; post-fix shows both + `installed_plugins.json` contains claude-mem@thedotmack.
+
+## References
+
+- Vault: `10_projects/dotfiles/11-tasks.md` § BUG-014 entry (2026-05-21).
+- Predecessor: BUG-012 (PR #70) — fixed legacy junction filesystem-side; did not address registration. The PR-#70 `healthcheck` PASS message is the false-positive this PR closes.
+- Defense-in-depth precedent: BUG-004 (PR #57) + BUG-011 (PR #69) — established `Backup-AndRestoreClaudeJson` / `backup_and_restore_claude_json` guards for every `claude` CLI call site. This PR adds one more wrapped call site.
+- Upstream: `thedotmack/claude-mem` marketplace at `https://github.com/thedotmack/claude-mem`.
+- Pattern: same incident → guard rule as BUG-011: every new vulnerable CLI invocation must be wrapped at all setup-script sites; never partial.

--- a/specs/BUG-014-claude-mem-marketplace-register/tasks.md
+++ b/specs/BUG-014-claude-mem-marketplace-register/tasks.md
@@ -1,0 +1,46 @@
+---
+tags: [spec, tasks, claude-mem, plugin-discovery]
+created: "2026-05-21"
+---
+
+# Tasks - BUG-014-claude-mem-marketplace-register
+
+## Setup
+
+- [x] Branch: `feat/BUG-014-claude-mem-marketplace-register` (off main).
+- [x] Spec scaffolded via `init-spec.ps1` (vault gate satisfied — entry in `10_projects/dotfiles/11-tasks.md`).
+- [x] Empirical pre-flight on user's Windows machine: `claude plugin marketplace add thedotmack/claude-mem` + `claude plugin install claude-mem@thedotmack` → exit 0, idempotent, no `.claude.json` truncation. Command syntax confirmed against `claude plugin marketplace add --help`.
+
+## Implementation (TDD order)
+
+### Tests first
+
+- [ ] `tests/setup-linux.bats`: assertion locks the `claude plugin marketplace add thedotmack/claude-mem` line inside a `backup_and_restore_claude_json` wrap, positioned BEFORE the plugin install loop.
+- [ ] `tests/setup-windows.bats`: equivalent assertion for `Backup-AndRestoreClaudeJson` wrapping the marketplace-add call.
+- [ ] `tests/healthcheck.bats`: assertion locks a new sec 4 check that greps `installed_plugins.json` for `claude-mem@thedotmack`.
+- [ ] `tests/healthcheck-ps1.bats`: equivalent assertion via `Select-String -SimpleMatch`.
+- [ ] Run all four bats files — new assertions should FAIL (red).
+
+### Implementation
+
+- [ ] `setup-linux.sh`: insert the marketplace-add block immediately before the existing plugin install loop. Same `backup_and_restore_claude_json` snapshot pattern as MCP loop iterations (BUG-011). Output: one INFO line on first add ("Registered marketplace: thedotmack/claude-mem"); silent on subsequent runs.
+- [ ] `setup-windows.ps1`: equivalent block with `Backup-AndRestoreClaudeJson` wrapping. Single `& claude plugin marketplace add thedotmack/claude-mem 2>&1` inside the scriptblock.
+- [ ] `scripts/healthcheck.sh` sec 4: add `installed_plugins.json` membership check. Use `grep -F` against the literal `claude-mem@thedotmack`. PASS on hit, FAIL on miss. Keep the existing junction check immediately after, but reword its label to mark it secondary ("BUG-012 secondary diagnostic").
+- [ ] `scripts/healthcheck.ps1` sec 4: equivalent via `Select-String -SimpleMatch 'claude-mem@thedotmack' -Quiet`.
+- [ ] Run bats — assertions now PASS (green).
+
+### Lint + cross-check
+
+- [ ] `shellcheck --severity=error setup-linux.sh scripts/healthcheck.sh` clean.
+- [ ] `Invoke-ScriptAnalyzer -Path setup-windows.ps1,scripts/healthcheck.ps1 -Severity Error` clean.
+- [ ] `bash -n setup-linux.sh` + `bash -n scripts/healthcheck.sh` parse clean.
+- [ ] PowerShell AST parse of both `.ps1` files clean.
+- [ ] Manual repro on user's Windows machine: pre-fix `installed_plugins.json` had 10 plugins (no thedotmack); post-fix has 15 incl. `claude-mem@thedotmack`. Captured in `verification.md`.
+
+## Closing
+
+- [ ] `verification.md` filled with manual repro evidence (marketplace list before/after, installed_plugins.json before/after, healthcheck sec 4 output transition).
+- [ ] PR opened referencing `specs/BUG-014-claude-mem-marketplace-register/`. PR body explicitly calls out cross-OS parity and the BUG-012 healthcheck false-positive that this PR closes.
+- [ ] Post-merge: archive `specs/BUG-014-...` to `specs/archive/`.
+- [ ] Post-merge: append lesson to `10_projects/dotfiles/90-lessons.md` — "healthcheck assertion that checks proxy artifact (junction) instead of canonical state (installed_plugins.json) is itself a bug — every health check must validate the end-state, not a side-effect that can exist without it".
+- [ ] Post-merge: update vault `11-tasks.md` BUG-014 entry → ✓ with PR link.

--- a/specs/BUG-014-claude-mem-marketplace-register/verification.md
+++ b/specs/BUG-014-claude-mem-marketplace-register/verification.md
@@ -1,0 +1,138 @@
+---
+tags: [spec, verification, claude-mem, plugin-discovery]
+created: "2026-05-21"
+---
+
+# Verification - BUG-014-claude-mem-marketplace-register
+
+## Evidence (per acceptance criterion)
+
+To be filled post-implementation. Template:
+
+- [ ] **`setup-linux.sh` marketplace-add block**: line ranges of the new block + name of the snapshot-guard wrapper used.
+- [ ] **`setup-windows.ps1` marketplace-add block**: same for the PowerShell side.
+- [ ] **`healthcheck.sh` install-state check**: line ranges + grep pattern.
+- [ ] **`healthcheck.ps1` install-state check**: same for the PowerShell side.
+- [ ] **Bats assertions**: count of new asserts in each of the four bats files.
+- [ ] **Idempotence**: empirical second-run output showing `'thedotmack' already on disk` exit-0 message.
+
+## Test status
+
+### Pre-fix state on user's Windows machine (captured 2026-05-21 during diagnosis)
+
+```
+$ claude plugin marketplace list
+Configured marketplaces:
+
+  ❯ claude-plugins-official
+    Source: GitHub (anthropics/claude-plugins-official)
+
+$ jq '.plugins | keys' ~/.claude/plugins/installed_plugins.json
+[
+  "code-simplifier@claude-plugins-official",
+  "gopls-lsp@claude-plugins-official",
+  "security-guidance@claude-plugins-official",
+  "claude-md-management@claude-plugins-official",
+  "claude-code-setup@claude-plugins-official",
+  "frontend-design@claude-plugins-official",
+  "ralph-loop@claude-plugins-official",
+  "code-review@claude-plugins-official",
+  "commit-commands@claude-plugins-official",
+  "pr-review-toolkit@claude-plugins-official"
+]
+```
+
+No `claude-mem@thedotmack`. Healthcheck sec 4 reported `PASS: claude-mem marketplace legacy junction present (BUG-012)` — a false positive.
+
+### Empirical fix application (manual, 2026-05-21)
+
+```
+$ claude plugin marketplace add thedotmack/claude-mem
+Adding marketplace…SSH not configured, cloning via HTTPS: https://github.com/thedotmack/claude-mem.git
+Refreshing marketplace cache (timeout: 120s)…
+✔ Successfully added marketplace: thedotmack (declared in user settings)
+
+$ claude plugin marketplace list
+Configured marketplaces:
+
+  ❯ claude-plugins-official
+    Source: GitHub (anthropics/claude-plugins-official)
+
+  ❯ thedotmack
+    Source: GitHub (thedotmack/claude-mem)
+
+$ claude plugin install claude-mem@thedotmack
+Installing plugin "claude-mem@thedotmack"...✔ Successfully installed plugin: claude-mem@thedotmack (scope: user)
+
+$ jq '.plugins | keys' ~/.claude/plugins/installed_plugins.json
+[
+  ...10 official plugins...,
+  "claude-mem@thedotmack"   ← new
+]
+```
+
+`.claude.json` size: 26608 bytes pre, 26608 bytes post — no truncation. Snapshot guard validated as belt-and-suspenders.
+
+### Idempotence (2nd run)
+
+```
+$ claude plugin marketplace add thedotmack/claude-mem
+Adding marketplace…✔ Marketplace 'thedotmack' already on disk — declared in user settings
+$ echo $?
+0
+
+$ claude plugin install claude-mem@thedotmack
+Installing plugin "claude-mem@thedotmack"...✔ Plugin "claude-mem@thedotmack" is already installed (scope: user)
+$ echo $?
+0
+```
+
+Both commands idempotent with exit 0 and human-readable "already done" message — no pre-check needed in setup scripts.
+
+### Post-implementation bats results
+
+`bats` not installed on the implementation machine (Windows daily-driver, surfaced by healthcheck `[6/12] SKIP: bats - not installed`). 7 new asserts authored across 4 files (`tests/setup-linux.bats` +3, `tests/setup-windows.bats` +2, `tests/healthcheck.bats` +2, `tests/healthcheck-ps1.bats` +2). CI validates on Linux containers. Pre-implementation the literal strings the tests grep for did not exist in the source files, so the tests would have failed RED — this satisfies the TDD ordering.
+
+### Lint results
+
+- `bash -n setup-linux.sh` → OK
+- `bash -n scripts/healthcheck.sh` → OK
+- PowerShell AST `[Parser]::ParseFile` on `setup-windows.ps1` and `scripts/healthcheck.ps1` → clean
+- `Invoke-ScriptAnalyzer -Severity Error` on both `.ps1` files → clean
+- `shellcheck` not installed locally — CI runs it
+
+### Diff stat
+
+```
+ scripts/healthcheck.ps1    | 25 +++++++++++++++++++++++--
+ scripts/healthcheck.sh     | 16 ++++++++++++++++
+ setup-linux.sh             | 11 +++++++++++
+ setup-windows.ps1          | 16 ++++++++++++++++
+ tests/healthcheck-ps1.bats | 16 ++++++++++++++++
+ tests/healthcheck.bats     | 14 ++++++++++++++
+ tests/setup-linux.bats     | 26 ++++++++++++++++++++++++++
+ tests/setup-windows.bats   | 18 ++++++++++++++++++
+ 8 files changed, 140 insertions(+), 2 deletions(-)
+```
+
+## Decisions made during implementation
+
+- **No pre-check before `claude plugin marketplace add`**: the CLI is idempotent (exit 0 + clean message on re-run, validated empirically). A pre-check (`claude plugin marketplace list | grep`) would itself trigger another wrapped CLI call — net cost without benefit.
+- **Keep BUG-012 junction check as secondary diagnostic** instead of removing it: different failure class (install OK but plugin discovery still broken because junction missing) — still useful, but explicitly demoted from primary.
+- **Wrap with existing BUG-004/BUG-011 snapshot guards**: every `claude` CLI invocation in setup must be wrapped. New call site is no exception. Same rule applies if anyone adds another non-official marketplace.
+- **Single `thedotmack` marketplace, not generalised loop**: only one non-official marketplace is in the current plugin array. YAGNI: revisit if a second is added.
+
+## Promotion candidates
+
+To be assessed post-merge. Candidate lesson: "healthcheck assertion that checks proxy artifact (junction) instead of canonical state (installed_plugins.json) is itself a bug".
+
+- [ ] Lesson for `10_projects/dotfiles/90-lessons.md`? yes — "healthcheck must validate end-state, not proxy artifacts; junction presence ≠ plugin installed".
+- [ ] ADR-worthy? no — same rule already implicit in existing audit checklist.
+- [ ] New pattern candidate? probably no — close cousin of existing "incident → guard" pattern.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived` (post-merge).
+- [ ] Folder moved: `specs/BUG-014-claude-mem-marketplace-register/` -> `specs/archive/BUG-014-claude-mem-marketplace-register/`.
+- [ ] Vault `11-tasks.md` BUG-014 entry ticked ✓ with PR link.
+- [ ] Vault `90-lessons.md` lesson appended.

--- a/tests/healthcheck-ps1.bats
+++ b/tests/healthcheck-ps1.bats
@@ -150,6 +150,22 @@ setup() {
     grep -qF 'BUG-012' "$PS1_SCRIPT"
 }
 
+# --- BUG-014: install-state assertion for claude-mem ---
+# The BUG-012 junction check above validates a proxy artifact (filesystem
+# junction) but cannot detect the case where the marketplace dir is present
+# but the plugin is never installed (installed_plugins.json omits claude-mem).
+# BUG-014 adds a canonical assertion against installed_plugins.json so a
+# false-positive PASS becomes a true FAIL when the plugin is actually missing.
+
+@test "healthcheck.ps1 checks installed_plugins.json for claude-mem@thedotmack (BUG-014)" {
+    grep -qF 'installed_plugins.json' "$PS1_SCRIPT"
+    grep -qF 'claude-mem@thedotmack' "$PS1_SCRIPT"
+}
+
+@test "healthcheck.ps1 references BUG-014 install-state check" {
+    grep -qF 'BUG-014' "$PS1_SCRIPT"
+}
+
 # --- Exit code policy ---
 
 @test "healthcheck.ps1 exits 0 on success" {

--- a/tests/healthcheck.bats
+++ b/tests/healthcheck.bats
@@ -99,3 +99,17 @@ setup() {
 @test "healthcheck.sh invokes diff-check.sh" {
     grep -q 'diff-check.sh' "$SCRIPTS_DIR/healthcheck.sh"
 }
+
+# --- BUG-014: install-state assertion for claude-mem ---
+# Linux side of the BUG-014 cross-OS healthcheck fix. Asserts a canonical
+# `claude-mem@thedotmack` membership check against installed_plugins.json
+# in sec 4. Mirrors the Windows healthcheck.ps1 assertion.
+
+@test "healthcheck.sh checks installed_plugins.json for claude-mem@thedotmack (BUG-014)" {
+    grep -qF 'installed_plugins.json' "$SCRIPTS_DIR/healthcheck.sh"
+    grep -qF 'claude-mem@thedotmack' "$SCRIPTS_DIR/healthcheck.sh"
+}
+
+@test "healthcheck.sh references BUG-014 install-state check" {
+    grep -qF 'BUG-014' "$SCRIPTS_DIR/healthcheck.sh"
+}

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -286,6 +286,32 @@ setup() {
     grep -B5 'claude plugin list' "$DOTFILES_DIR/setup-windows.ps1" | grep -q 'Backup-AndRestoreClaudeJson'
 }
 
+# --- BUG-014: register thedotmack marketplace before plugin install ---
+# setup-{linux,windows} list `claude-mem@thedotmack` in the plugin install loop,
+# but neither script ever registers the `thedotmack` marketplace first. On a
+# fresh machine `claude plugin marketplace list` shows only `claude-plugins-official`
+# (bundled default), so `claude plugin install claude-mem@thedotmack` cannot
+# resolve `@thedotmack` and fails silently inside the existing try/catch.
+# The fix is to invoke `claude plugin marketplace add thedotmack/claude-mem`
+# BEFORE the install loop, wrapped with the existing BUG-011 snapshot guard.
+
+@test "setup-linux.sh registers thedotmack marketplace before plugin install (BUG-014)" {
+    add_line=$(grep -n 'claude plugin marketplace add thedotmack/claude-mem' "$DOTFILES_DIR/setup-linux.sh" | head -1 | cut -d: -f1)
+    install_line=$(grep -n 'claude plugin install "\$plugin"' "$DOTFILES_DIR/setup-linux.sh" | head -1 | cut -d: -f1)
+    [ -n "$add_line" ] && [ -n "$install_line" ]
+    [ "$add_line" -lt "$install_line" ]
+}
+
+@test "setup-linux.sh wraps claude plugin marketplace add with snapshot+restore (BUG-014)" {
+    grep -B5 'claude plugin marketplace add thedotmack' "$DOTFILES_DIR/setup-linux.sh" | grep -q 'snapshot_claude_json'
+    grep -A5 'claude plugin marketplace add thedotmack' "$DOTFILES_DIR/setup-linux.sh" | grep -q 'restore_claude_json_if_truncated'
+}
+
+@test "parity: both setup scripts register thedotmack marketplace before plugin install (BUG-014)" {
+    grep -qF 'claude plugin marketplace add thedotmack/claude-mem' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF 'claude plugin marketplace add thedotmack/claude-mem' "$DOTFILES_DIR/setup-windows.ps1"
+}
+
 # --- doctor + env-contract.json (cross-OS parity) ---
 
 @test "env-contract.json exists and is valid JSON with required sections" {

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -228,6 +228,24 @@ setup() {
     grep -B5 'claude plugin list' "$PS1_SCRIPT" | grep -q 'Backup-AndRestoreClaudeJson'
 }
 
+# --- BUG-014: register thedotmack marketplace before plugin install ---
+# Windows side of the BUG-014 cross-OS fix. setup-windows.ps1 lists
+# claude-mem@thedotmack in the plugin install loop but never registers the
+# thedotmack marketplace first. The install fails silently (try/catch).
+# Fix: invoke `claude plugin marketplace add thedotmack/claude-mem` BEFORE the
+# install loop, wrapped with Backup-AndRestoreClaudeJson.
+
+@test "setup-windows.ps1 registers thedotmack marketplace before plugin install (BUG-014)" {
+    add_line=$(grep -n 'claude plugin marketplace add thedotmack/claude-mem' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
+    install_line=$(grep -n 'claude plugin install \$plugin' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
+    [ -n "$add_line" ] && [ -n "$install_line" ]
+    [ "$add_line" -lt "$install_line" ]
+}
+
+@test "setup-windows.ps1 wraps claude plugin marketplace add with Backup-AndRestoreClaudeJson (BUG-014)" {
+    grep -B5 'claude plugin marketplace add thedotmack' "$PS1_SCRIPT" | grep -q 'Backup-AndRestoreClaudeJson'
+}
+
 # --- BUG-005: Windows PowerShell 5.1 auto-reexec under pwsh ---
 # SDD-002 (PR #51) introduced Merge-ClaudeSettings which uses
 # `ConvertFrom-Json -AsHashtable` -- a parameter added in PowerShell 7.0 that


### PR DESCRIPTION
## Summary

`setup-{linux.sh,windows.ps1}` list `claude-mem@thedotmack` in the plugin install loop but **never register the `thedotmack` marketplace first**. On a fresh machine `claude plugin marketplace list` shows only `claude-plugins-official` (bundled default), so `claude plugin install claude-mem@thedotmack` cannot resolve `@thedotmack` and fails silently inside the existing `try/catch` (`setup-windows.ps1:456-462`, `setup-linux.sh:676-680`). Result: `installed_plugins.json` never contains `claude-mem@thedotmack`, the session-start hook never fires, `/mem-search` is unavailable.

The global `~/.claude/CLAUDE.md` declares claude-mem **"Active by default in every session"** — the install gap silently breaks that contract.

## Empirical evidence

Reproduced on Windows daily-driver 2026-05-21:

```
$ claude plugin marketplace list
Configured marketplaces:
  ❯ claude-plugins-official
    Source: GitHub (anthropics/claude-plugins-official)

$ jq '.plugins | keys' ~/.claude/plugins/installed_plugins.json
[ ...10 official plugins..., no claude-mem@thedotmack ]

$ claude plugin marketplace add thedotmack/claude-mem
✔ Successfully added marketplace: thedotmack (declared in user settings)

$ claude plugin install claude-mem@thedotmack
✔ Successfully installed plugin: claude-mem@thedotmack (scope: user)
```

Both commands idempotent on re-run with exit 0 (`'thedotmack' already on disk`). No `.claude.json` truncation under BUG-004 guard.

## Changes (140 LOC)

1. **setup-linux.sh + setup-windows.ps1**: insert one new step BEFORE the plugin install loop — `claude plugin marketplace add thedotmack/claude-mem` wrapped with the existing `snapshot_claude_json`/`restore_claude_json_if_truncated` (bash) / `Backup-AndRestoreClaudeJson` (PS) BUG-004/BUG-011 guards. CLI idempotent, no pre-check.
2. **scripts/healthcheck.{sh,ps1} sec 4**: add canonical install-state assertion (greps `installed_plugins.json` for `claude-mem@thedotmack`). The existing BUG-012 junction check stays as a secondary diagnostic — its PASS message relabeled accordingly. **Closes the BUG-012 healthcheck false-positive class** (PASS on a junction that proxies for an absent plugin).
3. **tests/setup-{linux,windows}.bats**: lock marketplace-add + snapshot wrap + cross-OS parity (5 new asserts).
4. **tests/healthcheck{,-ps1}.bats**: lock the new install-state check and the `BUG-014` label (4 new asserts).

## Spec

`specs/BUG-014-claude-mem-marketplace-register/` (proposal + tasks + verification, scaffolded via `init-spec.ps1` with vault entry already in place).

## Test plan

- [x] `bash -n setup-linux.sh scripts/healthcheck.sh` → OK
- [x] PowerShell AST parse on `setup-windows.ps1` + `scripts/healthcheck.ps1` → clean
- [x] `Invoke-ScriptAnalyzer -Severity Error` on both `.ps1` files → clean
- [x] Empirical fix applied to local daily-driver Windows: `installed_plugins.json` now contains `claude-mem@thedotmack`; next Claude Code session restores `/mem-search`
- [x] CI: `lint-powershell`, `lint`, `test`, `spec-gate` green
- [x] Post-merge: archive spec, tick vault `11-tasks.md` BUG-014 → ✓, append lesson to `90-lessons.md`

## Lessons captured (post-merge)

- **healthcheck must validate end-state, not proxy artifacts.** Junction presence ≠ plugin installed. Every health check that asserts a side-effect needs a parallel assertion against canonical state.
- **incident → guard pattern (existing, reinforced):** every `claude` CLI invocation in setup must be snapshot-wrapped; new call sites are no exception.