### PR TITLE
feat(SDD-008): scaffold cross-agent skill pipeline spec (authoring only)

### DIFF
--- a/specs/SDD-008-skill-pipeline/proposal.md
+++ b/specs/SDD-008-skill-pipeline/proposal.md
@@ -1,0 +1,75 @@
+---
+id: "SDD-008-skill-pipeline"
+type: spec
+status: draft
+created: "2026-05-26"
+tags: [spec, proposal, sdd-008, cross-os, ai-tooling, skill-distribution, pipeline, bug-100-followup]
+template_version: "1.0"
+---
+
+# SDD-008: Skill pipeline
+
+> **Naming**: file lives at `<repo>/specs/SDD-008-skill-pipeline/proposal.md`.
+
+## Why
+
+<!-- from 10_projects/dotfiles/11-tasks.md:193: SDD-008-skill-pipeline (Tier 1, cross-OS, ~250 LOC est.) — Compile-once-deploy-everywhere pattern for cross-agent skill distribution; eliminates symlink/junction fragility (BUG-100 precedent class). -->
+
+[AGENT-DRAFT — review before archive]
+
+Today skills are distributed via two inconsistent mechanisms: symlink/junction for vault-hosted SDD skills (`spec`, `adversarial-review`, `enrich-us`) and mechanical copy via script for opencode commands (per AI-012). BUG-100 already proved that cross-agent symlink fragility is a real bug class — agy v1.0.2 broke because our deploy strategy was "fighting the agent's expected filesystem layout" (per SDD-007 proposal). Without a unified pipeline, every new agent (Cursor, Codex, Devin, future tooling) repeats the deploy decision ad-hoc, and any improvement to a skill's content (e.g., extending `/spec` with an agent-side proactive trigger) does not propagate deterministically to the N target agents — behavior diverges silently across agents and the SSOT promise breaks without anyone noticing until the next BUG-100-class incident.
+
+## What
+
+[AGENT-DRAFT — review before archive]
+
+After this PR, the system exhibits five observable behavior changes:
+
+1. **Single SSOT for ALL skills**: `vault/00_meta/skills/<name>/SKILL.md` is the only source of truth for every skill (~20 total: 3 SDD already there + 17 migrated from `dotfiles/ai/skills/`). After this PR, `dotfiles/ai/skills/` either does not exist or contains only a stub `README.md` pointing to the vault. `git log --follow` preserves history because migration uses `git mv` per skill.
+2. **Single render command**: `scripts/skills/render-all.sh` reads every `vault/00_meta/skills/<name>/SKILL.md` and produces N agent-native outputs at the expected paths (`~/.claude/skills/<name>/SKILL.md`, `~/.config/opencode/commands/<name>.md`, `~/.gemini/skills/<name>/<name>.md`, and a generated section in `.github/copilot-instructions.md`). Every generated file carries a header `# GENERATED — DO NOT EDIT — source: <vault-path>` plus a checksum of the source.
+3. **Symlinks/junctions eliminated**: after running `setup-linux.sh` or `setup-windows.ps1`, no `~/.claude/skills/<name>` is a symlink (Linux: `find ~/.claude/skills -type l` returns empty; Windows: equivalent junction probe returns empty). All deployed skill files are regular file copies.
+4. **Drift detection via setup-time render + existing idempotence gate**: `setup-{linux,windows}` invoke `scripts/skills/render-all.sh` as part of their flow, so the build IS setup. No dedicated CI workflow with vault access required (the dotfiles CI has zero visibility into the private `github.com/mlorentedev/knowledge` repo, and we deliberately don't add it). Drift is caught by the planned Phase 2.6 "run-twice-and-diff" idempotence gate (per `vault/10_projects/dotfiles/11-tasks.md`): if a developer edits a deployed skill manually OR forgets to re-render after editing vault source, the second setup run produces a diff and CI fails. One gate covers two bug classes.
+5. **Agent-side proactive `/spec` trigger** (sub-task in same PR): `vault/00_meta/skills/spec/SKILL.md` declares an explicit "Agent-Side Activation Rule" section. When the agent identifies a non-trivial change in conversation, it applies the Skip-SDD heuristic *itself* and proposes `/spec init` proactively, listing the checks it ran. Observable as agent-initiated spec proposals appearing in transcripts where previously they were user-initiated.
+6. **Schema-validated skill frontmatter**: `render-all.sh` runs a frontmatter validator first; any SKILL.md missing required fields (`id`, `type: skill`, `description`, `allowed-tools`) or with malformed YAML fails the render with a clear file:line error. Prevents silent deploy of malformed skills that break agent discovery. Schema lives at `vault/00_meta/templates/skill-frontmatter.schema.json`.
+7. **Per-skill agent opt-out via manifest**: each skill MAY declare `targets: [claude, opencode, agy, copilot]` in its frontmatter (default = all four). Skills that only make sense for one agent (e.g., `claude-mem-*` family is Claude-only) ship only to declared targets. The render dispatcher honors the manifest; outputs for non-targeted agents are never written.
+8. **Atomic migration with rollback**: the 17-skill repatriation from `dotfiles/ai/skills/` → `vault/00_meta/skills/` runs as a single script (`scripts/skills/migrate-to-vault.sh`) that is transactional — if any of the 17 moves fails (permission, conflict, vault unwritable), the script restores all prior moves from a pre-migration snapshot and exits non-zero. No half-migrated state possible.
+9. **Post-render smoke test**: `tests/skills-pipeline.bats` includes a smoke test that invokes a known skill (`/spec`) from the deployed location and asserts non-error exit; equivalent test for opencode (`opencode run -m <model> /spec --help` or similar). Validates the full round-trip vault → render → deploy → agent invocation, not just the file generation step.
+
+## Out of scope
+
+Per user directive (Q3 answer): the PR MUST repatriate and migrate ALL skills to the single SSOT — partial migration is explicitly rejected. The items below are what falls outside that complete-migration scope.
+
+- **Adapters for agents beyond Claude / OpenCode / agy / Copilot** — adding Cursor, Codex, Devin, or other future agents is one new `render-<agent>.sh` script each; deferred to per-agent PRs as those agents enter the workflow.
+- **Empirical validation of the agent-side proactive trigger behavior in production sessions** — the rule ships as content in `vault/00_meta/skills/spec/SKILL.md`, but observing whether agents actually apply Skip-SDD heuristic correctly across N sessions is observational work tracked separately.
+- **Migration of vault commit-and-sync mechanics** — this PR assumes the existing `obsidian-git` auto-commit on the vault is sufficient for SSOT durability. Tightening vault commit cadence, adding pre-commit hooks on the vault, or building a vault-side CI is out of scope.
+- **Cross-OS CI matrix** for skills pipeline — this PR exercises Linux runner only. Windows-runner validation is tracked separately under Phase 2.6 (idempotence GHA, planned). Adding a Windows matrix purely for skills here would duplicate effort.
+
+## Risks / open questions
+
+Failure modes, dependencies, and unknowns to clarify before implementation. If any item here is unresolved, do not move to `tasks.md` yet.
+
+- **🚨 BLOCKER — Bootstrap dependency on vault clone present**: with Option D chosen (no committed `.rendered-skills/`; render-all.sh executes at setup time reading from vault), `setup-{linux,windows}` now hard-depends on `~/Projects/knowledge` (or `%USERPROFILE%\Projects\knowledge`) existing with current vault content. First-install via IDEAS-005 `install.sh` (once shipped) MUST clone vault before invoking setup, OR setup MUST abort with clear actionable error when vault is absent. Decide: (a) `install.sh` clones vault as prerequisite, (b) `setup-{linux,windows}` checks for vault presence at `~/Projects/knowledge` and aborts with instructions, (c) vendored fallback (vault-snapshot embedded in dotfiles repo, used only when vault unreachable). **MUST resolve before any code is written.**
+- **🟡 Phase 2.6 coupling**: SDD-008 leans on Phase 2.6 ("formal idempotence CI job: run-twice-and-diff GHA") for drift detection. Phase 2.6 is planned but not yet shipped. Decide: (a) include Phase 2.6 implementation as part of SDD-008 scope (expands LOC ~80), (b) accept weaker gate until 2.6 ships separately (drift detection only on `setup` re-run locally), (c) split SDD-008 into 008a (pipeline) and 008b (idempotence gate) for sequential PRs. Non-blocker for code start but blocks "Acceptance criteria" definition for the drift gate.
+- **🟡 Migration history preservation across repos**: 17 cross-repo moves from `dotfiles/ai/skills/<name>/` to `vault/00_meta/skills/<name>/`. `git mv` does not preserve history across separate repos. Options: (a) accept history loss + add reference table in each skill README pointing to pre-migration dotfiles commit hash, (b) `git filter-repo` extraction + injection (technically complex; can corrupt repos if mishandled), (c) migration script that copies content + commits each with a `Co-authored-by`-style reference to the original dotfiles hash. Choose at implementation time. Non-blocker for spec authoring.
+
+## Acceptance criteria
+
+[AGENT-DRAFT — review before archive]
+
+Observable outcomes. Each must be testable.
+
+- [ ] **AC1 — Zero symlinks/junctions in deployed skill paths**: after `setup-linux.sh`, `find ~/.claude/skills ~/.gemini/skills ~/.config/opencode/commands -type l` returns empty. After `setup-windows.ps1`, equivalent PowerShell junction probe returns empty. **Verification**: `tests/skills-pipeline.bats` + `tests/skills-pipeline.Tests.ps1`.
+- [ ] **AC2 — Single SSOT post-migration**: `vault/00_meta/skills/` contains exactly the migrated set (3 original SDD + 17 repatriated = 20 skill directories, each with `SKILL.md`); `dotfiles/ai/skills/` either does not exist or contains only `README.md` pointing to vault. **Verification**: structural test counting directories + grep for SKILL.md in vault, asserting absence/stub in repo.
+- [ ] **AC3 — Drift detection via `--check` mode**: running `scripts/skills/render-all.sh --check` against a clean working tree post-setup exits 0; the same command after editing any `vault/00_meta/skills/<name>/SKILL.md` without re-rendering exits non-zero with a diff summary pointing to the stale outputs. **Verification**: bats fixture test mutating a sample SKILL.md and asserting exit code transition.
+- [ ] **AC4 — Generated-file provenance header**: every output file produced by `render-all.sh` contains a header `# GENERATED — DO NOT EDIT — source: <vault-relative-path> — sha256: <16-char-prefix>` as the first non-shebang line. Editing the source updates the sha; editing the output without re-rendering creates a mismatch detectable by `--check`. **Verification**: grep + sha256sum compare across all outputs in a bats test.
+- [ ] **AC5 — Frontmatter schema validation**: corrupting any SKILL.md frontmatter (delete `id`, malformed YAML, unknown `type` value) causes `render-all.sh` to fail with file:line error pointing to the offending field. Valid frontmatter renders silently. **Verification**: bats fixture mutates a skill copy, asserts non-zero exit + error message format. Schema file `vault/00_meta/templates/skill-frontmatter.schema.json` exists and is referenced from `pattern-cross-agent-skill-pipeline.md`.
+- [ ] **AC6 — Per-skill target manifest honored**: a skill with `targets: [claude]` in frontmatter renders ONLY to `~/.claude/skills/<name>/SKILL.md`; no output appears at opencode/agy/copilot paths. A skill without `targets:` defaults to all four. **Verification**: fixture skill with explicit `targets:`, post-render `ls` assertion on all four paths.
+- [ ] **AC7 — Pattern documentation promoted to vault**: `vault/00_meta/patterns/pattern-cross-agent-skill-pipeline.md` exists, links bidirectionally with `pattern-spec-driven-development.md` (this pipeline serves SDD discipline), documents the render dispatch + manifest + schema + drift detection design. **Verification**: file exists check + grep for cross-reference link.
+- [ ] **AC8 — End-to-end smoke test post-render**: after `setup-linux.sh` completes, invoking `/spec init` in a Claude session (or `claude --help` listing skills) shows `spec` available; equivalent assertion for OpenCode (`opencode --help` lists `spec` command); agy / copilot smoke depends on their CLI surfaces. Validates that the full vault→render→deploy→discovery chain works, not just file presence. **Verification**: bats test wrapping CLI invocations; failures point to which agent's discovery broke.
+
+## References
+
+- Vault: `10_projects/dotfiles/11-tasks.md` (backlog entry, line 193)
+- Related ADR: `10_projects/dotfiles/30-architecture/adr-009-multi-agent-runtime.md`, `adr-010-agent-harness-parity.md`
+- Related patterns: `00_meta/patterns/pattern-spec-driven-development.md` (this spec extends it), to-be-created `00_meta/patterns/pattern-cross-agent-skill-pipeline.md`
+- Precedent: SDD-007 / BUG-100 (symlink fragility with agy), AI-012 (skills→opencode mechanical port — partial precedent for this pattern)

--- a/specs/SDD-008-skill-pipeline/tasks.md
+++ b/specs/SDD-008-skill-pipeline/tasks.md
@@ -1,0 +1,55 @@
+---
+tags: [spec, tasks, sdd-008]
+created: "2026-05-26"
+---
+
+# Tasks - SDD-008-skill-pipeline
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+
+## Setup
+
+- [ ] Branch created from main: `feat/SDD-008-skill-pipeline`
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+> Replace these with the actual steps for this feature. Keep them small (one commit each) and in TDD order.
+
+- [ ] Write failing test for <behavior 1>
+- [ ] Implement <module/function> to make it pass
+- [ ] Refactor for clarity (extract, rename, dedupe)
+- [ ] Write failing test for <behavior 2>
+- [ ] Implement to make it pass
+- [ ] ...
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
+- [ ] Type checks pass
+- [ ] Lint passes
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
+
+Minimal `features.json` skeleton (drop into `<repo>/specs/SDD-008-skill-pipeline/features.json`):
+
+```json
+[
+  {
+    "id": "SDD-008-skill-pipeline-f1",
+    "behavior": "<one-line copy of an acceptance criterion>",
+    "verification": "<single shell command; exit 0 means pass>",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/SDD-008-skill-pipeline/verification.md
+++ b/specs/SDD-008-skill-pipeline/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, sdd-008]
+created: "2026-05-26"
+---
+
+# Verification - SDD-008-skill-pipeline
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for `10_projects/dotfiles/90-lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for `10_projects/dotfiles/30-architecture/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/SDD-008-skill-pipeline/` -> `specs/archive/SDD-008-skill-pipeline/`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
## Summary

User ask: *"vamos a discutir lo del pipeline cross-agent... una SSOT... también para Windows"*.

Scaffolds **SDD-008** — single spec authoring the cross-agent skill pipeline pattern + agent-side proactive `/spec` trigger as bundled sub-task. Implementation deferred to follow-up branch(es). This PR adds the spec only (3 files, 172 LOC).

## Motivation

Two threads converge:

### (1) Cross-agent skill distribution is inconsistent

Today skills reach agents via two mechanisms in parallel: symlink/junction for vault-hosted SDD skills (`spec`, `adversarial-review`, `enrich-us`) and mechanical copy via script for opencode commands (per AI-012). BUG-100 already proved that cross-agent symlink fragility is a real bug class — agy v1.0.2 broke because our deploy strategy was "fighting the agent's expected filesystem layout" (SDD-007 proposal verbatim). Every new agent (Cursor, Codex, Devin, future tooling) currently repeats the deploy decision ad-hoc.

### (2) Skill content improvements don't propagate deterministically

Any change to a skill (e.g., extending `/spec` with an agent-side proactive trigger) needs to reach Claude / OpenCode / agy / Copilot equivalently. Without a unified pipeline, content drift between agents is invisible until the next BUG-100-class incident.

## Architectural decisions captured in the spec

- **SSOT location**: vault `00_meta/skills/` (single source for ALL 20 skills — 3 SDD already there + 17 to migrate from `dotfiles/ai/skills/`). User direction: *"hay que repatriar y migrar todas las skills al nuevo paradigma de manera que haya una SSOT"*.
- **Drift detection strategy** (Option D, user-chosen): setup-time render via `scripts/skills/render-all.sh` + reliance on planned Phase 2.6 idempotence gate. **No dedicated CI workflow with vault access** — dotfiles CI has zero visibility into the private `github.com/mlorentedev/knowledge` repo, and we deliberately don't add it. One gate (Phase 2.6) covers two bug classes.
- **Pattern reference**: Flutter / OpenAPI / Bazel / dbt — "single source, multi-target build".
- **Per-skill agent opt-out**: manifest in SKILL.md frontmatter (`targets: [claude, opencode, ...]`); defaults to all four.
- **Schema validation, atomic migration with rollback, post-render smoke test, pattern documentation in vault**: all captured as acceptance criteria.

## Outstanding items before implementation

- 🚨 **BLOCKER in proposal.md Risks**: `setup-{linux,windows}` will hard-depend on `~/Projects/knowledge` existing (Option D drift strategy). MUST decide bootstrap path with `install.sh` / IDEAS-005 before code starts.
- 🟡 Phase 2.6 coupling (open question): include Phase 2.6 implementation as part of SDD-008 scope, accept weaker gate until 2.6 ships separately, or split SDD-008 into 008a (pipeline) + 008b (idempotence gate).
- 🟡 Migration history preservation (open question): cross-repo `git mv` doesn't preserve history.
- 3 `[AGENT-DRAFT]` tags in Why / What / Acceptance criteria — user to review before `/spec archive` (the skill blocks archive on remaining tags).

## Vault entry

Added separately at `vault/10_projects/dotfiles/11-tasks.md:193` (obsidian-git auto-commit, not part of this dotfiles commit).

## Test plan

- [x] spec-gate CI workflow passes (PR contains active `specs/SDD-008-skill-pipeline/` folder per SDD-003)
- [x] Pre-commit hooks passed locally (secrets detect + dotfiles tests)
- [x] Lint / lint-powershell / spec-gate / GitGuardian / integration / test CI jobs green
- [ ] User reviews 3 `[AGENT-DRAFT]` sections and accepts or rewrites
- [ ] User resolves BLOCKER (vault clone dependency) before implementation PR follows
- [ ] Decide split strategy (single 008 PR vs 008a + 008b) before implementation