### PR TITLE
fix(SDD-007): finish GEMINI->AGY migration + StrictMode-safe MCP iteration

### DIFF
--- a/scripts/healthcheck.ps1
+++ b/scripts/healthcheck.ps1
@@ -223,7 +223,7 @@ Test-DeployedFile (Join-Path $env:USERPROFILE '.dotfiles')          '.dotfiles d
 # (Microsoft.PowerShell_profile.ps1 under pwsh 7, profile.ps1 under WinPS 5.1).
 Test-DeployedFile $PROFILE                                          "PowerShell profile ($([System.IO.Path]::GetFileName($PROFILE)))"
 Test-DeployedFile (Join-Path $env:USERPROFILE '.claude\CLAUDE.md')  'CLAUDE.md'
-Test-DeployedFile (Join-Path $env:USERPROFILE '.gemini\GEMINI.md')  'GEMINI.md'
+Test-DeployedFile (Join-Path $env:USERPROFILE '.gemini\AGY.md')     'AGY.md'
 Test-DeployedFile (Join-Path $env:USERPROFILE '.ssh\config')        'SSH config'
 
 # BUG-014 canonical install-state assertion (primary).

--- a/scripts/init-project.ps1
+++ b/scripts/init-project.ps1
@@ -222,12 +222,12 @@ if (Test-Path "$ClaudeHome\CLAUDE.md") {
     Write-Warn "CLAUDE.md not found in global config ($ClaudeHome)"
 }
 
-# Copy GEMINI.md
-if (Test-Path "$GeminiHome\GEMINI.md") {
-    Copy-Item "$GeminiHome\GEMINI.md" "." -Force
-    Write-Success "Injected GEMINI.md"
+# Copy AGY.md (post-SDD-007: agy replaces gemini-cli; Linux parity at init-project.sh:186-191)
+if (Test-Path "$GeminiHome\AGY.md") {
+    Copy-Item "$GeminiHome\AGY.md" "." -Force
+    Write-Success "Injected AGY.md"
 } else {
-    Write-Warn "GEMINI.md not found in global config ($GeminiHome)"
+    Write-Warn "AGY.md not found in global config ($GeminiHome) -- run setup-windows.ps1"
 }
 
 # Copy skills (Claude Code specific)
@@ -618,6 +618,6 @@ Write-Host ""
 Write-Success "Project initialized with Dual AI Configuration"
 Write-Host ""
 Write-Host "Structure:" -ForegroundColor Cyan
-Write-Host "  CLAUDE.md / GEMINI.md      - AI Memory files (Dual-Core)"
+Write-Host "  CLAUDE.md / AGY.md         - AI Memory files (Dual-Core)"
 Write-Host "  .claude\skills\            - Custom skills"
 Write-Host "  Knowledge Vault updated    - 11-tasks.md & 90-lessons.md in knowledge/10_projects/"

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -403,6 +403,14 @@ for skill_dir in "$CURRENT_DIR/ai/skills/"*/; do
     fi
 done
 
+# SDD-007 one-time migration: gemini-cli -> agy. Remove the legacy
+# ~/.gemini/GEMINI.md identity file so it doesn't linger as an orphan
+# pointing to the retired binary. Safe to repeat (no-op if absent).
+if [ -f "$GEMINI_HOME/GEMINI.md" ]; then
+    rm -f "$GEMINI_HOME/GEMINI.md"
+    log_info "Removed legacy GEMINI.md (SDD-007 migration: agy replaces gemini-cli)"
+fi
+
 # Force copy master files (Neural Hive Protocol)
 rm -f "$GEMINI_HOME/AGY.md"
 cp "$CURRENT_DIR/ai/agy/AGY.md" "$GEMINI_HOME/AGY.md"

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -378,15 +378,23 @@ if (-not ($claudeCmd -and $npxCmd)) {
     try {
         $servers = (Get-Content $mcpConfig -Raw | ConvertFrom-Json).servers
         foreach ($srv in $servers) {
-            if ($srv.prerequisite_binary) {
-                $prereqCmd = Get-Command $srv.prerequisite_binary -ErrorAction SilentlyContinue
+            # mcp-servers.json only declares prerequisite_binary/_command for
+            # MCPs that need a runtime install (e.g. hive needs uv). Under
+            # `Set-StrictMode -Version Latest` direct $srv.prerequisite_binary
+            # access throws for servers that omit the field. Probe via
+            # PSObject.Properties so missing fields are $null, not an error.
+            # Linux side handles this via jq `(.prerequisite_binary // "")`.
+            $prereqBin = if ($srv.PSObject.Properties['prerequisite_binary']) { $srv.prerequisite_binary } else { $null }
+            $prereqCmdStr = if ($srv.PSObject.Properties['prerequisite_command']) { $srv.prerequisite_command } else { $null }
+            if ($prereqBin) {
+                $prereqCmd = Get-Command $prereqBin -ErrorAction SilentlyContinue
                 if (-not $prereqCmd) {
-                    Write-Warn "MCP $($srv.name): prerequisite '$($srv.prerequisite_binary)' not found, skipping"
+                    Write-Warn "MCP $($srv.name): prerequisite '$prereqBin' not found, skipping"
                     $mcpFailed++
                     continue
                 }
-                if ($srv.prerequisite_command) {
-                    $prereqParts = $srv.prerequisite_command -split '\s+'
+                if ($prereqCmdStr) {
+                    $prereqParts = $prereqCmdStr -split '\s+'
                     & $prereqParts[0] @($prereqParts[1..($prereqParts.Length - 1)]) 2>&1 | Out-Null
                 }
             }
@@ -845,6 +853,15 @@ $projAgyCli = Join-Path $DotfilesDir ".antigravitycli"
 $projAgyBak = Join-Path $DotfilesDir ".antigravitycli.bak"
 if (Test-Path $projAgyCli) { Remove-Item -Recurse -Force $projAgyCli -ErrorAction SilentlyContinue }
 if (Test-Path $projAgyBak) { Remove-Item -Recurse -Force $projAgyBak -ErrorAction SilentlyContinue }
+
+# SDD-007 one-time migration: gemini-cli -> agy. Remove the legacy
+# ~/.gemini/GEMINI.md identity file so it doesn't linger as an orphan
+# pointing to the retired binary. Safe to repeat (no-op if absent).
+$geminiMdLegacy = Join-Path $GeminiHome 'GEMINI.md'
+if (Test-Path $geminiMdLegacy) {
+    Remove-Item -LiteralPath $geminiMdLegacy -Force -ErrorAction SilentlyContinue
+    Write-Info "Removed legacy GEMINI.md (SDD-007 migration: agy replaces gemini-cli)"
+}
 
 # Deploy AGY.md (Neural Hive Protocol pointer to AGENTS.md). Linux-parity.
 $agyMdSource = Join-Path $DotfilesDir 'ai\agy\AGY.md'
@@ -1309,7 +1326,7 @@ Write-Host "Next steps:" -ForegroundColor Yellow
 Write-Host "  1. Restart PowerShell to load the new profile"
 Write-Host "  2. Verify setup:"
 Write-Host "       Test-Path `"$ClaudeHome\CLAUDE.md`""
-Write-Host "       Test-Path `"$GeminiHome\GEMINI.md`""
+Write-Host "       Test-Path `"$GeminiHome\AGY.md`""
 Write-Host "       `$env:PATH -like `"*scripts*`""
 Write-Host "  3. Initialize a project:"
 Write-Host "       project-init test-project python"

--- a/specs/SDD-007-iac-deploy-strategy/tasks.md
+++ b/specs/SDD-007-iac-deploy-strategy/tasks.md
@@ -83,6 +83,23 @@ created: "2026-05-25"
 - [ ] `verification.md` filled in with evidence per AC
 - [ ] PR opened from `feature/antigravity-integration`, references this spec folder, closes issue #100
 
+## Post-merge follow-ups (discovered exercising the merged PR #102 on Windows)
+
+Three bugs surfaced when re-running setup-windows.ps1 on a real Windows machine after PR #102 merged — all from the same SDD-007 migration that wasn't completed end-to-end. Addressed in PR #105 (this PR):
+
+- [x] **MCP loop StrictMode-safe**. `$srv.prerequisite_binary` threw under `Set-StrictMode -Version Latest` for every MCP entry that omits the field (only `hive` declares it). Linux side already handles this via `jq '(.prerequisite_binary // "")'`. Fix: probe `PSObject.Properties['name']` first so missing fields read as `$null` instead of erroring. — `setup-windows.ps1:380-394`.
+- [x] **GEMINI.md orphan cleanup**. Pre-SDD-007 installs deployed `~/.gemini/GEMINI.md`; the rename to `AGY.md` (sec 6) never removed the old file. Added explicit `rm -f` in both `setup-windows.ps1` and `setup-linux.sh` before the AGY.md deploy (idempotent — no-op if absent). — `setup-windows.ps1:857-863`, `setup-linux.sh:407-413`.
+- [x] **Lingering GEMINI.md references** in tooling that asserted the old name post-rename:
+  - `scripts/healthcheck.ps1:226` — Test-DeployedFile checked `GEMINI.md` → always FAIL. Updated to `AGY.md`.
+  - `scripts/init-project.ps1:225-231, 621` — injected `GEMINI.md` into new projects + summary text. Updated to `AGY.md` (Linux side at `init-project.sh:186-191` was already correct — was missing parity).
+
+Bats regression coverage:
+
+- [x] `tests/setup-windows.bats`: two new tests — StrictMode-safe MCP probe; GEMINI.md cleanup line present.
+- [x] `tests/init-project-ps1.bats`: assert AGY.md injection + regression guard against the old GEMINI.md path returning (`! grep 'Injected GEMINI\.md'`).
+
+Empirical verification on a real Windows machine: two consecutive `setup-windows.ps1` runs produced identical state — second run's only difference was the `[INFO] Removed legacy GEMINI.md` line on the first run. AC5 idempotency holds on Windows.
+
 ## Machine-readable features
 
 Optional sibling `features.json` per [[pattern-feature-list-as-primitive]] — defer unless harness consumes it.

--- a/tests/init-project-ps1.bats
+++ b/tests/init-project-ps1.bats
@@ -69,8 +69,10 @@ setup() {
     grep -q 'CLAUDE.md' "$PS1_SCRIPT"
 }
 
-@test "init-project.ps1 injects GEMINI.md" {
-    grep -q 'GEMINI.md' "$PS1_SCRIPT"
+@test "init-project.ps1 injects AGY.md (post-SDD-007: agy replaces gemini-cli)" {
+    grep -q 'AGY.md' "$PS1_SCRIPT"
+    # Asserting the OLD file is NOT referenced (regression guard):
+    ! grep -qE 'Injected GEMINI\.md|GEMINI\.md.*not found' "$PS1_SCRIPT"
 }
 
 @test "init-project.ps1 initializes git" {

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -53,6 +53,23 @@ setup() {
     grep -q 'Registering Claude Code MCP servers' "$PS1_SCRIPT"
 }
 
+@test "setup-windows.ps1 MCP loop is StrictMode-safe (probes PSObject.Properties)" {
+    # Under Set-StrictMode -Version Latest, $srv.prerequisite_binary throws when
+    # the field is absent. Only the hive MCP declares this property; the other
+    # servers (sequential-thinking, context7) don't. The loop must probe via
+    # PSObject.Properties to treat missing fields as $null, matching Linux which
+    # uses jq's `(.prerequisite_binary // "")` null-coalesce.
+    grep -qF "PSObject.Properties['prerequisite_binary']" "$PS1_SCRIPT"
+    grep -qF "PSObject.Properties['prerequisite_command']" "$PS1_SCRIPT"
+}
+
+@test "setup-windows.ps1 removes legacy GEMINI.md (SDD-007 migration)" {
+    # Pre-SDD-007 setups deployed ~/.gemini/GEMINI.md. After agy replaced
+    # gemini-cli, AGY.md is the new identity file. Without explicit cleanup the
+    # orphan GEMINI.md lingers and confuses any tool that picks up either file.
+    grep -qF 'Removed legacy GEMINI.md' "$PS1_SCRIPT"
+}
+
 @test "setup-windows.ps1 sets up GitHub Copilot CLI" {
     grep -q 'Setting up GitHub Copilot CLI' "$PS1_SCRIPT"
 }


### PR DESCRIPTION
## Summary

Found 3 bugs masking the same migration when re-running setup-windows.ps1 post-PR-#102 on a real Windows machine:

1. **MCP loop crashes under StrictMode** — `\$srv.prerequisite_binary` throws "property cannot be found on this object" for every MCP that doesn't declare the field (only `hive` does). Linux side handles this via jq's `(.prerequisite_binary // \"\")` null-coalesce. Fixed by probing `PSObject.Properties['name']` first.
2. **GEMINI.md orphan never cleaned** — both setups deploy AGY.md but pre-SDD-007 installs still have GEMINI.md lingering. Added explicit `rm -f` in both `setup-windows.ps1` and `setup-linux.sh` for cross-OS parity.
3. **Tooling that still asserted the old file** — `healthcheck.ps1` Test-DeployedFile checked GEMINI.md (perma-FAIL); `init-project.ps1` injected GEMINI.md (Linux side already used AGY.md). Both updated.

Bats:
- Two new tests in `setup-windows.bats` (StrictMode-safe MCP probe; GEMINI.md cleanup).
- `init-project-ps1.bats` updated to assert AGY.md + regression guard against old paths.

## Test plan

- [x] Two consecutive `setup-windows.ps1` runs on this Windows machine — both exit 0, second run produces identical state (idempotence verified empirically).
- [x] PowerShell parser: all 3 edited .ps1 files PARSE OK.
- [x] `bash -n setup-linux.sh` valid.
- [x] CI: new bats tests must pass.