### PR TITLE
feat(WIN-SECRETS): preflight age identity key in setup-{linux,windows}

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -93,6 +93,21 @@ chmod +x "$DOTFILES_DIR/scripts/doctor.sh"
 
 # Copy sensitive directory (env-mapping.conf and encrypted files)
 log_info "Setting up sensitive directory..."
+
+# Preflight: warn if age identity key is missing. Without it, load-secrets.sh
+# silently no-ops at shell startup (Invoke-AgeDecrypt returns null on failure)
+# so $NAN_API_KEY / $OPENROUTER_API_KEY / etc. stay empty -- opencode + agy
+# then 401 with no clear cause. Non-fatal: encrypted files still get deployed
+# so a key imported later still works without re-running setup.
+AGE_KEY="${AGE_KEY_PATH:-$HOME/.config/age/key.txt}"
+if [ ! -f "$AGE_KEY" ]; then
+    log_warning "age identity key not found at $AGE_KEY"
+    log_warning "  Encrypted secrets will deploy but won't decrypt at shell startup."
+    log_warning "  To enable: place your age identity at \$HOME/.config/age/key.txt"
+    log_warning "  (or set AGE_KEY_PATH). Generate: age-keygen -o ~/.config/age/key.txt"
+    log_warning "  See: docs/SECRETS.md"
+fi
+
 ensure_directory "$DOTFILES_DIR/sensitive"
 if [ "$CURRENT_DIR" != "$DOTFILES_DIR" ]; then
     cp -rf "$CURRENT_DIR/sensitive/"* "$DOTFILES_DIR/sensitive/" 2>/dev/null || true

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1132,6 +1132,21 @@ if (Test-Path $loadSecretsSource) {
 
 Write-Info "Setting up secrets system..."
 
+# Preflight: warn if age identity key is missing. Without it, load-secrets.ps1
+# silently no-ops at shell startup (Invoke-AgeDecrypt returns $null on failure)
+# so $env:NAN_API_KEY / OPENROUTER_API_KEY / etc. stay empty -- opencode + agy
+# then 401 with no clear cause. Non-fatal: encrypted files still get deployed
+# so a key imported later still works without re-running setup. Mirrors the
+# Linux preflight in setup-linux.sh.
+$ageKey = if ($env:AGE_KEY_PATH) { $env:AGE_KEY_PATH } else { Join-Path $env:USERPROFILE '.config\age\key.txt' }
+if (-not (Test-Path -LiteralPath $ageKey)) {
+    Write-Warn "age identity key not found at $ageKey"
+    Write-Warn "  Encrypted secrets will deploy but won't decrypt at shell startup."
+    Write-Warn "  To enable: place your age identity at `$env:USERPROFILE\.config\age\key.txt"
+    Write-Warn "  (or set `$env:AGE_KEY_PATH). Generate: age-keygen -o `$HOME\.config\age\key.txt"
+    Write-Warn "  See: docs/SECRETS.md"
+}
+
 $sensitiveSource = "$DotfilesDir\sensitive"
 $sensitiveDest = "$DotfilesDest\sensitive"
 

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -63,6 +63,22 @@ setup() {
     grep -qF "PSObject.Properties['prerequisite_command']" "$PS1_SCRIPT"
 }
 
+@test "setup-windows.ps1 preflights the age identity key (warn, not fail)" {
+    # Without ~/.config/age/key.txt, load-secrets.ps1 silently no-ops at
+    # shell startup and opencode/agy 401 with no clue. Preflight WARNs (must
+    # not abort -- encrypted files still deploy so a key imported later works).
+    grep -qF 'age identity key not found' "$PS1_SCRIPT"
+    grep -qF 'AGE_KEY_PATH' "$PS1_SCRIPT"
+    grep -qF 'docs/SECRETS.md' "$PS1_SCRIPT"
+    # Must use Write-Warn (non-fatal), not Write-Err.
+    grep -B2 'age identity key not found' "$PS1_SCRIPT" | grep -q 'Test-Path'
+}
+
+@test "parity: age key preflight present in both setup-windows.ps1 and setup-linux.sh" {
+    grep -qF 'age identity key not found' "$PS1_SCRIPT"
+    grep -qF 'age identity key not found' "$DOTFILES_DIR/setup-linux.sh"
+}
+
 @test "setup-windows.ps1 removes legacy GEMINI.md (SDD-007 migration)" {
     # Pre-SDD-007 setups deployed ~/.gemini/GEMINI.md. After agy replaced
     # gemini-cli, AGY.md is the new identity file. Without explicit cleanup the


### PR DESCRIPTION
## Summary

Without `~/.config/age/key.txt`, `load-secrets.{sh,ps1}` silently no-ops at shell startup — `\$NAN_API_KEY`, `\$OPENROUTER_API_KEY` etc. stay empty and downstream tools (opencode, agy) 401 with no clear cause. A user setting up a fresh machine could spend a long time debugging that.

Both setups now emit a non-fatal warning before the secrets section if the key is missing:

- where the key is expected (`~/.config/age/key.txt` or `\$AGE_KEY_PATH`)
- how to generate one (`age-keygen -o ...`)
- where the docs live (`docs/SECRETS.md`)

**Non-fatal by design**: encrypted files still deploy, so importing or generating the key later works without re-running setup.

## Test plan

- [x] PowerShell parser: setup-windows.ps1 still parses (PARSE OK).
- [x] `bash -n setup-linux.sh` valid.
- [x] Local Windows: machine has the key — warning correctly silent.
- [x] CI: 2 new bats parity tests must pass.
- [ ] Manual on a fresh VM (no age key): expect single \`[WARNING] age identity key not found ...\` line, setup continues, exit 0.

## LOC

26 production LOC (under SDD discipline gate threshold of 50). Cross-OS parity fix, no public contract change.