### PR TITLE
feat(WIN-SECRETS): source load-secrets.ps1 in profile.ps1 (cross-OS parity)

### DIFF
--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -201,9 +201,19 @@ $env:AGY_HOME = "$env:USERPROFILE\.gemini\antigravity-cli"
 $env:COPILOT_HOME = "$env:USERPROFILE\.copilot"
 $env:OPENCODE_HOME = "$env:USERPROFILE\.config\opencode"
 
-# Uncomment and set if needed:
-# $env:GEMINI_API_KEY = "your-api-key"
-# $env:ANTHROPIC_API_KEY = "your-api-key"
+# AI provider endpoint -- NaN community (primary, OpenAI-compatible).
+# Mirrors NAN_BASE_URL set in .bashrc/.zshrc. API key comes from the
+# load-secrets.ps1 sourcing below (sensitive/nan.api-key.secret.age).
+$env:NAN_BASE_URL = 'https://api.nan.builders/v1'
+
+# Load encrypted secrets as environment variables (cross-OS parity with .bashrc:62-63).
+# load-secrets.ps1 decrypts sensitive/*.secret.age via age and sets each value
+# with SetEnvironmentVariable(..., 'Process') -- session-scoped, never persisted
+# to the user registry. Mandatory for opencode (reads {env:NAN_API_KEY} from
+# opencode.jsonc) and agy (reads ANTHROPIC_API_KEY etc. from environment).
+$_secretsScript = Join-Path $env:DOTFILES_DIR 'scripts\load-secrets.ps1'
+if (Test-Path -LiteralPath $_secretsScript) { . $_secretsScript }
+Remove-Variable -Name _secretsScript -ErrorAction SilentlyContinue
 
 # ============================================================================
 # STARTUP MESSAGE

--- a/tests/powershell-profile.bats
+++ b/tests/powershell-profile.bats
@@ -36,6 +36,22 @@ setup() {
     ! grep -qE '^function (ai|aic|aia) ' "$PROFILE_SCRIPT"
 }
 
+# --- Secrets sourcing (cross-OS parity: .bashrc sources load-secrets.sh) ---
+
+@test "profile.ps1 sources load-secrets.ps1 (cross-OS parity with .bashrc)" {
+    # .bashrc:63 sources load-secrets.sh. PowerShell parity requires profile.ps1
+    # to dot-source load-secrets.ps1 so $env:NAN_API_KEY / OPENROUTER_API_KEY /
+    # etc. are populated for opencode (reads {env:NAN_API_KEY} from opencode.jsonc),
+    # agy, and copilot. Without this, opencode.jsonc references resolve to empty.
+    grep -qE 'load-secrets\.ps1' "$PROFILE_SCRIPT"
+    grep -qF 'Test-Path -LiteralPath' "$PROFILE_SCRIPT"
+}
+
+@test "parity: load-secrets sourced in both .bashrc and profile.ps1" {
+    grep -qE 'load-secrets\.sh' "$DOTFILES_DIR/.bashrc"
+    grep -qE 'load-secrets\.ps1' "$PROFILE_SCRIPT"
+}
+
 # --- Parity check: oc alias exists in both shells ---
 
 @test "parity: oc with --pure defined in both aliases.zsh and profile.ps1" {


### PR DESCRIPTION
## Summary

- Adds `load-secrets.ps1` dot-source to `powershell/profile.ps1` — Linux already does this via `.bashrc:63`. Windows didn't, so `\$env:NAN_API_KEY`, `\$env:OPENROUTER_API_KEY`, etc. were always empty even with the encrypted secret files present.
- Also adds `\$env:NAN_BASE_URL = 'https://api.nan.builders/v1'` (mirror of `.bashrc:60`) so `opencode.jsonc`'s nan provider has its baseURL.
- Two new bats parity tests: assert the source line exists in `profile.ps1`, and assert both `.bashrc` and `profile.ps1` source their respective load-secrets script.

## Why this matters now

PR #102 (SDD-007, merged today) added the NaN provider as opencode default with `apiKey: {env:NAN_API_KEY}`. On Linux that resolves because `.bashrc` sources load-secrets.sh. On Windows it resolved to empty — opencode would silently 401 on every nan/* call.

Discovered while auditing this Windows machine post-merge.

## Security model preserved

`load-secrets.ps1` uses `[Environment]::SetEnvironmentVariable(\$VarName, \$value, 'Process')` (line 68) which scopes the secret to the current shell session only. **No registry persistence.** Identical model to `export VAR=...` in bash.

## Test plan

- [x] Local end-to-end: profile.ps1 loads → load-secrets.ps1 sourced → \$env:OPENROUTER_API_KEY populates (73 chars). Verified on this Windows machine.
- [x] PowerShell parser: profile.ps1 still parses (PARSE OK).
- [x] CI: 2 new bats parity tests must pass.
- [ ] Manual: after merge + setup-windows.ps1 re-run, opencode TUI nan/* calls succeed instead of 401.