### PR TITLE
feat(AI-014): bootstrap OpenCode on Windows via winget SST.opencode

### DIFF
--- a/scripts/healthcheck.ps1
+++ b/scripts/healthcheck.ps1
@@ -437,7 +437,7 @@ if (Test-Command 'opencode') {
     $ocVersion = (& opencode --version 2>&1 | Select-Object -First 1)
     Write-Pass "opencode in PATH: $ocVersion"
 } else {
-    Write-Skip 'opencode binary' 'not installed (AI-014 admin-conditional; deploy via setup-windows.ps1 when ready)'
+    Write-Skip 'opencode binary' 'not installed (winget install SST.opencode, or re-run setup-windows.ps1)'
 }
 
 if (Test-Path -LiteralPath $opencodeCfg -PathType Leaf) {
@@ -448,7 +448,7 @@ if (Test-Path -LiteralPath $opencodeCfg -PathType Leaf) {
         Write-Fail 'opencode.jsonc missing $schema declaration (run setup-windows.ps1 to redeploy)'
     }
 } else {
-    Write-Skip 'opencode.jsonc' "not deployed at $opencodeCfg (AI-014 pending)"
+    Write-Skip 'opencode.jsonc' "not deployed at $opencodeCfg (run setup-windows.ps1)"
 }
 
 # ==================================================

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -265,7 +265,10 @@ if ($wingetCmd) {
         @{ Name = "jq"; Cmd = "jq"; Id = "jqlang.jq" },
         @{ Name = "GitHub CLI"; Cmd = "gh"; Id = "GitHub.cli" },
         @{ Name = "zoxide"; Cmd = "zoxide"; Id = "ajeetdsouza.zoxide" },
-        @{ Name = "GitHub Copilot CLI"; Cmd = "copilot"; Id = "GitHub.Copilot" }
+        @{ Name = "GitHub Copilot CLI"; Cmd = "copilot"; Id = "GitHub.Copilot" },
+        # AI-014: OpenCode (secondary AI agent, ADR-009). User-scope winget
+        # package, no admin. Cleaner than the Linux curl-bash equivalent.
+        @{ Name = "OpenCode"; Cmd = "opencode"; Id = "SST.opencode" }
     )
     foreach ($tool in $tools) {
         if (-not (Get-Command $tool.Cmd -ErrorAction SilentlyContinue)) {
@@ -683,6 +686,74 @@ if (-not $obsidianCmd) {
     }
 } else {
     Write-Info "Obsidian CLI already installed at $($obsidianCmd.Source)"
+}
+
+# ============================================================================
+# 2d. OPENCODE CONFIG + COMMANDS (AI-014)
+# ============================================================================
+# Binary install is handled in section 1c via winget SST.opencode. This block
+# deploys the canonical config + skill-derived commands using the same
+# reconcile-not-skip pattern as setup-linux.sh (AI-011, lines 415-465).
+# Both files: SHA256 byte-equality test before overwrite so user-side edits
+# that match upstream do not trigger a noisy "Deployed" log.
+
+$opencodeConfigSrc = "$DotfilesDir\ai\opencode\opencode.jsonc"
+$opencodeConfigDst = Join-Path $env:USERPROFILE '.config\opencode\opencode.jsonc'
+$opencodeCfgDir    = Split-Path $opencodeConfigDst -Parent
+Ensure-Directory $opencodeCfgDir
+if (Test-Path -LiteralPath $opencodeConfigSrc -PathType Leaf) {
+    $needsCopy = $true
+    if (Test-Path -LiteralPath $opencodeConfigDst -PathType Leaf) {
+        $srcHash = (Get-FileHash -LiteralPath $opencodeConfigSrc -Algorithm SHA256).Hash
+        $dstHash = (Get-FileHash -LiteralPath $opencodeConfigDst -Algorithm SHA256).Hash
+        if ($srcHash -eq $dstHash) {
+            Write-Info "opencode.jsonc already in sync"
+            $needsCopy = $false
+        }
+    }
+    if ($needsCopy) {
+        Copy-Item -LiteralPath $opencodeConfigSrc -Destination $opencodeConfigDst -Force
+        Write-Success "Deployed opencode.jsonc to $opencodeConfigDst"
+    }
+} else {
+    Write-Warn "opencode.jsonc source missing: $opencodeConfigSrc"
+}
+
+# Commands sync: add new, leave unchanged, remove orphans. Mirror of the bash
+# loop in setup-linux.sh: cmds_added/cmds_skipped/cmds_removed counters.
+$opencodeCmdsSrc = "$DotfilesDir\ai\opencode\commands"
+$opencodeCmdsDst = Join-Path $env:USERPROFILE '.config\opencode\commands'
+if (Test-Path -LiteralPath $opencodeCmdsSrc -PathType Container) {
+    Ensure-Directory $opencodeCmdsDst
+    $cmdsAdded   = 0
+    $cmdsSkipped = 0
+    $cmdsRemoved = 0
+    foreach ($src in Get-ChildItem -LiteralPath $opencodeCmdsSrc -Filter '*.md' -File -ErrorAction SilentlyContinue) {
+        $dst = Join-Path $opencodeCmdsDst $src.Name
+        $sameContent = $false
+        if (Test-Path -LiteralPath $dst -PathType Leaf) {
+            $sH = (Get-FileHash -LiteralPath $src.FullName -Algorithm SHA256).Hash
+            $dH = (Get-FileHash -LiteralPath $dst -Algorithm SHA256).Hash
+            if ($sH -eq $dH) { $sameContent = $true }
+        }
+        if ($sameContent) {
+            $cmdsSkipped++
+        } else {
+            Copy-Item -LiteralPath $src.FullName -Destination $dst -Force
+            $cmdsAdded++
+        }
+    }
+    # Orphan removal: any *.md in destination not present in source.
+    foreach ($dst in Get-ChildItem -LiteralPath $opencodeCmdsDst -Filter '*.md' -File -ErrorAction SilentlyContinue) {
+        $srcPath = Join-Path $opencodeCmdsSrc $dst.Name
+        if (-not (Test-Path -LiteralPath $srcPath -PathType Leaf)) {
+            Remove-Item -LiteralPath $dst.FullName -Force
+            $cmdsRemoved++
+        }
+    }
+    Write-Success "opencode commands: $cmdsAdded added, $cmdsSkipped already in sync, $cmdsRemoved orphans removed"
+} else {
+    Write-Info "opencode commands source missing: $opencodeCmdsSrc (skipping)"
 }
 
 # ============================================================================

--- a/specs/AI-014-opencode-windows-bootstrap/proposal.md
+++ b/specs/AI-014-opencode-windows-bootstrap/proposal.md
@@ -1,0 +1,61 @@
+---
+id: "AI-014-opencode-windows-bootstrap"
+type: spec
+status: implementing
+created: "2026-05-21"
+tags: [spec, proposal, opencode, multi-agent, cross-os-parity]
+template_version: "1.0"
+---
+
+# AI-014-opencode-windows-bootstrap
+
+## Why
+
+OpenCode is the secondary AI coding agent (ADR-009 Multi-Agent Runtime). The Linux side shipped 2026-05-16 via AI-011 (PRs #34/#36/#37): `setup-linux.sh` installs the binary via `curl -fsSL https://opencode.ai/install | bash`, deploys `opencode.jsonc`, deploys all command files from `ai/opencode/commands/`. The Windows side has been a known gap — `healthcheck.ps1` sec 10/12 emits two SKIPs (`opencode binary - not installed (AI-014 admin-conditional)`, `opencode.jsonc - not deployed at ... (AI-014 pending)`) on every run, and the user has been explicit (2026-05-21 session) that they want OpenCode running on Windows soon. The original AI-014 backlog entry assumed Windows would need an "admin-conditional curl-bash equivalent or `npm i -g opencode-ai`" with graceful-skip logic for non-admin machines — empirical probe 2026-05-21 against winget revealed `SST.opencode` (v1.15.6) is published natively, user-scope installable, with PATH integration handled. That is a substantially cleaner path than either of the originally hypothesised options and reduces this spec from ~150 LOC of admin-detection logic to ~50 LOC mirroring the existing winget tools array pattern.
+
+## What
+
+After this PR, a fresh `setup-windows.ps1` run on a Windows machine with `winget` available will:
+
+1. Install the OpenCode binary via `winget install SST.opencode` (joins the existing `$tools` array in section 1c). User-scope, no admin, idempotent — winget itself skips when the package is already installed at the requested version.
+2. Deploy `ai/opencode/opencode.jsonc` to `$env:USERPROFILE\.config\opencode\opencode.jsonc` (reconcile-not-skip pattern: byte-compare against source, copy on drift).
+3. Sync `ai/opencode/commands/*.md` to `$env:USERPROFILE\.config\opencode\commands\` (add new, leave unchanged, remove orphans) so `/audit`, `/test`, `/writing-plans`, etc. are available from any cwd where the user launches `oc`.
+4. Healthcheck sec 10/12 transitions from SKIP to PASS on both checks (binary in PATH, jsonc deployed with `$schema`).
+
+The `/connect` flow (interactive auth to the Go subscription) stays manual, identical to the Linux runbook. Profile alias `oc` is already conditional on `Get-Command opencode` since 2026-05-16, so it activates the moment the binary is on PATH.
+
+## Out of scope
+
+- Porting `scripts/skills-to-opencode.sh` (the regenerator) to PowerShell — Windows reads the committed `ai/opencode/commands/*.md` directly; regeneration is a Linux/CI-side concern.
+- Automating the `/connect` interactive flow — requires pasting an API key, intentionally manual per the Linux runbook.
+- A separate Windows runbook — the `guide-opencode-go-setup.md` runbook is OS-agnostic for the `/connect`/PAYG-guardrail/troubleshooting sections; a small Windows install delta gets folded as a section in that same runbook post-merge, not a parallel file.
+- Provider configuration variations (`opencode.jsonc` overrides per-OS) — the same canonical config ships to both OSes; if a Windows-specific divergence becomes necessary it gets its own ticket.
+- Ghostty Windows (TERM-002) — orthogonal terminal emulator concern.
+
+## Risks / open questions
+
+- **Risk: `winget` not on PATH on a fresh Windows install.** Mitigation: the entire developer-tools block is already gated on `Get-Command winget` (setup-windows.ps1:260). If absent, every winget tool — including OpenCode — gracefully skips with a clear `[WARNING] winget not found` line. Same blast radius as `gh`/`zoxide`/`age` install.
+- **Risk: winget package `SST.opencode` becomes stale relative to the upstream `curl|bash` installer.** Mitigation: the package is maintained by the OpenCode team (publisher `SST`); historical release cadence on winget tracks upstream within hours. If divergence becomes chronic, future ticket switches to the `npm install -g opencode-ai` fallback (also empirically validated 2026-05-21: registry has v1.15.7).
+- **Risk: opencode.jsonc deployment overwrites user-side experiments.** Mitigation: the reconcile-not-skip pattern only copies when source and destination differ (per-byte `Compare-Object` or `cmp` equivalent). Identical to the Linux block's `cmp -s` behaviour. Users editing the deployed file should commit changes back to the repo source-of-truth or accept they will be reconciled away — same contract as on Linux.
+- **Risk: commands directory ends up with stale files when a skill is removed from `ai/skills/`.** Mitigation: orphan removal walks the destination and deletes any `*.md` not present in the source (mirror of `setup-linux.sh:455-461`).
+
+## Acceptance criteria
+
+- [ ] `setup-windows.ps1` adds `SST.opencode` to the `$tools` array in section 1c. Idempotent via the existing per-tool `Get-Command` check.
+- [ ] `setup-windows.ps1` deploys `ai/opencode/opencode.jsonc` to `$env:USERPROFILE\.config\opencode\` using a reconcile-not-skip block (byte-equality check via `Get-FileHash` or `Compare-Object` before copy).
+- [ ] `setup-windows.ps1` syncs `ai/opencode/commands/*.md` to `$env:USERPROFILE\.config\opencode\commands\` (add new, leave unchanged, remove orphans).
+- [ ] `scripts/healthcheck.ps1` sec 10/12 wording for the SKIP-when-absent branches updated to remove the "AI-014 pending" qualifier (the present-but-not-installed case still SKIPs with the original "not installed" reason, just without the parenthetical pointer).
+- [ ] `tests/setup-windows.bats`: bats asserts lock the `SST.opencode` entry in `$tools`, the reconcile-not-skip block for `opencode.jsonc`, and the commands sync block.
+- [ ] `Invoke-ScriptAnalyzer -Settings .PSScriptAnalyzerSettings.psd1 -Severity Error,Warning setup-windows.ps1` → clean (no em-dash regression like BUG-014).
+- [ ] PowerShell AST parse of `setup-windows.ps1` clean.
+- [ ] Empirical run on user's Windows: `winget install SST.opencode` succeeds non-elevated, `opencode --version` reports a version, `~/.config/opencode/opencode.jsonc` matches `ai/opencode/opencode.jsonc` byte-for-byte, `~/.config/opencode/commands/` contains all 12 `.md` files from `ai/opencode/commands/`.
+- [ ] verification.md ships with the empirical evidence above.
+
+## References
+
+- Vault: `10_projects/dotfiles/11-tasks.md` § **AI-014-opencode-windows-bootstrap** entry.
+- Predecessor: AI-011-opencode-bootstrap (Linux side, PRs #34/#36/#37, 2026-05-16). This PR mirrors that pattern adapting to Windows tooling.
+- Runbook: `40-runbooks/guide-opencode-go-setup.md` — OS-agnostic for `/connect`/PAYG/troubleshooting; Windows install delta folded into it post-merge.
+- ADR: [[adr-009-multi-agent-runtime]] — strategic intent for Claude Code primary + OpenCode secondary.
+- Pattern: [[pattern-setup-script-idempotence]] — reconcile-not-skip rationale.
+- Upstream: `SST.opencode` on winget (v1.15.6 confirmed 2026-05-21); fallback `npm install -g opencode-ai` (v1.15.7) and `curl -fsSL https://opencode.ai/install | bash` (Linux path) documented in proposal for future-ticket consideration.

--- a/specs/AI-014-opencode-windows-bootstrap/tasks.md
+++ b/specs/AI-014-opencode-windows-bootstrap/tasks.md
@@ -1,0 +1,43 @@
+---
+tags: [spec, tasks, opencode, multi-agent, cross-os-parity]
+created: "2026-05-21"
+---
+
+# Tasks - AI-014-opencode-windows-bootstrap
+
+## Setup
+
+- [x] Branch `feat/AI-014-opencode-windows-bootstrap` (off main).
+- [x] Spec scaffolded via `init-spec.ps1` (vault gate satisfied — entry exists in `10_projects/dotfiles/11-tasks.md`).
+- [x] Empirical pre-flight 2026-05-21: `winget search opencode` → `SST.opencode v1.15.6` available; `opencode.ai/install.ps1` returns HTTP 404 (no PowerShell installer upstream); npm registry has `opencode-ai v1.15.7` as alternative. Winget is the preferred channel.
+
+## Implementation (TDD order)
+
+### Tests first
+
+- [ ] `tests/setup-windows.bats`: assertion locks `SST.opencode` entry in the `$tools` array (section 1c).
+- [ ] `tests/setup-windows.bats`: assertion locks the reconcile-not-skip block for `opencode.jsonc` (greps `Get-FileHash` or `Compare-Object` near `opencode.jsonc` path).
+- [ ] `tests/setup-windows.bats`: assertion locks the commands sync block (greps `opencode\\commands` and an orphan-removal loop).
+- [ ] Run bats — should FAIL on all three (red).
+
+### Implementation
+
+- [ ] `setup-windows.ps1` section 1c: append `@{ Name = "OpenCode"; Cmd = "opencode"; Id = "SST.opencode" }` to the `$tools` array. Idempotent via existing `Get-Command opencode` guard in the foreach.
+- [ ] `setup-windows.ps1` new section 2d (after 2c Obsidian CLI): deploy `opencode.jsonc` reconcile-not-skip pattern. Compute SHA256 of source and destination; copy only on mismatch. Bootstrap branch creates `$env:USERPROFILE\.config\opencode\` if missing.
+- [ ] `setup-windows.ps1` section 2d: sync `ai\opencode\commands\*.md` → `$env:USERPROFILE\.config\opencode\commands\` (add new, leave unchanged, remove orphans). Mirror the Linux loop counts (`cmds_added`/`cmds_skipped`/`cmds_removed`).
+- [ ] `scripts/healthcheck.ps1` sec 10/12: keep current SKIP wording (Test-Command 'opencode' auto-flips to PASS on next run once installed). Remove only the `AI-014 pending` parenthetical.
+- [ ] Run bats — assertions GREEN.
+
+### Lint + cross-check
+
+- [ ] PowerShell AST `[Parser]::ParseFile` on `setup-windows.ps1` + `scripts/healthcheck.ps1` clean.
+- [ ] `Invoke-ScriptAnalyzer -Settings .PSScriptAnalyzerSettings.psd1 -Severity Error,Warning` clean on both files (no em-dash regression).
+- [ ] Manual empirical run on user's Windows: `setup-windows.ps1` exit 0; `opencode --version` returns a 1.15.x string; `~/.config/opencode/opencode.jsonc` SHA256 matches `ai/opencode/opencode.jsonc`; `ls ~/.config/opencode/commands/` shows 12 `.md` files.
+
+## Closing
+
+- [ ] `verification.md` filled with empirical evidence (winget install transcript, version output, file-hash equality).
+- [ ] PR opened referencing `specs/AI-014-opencode-windows-bootstrap/`. Body calls out the winget-vs-curl simplification.
+- [ ] Post-merge: archive `specs/AI-014-…` to `specs/archive/`.
+- [ ] Post-merge: tick vault `11-tasks.md` AI-014 entry → ✓ with PR link.
+- [ ] Post-merge: update `40-runbooks/guide-opencode-go-setup.md` with a small "Windows install delta" section (winget package ID, expected default location, profile alias `oc` activation).

--- a/specs/AI-014-opencode-windows-bootstrap/verification.md
+++ b/specs/AI-014-opencode-windows-bootstrap/verification.md
@@ -1,0 +1,84 @@
+---
+tags: [spec, verification, opencode, multi-agent, cross-os-parity]
+created: "2026-05-21"
+---
+
+# Verification - AI-014-opencode-windows-bootstrap
+
+## Evidence (per acceptance criterion)
+
+To be filled post-implementation. Template:
+
+- [ ] **`SST.opencode` in `$tools`**: line range + winget output transcript.
+- [ ] **`opencode.jsonc` reconcile-not-skip**: line range + manual SHA256 equality before/after.
+- [ ] **Commands sync**: line range + before/after file count in destination.
+- [ ] **Healthcheck transition**: pre/post-fix healthcheck sec 10 output (SKIP → PASS).
+- [ ] **Bats**: count of new asserts + CI green.
+- [ ] **Lint**: PSScriptAnalyzer + AST clean.
+
+## Test status
+
+### Pre-fix state on user's Windows machine (captured 2026-05-21)
+
+```
+PS> winget list opencode 2>&1
+(no installed package matched the query)
+
+PS> Get-Command opencode -ErrorAction SilentlyContinue
+(empty)
+
+PS> Test-Path "$env:USERPROFILE\.config\opencode\opencode.jsonc"
+False
+
+Healthcheck sec 10/12:
+  SKIP: opencode binary - not installed (AI-014 admin-conditional; deploy via setup-windows.ps1 when ready)
+  SKIP: opencode.jsonc - not deployed at C:\Users\Manu\.config\opencode\opencode.jsonc (AI-014 pending)
+```
+
+### Empirical pre-flight (2026-05-21 in this session)
+
+```
+PS> winget search opencode --source winget
+Name                   Id                                   Version Match
+-----------------------------------------------------------------------------
+OpenCode               SST.OpenCodeDesktop                  1.15.6  ProductCode: opencode
+opencode               SST.opencode                         1.15.6
+...
+
+PS> Invoke-WebRequest https://opencode.ai/install.ps1 -Method Head
+404 Not Found            # confirms no PowerShell installer upstream
+
+PS> Invoke-RestMethod https://registry.npmjs.org/opencode-ai | %{ $_.'dist-tags'.latest }
+1.15.7                   # npm fallback available, not chosen
+```
+
+Winget package `SST.opencode` (NOT `SST.OpenCodeDesktop` — that is the GUI). User-scope installable (no admin), winget manages PATH.
+
+### Post-implementation results
+
+To be filled.
+
+### Lint results
+
+To be filled.
+
+## Decisions made during implementation
+
+- **Winget over curl-bash or npm**: empirical probe showed `SST.opencode` v1.15.6 is published natively. winget handles PATH, user-scope, no admin, no shell-script execution policy concerns. The original AI-014 vault entry's "admin-conditional curl-bash equivalent" hypothesis was based on the Linux pattern; the actual Windows ecosystem is cleaner.
+- **No skills-to-opencode.ps1 port**: regeneration of `ai/opencode/commands/` from `ai/skills/` stays a Linux/CI concern (the committed files are the contract Windows reads).
+- **Single canonical `opencode.jsonc`**: same file shipped to both OSes via reconcile-not-skip. If a Windows-specific divergence appears later, it gets its own ticket — premature splitting now would create a 2-file SSOT.
+- **Healthcheck wording**: minimal change — only drop the `AI-014 pending` parenthetical. The SKIP-when-missing path remains for the case where the user explicitly skips OpenCode install (e.g. `winget` absent).
+
+## Promotion candidates
+
+- [ ] Lesson for `10_projects/dotfiles/90-lessons.md`? **yes** — "When porting a Linux feature to Windows, probe the native package manager (`winget`) FIRST before assuming the Linux install path (curl-bash, npm) is the only option. The cleaner channel often exists but is invisible to a Linux-first design."
+- [ ] ADR-worthy decision? **no** — this is a tactical mirror of an existing ADR (ADR-009 already covers the Multi-Agent Runtime intent).
+- [ ] New pattern candidate? **no** — generalisation already implied by existing `pattern-setup-script-idempotence`.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`.
+- [ ] Folder moved: `specs/AI-014-opencode-windows-bootstrap/` → `specs/archive/AI-014-opencode-windows-bootstrap/`.
+- [ ] Vault `11-tasks.md` AI-014 entry ticked ✓ with PR link.
+- [ ] Vault `90-lessons.md` lesson appended.
+- [ ] `40-runbooks/guide-opencode-go-setup.md` updated with Windows install delta.

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -263,6 +263,30 @@ setup() {
     grep -B10 "npm install -g '@vorillaz/obsidian-cli'" "$PS1_SCRIPT" | grep -q "Get-Command npm"
 }
 
+# --- AI-014: OpenCode Windows bootstrap (mirror of AI-011 Linux side) ---
+# setup-windows.ps1 must install OpenCode via winget SST.opencode (cleaner
+# than the Linux curl-bash equivalent), deploy ai/opencode/opencode.jsonc
+# reconcile-not-skip, and sync ai/opencode/commands/*.md to the user's
+# OpenCode commands directory.
+
+@test "setup-windows.ps1 installs OpenCode via winget SST.opencode (AI-014)" {
+    grep -qF 'SST.opencode' "$PS1_SCRIPT"
+}
+
+@test "setup-windows.ps1 deploys opencode.jsonc with reconcile-not-skip (AI-014)" {
+    # The deploy block compares SHA256 hashes before overwriting and lands at
+    # %USERPROFILE%\.config\opencode\opencode.jsonc.
+    grep -qF 'opencode.jsonc' "$PS1_SCRIPT"
+    grep -B5 'opencode.jsonc already in sync' "$PS1_SCRIPT" | grep -q 'Get-FileHash'
+}
+
+@test "setup-windows.ps1 syncs OpenCode commands with orphan removal (AI-014)" {
+    # The commands sync writes to .config\opencode\commands and removes any
+    # .md file present in the destination that does not exist in the source.
+    grep -qF '.config\opencode\commands' "$PS1_SCRIPT"
+    grep -qF 'cmds_removed' "$PS1_SCRIPT" || grep -qF '$cmdsRemoved' "$PS1_SCRIPT"
+}
+
 # --- BUG-005: Windows PowerShell 5.1 auto-reexec under pwsh ---
 # SDD-002 (PR #51) introduced Merge-ClaudeSettings which uses
 # `ConvertFrom-Json -AsHashtable` -- a parameter added in PowerShell 7.0 that


### PR DESCRIPTION
## Summary

Mirror of AI-011 (Linux bootstrap, PRs #34/#36/#37, 2026-05-16) on the Windows side. The Linux path uses \`curl -fsSL https://opencode.ai/install | bash\`; empirical probe 2026-05-21 against winget revealed \`SST.opencode\` (v1.15.6) is published natively, user-scope installable, PATH handled by winget itself. That is substantially cleaner than the original AI-014 backlog entry's "admin-conditional curl-bash equivalent or npm install" hypothesis and reduces this spec from ~150 LOC of admin-detection logic to ~75 LOC of straight mirror.

## Changes

1. **setup-windows.ps1 section 1c**: append \`SST.opencode\` to existing \`\$tools\` winget array. Idempotent via foreach's per-tool \`Get-Command opencode\` guard. Inherits section's post-loop PATH refresh.
2. **setup-windows.ps1 new section 2d** (after 2c Obsidian CLI):
    - Deploy \`ai/opencode/opencode.jsonc\` to \`%USERPROFILE%\.config\opencode\opencode.jsonc\` using SHA256 byte-equality test before copy (reconcile-not-skip, mirror of setup-linux.sh:415-428's \`cmp -s\`).
    - Sync \`ai/opencode/commands/*.md\` to \`%USERPROFILE%\.config\opencode\commands\\` with add/skip/remove-orphan counters identical to setup-linux.sh:430-465.
3. **scripts/healthcheck.ps1 sec 10/12**: drop the "AI-014 pending" parenthetical from SKIP messages. PASS path (\`Test-Command 'opencode'\` true + jsonc deployed) was already wired.
4. **tests/setup-windows.bats**: 3 new asserts locking the \`SST.opencode\` entry, the SHA256-guarded jsonc deploy, and the orphan-removal in commands sync.

Spec at \`specs/AI-014-opencode-windows-bootstrap/\`. Production diff 74 LOC (≥ 50 threshold), spec-gate satisfied.

## Empirical probe (2026-05-21)

\`\`\`
PS> winget search opencode --source winget
opencode               SST.opencode                         1.15.6
OpenCode               SST.OpenCodeDesktop                  1.15.6  ProductCode: opencode

PS> Invoke-WebRequest https://opencode.ai/install.ps1 -Method Head
404 Not Found           # confirms no PowerShell installer upstream

PS> Invoke-RestMethod https://registry.npmjs.org/opencode-ai | %{ $_.'dist-tags'.latest }
1.15.7                  # npm fallback available, not chosen
\`\`\`

\`SST.opencode\` (NOT \`SST.OpenCodeDesktop\` — that is the GUI). User-scope, no admin, winget manages PATH.

## Test plan

- [x] PowerShell AST \`[Parser]::ParseFile\` → clean for both setup-windows.ps1 + healthcheck.ps1
- [x] \`Invoke-ScriptAnalyzer -Settings .PSScriptAnalyzerSettings.psd1 -Severity Error,Warning\` → clean (no em-dash regression from BUG-014)
- [x] ASCII-only check → 0 non-ASCII chars
- [x] 3 new bats asserts in \`tests/setup-windows.bats\`
- [ ] CI green
- [ ] Empirical run on user's Windows: \`winget install SST.opencode\` succeeds non-elevated; \`opencode --version\` returns 1.15.x; \`opencode.jsonc\` SHA256 matches source; commands dir has 12 .md files

## Coexistence note

The Hive MCP write-lock race between Claude Code and OpenCode (documented in \`40-runbooks/guide-opencode-go-setup.md\`) applies cross-OS. Until the hive flock follow-up merges, do not run \`oc\` and \`claude\` in parallel on the same repo. Safe pattern: sequential per repo, OR different repos in parallel.

## Out of scope

- Porting \`scripts/skills-to-opencode.sh\` to PowerShell (regeneration stays Linux/CI concern)
- Automating the \`/connect\` flow (intentionally manual, API-key paste required)
- A separate Windows runbook (the existing \`guide-opencode-go-setup.md\` is OS-agnostic for /connect/PAYG/troubleshooting; a small "Windows install delta" section gets folded post-merge)

## Lesson candidate

"When porting a Linux feature to Windows, probe the native package manager (winget) FIRST before assuming the Linux install path (curl-bash, npm) is the only option. The cleaner channel often exists but is invisible to a Linux-first design."