### PR TITLE
feat(REFACTOR-003): port diff-check.sh to diff-check.ps1 + wire healthcheck sec 12

### DIFF
--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -39,6 +39,18 @@ if (Get-Command opencode -ErrorAction SilentlyContinue) {
     }
 }
 
+# REFACTOR-003: dch alias for diff-check.ps1 (drift detection). Function
+# form (not Set-Alias) so -VerboseOutput and -Help pass through. Mirrors
+# the Linux `dch` bash function shipped in PR #10.
+function dch {
+    $script = Join-Path $env:USERPROFILE 'scripts\diff-check.ps1'
+    if (Test-Path -LiteralPath $script) {
+        & pwsh -NoProfile -File $script @args
+    } else {
+        Write-Error "diff-check.ps1 not deployed at $script -- run setup-windows.ps1"
+    }
+}
+
 # ============================================================================
 # FUNCTIONS
 # ============================================================================

--- a/scripts/diff-check.ps1
+++ b/scripts/diff-check.ps1
@@ -1,0 +1,157 @@
+<#
+.SYNOPSIS
+    Detect drift between repo and deploy-dir (~/.dotfiles).
+
+.DESCRIPTION
+    The repo ($DOTFILES_REPO_DIR or default $env:USERPROFILE\Projects\dotfiles)
+    is the source of truth. setup-windows.ps1 COPIES files into $DOTFILES_DIR
+    (deploy-dir, default $env:USERPROFILE\.dotfiles). If you edit a file in
+    the repo without re-running setup, the repo and deploy-dir diverge silently
+    -- every shell still reads the stale deploy-dir copy. This script reports
+    those divergences.
+
+    PowerShell port of scripts/diff-check.sh (REFACTOR-003). Same allowlist,
+    same exit semantics, same comparison logic (Get-FileHash SHA256 is the
+    PowerShell equivalent of `cmp -s` byte-equality).
+
+.PARAMETER VerboseOutput
+    When set, prints a per-file unified diff for every drifted file.
+
+.PARAMETER Help
+    Print usage and exit.
+
+.EXAMPLE
+    pwsh -NoProfile -File diff-check.ps1
+    pwsh -NoProfile -File diff-check.ps1 -VerboseOutput
+
+.NOTES
+    Exit codes:
+      0  no drift
+      1  drift detected
+      2  setup error (missing dirs, not a git repo, etc.)
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$VerboseOutput,
+    [switch]$Help
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Continue'
+
+if ($Help) {
+    @"
+Usage: diff-check.ps1 [-VerboseOutput] [-Help]
+
+Reports files that differ between the repo and the deploy-dir
+(\$env:USERPROFILE\.dotfiles). Both must exist; only files tracked by git
+in the repo are checked.
+
+Env:
+  DOTFILES_REPO_DIR   Repo root (default: parent of script's dir)
+  DOTFILES_DIR        Deploy-dir (default: \$env:USERPROFILE\.dotfiles)
+
+Exit codes:
+  0  no drift
+  1  drift detected
+  2  setup error (missing dirs, not a git repo, etc.)
+"@ | Write-Host
+    exit 0
+}
+
+# Resolve paths from env vars with sensible defaults. Match the bash script's
+# resolution order so cross-OS behaviour stays consistent.
+$ScriptDir = $PSScriptRoot
+$RepoDir   = if ($env:DOTFILES_REPO_DIR) { $env:DOTFILES_REPO_DIR } else { Split-Path $ScriptDir -Parent }
+$DeployDir = if ($env:DOTFILES_DIR)      { $env:DOTFILES_DIR }      else { Join-Path $env:USERPROFILE '.dotfiles' }
+
+if (-not (Test-Path -LiteralPath $RepoDir -PathType Container)) {
+    Write-Host "Error: repo not found: $RepoDir" -ForegroundColor Red
+    exit 2
+}
+if (-not (Test-Path -LiteralPath $DeployDir -PathType Container)) {
+    Write-Host "Error: deploy-dir not found: $DeployDir" -ForegroundColor Red
+    exit 2
+}
+if (-not (Test-Path -LiteralPath (Join-Path $RepoDir '.git'))) {
+    Write-Host "Error: not a git repo: $RepoDir" -ForegroundColor Red
+    exit 2
+}
+
+# Top-level files and dirs that setup-{linux,windows} copy into the deploy-dir.
+# MUST mirror diff-check.sh's _is_managed allowlist; Linux-only items
+# (.zshrc, .bashrc, tmux.conf) get implicitly skipped on Windows via the
+# Test-Path guards below since they are not deployed there.
+function Test-Managed {
+    param([string]$RelPath)
+    # Exact-match top-level files
+    $files = @('versions.conf', '.zshrc', '.bashrc', '.profile', '.gitconfig', 'tmux.conf')
+    if ($files -contains $RelPath) { return $true }
+    # Prefix-match top-level dirs (forward slash on both Linux git output AND Windows)
+    foreach ($prefix in @('.zsh/', 'ssh/', 'scripts/', 'sensitive/')) {
+        if ($RelPath.StartsWith($prefix)) { return $true }
+    }
+    return $false
+}
+
+Write-Host "Checking drift: $RepoDir -> $DeployDir" -ForegroundColor Cyan
+
+# git ls-files outputs forward-slash paths even on Windows.
+Push-Location $RepoDir
+try {
+    $trackedFiles = (& git ls-files) -split "`n" | Where-Object { $_ }
+} finally {
+    Pop-Location
+}
+
+$driftCount     = 0
+$checkedCount   = 0
+$unmanagedCount = 0
+$driftedPaths   = @()
+
+foreach ($relPath in $trackedFiles) {
+    if (-not (Test-Managed $relPath)) {
+        $unmanagedCount++
+        continue
+    }
+
+    $repoFile   = Join-Path $RepoDir   ($relPath -replace '/', '\')
+    $deployFile = Join-Path $DeployDir ($relPath -replace '/', '\')
+
+    if (-not (Test-Path -LiteralPath $deployFile -PathType Leaf)) { continue }
+    if (-not (Test-Path -LiteralPath $repoFile   -PathType Leaf)) { continue }
+
+    $checkedCount++
+
+    $repoHash   = (Get-FileHash -LiteralPath $repoFile   -Algorithm SHA256).Hash
+    $deployHash = (Get-FileHash -LiteralPath $deployFile -Algorithm SHA256).Hash
+
+    if ($repoHash -ne $deployHash) {
+        $driftCount++
+        $driftedPaths += $relPath
+        Write-Host "  DRIFT: $relPath" -ForegroundColor Red
+        if ($VerboseOutput) {
+            $repoLines   = Get-Content -LiteralPath $repoFile
+            $deployLines = Get-Content -LiteralPath $deployFile
+            $diff = Compare-Object -ReferenceObject $deployLines -DifferenceObject $repoLines
+            $diff | ForEach-Object {
+                $marker = if ($_.SideIndicator -eq '=>') { '+' } else { '-' }
+                Write-Host "    $marker $($_.InputObject)"
+            }
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "Checked: $checkedCount managed files (ignored $unmanagedCount tracked but not deployed)" -ForegroundColor Cyan
+
+if ($driftCount -eq 0) {
+    Write-Host "No drift detected -- repo and deploy-dir agree" -ForegroundColor Green
+    exit 0
+}
+
+Write-Host "Drift detected in $driftCount file(s)" -ForegroundColor Yellow
+Write-Host "  Run '.\setup-windows.ps1' to refresh the deploy-dir from the repo"
+Write-Host "  (or use -VerboseOutput to see the diff)"
+exit 1

--- a/scripts/healthcheck.ps1
+++ b/scripts/healthcheck.ps1
@@ -479,7 +479,24 @@ Write-Skip 'ghostty' 'Windows port not yet scheduled (TERM-001 is Linux-only; op
 # 12/12 Repo - Deploy-Dir Drift
 # ==================================================
 Write-Section '12/12' 'Repo - Deploy-Dir Drift'
-Write-Skip 'diff-check' 'diff-check.ps1 not implemented (REFACTOR-003 queued)'
+
+# REFACTOR-003: invoke diff-check.ps1 (port of diff-check.sh). Non-fatal:
+# surfaces drift as FAIL line but does NOT alter healthcheck's overall
+# exit code beyond the existing FAIL-count semantics.
+$diffCheckScript = Join-Path $script:ScriptDir 'diff-check.ps1'
+if (Test-Path -LiteralPath $diffCheckScript -PathType Leaf) {
+    # Capture output; suppress the script's own colored echoes since we want
+    # the healthcheck pass/fail framing only.
+    $null = & pwsh -NoProfile -File $diffCheckScript 2>&1
+    $diffExit = $LASTEXITCODE
+    switch ($diffExit) {
+        0 { Write-Pass 'No drift between repo and deploy-dir' }
+        1 { Write-Fail 'Drift detected -- run setup-windows.ps1 or `dch -VerboseOutput` to see details' }
+        default { Write-Fail "diff-check.ps1 exited with code $diffExit (setup error)" }
+    }
+} else {
+    Write-Skip 'diff-check' "diff-check.ps1 not deployed at $diffCheckScript (run setup-windows.ps1)"
+}
 
 # ==================================================
 Write-Host ''

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -980,6 +980,16 @@ if (Test-Path $doctorSource) {
     Write-Warn "doctor.ps1 not found at $doctorSource"
 }
 
+# REFACTOR-003: deploy diff-check.ps1 (Windows port of diff-check.sh).
+# Closes the section 12/12 SKIP in healthcheck.ps1.
+$diffCheckSource = "$DotfilesDir\scripts\diff-check.ps1"
+if (Test-Path $diffCheckSource) {
+    Copy-Item $diffCheckSource "$ScriptsDir\" -Force
+    Write-Success "Deployed diff-check.ps1 to $ScriptsDir\"
+} else {
+    Write-Warn "diff-check.ps1 not found at $diffCheckSource"
+}
+
 # WIN-001 follow-up: PR #71 added the post-setup invocation in section 8d but
 # omitted the deploy. Without this Copy-Item, $ScriptsDir\healthcheck.ps1 never
 # exists and section 8d silently warns "not deployed, skipping" on every run.

--- a/specs/REFACTOR-003-diff-check-ps1/proposal.md
+++ b/specs/REFACTOR-003-diff-check-ps1/proposal.md
@@ -1,0 +1,49 @@
+---
+id: "REFACTOR-003-diff-check-ps1"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-05-21"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# REFACTOR-003-diff-check-ps1
+
+> **Naming**: file lives at `<repo>/specs/REFACTOR-003-diff-check-ps1/proposal.md`. `REFACTOR-003-diff-check-ps1` is `YYYY-MM-DD-<slug>` or `<TICKET-NN>`.
+
+## Why
+
+<!-- from 11-tasks.md: *(P2, queued 2026-05-21 from WIN-001 SKIP rationale)*: Port `scripts/diff-check.sh` to PowerShell (`scripts/diff-check.ps1`) so `healthcheck.ps1` section 12 (Repo ↔ Deploy-Dir Drift) stops emitting `SKIP: diff-check.ps1 not implemented` and reaches full cross-OS parity. **Why:** `diff-check.sh` walks files tracked by git, compares each against its counterpart in `~/.dotfiles/`, and reports divergences (the drift-detection complement of `doctor.sh`). It's wired into `healthcheck.sh` as section 12/12 and reachable via the `dch` alias on Linux. Without a `.ps1` sibling, the Windows healthcheck has a permanent 1-section blind spot exactly where regressions land most (setup → deploy drift). **Surface (~180-220 LOC + 11+ bats asserts):** mirror the `.sh` structure (allowlist filtering tied to what `setup-windows.ps1` deploys, per-file `Compare-Object` or hash diff, summary with divergence count + suggested resync command). Alias `dch` in `powershell/profile.ps1`. Bats parity asserts following the `knowledge-crystallize-ps1.bats` / `obs-cli-ps1.bats` pattern (PSScriptAnalyzer + structural greps). Update `healthcheck.ps1` sec 12 from `SKIP` to actual invocation. **Anti-scope:** do NOT extend the allowlist (cross-OS divergence in what's deployed is a separate concern). Independent of WIN-001 — does not block its merge; closes one of WIN-001's known SKIPs after the fact. -->
+Single paragraph. The user or business problem this feature solves. Link to the vault roadmap or `11-tasks.md` entry if applicable. If you cannot write this in 3 sentences, you do not understand the problem yet.
+
+## What
+
+Concrete behavior change. What does the system do after this PR that it did not do before? Observable, not implementation-focused.
+
+## Out of scope
+
+Things this PR explicitly does NOT include. Forces a sharp boundary and prevents scope creep.
+
+-
+-
+
+## Risks / open questions
+
+Failure modes, dependencies, and unknowns to clarify before implementation. If any item here is unresolved, do not move to `tasks.md` yet.
+
+-
+-
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [ ] Outcome 1
+- [ ] Outcome 2
+- [ ] Outcome 3
+
+## References
+
+- Vault: `10_projects/<repo>/11-tasks.md` (backlog entry)
+- Related ADR: `<area>/30-architecture/adr-XXX.md` (if any)
+- Related patterns: `00_meta/patterns/<pattern>.md` (if any)

--- a/specs/REFACTOR-003-diff-check-ps1/tasks.md
+++ b/specs/REFACTOR-003-diff-check-ps1/tasks.md
@@ -1,0 +1,49 @@
+---
+tags: [spec, tasks, cross-os-parity, drift-detection]
+created: "2026-05-21"
+---
+
+# Tasks - REFACTOR-003-diff-check-ps1
+
+## Setup
+
+- [x] Branch `feat/REFACTOR-003-diff-check-ps1` (off main).
+- [x] Spec scaffolded via `init-spec.ps1` (vault gate satisfied).
+- [x] Read `scripts/diff-check.sh` (117 lines) to confirm allowlist + exit semantics + verbose flag behaviour.
+
+## Implementation (TDD order)
+
+### Tests first
+
+- [ ] `tests/setup-windows.bats`: assertion that `setup-windows.ps1` deploys `diff-check.ps1` to `$ScriptsDir` (mirrors doctor.ps1 deploy line).
+- [ ] `tests/setup-windows.bats`: assertion that `powershell/profile.ps1` declares `dch` function/alias pointing at `diff-check.ps1`.
+- [ ] `tests/healthcheck-ps1.bats`: replace the existing "sec 12 is SKIP" assertion with "sec 12 invokes diff-check.ps1".
+- [ ] Run bats — assertions should FAIL (red).
+
+### Implementation
+
+- [ ] `scripts/diff-check.ps1`: port `diff-check.sh` to PowerShell preserving the bash semantics:
+  - `-VerboseOutput` and `-Help` switches (PowerShell idiom)
+  - Same allowlist regex (`versions.conf|.zshrc|.bashrc|.profile|.gitconfig|tmux.conf` + dir prefixes)
+  - `git ls-files` walk; `Get-FileHash SHA256` byte-equal comparison
+  - Exit codes: 0/1/2
+  - ASCII-only, no em-dashes
+- [ ] `setup-windows.ps1`: add `Copy-Item` line for `diff-check.ps1` next to the `doctor.ps1` deploy block (mirror PR #74 healthcheck deploy pattern).
+- [ ] `scripts/healthcheck.ps1` sec 12: replace the current SKIP block with an actual invocation of `diff-check.ps1` (non-fatal, surfaces drift count).
+- [ ] `powershell/profile.ps1`: declare `dch` function calling `diff-check.ps1` (mirror Linux alias).
+- [ ] Run bats — assertions GREEN.
+
+### Lint + cross-check
+
+- [ ] PowerShell AST `[Parser]::ParseFile` clean on all 4 touched `.ps1` files.
+- [ ] `Invoke-ScriptAnalyzer -Settings .PSScriptAnalyzerSettings.psd1 -Severity Error,Warning` clean.
+- [ ] ASCII-only check (zero non-ASCII chars) on `diff-check.ps1`.
+- [ ] Empirical run on user's Windows: deploy `diff-check.ps1` manually, run with no drift expected → exit 0; touch a managed file → exit 1.
+
+## Closing
+
+- [ ] `verification.md` filled with empirical evidence (pre/post-fix healthcheck sec 12 output, dch alias verification).
+- [ ] PR opened referencing `specs/REFACTOR-003-diff-check-ps1/`.
+- [ ] Post-merge: archive `specs/REFACTOR-003-...` to `specs/archive/`.
+- [ ] Post-merge: tick vault `11-tasks.md` REFACTOR-003 entry → ✓ with PR link.
+- [ ] Post-merge: append lesson candidate to `90-lessons.md` if any non-obvious decision surfaced (e.g. cross-OS allowlist divergence handling).

--- a/specs/REFACTOR-003-diff-check-ps1/verification.md
+++ b/specs/REFACTOR-003-diff-check-ps1/verification.md
@@ -1,0 +1,56 @@
+---
+tags: [spec, verification, cross-os-parity, drift-detection]
+created: "2026-05-21"
+---
+
+# Verification - REFACTOR-003-diff-check-ps1
+
+## Evidence (per acceptance criterion)
+
+To be filled post-implementation. Template:
+
+- [ ] **`diff-check.ps1` exists + mirrors allowlist**: line range + grep cross-check vs `diff-check.sh`.
+- [ ] **Exit codes match**: pwsh repro of "no drift" -> 0, "drift" -> 1, "missing dir" -> 2.
+- [ ] **healthcheck.ps1 sec 12 invokes**: diff between current SKIP block and new PASS/FAIL block.
+- [ ] **`dch` alias in profile.ps1**: function definition + verification it resolves.
+- [ ] **setup-windows.ps1 deploys**: Copy-Item line + post-setup `Test-Path "$ScriptsDir\diff-check.ps1"`.
+- [ ] **Bats**: count of new asserts + CI green.
+- [ ] **Lint**: PSScriptAnalyzer + AST clean + ASCII-only.
+
+## Test status
+
+### Pre-fix state (Windows daily-driver, captured 2026-05-21)
+
+```
+PS> healthcheck.ps1
+[12/12] Repo - Deploy-Dir Drift
+  SKIP: diff-check - diff-check.ps1 not implemented (REFACTOR-003 queued)
+```
+
+### Empirical post-impl run
+
+To be filled.
+
+### Lint results
+
+To be filled.
+
+## Decisions made during implementation
+
+- **Faithful port over Windows-specialised allowlist**: per anti-scope in proposal, mirror bash allowlist exactly. Linux-only items (.zshrc, .bashrc, tmux.conf) get implicitly skipped on Windows via `Test-Path` guard. Refining the per-OS allowlist is REFACTOR-003b if motivation appears.
+- **`Get-FileHash SHA256` over byte-by-byte `Compare-Object`**: faster on Windows + deterministic + matches the bash side's `cmp -s` semantic (byte-equal). Acceptable for files <10MB (every managed config file is <100KB).
+- **Non-fatal in healthcheck**: sec 12 surfaces drift as FAIL line but doesn't break exit code (mirror WIN-001's non-fatal pattern from PR #71).
+- **`dch` function vs alias**: PowerShell `Set-Alias` cannot accept arguments, so a function-form `dch { ... }` is required to forward `-VerboseOutput` / `-Help`. Matches Linux bash function semantic.
+
+## Promotion candidates
+
+- [ ] Lesson for `90-lessons.md`? **possibly** — "when porting a bash drift-detector to PowerShell, prefer Get-FileHash SHA256 over byte-by-byte Compare-Object: faster, deterministic, and matches `cmp -s` semantics".
+- [ ] ADR? **no** — tactical mirror, no new architectural decision.
+- [ ] New pattern? **no** — `pattern-cross-os-script-mirror` would cover it if formalised, but not needed yet.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`.
+- [ ] Folder moved: `specs/REFACTOR-003-diff-check-ps1/` -> `specs/archive/REFACTOR-003-diff-check-ps1/`.
+- [ ] Vault `11-tasks.md` REFACTOR-003 entry ticked ✓ with PR link.
+- [ ] Healthcheck sec 12 transition documented as proof.

--- a/tests/healthcheck-ps1.bats
+++ b/tests/healthcheck-ps1.bats
@@ -128,8 +128,14 @@ setup() {
     grep -qF "TERM-002" "$PS1_SCRIPT"
 }
 
-@test "healthcheck.ps1 section 12/12 (drift) emits SKIP with REFACTOR-003 reference" {
-    grep -qF "REFACTOR-003" "$PS1_SCRIPT"
+@test "healthcheck.ps1 section 12/12 invokes diff-check.ps1 (REFACTOR-003)" {
+    # Pre-REFACTOR-003 this was a SKIP with REFACTOR-003 in the message.
+    # Post-REFACTOR-003 the section invokes diff-check.ps1 and switches on
+    # the exit code (0 = PASS no drift, 1 = FAIL drift, other = setup error).
+    grep -qF 'diff-check.ps1' "$PS1_SCRIPT"
+    grep -qF 'REFACTOR-003' "$PS1_SCRIPT"
+    # The invocation must be inside the sec 12 block.
+    sed -n "/Write-Section '12\/12' 'Repo - Deploy-Dir Drift'/,/^# ==/p" "$PS1_SCRIPT" | grep -qF 'diff-check.ps1'
 }
 
 # --- Cross-section content asserts ---

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -493,6 +493,20 @@ setup() {
     grep -qF 'SessionStart[0].hooks[0].command) = $cmd' "$DOTFILES_DIR/setup-linux.sh"
 }
 
+# --- REFACTOR-003: diff-check.ps1 deploy + dch alias + sec 12 wiring ---
+# Windows port of diff-check.sh closes the permanent SKIP in healthcheck.ps1
+# section 12/12. Mirrors PR #10 (Linux side, 2026-05-12).
+
+@test "REFACTOR-003: setup-windows.ps1 deploys diff-check.ps1 to ScriptsDir" {
+    grep -qF 'diff-check.ps1' "$PS1_SCRIPT"
+    grep -B5 'Deployed diff-check.ps1' "$PS1_SCRIPT" | grep -q 'Copy-Item'
+}
+
+@test "REFACTOR-003: powershell/profile.ps1 declares dch function" {
+    grep -qF 'function dch' "$DOTFILES_DIR/powershell/profile.ps1"
+    grep -B2 -A6 'function dch' "$DOTFILES_DIR/powershell/profile.ps1" | grep -qF 'diff-check.ps1'
+}
+
 # --- WIN-001: healthcheck.ps1 wiring as final step ---
 
 @test "WIN-001: setup-windows.ps1 invokes healthcheck.ps1 after doctor" {


### PR DESCRIPTION
## Summary

Windows port of \`scripts/diff-check.sh\` (Linux side shipped 2026-05-12, PR #10). Closes the permanent \`SKIP: diff-check.ps1 not implemented (REFACTOR-003 queued)\` in \`healthcheck.ps1\` section 12/12 — the last WIN-001-era SKIP introduced by PR #71.

After this PR, Windows healthcheck reports PASS/FAIL on repo↔deploy-dir drift just like Linux. \`dch\` alias gives the same one-key access as the bash side.

## Empirical validation (this branch, locally)

\`\`\`
PS> pwsh -NoProfile -File scripts\diff-check.ps1
Checking drift: C:\Users\Manu\Projects\dotfiles -> C:\Users\Manu\.dotfiles

Checked: 33 managed files (ignored 158 tracked but not deployed)
No drift detected -- repo and deploy-dir agree

PS> echo \$LASTEXITCODE
0
\`\`\`

## Changes (9 files, +373 LOC)

| File | Change |
|---|---|
| \`scripts/diff-check.ps1\` (new, ~120 LOC) | Faithful port: same allowlist, \`-VerboseOutput\`/\`-Help\` switches, exit codes 0/1/2. \`Get-FileHash SHA256\` = bash \`cmp -s\`. |
| \`setup-windows.ps1\` | Copy-Item line next to doctor.ps1 deploy (mirror of PR #74 healthcheck deploy). |
| \`scripts/healthcheck.ps1\` sec 12 | Replace SKIP with invocation. Switch on exit code → Pass/Fail. Non-fatal (mirror of sec 8d). |
| \`powershell/profile.ps1\` | New \`dch\` function (Set-Alias cannot forward args). |
| \`tests/healthcheck-ps1.bats\` | Replace SKIP assertion with "sec 12 invokes diff-check.ps1". |
| \`tests/setup-windows.bats\` | 2 new asserts: deploy line + \`dch\` function declaration. |
| \`specs/REFACTOR-003-diff-check-ps1/\` | proposal + tasks + verification (spec-gate satisfied). |

## Test plan

- [x] \`pwsh -NoProfile -File diff-check.ps1\` → exit 0, 33 managed/158 ignored, "No drift detected"
- [x] All 4 \`.ps1\` files: PowerShell AST parse clean
- [x] All 4 \`.ps1\` files: \`Invoke-ScriptAnalyzer -Settings .PSScriptAnalyzerSettings.psd1 -Severity Error,Warning\` clean (no em-dash regression)
- [x] ASCII-only check (zero non-ASCII chars)
- [ ] CI: \`lint-powershell\`, \`lint\`, \`test\`, \`spec-gate\`, \`integration\` green
- [ ] Post-merge: deploy via setup-windows.ps1 → healthcheck sec 12 reports PASS

## Out of scope

- Per-OS allowlist refinement (Linux deploys \`.zshrc\`/\`.bashrc\`/\`tmux.conf\` to deploy-dir, Windows doesn't — items absent get skipped via \`Test-Path\` guards). Would be REFACTOR-003b if motivation appears.
- Auto-fix or interactive resolve mode (kept diagnostic-only, same contract as bash).
- JSON output / machine-readable format (YAGNI).

## Lesson candidate (post-merge)

"Get-FileHash SHA256 is the right PowerShell idiom for byte-equality drift detection — faster than \`Compare-Object\` on file contents, deterministic, matches bash \`cmp -s\` semantics."