### PR TITLE
feat(BUG-013b): install @vorillaz/obsidian-cli on Linux via npm global (parity)

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -387,6 +387,26 @@ if [ -n "$PYTHON_DIR" ] && [ -d "$PYTHON_DIR/bin" ] && [ ! -e "$PYTHON_DIR/bin/p
     log_success "python -> python3 symlink created"
 fi
 
+# BUG-013b: install @vorillaz/obsidian-cli via npm global. Mirror of the
+# Windows side shipped in PR #77. The CLI provides the `obsidian` binary
+# used by obs-cli.sh and the vault-health workflow. Idempotent: skip when
+# `obsidian` is already on PATH. Gated on `npm` so machines without
+# Node.js gracefully skip with a clear hint.
+if ! command -v obsidian >/dev/null 2>&1; then
+    if command -v npm >/dev/null 2>&1; then
+        log_info "Installing Obsidian CLI (@vorillaz/obsidian-cli) via npm..."
+        if npm install -g '@vorillaz/obsidian-cli' >/dev/null 2>&1; then
+            log_success "Obsidian CLI installed"
+        else
+            log_warning "Failed to install Obsidian CLI (npm install -g exited non-zero)"
+        fi
+    else
+        log_warning "npm not available, skipping Obsidian CLI install (install Node.js then re-run)"
+    fi
+else
+    log_info "Obsidian CLI already installed at $(command -v obsidian)"
+fi
+
 # OpenCode (secondary AI coding agent — see ADR-009 and specs/AI-011-opencode-bootstrap)
 # Idempotent per pattern-setup-script-idempotence:
 #   - install only if absent (no forced re-install on every run)

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -352,6 +352,21 @@ setup() {
     grep -q 'doctor\.ps1' "$DOTFILES_DIR/setup-windows.ps1"
 }
 
+# BUG-013b: cross-OS parity for the Obsidian CLI (@vorillaz/obsidian-cli)
+# install. Windows side shipped in PR #77 via npm global. Linux side
+# mirrors with the same idempotent + gated-on-npm pattern.
+@test "parity: both setup scripts install Obsidian CLI via npm (BUG-013/b)" {
+    grep -qF "npm install -g '@vorillaz/obsidian-cli'" "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF "npm install -g '@vorillaz/obsidian-cli'" "$DOTFILES_DIR/setup-windows.ps1"
+}
+
+@test "setup-linux.sh Obsidian CLI install is gated on npm + idempotent (BUG-013b)" {
+    # idempotence: skip if `obsidian` already on PATH
+    grep -B10 "npm install -g '@vorillaz/obsidian-cli'" "$DOTFILES_DIR/setup-linux.sh" | grep -q "command -v obsidian"
+    # gating: only run if npm is available
+    grep -B10 "npm install -g '@vorillaz/obsidian-cli'" "$DOTFILES_DIR/setup-linux.sh" | grep -q "command -v npm"
+}
+
 # WIN-001b: cross-OS parity for the post-setup healthcheck auto-invoke.
 # setup-windows.ps1 has wired healthcheck.ps1 after doctor since PR #71 (WIN-001).
 # setup-linux.sh now mirrors that wiring with bash healthcheck.sh so the


### PR DESCRIPTION
## Summary

Linux mirror of PR #77 (Windows side, BUG-013). The original BUG-013 backlog entry assumed setup-linux.sh already installed the Obsidian CLI; empirical check 2026-05-21 confirmed neither setup script installed it. PR #77 fixed the Windows gap; this fix closes the symmetric Linux gap so the cross-OS contract converges.

## Behavior

Insertion point: right before the OpenCode block in setup-linux.sh (line ~390), following the existing Python tooling. Same shape as the Windows side (setup-windows.ps1 sec 2c):

- **Idempotent**: skip when \`obsidian\` already on PATH
- **Gated**: skip when \`npm\` not available, with clear "install Node.js" hint
- **Install**: \`npm install -g '@vorillaz/obsidian-cli'\`
- **Log**: success or warning

## Diff

\`\`\`
 setup-linux.sh         | 20 ++++++++++++++++++++
 tests/setup-linux.bats | 15 +++++++++++++++
 2 files changed, 35 insertions(+)
\`\`\`

Production diff 20 LOC (below spec-gate threshold of 50). Skip SDD — mechanical mirror.

## Test plan

- [x] \`bash -n setup-linux.sh\` → OK
- [x] 2 new bats asserts in \`tests/setup-linux.bats\`:
  - cross-OS parity: both setup scripts install Obsidian CLI via npm
  - Linux install is gated on \`command -v npm\` AND idempotent on \`command -v obsidian\`
- [x] CI green
- [ ] Post-merge: a fresh setup-linux.sh on a Linux machine with npm gets \`obsidian\` on PATH; healthcheck.sh sec 7 \`Obsidian CLI in PATH\` PASSes

## Context

After merge, BOTH setup scripts handle Obsidian CLI install identically. Closes the symmetry gap surfaced in BUG-013 (Windows side, PR #77).