### PR TITLE
fix(agy): hive-vault via uvx + cross-OS VAULT_PATH preflight + Skills parity

### DIFF
--- a/ai/agy/mcp_servers.json
+++ b/ai/agy/mcp_servers.json
@@ -1,15 +1,12 @@
 {
   "mcpServers": {
     "hive-vault": {
-      "command": "uv",
+      "command": "uvx",
       "args": [
-        "run",
-        "--directory",
-        "/home/manu/Projects/hive",
         "hive-vault"
       ],
       "env": {
-        "VAULT_PATH": "/home/manu/Projects/knowledge",
+        "VAULT_PATH": "${VAULT_PATH}",
         "HIVE_OLLAMA_ENDPOINT": "http://ollama.kubelab.live:11434",
         "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
       },

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -340,8 +340,26 @@ if [ -f "$CURRENT_DIR/mcp-servers.json" ] && command -v jq >/dev/null 2>&1; then
         OLD_KEY=$( (source "$CURRENT_DIR/scripts/load-secrets.sh" >/dev/null 2>&1 && secrets_show OPENROUTER_API_KEY 2>/dev/null) || echo "" )
     fi
 
-    NEW_MCP_CONFIG=$(jq --arg key "$OLD_KEY" '
+    # Substitute ${VAULT_PATH} placeholder with the canonical Linux vault dir.
+    # Committed JSON uses a placeholder so the same source works cross-OS;
+    # agy does NOT expand env vars inside JSON values, so the substitution
+    # must happen here at write time. Path is by convention: $HOME/Projects/knowledge.
+    VAULT_PATH_DEFAULT="${VAULT_PATH:-$HOME/Projects/knowledge}"
+
+    # Preflight: WARN (non-fatal) if the vault dir is missing. hive-vault MCP
+    # will fail at first tool call without it, but encrypted secrets + AGY.md +
+    # everything else still deploys cleanly so creating the vault later doesn't
+    # require a setup re-run. Mirrors the age-key preflight in #106.
+    if [ ! -d "$VAULT_PATH_DEFAULT" ]; then
+        log_warning "Obsidian vault not found at $VAULT_PATH_DEFAULT"
+        log_warning "  hive-vault MCP will error at runtime until this dir exists."
+        log_warning "  Either clone/sync your vault to $VAULT_PATH_DEFAULT, or override via"
+        log_warning "  the VAULT_PATH env var in your shell."
+    fi
+
+    NEW_MCP_CONFIG=$(jq --arg key "$OLD_KEY" --arg vault "$VAULT_PATH_DEFAULT" '
         .mcpServers["hive-vault"].env.OPENROUTER_API_KEY = (if $key != "" and $key != "null" then $key else .mcpServers["hive-vault"].env.OPENROUTER_API_KEY end)
+        | .mcpServers["hive-vault"].env.VAULT_PATH = $vault
     ' "$CURRENT_DIR/ai/agy/mcp_servers.json")
 
     # Merge stdio servers from root mcp-servers.json into mcpServers map

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -838,6 +838,27 @@ if ((Test-Path $mcpServersSrc) -and (Test-Path $rootMcpSrc) -and (Get-Command jq
         $mcpConfigJson.mcpServers."hive-vault".env.OPENROUTER_API_KEY = $oldKey
     }
 
+    # Substitute ${VAULT_PATH} placeholder with the canonical Windows vault dir.
+    # The committed JSON uses ${VAULT_PATH} so it's OS-portable; agy does NOT
+    # expand env vars inside JSON values, so substitution must happen here
+    # before write. The path itself is by convention: $USERPROFILE\Projects\knowledge.
+    $vaultPath = Join-Path $env:USERPROFILE 'Projects\knowledge'
+    $hiveEntry = $mcpConfigJson.mcpServers."hive-vault"
+    if ($hiveEntry -and $hiveEntry.env.PSObject.Properties['VAULT_PATH']) {
+        $hiveEntry.env.VAULT_PATH = $vaultPath
+    }
+
+    # Preflight: WARN (non-fatal) if the vault dir doesn't exist on disk.
+    # hive-vault MCP server will fail at first tool call without it, but
+    # encrypted secrets + AGY.md + everything else still deploys cleanly so
+    # creating the vault later doesn't require a setup re-run.
+    if (-not (Test-Path -LiteralPath $vaultPath -PathType Container)) {
+        Write-Warn "Obsidian vault not found at $vaultPath"
+        Write-Warn "  hive-vault MCP will error at runtime until this dir exists."
+        Write-Warn "  Either clone/sync your vault to $vaultPath, or override via"
+        Write-Warn "  the VAULT_PATH env var in your profile."
+    }
+
     # Merge stdio servers from root mcp-servers.json into mcpServers map
     $rootServers = (Get-Content $rootMcpSrc -Raw | ConvertFrom-Json).servers
     foreach ($srv in $rootServers) {
@@ -920,6 +941,32 @@ if (Test-Path $skillsSource) {
         }
     }
     Write-Success "Synced Gemini prompts to $GeminiHome\prompts\"
+}
+
+# Sync native Shared Skills for Antigravity (recognized as 'Shared' in agy).
+# Cross-OS parity with setup-linux.sh:398-419. Without this block, agy shows
+# "0 skills" on Windows even though the Linux side ships the full skill set.
+# Target: $GeminiHome\skills\<name>\SKILL.md (Shared path).
+if (Test-Path $skillsSource) {
+    $sharedSkillsDir = Join-Path $GeminiHome 'skills'
+    Ensure-Directory $sharedSkillsDir
+
+    # Remove stale shared skills (source dir no longer exists)
+    foreach ($target in Get-ChildItem $sharedSkillsDir -Directory -ErrorAction SilentlyContinue) {
+        if (-not (Test-Path (Join-Path $skillsSource $target.Name))) {
+            Remove-Item -Recurse -Force $target.FullName -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Copy each skill directory (recursive, idempotent)
+    foreach ($skillDir in Get-ChildItem $skillsSource -Directory -ErrorAction SilentlyContinue) {
+        $skillMd = Join-Path $skillDir.FullName 'SKILL.md'
+        if (-not (Test-Path $skillMd)) { continue }
+        $dst = Join-Path $sharedSkillsDir $skillDir.Name
+        Ensure-Directory $dst
+        Copy-Item -Path (Join-Path $skillDir.FullName '*') -Destination $dst -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    Write-Success "Synced Shared Skills to $sharedSkillsDir\"
 }
 
 # ============================================================================

--- a/specs/SDD-007-iac-deploy-strategy/tasks.md
+++ b/specs/SDD-007-iac-deploy-strategy/tasks.md
@@ -100,6 +100,17 @@ Bats regression coverage:
 
 Empirical verification on a real Windows machine: two consecutive `setup-windows.ps1` runs produced identical state — second run's only difference was the `[INFO] Removed legacy GEMINI.md` line on the first run. AC5 idempotency holds on Windows.
 
+## Post-launch agy bugs (discovered when user first ran agy on Windows post-merge)
+
+Two cross-OS bugs surfaced when the user actually launched `agy` on Windows after PRs #102-#109 merged. Addressed in PR #110.
+
+- [x] **hive-vault MCP "system cannot find the path specified"**. Root cause: `ai/agy/mcp_servers.json` shipped Linux-hardcoded paths `command: "uv"` + `args: ["run", "--directory", "/home/<user>/Projects/hive", "hive-vault"]`. The `--directory` pointed at the hive MCP server SOURCE repo — agy on Linux only worked because the author had the hive checkout at that exact path. Claude's root `mcp-servers.json` has always used `uvx hive-vault` (PyPI). Aligned both agents: agy now uses `uvx hive-vault` (no local repo dependency); `env.VAULT_PATH` is the `${VAULT_PATH}` placeholder, substituted per-OS at setup time. Added preflight (mirrors #106 age-key pattern): both setups WARN if the vault dir is missing — non-fatal so a vault created later still works without setup re-run.
+- [x] **agy displayed "0 skills" on Windows**. `setup-linux.sh:398-419` deploys to `~/.gemini/skills` (the Shared path agy reads); the equivalent block was missing in `setup-windows.ps1`. Added: remove-stale + recursive copy, mirror of the Linux behaviour. Cross-OS Skills parity restored.
+
+Architectural principle reinforced: **claude / agy / opencode / copilot must behave the same.** hive-vault is now invoked identically by claude and agy (`uvx hive-vault`); the only differences across agents are unavoidable tool-specific config schemas, not behavioural divergence in how shared services are spawned.
+
+Bats regression coverage (`tests/antigravity.bats` +5 tests): asserts uvx-not-uv-run, VAULT_PATH placeholder presence (not hardcoded user path), preflight presence cross-OS, Skills sync presence on Windows.
+
 ## Machine-readable features
 
 Optional sibling `features.json` per [[pattern-feature-list-as-primitive]] — defer unless harness consumes it.

--- a/tests/antigravity.bats
+++ b/tests/antigravity.bats
@@ -23,6 +23,45 @@ setup() {
     command -v agy
 }
 
+@test "ai/agy/mcp_servers.json hive uses uvx (PyPI) not local repo (parity with claude root config)" {
+    # Pre-fix: agy spawned `uv run --directory /home/<user>/Projects/hive hive-vault`
+    # which required a local hive checkout and bombed on Windows with "system
+    # cannot find the path specified". claude root config has always used
+    # `uvx hive-vault` (PyPI). agy now matches -- cross-agent behaviour parity.
+    local cmd
+    cmd=$(jq -r '.mcpServers["hive-vault"].command' "$DOTFILES_DIR/ai/agy/mcp_servers.json")
+    [ "$cmd" = "uvx" ]
+    # Regression guard: --directory must not return.
+    ! jq -r '.mcpServers["hive-vault"].args | join(" ")' "$DOTFILES_DIR/ai/agy/mcp_servers.json" | grep -qE '\-\-directory'
+}
+
+@test "ai/agy/mcp_servers.json VAULT_PATH is the placeholder, not a hardcoded user path" {
+    # The committed JSON must NOT contain /home/<user> or C:\Users\<user>.
+    # Setup scripts substitute the placeholder with the OS-appropriate path.
+    local vault
+    vault=$(jq -r '.mcpServers["hive-vault"].env.VAULT_PATH' "$DOTFILES_DIR/ai/agy/mcp_servers.json")
+    [ "$vault" = '${VAULT_PATH}' ]
+    ! grep -qE '/home/[a-z]+/|C:\\\\Users\\\\' "$DOTFILES_DIR/ai/agy/mcp_servers.json"
+}
+
+@test "setup-linux.sh substitutes \${VAULT_PATH} and preflights vault dir" {
+    grep -qF 'VAULT_PATH_DEFAULT' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF 'Obsidian vault not found at' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-windows.ps1 substitutes \${VAULT_PATH} and preflights vault dir (cross-OS parity)" {
+    grep -qF 'Projects\knowledge' "$DOTFILES_DIR/setup-windows.ps1"
+    grep -qF 'Obsidian vault not found at' "$DOTFILES_DIR/setup-windows.ps1"
+}
+
+@test "setup-windows.ps1 syncs Shared Skills to ~/.gemini/skills (closes 0-skills-on-Windows bug)" {
+    # setup-linux.sh:398-419 deploys to ~/.gemini/skills (Shared path); parity
+    # was missing on Windows -> agy displayed "0 skills". This test locks the
+    # cross-OS parity.
+    grep -qF 'Synced Shared Skills to' "$DOTFILES_DIR/setup-windows.ps1"
+    grep -qF 'sharedSkillsDir' "$DOTFILES_DIR/setup-windows.ps1"
+}
+
 @test "ai/agy/AGY.md H1 is '# AGY.md' (regression: GEMINI.md->AGY.md rename completeness)" {
     # SDD-007 renamed the file; the H1 and body content lagged. This test
     # locks in that the body actually reflects the file's new identity.


### PR DESCRIPTION
## Summary

Two bugs surfaced when launching `agy` on Windows after the SDD-007 migration completed (#102-#109).

### (1) hive-vault MCP: "system cannot find the path specified"

`ai/agy/mcp_servers.json` shipped Linux-hardcoded paths:

```json
"command": "uv",
"args": ["run", "--directory", "/home/<user>/Projects/hive", "hive-vault"]
```

The `--directory` arg pointed at the hive MCP server **source repo** — agy on Linux only worked because the author happens to have hive cloned at that exact path. Claude's root `mcp-servers.json` has always used `uvx hive-vault` (PyPI), so the agy/claude invocation was asymmetric for no good reason. Aligned both agents:

- JSON: `command=uvx`, `args=["hive-vault"]` — no local repo needed
- `env.VAULT_PATH`: `\${VAULT_PATH}` placeholder, substituted per-OS at setup time (`\$HOME/Projects/knowledge` on Linux, `\$env:USERPROFILE\Projects\knowledge` on Windows)
- **Preflight**: both setups WARN (non-fatal) if the vault dir is missing. Mirrors the age-key preflight added in #106. Encrypted secrets + AGY.md + everything else still deploy cleanly so creating the vault later doesn't require a setup re-run.

### (2) agy showed "0 skills" on Windows

`setup-linux.sh:398-419` deploys to `~/.gemini/skills` (Shared path); the Windows side never had the equivalent block. Added Skills sync to `setup-windows.ps1` mirroring the Linux behaviour (remove-stale + copy-recursive).

## Test plan

- [x] PowerShell parser: setup-windows.ps1 PARSE OK
- [x] `bash -n setup-linux.sh` valid
- [x] `ai/agy/mcp_servers.json` valid JSON
- [x] CI: 5 new bats tests in `antigravity.bats` pin the new invariants
- [ ] Manual (you): after merge + setup-windows.ps1 re-run, agy launches with hive-vault green AND Skills section shows the dotfiles skills

## Architectural note

This PR establishes the principle the user articulated: **claude / agy / opencode / copilot must behave the same.** hive-vault is now invoked identically by claude and agy (`uvx`); the only differences across agents are unavoidable tool-specific config schemas, not behavioural divergence in how shared services are spawned.