### PR TITLE
chore: update dockerhub token

### DIFF
--- a/sensitive/dockerhub.token.secret.age
+++ b/sensitive/dockerhub.token.secret.age
@@ -1,5 +1,5 @@
 age-encryption.org/v1
--> X25519 YCfCtfbDMynvSxsKl/iqSmgONzt/AcpWusbwPGrs6A4
-42zSNHoa2mdze5m3Mzh0cQzhHcF93dAEfRxt1nw+4r0
---- CZJtA02TCqgiCau60OY2AyqrK9HXUbK1ypdFTuUoObw
-@ΐΦ#Ϋΰ‘”<Ώρφ.θ•ΆlΙ®(€ρηc[mϋτq‰Σp¥Α:ΉEoBµ«Φ^Ρx¥Ε$¦θ<όZƒ
+-> X25519 Zevu2uC6VjiHuLvLyKb1IgS74ZxQVpDm5I0vQWqzaUE
+ZwBsbbritWDXkq8DEG8JW3qZjpxabJE3x17dAR1EPF0
+--- 0Fy7NlpwrtuY5RC2F5lhNt/hhuJ1XCq4T52VLPkGZCo
+‡ΉP½4ZιQάΤAΗβωE•Σ€‰…®DύΈό¬εόσ9DxΨ™e'	θK§‡YAjh­Cι«ψ~	pn'ψ¤·2ν


### PR DESCRIPTION
## Summary
- Rotates the encrypted DockerHub token (`sensitive/dockerhub.token.secret.age`)

## Test plan
- [x] CI secrets check passes (pre-commit hook already passed locally)
- [x] DockerHub login works after merge + secrets reload