### PR TITLE
fix(WIN): hc function path + drop dead GEMINI.md from agy settings

### DIFF
--- a/ai/agy/settings.json
+++ b/ai/agy/settings.json
@@ -50,7 +50,6 @@
   "context": {
     "fileName": [
       "AGENTS.md",
-      "GEMINI.md",
       "AGY.md",
       "MEMORY.md"
     ],

--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -135,14 +135,30 @@ if (Get-Command copilot -ErrorAction SilentlyContinue) {
     function cops { copilot -p "$args" --allow-all-tools -s }
 }
 
-# Healthcheck (WIN-001): mirrors the Linux `hc` alias. Runs the full 12-section
+# Healthcheck (WIN-001): mirrors the Linux `hc` alias. Runs the full 13-section
 # structural verification of the deployed dotfiles install.
+#
+# Path-resolution note: env-contract.json declares SCRIPTS_DIR =
+# $USERPROFILE\.dotfiles\scripts, but setup-windows.ps1 actually deploys
+# scripts to $USERPROFILE\scripts (and adds THAT to User PATH). Until that
+# contract drift is fixed (tracked as Phase 2.7), try both locations -- the
+# deployed path first (where setup actually puts it), the env-contract path
+# as a future-proof fallback.
 function hc {
-    $healthcheck = "$env:SCRIPTS_DIR\healthcheck.ps1"
-    if (Test-Path $healthcheck) {
-        & pwsh -NoProfile -File $healthcheck
+    # First match wins. Explicit foreach (not Where-Object) so a single-hit
+    # result stays a [string] and not the indexed-as-char trap.
+    $found = $null
+    foreach ($p in @(
+        (Join-Path $env:USERPROFILE 'scripts\healthcheck.ps1'),
+        $(if ($env:SCRIPTS_DIR) { Join-Path $env:SCRIPTS_DIR 'healthcheck.ps1' } else { $null })
+    )) {
+        if ($p -and (Test-Path -LiteralPath $p)) { $found = $p; break }
+    }
+
+    if ($found) {
+        & pwsh -NoProfile -File $found
     } else {
-        Write-Host "[ERROR] healthcheck.ps1 not found at $healthcheck" -ForegroundColor Red
+        Write-Host "[ERROR] healthcheck.ps1 not found at `$USERPROFILE\scripts\ or `$env:SCRIPTS_DIR" -ForegroundColor Red
         Write-Host "Run setup-windows.ps1 from your dotfiles repository first." -ForegroundColor Yellow
     }
 }

--- a/tests/powershell-profile.bats
+++ b/tests/powershell-profile.bats
@@ -84,8 +84,13 @@ setup() {
     grep -qE '^function hc' "$PROFILE_SCRIPT"
 }
 
-@test "profile.ps1 hc function references SCRIPTS_DIR\\healthcheck.ps1" {
-    grep -qF 'healthcheck.ps1' "$PROFILE_SCRIPT"
+@test "profile.ps1 hc function probes both deploy locations (Phase 2.7 contract drift workaround)" {
+    # Until env-contract drift is resolved, hc must look at the actual deploy
+    # location ($USERPROFILE\scripts -- where setup-windows.ps1 puts it AND
+    # the dir added to PATH) BEFORE the env-contract path. Without this fix
+    # hc was permanently FAIL-on-not-found on Windows.
+    grep -qF 'scripts\healthcheck.ps1' "$PROFILE_SCRIPT"
+    grep -qF '$env:USERPROFILE' "$PROFILE_SCRIPT"
 }
 
 @test "profile.ps1 valid PowerShell syntax (if pwsh available)" {


### PR DESCRIPTION
## Summary

Two cleanup items I detected while auditing the merged Windows migration (PRs #102-#108).

### (1) `hc` function permanently broken on Windows

`profile.ps1:141` looked for `healthcheck.ps1` at `\$env:SCRIPTS_DIR` (which `env-contract.json` declares = `\$HOME\.dotfiles\scripts`), but `setup-windows.ps1` actually deploys ALL scripts to `\$env:USERPROFILE\scripts` and adds *that* to User PATH. The two paths never intersect on a default install → `hc` always hit the "not found" branch.

**Workaround in this PR**: `hc` probes both paths, deployed-location first. The deeper env-contract drift is logged as **Phase 2.7** (bigger refactor) — fixing that is "change setup-windows.ps1 to honour the contract" OR "amend the contract to reflect actual Windows reality" — needs a decision.

**Subtle secondary bug I caught in my own first draft**: used `Where-Object {...}` + `\$candidates[0]`. When a single match passes through the pipeline it collapses to a `[string]`, and `[0]` indexes the first CHARACTER. Replaced with explicit `foreach` to keep the type stable. Catch-by-running.

### (2) `ai/agy/settings.json` referenced dead `GEMINI.md`

`context.fileName` listed `"GEMINI.md"` as a fallback context source. The file was removed in PR #105 (SDD-007 cleanup). Harmless dead ref but inconsistent with the rest of the migration. Removed.

## Test plan

- [x] Local Windows: `hc` resolves to `C:\Users\Manu\scripts\healthcheck.ps1` correctly (verified after the type-bug fix).
- [x] PowerShell parser: profile.ps1 PARSE OK.
- [x] `ai/agy/settings.json` is valid JSON.
- [ ] CI bats: updated `hc function path-probe` assertion.

## Out of scope (logged separately)

- **Phase 2.7**: env-contract.json SCRIPTS_DIR vs setup-windows.ps1 actual deploy location drift.