### PR TITLE
feat(AGENTS): deploy canonical AGENTS.md to ~/.config/opencode/ (cross-OS)

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -582,6 +582,23 @@ else
     log_warning "opencode.jsonc source missing: $OPENCODE_CONFIG_SRC"
 fi
 
+# Deploy the canonical AGENTS.md as opencode's global system prompt.
+# OpenCode reads ~/.config/opencode/AGENTS.md (per upstream docs); unlike
+# claude/agy/copilot which use pointer files, opencode reads the filename
+# "AGENTS.md" natively so we copy the full SSOT (~22KB) verbatim.
+AGENTS_SRC="$CURRENT_DIR/AGENTS.md"
+AGENTS_DST="$HOME/.config/opencode/AGENTS.md"
+if [ -f "$AGENTS_SRC" ]; then
+    if [ -f "$AGENTS_DST" ] && cmp -s "$AGENTS_SRC" "$AGENTS_DST"; then
+        log_info "AGENTS.md (opencode) already in sync"
+    else
+        cp "$AGENTS_SRC" "$AGENTS_DST"
+        log_success "Deployed AGENTS.md to $AGENTS_DST"
+    fi
+else
+    log_warning "AGENTS.md source missing at $AGENTS_SRC"
+fi
+
 # Deploy opencode commands (AI-012: skills→commands port).
 # Source: ai/opencode/commands/*.md (kept in sync with ai/skills/ via
 # scripts/skills-to-opencode.sh; CI gate enforces parity). Target: the

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -728,6 +728,24 @@ if (Test-Path -LiteralPath $opencodeConfigSrc -PathType Leaf) {
     Write-Warn "opencode.jsonc source missing: $opencodeConfigSrc"
 }
 
+# Deploy the canonical AGENTS.md as opencode's global system prompt.
+# OpenCode reads ~/.config/opencode/AGENTS.md (per upstream docs); unlike
+# claude/agy/copilot which use pointer files, opencode reads the filename
+# "AGENTS.md" natively so we copy the full SSOT (~22KB) verbatim.
+# Linux parity: setup-linux.sh:584+
+$agentsSrc = Join-Path $DotfilesDir 'AGENTS.md'
+$agentsDst = Join-Path $env:USERPROFILE '.config\opencode\AGENTS.md'
+if (Test-Path -LiteralPath $agentsSrc -PathType Leaf) {
+    if (Get-Command Deploy-File -ErrorAction SilentlyContinue) {
+        [void](Deploy-File -Source $agentsSrc -Destination $agentsDst)
+    } else {
+        Copy-Item -LiteralPath $agentsSrc -Destination $agentsDst -Force
+        Write-Success "Deployed AGENTS.md to $agentsDst (fallback)"
+    }
+} else {
+    Write-Warn "AGENTS.md source missing at $agentsSrc"
+}
+
 # Commands sync: add new, leave unchanged, remove orphans. Mirror of the bash
 # loop in setup-linux.sh: cmds_added/cmds_skipped/cmds_removed counters.
 $opencodeCmdsSrc = "$DotfilesDir\ai\opencode\commands"

--- a/tests/opencode.bats
+++ b/tests/opencode.bats
@@ -153,6 +153,18 @@ setup() {
     [[ -f "$AGENTS_MD" ]]
 }
 
+@test "setup-linux.sh deploys AGENTS.md to ~/.config/opencode/ (opencode global SSOT)" {
+    # opencode reads ~/.config/opencode/AGENTS.md natively (per upstream docs).
+    # Unlike claude/agy/copilot which use pointer files, opencode loads the
+    # canonical filename so we copy the full SSOT verbatim.
+    grep -qF '$HOME/.config/opencode/AGENTS.md' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF 'AGENTS.md source missing' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-windows.ps1 deploys AGENTS.md to ~/.config/opencode/ (cross-OS parity)" {
+    grep -qF "'.config\\opencode\\AGENTS.md'" "$DOTFILES_DIR/setup-windows.ps1"
+}
+
 @test "AGENTS.md contains Standing Orders section" {
     grep -q "^## Standing Orders" "$AGENTS_MD"
 }

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -304,6 +304,15 @@ setup() {
     [ ! -d "$HOME/.copilot" ]
 }
 
+@test "AGENTS.md deployed to ~/.config/opencode/AGENTS.md (cross-agent SSOT)" {
+    # opencode reads AGENTS.md natively (per upstream docs). Deploying the
+    # repo-root canonical SSOT verbatim gives opencode the same system prompt
+    # claude/agy/copilot get via their pointer files.
+    [ -f "$HOME/.config/opencode/AGENTS.md" ]
+    grep -q '^# AGENTS.md' "$HOME/.config/opencode/AGENTS.md"
+    grep -q 'Single Source of Truth' "$HOME/.config/opencode/AGENTS.md"
+}
+
 @test "opencode commands deployed to ~/.config/opencode/commands/ (AI-012)" {
     # Post-AI-012: setup-linux.sh copies ai/opencode/commands/*.md to the
     # global opencode commands directory. 12 portable commands expected


### PR DESCRIPTION
## Summary

The cross-agent SSOT (`AGENTS.md`, ~22KB) was only reachable for opencode if the user happened to launch it inside the dotfiles repo. Outside the repo, opencode had no global system prompt — inconsistent with claude/agy/copilot which each get their pointer file deployed at setup time.

Both setups now deploy the canonical `AGENTS.md` to `~/.config/opencode/AGENTS.md` using the reconcile-not-skip pattern (compare bytes, skip if in-sync).

## Why opencode gets the full file (not a pointer)

OpenCode reads `AGENTS.md` natively (per upstream docs). Unlike claude/agy/copilot which need name remapping (their identity files are pointers back to AGENTS.md), opencode loads the canonical filename directly. So we copy the SSOT verbatim — no indirection.

## Test plan

- [x] PowerShell parser: setup-windows.ps1 PARSE OK.
- [x] `bash -n setup-linux.sh` valid.
- [x] Local Windows deploy smoke: 22020 bytes copied to `~/.config/opencode/AGENTS.md`.
- [x] CI: new bats test in opencode.bats + verify-setup.bats (integration container).