### PR TITLE
feat(BUG-013): install @vorillaz/obsidian-cli on Windows via npm global

### DIFF
--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -653,6 +653,39 @@ if (-not $poetryCmd) {
 }
 
 # ============================================================================
+# 2c. OBSIDIAN CLI (BUG-013)
+# ============================================================================
+# @vorillaz/obsidian-cli provides the `obsidian` binary used by obs-cli.ps1 and
+# the vault-health workflow. npm global install writes to %APPDATA%\npm
+# (user-writable, no admin). Idempotent: skip if `obsidian` already on PATH.
+# Guarded on `npm` availability so machines without Node.js gracefully skip.
+
+$obsidianCmd = Get-Command obsidian -ErrorAction SilentlyContinue
+if (-not $obsidianCmd) {
+    $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
+    if ($npmCmd) {
+        Write-Info "Installing Obsidian CLI (@vorillaz/obsidian-cli) via npm..."
+        try {
+            & npm install -g '@vorillaz/obsidian-cli' 2>$null | Out-Null
+            # Refresh PATH so the freshly-installed binary is visible in this
+            # session (same trick as the winget block in section 1c).
+            $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [Environment]::GetEnvironmentVariable("PATH", "User")
+            if (Get-Command obsidian -ErrorAction SilentlyContinue) {
+                Write-Success "Obsidian CLI installed"
+            } else {
+                Write-Warn "Obsidian CLI install completed but binary not on PATH (restart shell)"
+            }
+        } catch {
+            Write-Warn "Failed to install Obsidian CLI: $_"
+        }
+    } else {
+        Write-Warn "npm not available, skipping Obsidian CLI install (install Node.js then re-run)"
+    }
+} else {
+    Write-Info "Obsidian CLI already installed at $($obsidianCmd.Source)"
+}
+
+# ============================================================================
 # 3. DEPLOY GEMINI CONFIGURATION (config deploy is always safe)
 # ============================================================================
 

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -246,6 +246,23 @@ setup() {
     grep -B5 'claude plugin marketplace add thedotmack' "$PS1_SCRIPT" | grep -q 'Backup-AndRestoreClaudeJson'
 }
 
+# --- BUG-013: install Obsidian CLI on Windows ---
+# `@vorillaz/obsidian-cli` provides the `obsidian` binary used by
+# obs-cli.ps1 and the vault-health workflow. setup-windows.ps1 must install
+# it idempotently via npm global (user scope, no admin), gated on npm
+# availability so machines without Node.js gracefully skip.
+
+@test "setup-windows.ps1 installs Obsidian CLI via npm (BUG-013)" {
+    grep -qF "npm install -g '@vorillaz/obsidian-cli'" "$PS1_SCRIPT"
+}
+
+@test "setup-windows.ps1 Obsidian CLI install is gated on npm + idempotent (BUG-013)" {
+    # idempotence: skip if `obsidian` already on PATH
+    grep -B10 "npm install -g '@vorillaz/obsidian-cli'" "$PS1_SCRIPT" | grep -q "Get-Command obsidian"
+    # gating: only run if npm is available
+    grep -B10 "npm install -g '@vorillaz/obsidian-cli'" "$PS1_SCRIPT" | grep -q "Get-Command npm"
+}
+
 # --- BUG-005: Windows PowerShell 5.1 auto-reexec under pwsh ---
 # SDD-002 (PR #51) introduced Merge-ClaudeSettings which uses
 # `ConvertFrom-Json -AsHashtable` -- a parameter added in PowerShell 7.0 that


### PR DESCRIPTION
## Summary

\`setup-windows.ps1\` had no Obsidian CLI install. Empirical check 2026-05-21: the binary \`obsidian\` is not on PATH and \`%APPDATA%\npm\node_modules\` has zero \`@vorillaz\`-scoped packages, so healthcheck.ps1 sec 7 emits \`FAIL: Obsidian CLI not in PATH\` on every run. The CLI is required by \`obs-cli.ps1\` and the vault-health workflow.

Add a new section 2c immediately after Python tooling (2b), installing \`@vorillaz/obsidian-cli\` via \`npm install -g\` (writes to \`%APPDATA%\npm\`, user-writable, no admin).

## Behavior

- **Idempotent**: skip when \`obsidian\` is already on PATH.
- **Gated**: skip when \`npm\` is unavailable (Node.js prerequisite missing) with a clear "install Node.js then re-run" warning.
- **PATH refresh**: re-pulls User+Machine PATH so the freshly installed binary is visible in the same setup session (mirrors the section 1c winget trick from BUG-003).
- **Verification**: post-install \`Get-Command obsidian\`; warn if still missing (restart-shell hint).

## Test plan

- [x] PowerShell AST \`[Parser]::ParseFile\` → clean
- [x] \`Invoke-ScriptAnalyzer -Settings .PSScriptAnalyzerSettings.psd1 -Severity Error,Warning\` → clean
- [x] ASCII-only (no em-dash regression from BUG-014)
- [x] 2 new bats asserts in \`tests/setup-windows.bats\` lock install line + npm/obsidian guards
- [x] CI green
- [ ] Post-merge: re-run \`setup-windows.ps1\` on daily-driver Windows → expect \`[SUCCESS] Obsidian CLI installed\` and healthcheck sec 7 \`PASS: Obsidian CLI in PATH\`

## Diff

\`\`\`
 setup-windows.ps1        | 33 +++++++++++++++++++++++++++++++++
 tests/setup-windows.bats | 17 +++++++++++++++++
 2 files changed, 50 insertions(+)
\`\`\`

Production diff: 33 LOC (below spec-gate threshold of 50). Skip SDD.

## Scope note

The original BUG-013 vault entry said "the way \`setup-linux.sh\` does" — that was an incorrect assumption. \`setup-linux.sh\` doesn't install the CLI either (verified by \`grep\` + user's npm prefix probe). This PR ships **Windows-only** per the literal backlog scope; Linux parity becomes a follow-up (BUG-013b, ~10 LOC) if wanted.

## Context

Closes the last dotfiles-side healthcheck FAIL on Windows daily-driver. After merge + re-run, only the user-side Obsidian Linter \`lintOnSave\` toggle remains as a FAIL (not a code issue).