### PR TITLE
polish(SDD-007): finish GEMINI->AGY content migration + drop Windows --pure

### DIFF
--- a/ai/agy/AGY.md
+++ b/ai/agy/AGY.md
@@ -1,15 +1,15 @@
-# GEMINI.md
+# AGY.md
 
-> **SYSTEM META-INSTRUCTION:** Target Model: Gemini 1.5 Pro / Ultra / 3.0+.
-> **CAPABILITY HANDSHAKE:** Assess your current runtime version. **Activate maximum reasoning depth (System 2) and full context scanning.** Do not simulate lower intelligence.
+> **SYSTEM META-INSTRUCTION:** Target tool: Google Antigravity CLI (`agy`). Target model: see `settings.json` (`modelConfigs.defaultModel`, currently `gemini-3.5-flash`).
+> **CAPABILITY HANDSHAKE:** Activate maximum reasoning depth and full context scanning. Do not simulate lower intelligence than the active model supports.
 >
-> **First, read `AGENTS.md` at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Gemini-specific extensions on top.
+> **First, read `AGENTS.md` at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only agy-specific extensions on top.
 >
 > If `AGENTS.md` is missing from the current repo, default to the canonical version at `~/Projects/dotfiles/AGENTS.md` (Linux/macOS) or `%USERPROFILE%\Projects\dotfiles\AGENTS.md` (Windows).
 
 ## Dynamic Capability Adaptation
 
-1. **Context Sovereignty:** You have a massive context window. **Read ALL provided files** before answering. If existing codebase patterns contradict the rules in `AGENTS.md`, **adapt to the codebase** (Consistency > Static Rules).
+1. **Context Sovereignty:** You have a massive context window (`maxContextTokens: 2000000` in `settings.json`). **Read ALL provided files** before answering. If existing codebase patterns contradict the rules in `AGENTS.md`, **adapt to the codebase** (Consistency > Static Rules).
 2. **Native Multimodality:** If a diagram explains the architecture better than text, generate the Mermaid/Graphviz code automatically — do not wait to be asked.
 
 ## Tool & Sub-Agent Usage Rules
@@ -18,17 +18,18 @@
 * **Documentation:** Use `get_code_context_exa` to search for updated documentation, library usage, and real-world snippets instead of hallucinating API signatures.
 * **Deep Investigation:** Invoke the `codebase_investigator` sub-agent for vague requests, root-cause analysis of bugs, or large-scale architectural mapping before making broad changes.
 
-## Output Protocol (Gemini-specific)
+## Output Protocol (agy-specific)
 
 In addition to the Response Protocol in `AGENTS.md`:
 
-* Generate **full files or precise diffs** — Gemini's context window makes full-file outputs cheaper for the user to review than diffs in many cases. Choose based on file size and change density.
+* Generate **full files or precise diffs** — agy's context window makes full-file outputs cheaper for the user to review than diffs in many cases. Choose based on file size and change density.
 * **No Fluff:** No intro/outro conversational filler. Markdown headings and code fences only when they aid scanning.
 
 ## Model Tier (per AGENTS.md "Model Selection")
 
-- **Top:** `gemini-2.5-pro` — hard debug / architecture / root-cause (TBD — empirically verify on next Gemini session)
-- **Mid:** `gemini-2.5-flash` — mechanical refactor / docs / single-file fixes
-- **Low:** `gemini-2.5-flash-lite` — syntax lookups / autocomplete
+The active default lives in `ai/agy/settings.json` (`modelConfigs.defaultModel`). Single source of truth for model selection — update there, not here.
 
-Selection: per-prompt `--model` flag on the Gemini CLI. Model IDs marked TBD pending empirical verification.
+- **Default:** `gemini-3.5-flash` — daily driver (see `settings.json`).
+- **High-reasoning alias:** `chat-base` profile (`thinkingConfig.thinkingLevel: HIGH`) for hard debug / architecture / root-cause.
+
+Selection: configure via `agy` UI or per-prompt model override. Model IDs reflect the Antigravity CLI runtime; verify availability in `agy` itself if the listed model is rejected.

--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -19,11 +19,13 @@ $env:NAN_BASE_URL = 'https://api.nan.builders/v1'
 # the alias is conditional. On machines without opencode installed, this
 # block is a no-op and `oc` reports "command not found" as expected.)
 if (Get-Command opencode -ErrorAction SilentlyContinue) {
-    # oc / ocfull: opencode TUI dispatch. --pure bypasses MCPs+skills+plugins,
-    # avoiding the tool-resolution hang on complex queries (empirical 2026-05-25).
-    # Set-Alias does not support args, so we use functions to pass --pure flag.
-    function oc     { opencode --pure @args }
-    function ocfull { opencode @args }
+    # oc: opencode TUI dispatch. Plain (no --pure flag) -- Windows PowerShell
+    # does NOT exhibit the Linux tool-resolution hang. Empirical 2026-05-26:
+    # opencode launched bare from a Windows terminal works correctly with
+    # MCPs+plugins enabled. The Linux side keeps `opencode --pure` pending
+    # the Ghostty hypothesis investigation (Phase 2.4 backlog) -- documented
+    # cross-OS asymmetry, not parity drift.
+    Set-Alias -Name oc -Value opencode
 
     # qq / qf: one-shot quick-question wrappers. Mirrors .zsh/aliases.zsh and
     # .bashrc. One-shot: each call is a fresh session.

--- a/tests/antigravity.bats
+++ b/tests/antigravity.bats
@@ -23,6 +23,17 @@ setup() {
     command -v agy
 }
 
+@test "ai/agy/AGY.md H1 is '# AGY.md' (regression: GEMINI.md->AGY.md rename completeness)" {
+    # SDD-007 renamed the file; the H1 and body content lagged. This test
+    # locks in that the body actually reflects the file's new identity.
+    [[ "$(head -n1 "$DOTFILES_DIR/ai/agy/AGY.md")" == "# AGY.md" ]]
+    # No stray "Gemini-specific" / "GEMINI.md" body references in the
+    # canonical SSOT (archived specs and the cleanup logic in setup-*.{sh,ps1}
+    # are excluded by file scope).
+    ! grep -qF 'Gemini-specific' "$DOTFILES_DIR/ai/agy/AGY.md"
+    ! grep -qF '# GEMINI.md' "$DOTFILES_DIR/ai/agy/AGY.md"
+}
+
 @test "ANTIGRAVITY_ENDPOINT is set to production in .zshrc" {
     grep -q 'export ANTIGRAVITY_ENDPOINT="https://cloudcode-pa.googleapis.com"' "$DOTFILES_DIR/.zshrc"
 }

--- a/tests/powershell-profile.bats
+++ b/tests/powershell-profile.bats
@@ -24,12 +24,16 @@ setup() {
 
 # --- OpenCode alias (admin-conditional on Windows; aider sunset) ---
 
-@test "profile.ps1 defines conditional oc function for opencode (--pure)" {
-    # Guarded by Get-Command — non-admin Windows machines without opencode
-    # skip the alias rather than producing broken references. Function form
-    # (not Set-Alias) so the --pure flag can be passed; mirrors bash/zsh.
+@test "profile.ps1 defines conditional oc alias for opencode (plain, no --pure)" {
+    # Guarded by Get-Command -- non-admin Windows machines without opencode
+    # skip the alias rather than producing broken references. Plain Set-Alias
+    # (no --pure) because empirically opencode launched bare from a Windows
+    # terminal works correctly with MCPs+plugins (2026-05-26). Linux keeps
+    # --pure pending Ghostty hypothesis investigation (Phase 2.4 backlog).
     grep -qE 'if \(Get-Command opencode' "$PROFILE_SCRIPT"
-    grep -qE 'function oc\s+\{\s*opencode --pure' "$PROFILE_SCRIPT"
+    grep -qF 'Set-Alias -Name oc -Value opencode' "$PROFILE_SCRIPT"
+    # Regression guard: ensure --pure isn't quietly reintroduced for Windows.
+    ! grep -qE 'function oc\s+\{\s*opencode --pure' "$PROFILE_SCRIPT"
 }
 
 @test "profile.ps1 no longer defines aider tier functions (sunset)" {
@@ -52,14 +56,16 @@ setup() {
     grep -qE 'load-secrets\.ps1' "$PROFILE_SCRIPT"
 }
 
-# --- Parity check: oc alias exists in both shells ---
+# --- Cross-OS oc behaviour (intentional asymmetry, documented) ---
 
-@test "parity: oc with --pure defined in both aliases.zsh and profile.ps1" {
-    # Cross-OS parity is the architectural invariant: same finger pattern,
-    # same effective command. Zsh uses alias; PowerShell uses a function
-    # because Set-Alias cannot pass arguments. Both invoke `opencode --pure`.
+@test "oc is defined on both POSIX and PowerShell (intentional asymmetry on --pure)" {
+    # Same finger pattern, different underlying invocation:
+    #   Linux/.zsh : alias oc="opencode --pure"   (Ghostty hang workaround)
+    #   Windows    : Set-Alias -Name oc -Value opencode  (no hang observed)
+    # Tracked as Phase 2.4: once the Linux hang root cause is found (Ghostty
+    # hypothesis), the --pure workaround drops everywhere and parity restores.
     grep -qE '^alias oc="opencode --pure"' "$DOTFILES_DIR/.zsh/aliases.zsh"
-    grep -qE 'function oc\s+\{\s*opencode --pure' "$PROFILE_SCRIPT"
+    grep -qF 'Set-Alias -Name oc -Value opencode' "$PROFILE_SCRIPT"
 }
 
 # --- Other functions ---


### PR DESCRIPTION
## Summary

Two migration-completion items discovered while validating PRs #102-#107 end-to-end on Windows.

### (1) `ai/agy/AGY.md` content was a stale rename

The file was renamed GEMINI.md → AGY.md in SDD-007 but the body never moved:

- H1 still `# GEMINI.md`
- Target Model still "Gemini 1.5 Pro / Ultra / 3.0+"
- Model Tier listed `gemini-2.5-pro/flash/flash-lite` while `ai/agy/settings.json:34` declares `gemini-3.5-flash`
- "Gemini-specific" headers and references throughout

Refreshed in place. Model Tier section now points at `ai/agy/settings.json` as the single source of truth instead of duplicating model IDs.

### (2) Windows `profile.ps1`: drop the `--pure` workaround

Empirical on this Windows machine 2026-05-26: opencode launched bare from a PowerShell terminal works correctly with MCPs+plugins enabled. The hang that `--pure` works around is Linux-specific (Ghostty hypothesis, Phase 2.4 backlog), so the Windows-side defense is unnecessary friction.

Switched `function oc { opencode --pure @args }` + `ocfull` to a single `Set-Alias -Name oc -Value opencode`. Linux `.bashrc` keeps `alias oc='opencode --pure'` pending the hang investigation — intentional, documented cross-OS asymmetry.

## Test plan

- [x] PowerShell parser: profile.ps1 PARSE OK.
- [x] Local Windows: opencode invoked bare via `oc` works (no hang, MCPs visible).
- [ ] CI: 3 new/updated bats tests covering AGY.md content + Windows oc alias form + asymmetry parity.

## Why this is "polish" not "fix"

Neither item is broken in CI today (CI doesn't render AGY.md content; `--pure` works either way). These are correctness items the migration left behind, only visible when a human actually exercised the deployed config.