### PR TITLE
fix(WIN-002a): collapse inverted vault-health.sh check to unconditional Skip

### DIFF
--- a/scripts/healthcheck.ps1
+++ b/scripts/healthcheck.ps1
@@ -341,13 +341,12 @@ if (Test-Command 'obsidian') {
     Write-Fail 'Obsidian CLI not in PATH'
 }
 
-# vault-health.sh is Linux-only (no .ps1 sibling yet); skip with explanation
-$vaultHealthSh = Join-Path $script:ScriptDir 'vault-health.sh'
-if (Test-Path -LiteralPath $vaultHealthSh) {
-    Write-Skip 'vault-health.sh' 'Linux-only script (no .ps1 sibling; runs under WSL or Git Bash if needed)'
-} else {
-    Write-Fail "vault-health.sh missing at $vaultHealthSh"
-}
+# WIN-002a: vault-health.sh is Linux-only by design (no .ps1 sibling). On
+# Windows the .sh is intentionally NOT deployed to $ScriptsDir, so an
+# existence check always FAILs and a Skip-when-present/Fail-when-missing
+# branch is inverted relative to its leading comment. Collapse to an
+# unconditional Skip with the same rationale.
+Write-Skip 'vault-health.sh' 'Linux-only script (no .ps1 sibling; runs under WSL or Git Bash if needed)'
 
 $linterConfig = Join-Path $obsidianDir 'plugins\obsidian-linter\data.json'
 if (Test-Path -LiteralPath $linterConfig -PathType Leaf) {


### PR DESCRIPTION
## Summary

`scripts/healthcheck.ps1:323-329` had a comment saying *"Linux-only; skip with explanation"* but the conditional was **inverted**: \`Write-Skip\` when the file EXISTS, \`Write-Fail\` when MISSING. On Windows the \`.sh\` is intentionally not deployed to \`\$ScriptsDir\` (no \`.ps1\` sibling exists yet), so the check always emitted:

\`\`\`
FAIL: vault-health.sh missing at C:\Users\Manu\scripts\vault-health.sh
\`\`\`

Collapse the \`if/else\` block to an unconditional \`Write-Skip\` with the original rationale. Same pattern as PR #74 (atomic, surgical Windows fix).

## Why it slipped past PR #71 (WIN-001 healthcheck port)

PR #71 mechanically ported \`healthcheck.sh\` to PowerShell preserving structure. PR #73 (WIN-002 partial) tightened sec 1/3/5 to Windows install reality but left sec 7 untouched because it has more nuanced bits (Obsidian, Linter). This 3-line collapse finishes that scope for the \`vault-health.sh\` check specifically.

## Diff

\`\`\`
1 file changed, 6 insertions(+), 7 deletions(-)
\`\`\`

Skip SDD per "bug fix <20 lines with obvious cause" rule.

## Test plan

- [x] PowerShell AST \`[Parser]::ParseFile\` → clean
- [x] \`Invoke-ScriptAnalyzer -Settings .PSScriptAnalyzerSettings.psd1 -Severity Error,Warning\` → clean
- [x] ASCII-only (no em-dash regression from BUG-014 lint failure)
- [ ] Post-merge: re-run \`setup-windows.ps1\` → 1 FAIL fewer in sec 7

## Context

Closes 1 of the 3 healthcheck FAILs on Windows daily-driver. Remaining:
- \`Obsidian CLI not in PATH\` → BUG-013 (separate ticket, ~25 LOC, P2)
- \`Linter lintOnSave disabled\` → user-side toggle in Obsidian Settings (no code)