### PR TITLE
fix(BUG-020): export DOTFILES_REPO_DIR in PowerShell profile (cross-OS parity)

### DIFF
--- a/env-contract.json
+++ b/env-contract.json
@@ -12,6 +12,16 @@
       "validation": "path_exists"
     },
     {
+      "name": "DOTFILES_REPO_DIR",
+      "required": false,
+      "description": "Repo source-of-truth for dotfiles (BUG-020). Distinct from DOTFILES_DIR which is the deployed copy. Used by diff-check.{sh,ps1} (REFACTOR-003) to locate the git repo; without it the script falls back to the script's parent dir (deploy location, not a repo) and exits 2.",
+      "default": {
+        "linux": "$HOME/Projects/dotfiles",
+        "windows": "$env:USERPROFILE\\Projects\\dotfiles"
+      },
+      "validation": "path_exists"
+    },
+    {
       "name": "CLAUDE_CONFIG_DIR",
       "required": false,
       "description": "Override for Claude Code's config dir. When unset, ~/.claude is assumed. Used by claude-mem-heal to locate the plugin cache. Canonical for Claude (upstream contract — Claude Code CLI reads it at startup); intentionally NOT renamed to CLAUDE_HOME (see REFACTOR-002).",

--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -164,6 +164,13 @@ function prompt {
 # silences `doctor.ps1` warnings and makes the install location unambiguous
 # to every subshell.
 $env:DOTFILES_DIR = "$env:USERPROFILE\.dotfiles"
+# BUG-020: cross-OS parity with .bashrc/.zshrc which both export
+# DOTFILES_REPO_DIR. diff-check.ps1 (REFACTOR-003) needs it to locate the
+# repo root; without it, the script falls back to parent of $PSScriptRoot
+# which is $env:USERPROFILE\scripts (the deploy location, NOT a git repo)
+# and exits 2 -- which is what healthcheck.ps1 sec 12 was reporting after
+# REFACTOR-003 wired in the drift check.
+$env:DOTFILES_REPO_DIR = "$env:USERPROFILE\Projects\dotfiles"
 $env:CLAUDE_CONFIG_DIR = "$env:USERPROFILE\.claude"
 # Per-agent install dirs + scripts deploy target (REFACTOR-002).
 $env:SCRIPTS_DIR = "$env:DOTFILES_DIR\scripts"

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -230,6 +230,26 @@ setup() {
     grep -qF 'BUG-017' "$DOTFILES_DIR/scripts/claude-mem-heal.ps1"
 }
 
+# --- BUG-020: DOTFILES_REPO_DIR cross-OS export parity ---
+# .bashrc + .zshrc export it; powershell/profile.ps1 was missing it.
+# Required by diff-check.{sh,ps1} (REFACTOR-003) to locate the repo root.
+# Without it, diff-check falls back to script's parent dir (deploy location,
+# not a git repo) and exits 2 -- healthcheck sec 12 then reports a setup
+# error rather than drift / no-drift.
+
+@test "parity: all 3 profiles export DOTFILES_REPO_DIR (BUG-020)" {
+    grep -qF 'export DOTFILES_REPO_DIR=' "$DOTFILES_DIR/.bashrc"
+    grep -qF 'export DOTFILES_REPO_DIR=' "$DOTFILES_DIR/.zshrc"
+    grep -qF '$env:DOTFILES_REPO_DIR' "$DOTFILES_DIR/powershell/profile.ps1"
+}
+
+@test "env-contract.json declares DOTFILES_REPO_DIR (BUG-020)" {
+    if command -v jq >/dev/null 2>&1; then
+        run jq -e '.env_vars | map(select(.name == "DOTFILES_REPO_DIR")) | length == 1' "$DOTFILES_DIR/env-contract.json"
+        [ "$status" -eq 0 ]
+    fi
+}
+
 # --- BUG-018: ALL 5 `hook claude-code <X>` hooks missing continue directive ---
 # After BUG-017 closed the EPIPE race, every claude-mem hook that terminates
 # with `node ... hook claude-code <event>"` blocks Claude Code because the


### PR DESCRIPTION
## Summary

User's post-merge \`setup-windows.ps1\` run reported \`FAIL: diff-check.ps1 exited with code 2 (setup error)\` in healthcheck sec 12 (introduced by REFACTOR-003 PR #82). Tracing: diff-check.ps1 exits 2 because \`DOTFILES_REPO_DIR\` is unset on Windows — the script falls back to \`Split-Path $PSScriptRoot\` which resolves to \`$env:USERPROFILE\scripts\` (deploy location, NOT a git repo) and hits the "not a git repo" guard.

Linux side (.bashrc + .zshrc) has exported \`DOTFILES_REPO_DIR\` since forever. PowerShell profile was the only one missing it.

## Changes

| File | Change |
|---|---|
| \`powershell/profile.ps1\` | \`\$env:DOTFILES_REPO_DIR = "\$env:USERPROFILE\Projects\dotfiles"\` next to existing \$env:DOTFILES_DIR |
| \`env-contract.json\` | New entry for \`DOTFILES_REPO_DIR\` (required: false, validated by \`doctor.{sh,ps1}\`) |
| \`tests/setup-linux.bats\` | 2 new asserts: profile parity + env-contract declaration |

37 LOC total (17 prod + 20 test). Below spec-gate threshold. Skip SDD.

## Test plan

- [x] PowerShell AST + PSScriptAnalyzer clean
- [x] ASCII-only check passes
- [x] \`env-contract.json\` valid JSON (9 entries, DOTFILES_REPO_DIR present)
- [x] CI green
- [x] Post-merge: restart PowerShell + run healthcheck → sec 12 reports PASS / FAIL based on actual drift, not "setup error" exit 2

## Companion

- REFACTOR-003 (PR #82) — introduced diff-check.ps1 that exposed the gap
- BUG-017/BUG-018 sequence — the prior round of cross-OS heal parity fixes