### PR TITLE
chore(CHORE-001): expose shell-profile.sh via profile-shell alias + README docs

### DIFF
--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -30,6 +30,7 @@ alias kca="knowledge-crystallize.sh --all"        # Stamp all projects at once
 # Repo maintenance
 alias dch="diff-check.sh"                         # Detect drift between repo and ~/.dotfiles
 alias cl="changelog-gen.sh"                       # Regenerate CHANGELOG.md from git log
+alias profile-shell="shell-profile.sh"            # Measure shell startup (use --detail for per-function breakdown via zprof/xtrace)
 
 # OpenCode (primary AI coding agent — replaces aider)
 alias oc="opencode"                                                                       # TUI: opencode Go subscription

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ dotfiles-sync                       # Bidirectional sync + git push/pull
 dotfiles-sync --secrets-only        # Only sync sensitive/ files
 ```
 
+### Diagnostics
+
+```bash
+hc                                  # Run healthcheck (versions, paths, symlinks, env vars)
+dch                                 # Drift check: repo vs ~/.dotfiles deploy dir
+profile-shell                       # Measure shell startup time (zsh default)
+profile-shell --shell bash --detail # Per-function breakdown via zprof/xtrace
+```
+
 ### tmux
 
 Two use cases this setup is tuned for: **(1) split-pane multiplexing** (editor + AI agent + tests side by side) and **(2) session persistence** (close the laptop / drop SSH and come back to the same state).

--- a/tests/aliases.bats
+++ b/tests/aliases.bats
@@ -94,6 +94,15 @@ setup() {
     ! grep -qE '^(alias ghce|ghce\(\)|function ghce)' "$ALIASES_FILE"
 }
 
+# CHORE-001: shell-profile.sh discoverability via `profile-shell` alias.
+# Dormant-but-load-bearing diagnostic tool (shell startup profiling); was
+# orphan-by-metric per AUDIT-005 but kept by anti-scope rule. Alias makes
+# it discoverable when interactive shell startup feels slow.
+@test "aliases.zsh defines profile-shell alias for shell-profile.sh (CHORE-001)" {
+    grep -qE '^alias profile-shell=' "$ALIASES_FILE"
+    grep -qF 'shell-profile.sh' "$ALIASES_FILE"
+}
+
 # --- Knowledge aliases ---
 
 @test "aliases.zsh defines kc alias" {


### PR DESCRIPTION
## Summary

[AUDIT-005](https://github.com/mlorentedev/dotfiles/blob/main/specs/archive/REFACTOR-001-scripts-audit) initially flagged `shell-profile.sh` as orphan (0 references outside `setup-linux.sh` chmod). Verification surfaced it's actually **dormant-but-load-bearing**: a legitimate shell-startup diagnostic tool, invisible-until-needed like `claude-mem-heal.sh`. AUDIT-005's own anti-scope rule applies: do not delete dormant-but-load-bearing scripts.

Resolution: surface discoverability. No deletion, no behaviour change.

## Changes

- `.zsh/aliases.zsh` — new `profile-shell` alias in the Repo maintenance section (sibling to existing diagnostic aliases `dch` / `cl`).
- `README.md` — new "Diagnostics" subsection under Key Commands (`hc` + `dch` + `profile-shell` + `profile-shell --detail`).
- `tests/aliases.bats` — 1 new parity assert (`profile-shell` alias points to `shell-profile.sh`).
- `scripts/shell-profile.sh` — **unchanged** (anti-scope guarantee).
- `tests/shell-profile.bats` — **unchanged**.

## Test plan

- [x] `bats tests/aliases.bats` → all 35 PASS (+1 new)
- [x] `bats tests/` → **775/775 PASS** (was 774/774 pre-PR), 0 regressions

## SDD

Production diff ~10 LOC (1 alias + 6 README lines + 1 bats assert). Below 50 LOC spec-gate threshold; no spec folder required.

Third of the AUDIT-005 follow-up roadmap items (after PR #89/#91). Remaining: REFACTOR-005, POLISH-001.