### PR TITLE
feat(setup): eager-load secrets in setup-{linux,windows} after sensitive deploy

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -113,6 +113,18 @@ if [ "$CURRENT_DIR" != "$DOTFILES_DIR" ]; then
     cp -rf "$CURRENT_DIR/sensitive/"* "$DOTFILES_DIR/sensitive/" 2>/dev/null || true
 fi
 
+# Eager-load secrets: source load-secrets.sh NOW (after sensitive/ deploy is in
+# place at $DOTFILES_DIR/sensitive) so every subsequent block in this setup
+# has $NAN_API_KEY / $OPENROUTER_API_KEY / $VAULT_PATH / $TS_AUTHKEY / etc.
+# available. Soft-source (subshell + `|| true`) so failures (no age key, no
+# env-mapping yet, etc.) don't abort setup. Replaces the lazy on-demand
+# sourcing previously scattered through this script (e.g. the agy MCP
+# OPENROUTER_API_KEY recovery block).
+if [ -f "$CURRENT_DIR/scripts/load-secrets.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$CURRENT_DIR/scripts/load-secrets.sh" >/dev/null 2>&1 || true
+fi
+
 
 # Update functions.zsh to source utils.sh if not already done
 if [ -f "$DOTFILES_DIR/.zsh/functions.zsh" ]; then

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1237,6 +1237,18 @@ if (Test-Path $sensitiveSource) {
     Write-Warn "Sensitive directory not found at $sensitiveSource"
 }
 
+# Eager-load secrets: dot-source load-secrets.ps1 NOW (after the .secret.age
+# files + env-mapping.conf are at $DotfilesDest\sensitive) so every subsequent
+# block in this setup has $env:NAN_API_KEY / OPENROUTER_API_KEY / VAULT_PATH /
+# TS_AUTHKEY / etc. available. Cross-OS parity with setup-linux.sh:115-122.
+# Wrapped to swallow internal failures (no age key, no env-mapping, etc.) so
+# setup never aborts on secrets issues -- preflight already warned the user.
+$loadSecretsDeployed = Join-Path $DotfilesDest 'scripts\load-secrets.ps1'
+if (Test-Path -LiteralPath $loadSecretsDeployed) {
+    $env:DOTFILES_DIR = $DotfilesDest
+    try { . $loadSecretsDeployed 2>&1 | Out-Null } catch { }
+}
+
 # ============================================================================
 # 7c. REGISTER SESSIONSTART HOOK
 # ============================================================================

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -63,6 +63,20 @@ setup() {
     grep -qF "PSObject.Properties['prerequisite_command']" "$PS1_SCRIPT"
 }
 
+@test "setup-windows.ps1 eager-sources load-secrets.ps1 after sensitive deploy" {
+    # Every block AFTER sensitive/ copy must see $env:NAN_API_KEY / VAULT_PATH /
+    # TS_AUTHKEY etc. populated. Cross-OS parity with setup-linux.sh's same
+    # eager source. Wrapped in try/catch so setup never aborts on secrets issues.
+    grep -qF 'Eager-load secrets' "$PS1_SCRIPT"
+    grep -qE '\. \$loadSecretsDeployed' "$PS1_SCRIPT"
+    grep -qF 'try { . $loadSecretsDeployed' "$PS1_SCRIPT"
+}
+
+@test "parity: both setups eager-load secrets after sensitive deploy" {
+    grep -qF 'Eager-load secrets' "$PS1_SCRIPT"
+    grep -qF 'Eager-load secrets' "$DOTFILES_DIR/setup-linux.sh"
+}
+
 @test "setup-windows.ps1 preflights the age identity key (warn, not fail)" {
     # Without ~/.config/age/key.txt, load-secrets.ps1 silently no-ops at
     # shell startup and opencode/agy 401 with no clue. Preflight WARNs (must


### PR DESCRIPTION
## Summary

User ask: *"quiero que al lanzar cualquier setup las tenga disponibles en el sistema siempre"*.

Until now:
- `setup-linux.sh` lazy-sourced `load-secrets.sh` only when it needed `\$OPENROUTER_API_KEY` for MCP config substitution (ad-hoc, scattered)
- `setup-windows.ps1` didn't source it at all — any block downstream depended on the parent shell having the env vars already

Both setups now **dot-source `load-secrets.{sh,ps1}` right after the `sensitive/` deploy block**. Every subsequent block sees `\$NAN_API_KEY`, `\$OPENROUTER_API_KEY`, `\$VAULT_PATH`, `\$TS_AUTHKEY`, etc. populated. Wrapped in `try/catch` (PowerShell) / `|| true` (bash) so setup never aborts on secrets issues — the preflight added in #106 already warned the user.

## Verified locally

```powershell
PS> Remove-Item env:NAN_API_KEY,env:TS_AUTHKEY -ErrorAction SilentlyContinue
PS> $env:DOTFILES_DIR = "\$env:USERPROFILE\.dotfiles"
PS> try { . "\$env:DOTFILES_DIR\scripts\load-secrets.ps1" 2>&1 | Out-Null } catch { }
PS> $env:NAN_API_KEY.Length    # 25
PS> $env:TS_AUTHKEY.Length     # 61
```

## Test plan

- [x] PowerShell parser: setup-windows.ps1 PARSE OK
- [x] `bash -n setup-linux.sh` valid
- [x] Local Windows simulation: eager source populates env correctly
- [x] CI: 2 new bats tests + cross-OS parity assertion

## LOC

23 production LOC (12 Linux + 11 Windows). Well under SDD discipline gate threshold.

## Architectural notes

- Replaces the lazy on-demand sourcing previously scattered (setup-linux.sh:336-340 OPENROUTER_API_KEY recovery becomes unnecessary, though kept for now to avoid scope creep — can be cleaned up in a follow-up).
- Cross-OS parity: both setups have a marker comment "Eager-load secrets" enforced by a parity bats test.