### PR TITLE
feat(BUG-015): detection layer for claude-mem hook resolution failure (cross-OS)

### DIFF
--- a/scripts/healthcheck.ps1
+++ b/scripts/healthcheck.ps1
@@ -259,6 +259,24 @@ if (Test-Path -LiteralPath $marketplaceReal -PathType Container) {
     Write-Skip 'claude-mem marketplace junction' 'marketplace not installed'
 }
 
+# BUG-015: assert the claude-mem hook's path-resolution cascade succeeds.
+# The upstream hook command is bash; run the same one-liner via Git Bash so
+# this check reflects what the hook ACTUALLY does at runtime. Prevention
+# layer: detects breakage BEFORE the user encounters the intermittent
+# UserPromptSubmit "printf: write error: Permission denied" symptom.
+$bashCmd = Get-Command bash -ErrorAction SilentlyContinue
+if ($bashCmd) {
+    $cmHookProbe = '_C="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"; _E="${PLUGIN_ROOT:-}"; _P=$({ [ -n "$_E" ] && printf ''%s\n'' "$_E"; ls -dt "$_C/plugins/cache/thedotmack/claude-mem"/[0-9]*/ 2>/dev/null; printf ''%s\n'' "$_C/plugins/marketplaces/thedotmack-claude-mem/plugin"; } | while IFS= read -r _R; do _R="${_R%/}"; [ -d "$_R/plugin/scripts" ] && _Q="$_R/plugin" || _Q="$_R"; [ -f "$_Q/scripts/bun-runner.js" ] && [ -f "$_Q/scripts/worker-service.cjs" ] && { printf ''%s\n'' "$_Q"; break; }; done); [ -n "$_P" ] && printf ''%s'' "$_P" || exit 1'
+    $resolved = & bash -c $cmHookProbe 2>&1
+    if ($LASTEXITCODE -eq 0 -and $resolved) {
+        Write-Pass "claude-mem hook path resolves to: $resolved (BUG-015)"
+    } else {
+        Write-Fail 'claude-mem hook path resolution FAILED -- run claude-mem-heal.ps1 (BUG-015)'
+    }
+} else {
+    Write-Skip 'claude-mem hook path check' 'bash not available (install Git for Windows)'
+}
+
 # ==================================================
 # 5/12 Environment Variables
 # ==================================================

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -184,6 +184,28 @@ else
     skip "claude-mem install state -- installed_plugins.json missing (Claude Code never ran)"
 fi
 
+# BUG-015: assert the claude-mem hook's path-resolution cascade actually
+# returns a valid path. Reproduces the same one-liner the upstream
+# hooks.json runs (cache version dir -> marketplace junction) and reports
+# whether _P would be populated. Prevention layer: detects breakage BEFORE
+# user encounters the intermittent UserPromptSubmit fail.
+_cmhook_C="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+_cmhook_E="${PLUGIN_ROOT:-}"
+_cmhook_P=$({
+    [ -n "$_cmhook_E" ] && printf '%s\n' "$_cmhook_E"
+    ls -dt "$_cmhook_C/plugins/cache/thedotmack/claude-mem"/[0-9]*/ 2>/dev/null
+    printf '%s\n' "$_cmhook_C/plugins/marketplaces/thedotmack-claude-mem/plugin"
+} | while IFS= read -r _r; do
+    _r="${_r%/}"
+    [ -d "$_r/plugin/scripts" ] && _q="$_r/plugin" || _q="$_r"
+    [ -f "$_q/scripts/bun-runner.js" ] && [ -f "$_q/scripts/worker-service.cjs" ] && { printf '%s\n' "$_q"; break; }
+done)
+if [ -n "$_cmhook_P" ]; then
+    pass "claude-mem hook path resolves to: $_cmhook_P (BUG-015)"
+else
+    fail "claude-mem hook path resolution FAILED -- run claude-mem-heal.sh (BUG-015)"
+fi
+
 # ==================================================
 section "5/12" "Environment Variables"
 

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -367,6 +367,19 @@ setup() {
     grep -B10 "npm install -g '@vorillaz/obsidian-cli'" "$DOTFILES_DIR/setup-linux.sh" | grep -q "command -v npm"
 }
 
+# --- BUG-015: detection layer for claude-mem hook intermittent fails ---
+# The originally proposed prevention via PLUGIN_ROOT export was empirically
+# invalidated: setting PLUGIN_ROOT adds a third producer to the upstream
+# hooks' `{ printf; ls; printf; } | while ... break` pipe, tightening the
+# race that causes `printf: write error: Permission denied` on Git Bash.
+# The root cause is unfixable from outside (upstream hook pattern issue).
+# We keep ONLY the detection assertion: both healthchecks actually run
+# the hook resolution and report.
+@test "parity: both healthchecks include BUG-015 hook resolution assertion" {
+    grep -qF 'BUG-015' "$DOTFILES_DIR/scripts/healthcheck.sh"
+    grep -qF 'BUG-015' "$DOTFILES_DIR/scripts/healthcheck.ps1"
+}
+
 # WIN-001b: cross-OS parity for the post-setup healthcheck auto-invoke.
 # setup-windows.ps1 has wired healthcheck.ps1 after doctor since PR #71 (WIN-001).
 # setup-linux.sh now mirrors that wiring with bash healthcheck.sh so the


### PR DESCRIPTION
## Summary

User encountered the same intermittent BUG-012-family hook fail in a fresh hive project session today, hours after BUG-014 (PR #75) restored the claude-mem install:

\`\`\`
UserPromptSubmit operation blocked by hook:
/usr/bin/bash: line 1: printf: write error: Permission denied
\`\`\`

Filesystem state was healthy. The fail is an intermittent race in the upstream hook pattern:

\`\`\`bash
{ printf; ls -dt; printf; } | while IFS= read -r ... break
\`\`\`

When the consumer breaks early (first match), remaining producers in the \`{ }\` block try to write to a closed pipe and get EPIPE → \`printf: write error: Permission denied\` on Git Bash Windows. Claude Code interprets the stderr output as hook failure.

## Original prevention proposal: invalidated empirically

Initial plan: set \`PLUGIN_ROOT\` in .bashrc/.zshrc/profile.ps1 so the upstream hook's first-branch (\`[ -n "\$_E" ] && printf\`) would win the resolution race deterministically. Empirical repro 2026-05-21 demonstrated the OPPOSITE effect: adding PLUGIN_ROOT introduces a THIRD producer to the pipe, tightening the race window and making the printf write error MORE likely, not less.

\`\`\`
=== verify BUG-015 bash one-liner (no PLUGIN_ROOT) ===
_P='C:\Users\Manu\.claude/plugins/cache/thedotmack/claude-mem/13.3.0'
(no error)

=== verify with PLUGIN_ROOT set ===
/usr/bin/bash: line 54: printf: write error: Permission denied
_P='C:\Users\Manu\.claude/plugins/marketplaces/thedotmack-claude-mem/plugin'
\`\`\`

Reverted L1.

## What ships

**Detection-only** (L2 of the original 3-layer design):

1. \`scripts/healthcheck.sh\` sec 4: faithful repro of upstream hook path resolution. PASS reports resolved \`\$_P\`; FAIL means hook would have exited non-zero (cache wiped, junction broken, etc.).
2. \`scripts/healthcheck.ps1\` sec 4: equivalent via Git Bash one-liner. SKIPs cleanly when \`bash\` absent.
3. \`tests/setup-linux.bats\`: cross-OS parity assert.

## What does NOT ship

- **L1 PLUGIN_ROOT export** — empirically worsens the race.
- **L3 claude-mem-heal post-action assertion** — moot: heal can't fix an upstream pipe race; cache + junction are already healthy when the EPIPE fires.

## Diff

\`\`\`
 scripts/healthcheck.ps1 | 18 ++++++++++++++++++
 scripts/healthcheck.sh  | 22 ++++++++++++++++++++++
 tests/setup-linux.bats  | 13 +++++++++++++
 3 files changed, 53 insertions(+)
\`\`\`

Production diff 40 LOC (below spec-gate threshold). Skip SDD.

## Test plan

- [x] \`bash -n scripts/healthcheck.sh\` → OK
- [x] PowerShell AST + PSScriptAnalyzer clean
- [x] ASCII-only
- [x] Empirical repro of the L2 assertion on user's Windows (PASS on healthy state, would FAIL if cache wiped)
- [x] CI green
- [ ] Post-merge: re-run healthcheck on user's Windows + Linux → BUG-015 line appears

## Upstream fix (out of scope, follow-up)

The real fix is upstream: rewrite the cascading-printf pattern in \`thedotmack/claude-mem\` hooks.json. Candidates: \`head -n1\` instead of while/break, or a single atomic resolver script. **GitHub issue to file against thedotmack/claude-mem** as a follow-up (user requested 2026-05-21).

## Lesson candidate (post-merge)

"Prevention design must be empirically validated against the failure mode, not just the symptom. The BUG-015 PLUGIN_ROOT hypothesis addressed the WRONG cause: it assumed the resolution path was non-deterministic, but the real bug is pipe scheduling between producers and a fast-breaking consumer. Adding more producers worsens the race rather than bypassing it."