### PR TITLE
fix(BUG-023): rewrite claude-mem hook probe to materialize+break (cross-OS)

### DIFF
--- a/scripts/healthcheck.ps1
+++ b/scripts/healthcheck.ps1
@@ -266,12 +266,17 @@ if (Test-Path -LiteralPath $marketplaceReal -PathType Container) {
 # UserPromptSubmit "printf: write error: Permission denied" symptom.
 $bashCmd = Get-Command bash -ErrorAction SilentlyContinue
 if ($bashCmd) {
-    # BUG-022 (2026-05-21): the probe itself used the same `break; }; done`
-    # cascade pattern as the upstream hook, hitting the EPIPE race when
-    # called from setup. Apply the same `head -n1` fix (Option A from
-    # claude-mem#2607) so the probe is race-free and reports the actual
-    # state of the install rather than spurious failures.
-    $cmHookProbe = '_C="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"; _E="${PLUGIN_ROOT:-}"; _P=$({ [ -n "$_E" ] && printf ''%s\n'' "$_E"; ls -dt "$_C/plugins/cache/thedotmack/claude-mem"/[0-9]*/ 2>/dev/null; printf ''%s\n'' "$_C/plugins/marketplaces/thedotmack-claude-mem/plugin"; } | while IFS= read -r _R; do _R="${_R%/}"; [ -d "$_R/plugin/scripts" ] && _Q="$_R/plugin" || _Q="$_R"; [ -f "$_Q/scripts/bun-runner.js" ] && [ -f "$_Q/scripts/worker-service.cjs" ] && printf ''%s\n'' "$_Q"; done | head -n1); [ -n "$_P" ] && printf ''%s'' "$_P" || exit 1'
+    # BUG-023 (2026-05-21): the BUG-022 pipe-to-head form still raced
+    # under Linux `set -euo pipefail` when 2+ candidates matched (the
+    # consumer closed after the first line, leftover printfs got EPIPE,
+    # pipefail killed the script). Cross-OS parity: rewrite to
+    # materialize candidates first, then iterate in pure bash with
+    # `break` -- no consumer-close, no pipe race. Git Bash on Windows
+    # doesn't set pipefail in this sub-context so it never observed the
+    # symptom, but the race-free form keeps both probes structurally
+    # identical (lesson: probe must use the race-free pattern, not
+    # faithfully reproduce broken upstream behaviour).
+    $cmHookProbe = '_C="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"; _E="${PLUGIN_ROOT:-}"; _CANDS=$({ [ -n "$_E" ] && printf ''%s\n'' "$_E"; ls -dt "$_C/plugins/cache/thedotmack/claude-mem"/[0-9]*/ 2>/dev/null; printf ''%s\n'' "$_C/plugins/marketplaces/thedotmack-claude-mem/plugin"; }); _P=""; while IFS= read -r _R; do _R="${_R%/}"; [ -d "$_R/plugin/scripts" ] && _Q="$_R/plugin" || _Q="$_R"; if [ -f "$_Q/scripts/bun-runner.js" ] && [ -f "$_Q/scripts/worker-service.cjs" ]; then _P="$_Q"; break; fi; done <<<"$_CANDS"; [ -n "$_P" ] && printf ''%s'' "$_P" || exit 1'
     $resolved = & bash -c $cmHookProbe 2>&1
     if ($LASTEXITCODE -eq 0 -and $resolved) {
         Write-Pass "claude-mem hook path resolves to: $resolved (BUG-015)"

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -191,20 +191,27 @@ fi
 # user encounters the intermittent UserPromptSubmit fail.
 _cmhook_C="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 _cmhook_E="${PLUGIN_ROOT:-}"
-# BUG-022 (2026-05-21): probe itself used the same `break; }; done` cascade
-# as the upstream hooks (which BUG-017 patched away). Apply the same
-# `head -n1` fix locally so the probe is race-free and reports actual state
-# instead of spurious failures. On Linux SIGPIPE is silent so the race rarely
-# fires here, but cross-OS parity with healthcheck.ps1 matters.
-_cmhook_P=$({
+# BUG-023 (2026-05-21): the BUG-022 pipe-to-head form still raced under
+# `set -euo pipefail` when 2+ candidates matched: the consumer closed
+# after the first line, leftover printfs in the while loop got EPIPE,
+# pipefail propagated 141 to the $() and set -e killed the script
+# mid-section 4/12. Race-free pattern: materialize all candidates into a
+# variable (no pipe), then iterate in pure bash with `break` -- no
+# consumer-close, no EPIPE. Supersedes the BUG-022 approach.
+_cmhook_cands=$({
     [ -n "$_cmhook_E" ] && printf '%s\n' "$_cmhook_E"
     ls -dt "$_cmhook_C/plugins/cache/thedotmack/claude-mem"/[0-9]*/ 2>/dev/null
     printf '%s\n' "$_cmhook_C/plugins/marketplaces/thedotmack-claude-mem/plugin"
-} | while IFS= read -r _r; do
+})
+_cmhook_P=""
+while IFS= read -r _r; do
     _r="${_r%/}"
     [ -d "$_r/plugin/scripts" ] && _q="$_r/plugin" || _q="$_r"
-    [ -f "$_q/scripts/bun-runner.js" ] && [ -f "$_q/scripts/worker-service.cjs" ] && printf '%s\n' "$_q"
-done | head -n1)
+    if [ -f "$_q/scripts/bun-runner.js" ] && [ -f "$_q/scripts/worker-service.cjs" ]; then
+        _cmhook_P="$_q"
+        break
+    fi
+done <<<"$_cmhook_cands"
 if [ -n "$_cmhook_P" ]; then
     pass "claude-mem hook path resolves to: $_cmhook_P (BUG-015)"
 else

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -478,6 +478,27 @@ setup() {
     grep -qF 'BUG-015' "$DOTFILES_DIR/scripts/healthcheck.ps1"
 }
 
+# BUG-023: the BUG-015 probe must use the race-free materialize+break form,
+# NOT the BUG-022 `done | head -n1` pipe (which races under `set -euo
+# pipefail` when 2+ candidates match -> EPIPE on leftover printfs -> exit
+# 141 mid-section). Locks the new pattern present AND the old pattern
+# absent so a future "simplification" can't regress us back.
+@test "BUG-023: healthcheck.sh probe uses materialize+break (no pipe-to-head race)" {
+    # Positive: the materialized candidates variable + heredoc loop is there.
+    grep -qF '_cmhook_cands=$(' "$DOTFILES_DIR/scripts/healthcheck.sh"
+    grep -qF 'done <<<"$_cmhook_cands"' "$DOTFILES_DIR/scripts/healthcheck.sh"
+    # Negative: the broken pipe-to-head form must not reappear in the probe.
+    ! grep -qF 'done | head -n1' "$DOTFILES_DIR/scripts/healthcheck.sh"
+}
+
+@test "BUG-023: healthcheck.ps1 bash one-liner mirrors the race-free form" {
+    # Positive: the PS1 bash sub-invocation uses the same materialize+break.
+    grep -qF '_CANDS=$(' "$DOTFILES_DIR/scripts/healthcheck.ps1"
+    grep -qF 'done <<<"$_CANDS"' "$DOTFILES_DIR/scripts/healthcheck.ps1"
+    # Negative: lock out the broken pipe-to-head form so PS1 stays in parity.
+    ! grep -qF 'done | head -n1' "$DOTFILES_DIR/scripts/healthcheck.ps1"
+}
+
 # WIN-001b: cross-OS parity for the post-setup healthcheck auto-invoke.
 # setup-windows.ps1 has wired healthcheck.ps1 after doctor since PR #71 (WIN-001).
 # setup-linux.sh now mirrors that wiring with bash healthcheck.sh so the


### PR DESCRIPTION
## Summary

BUG-022 ([PR #87](https://github.com/mlorentedev/dotfiles/pull/87)) appended `head -n1` after the while-loop in the BUG-015 hook-resolution probe, but the form still raced under `set -euo pipefail` when **2+ candidates matched** in `~/.claude/plugins/cache/thedotmack/claude-mem/`: the consumer closed after the first line, leftover `printf`s in the while loop got EPIPE, pipefail propagated 141 to the `$(...)` and `set -e` killed `healthcheck.sh` mid-section 4/12. `setup-linux.sh` then logged a false-positive `WARNING: healthcheck reported one or more FAIL items`.

Race-free pattern: **materialize candidates into a variable first** (no pipe), then iterate in pure bash with `break` — no consumer-close, no EPIPE, no pipefail propagation. Supersedes BUG-022.

Cross-OS parity: `healthcheck.ps1`'s bash sub-invocation never observed the symptom (its `bash -c` context doesn't set pipefail), but the race-free form keeps both probes structurally identical. Applies the recently-captured lesson "the detection probe MUST use the race-free pattern, not faithfully reproduce broken upstream behaviour".

## Empirical evidence

This user has 6 versions of claude-mem in cache (`12.7.4` → `13.3.0`), so the race fires **deterministically** on every setup run. Post-fix `healthcheck.sh` completes all 12/12 sections; probe resolves to `13.3.0`.

```
$ ls ~/.claude/plugins/cache/thedotmack/claude-mem/
12.7.4  13.0.0  13.0.1  13.1.0  13.2.0  13.3.0

# Before:
$ ./scripts/healthcheck.sh; echo "EXIT=$?"
...
[4/12] Key Symlinks
  PASS: claude-mem@thedotmack installed (BUG-014 canonical check)
EXIT=141                                       # SIGPIPE; sections 5-12 never ran

# After:
$ ./scripts/healthcheck.sh | grep BUG-015
  PASS: claude-mem hook path resolves to: /home/manu/.claude/plugins/cache/thedotmack/claude-mem/13.3.0 (BUG-015)
# Healthcheck now completes all 12/12 sections.
```

## SDD skip rationale

Atomic fix to an existing safety-net probe; production diff ~42 LOC (under the 50 LOC spec-gate threshold). Same shape + precedent as [PR #87](https://github.com/mlorentedev/dotfiles/pull/87) (BUG-022) and [PR #79](https://github.com/mlorentedev/dotfiles/pull/79) (WIN-001b). No public-contract surface touched (probe is an internal helper inside `healthcheck.{sh,ps1}`). Lesson capture goes to vault post-merge.

## Test plan

- [x] `shellcheck scripts/healthcheck.sh` clean
- [x] `bash -n scripts/healthcheck.sh` clean
- [x] `bats tests/setup-linux.bats --filter "BUG-023|BUG-015"` → 3/3 PASS
- [x] `bats tests/` → 765/765 PASS, 0 fail (no regressions)
- [x] Live `healthcheck.sh` run completes all 12/12 sections, exit no longer 141
- [x] Probe resolves to expected path (`13.3.0`, latest cache version)
- [x] 2 new parity asserts lock both positive (new pattern present) AND negative (pipe-to-head absent) in both `.sh` and `.ps1`

## Cross-OS validation

- **Linux** (this PR author's primary): empirically validated, SIGPIPE eliminated.
- **Windows**: PS1 change is comment + bash one-liner rewrite to mirror Linux form. Symptom never observed there (no pipefail in `bash -c` sub-context), so this is parity-only. Empirical Windows validation tracked in `WIN-002-windows-smoke-sweep` spec (full clean-VM sweep).