### PR TITLE
fix: Split-Path -LiteralPath/-Parent bug + .gitconfig hash check

### DIFF
--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -55,7 +55,7 @@ function Deploy-File {
     }
 
     # Ensure parent directory exists
-    $dstDir = Split-Path -LiteralPath $Destination -Parent
+    $dstDir = Split-Path -Path $Destination -Parent
     if ($dstDir -and -not (Test-Path -LiteralPath $dstDir)) {
         New-Item -ItemType Directory -Path $dstDir -Force | Out-Null
     }

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1065,9 +1065,15 @@ $gitconfigTarget = "$env:USERPROFILE\.gitconfig"
 if (Test-Path $gitconfigSource) {
     # Check if target already exists
     if (Test-Path $gitconfigTarget) {
-        Write-Warn ".gitconfig already exists at $gitconfigTarget"
-        Write-Info "Skipping to avoid overwriting existing configuration"
-        Write-Info "To update manually: Copy-Item '$gitconfigSource' '$gitconfigTarget' -Force"
+        $srcHash = (Get-FileHash -LiteralPath $gitconfigSource -Algorithm SHA256).Hash
+        $dstHash = (Get-FileHash -LiteralPath $gitconfigTarget -Algorithm SHA256).Hash
+        if ($srcHash -eq $dstHash) {
+            Write-Info ".gitconfig already exists and matches repo (no action needed)"
+        } else {
+            Write-Warn ".gitconfig already exists at $gitconfigTarget (differs from repo version)"
+            Write-Info "Skipping to avoid overwriting existing configuration"
+            Write-Info "To merge manually: Copy-Item '$gitconfigSource' '$gitconfigTarget' -Force"
+        }
     } else {
         Copy-Item $gitconfigSource $gitconfigTarget -Force
         Write-Success "Deployed .gitconfig"


### PR DESCRIPTION
## Summary

Two small fixes surfaced by `setup-windows.ps1` post-run validation.

### BUG-020: Split-Path -LiteralPath/-Parent parameter conflict

`scripts/utils.ps1:58` used `Split-Path -LiteralPath $Destination -Parent`, which throws:

```
Parameter set cannot be resolved using the specified named parameters.
```

`-LiteralPath` and `-Parent` are mutually exclusive parameter sets in PowerShell 5.1 and 7.x.

**Fix:** Replace `-LiteralPath` with `-Path` (1 line).

### BUG-021: .gitconfig false WARNING on matching files

`setup-windows.ps1` emitted `[WARNING] .gitconfig already exists` even when the deployed file was byte-identical to the repo version.

**Fix:** SHA256 hash comparison - if hashes match, emit `[INFO]`; if different, keep the warning with merge hint (~10 LOC).

## Verification

- `pwsh -Command "Split-Path -Path 'C:\Users\mlorente\.config\opencode\opencode.jsonc' -Parent"` succeeds (was failing before)
- Manual test: run `setup-windows.ps1` on a machine where `.gitconfig` matches repo - should show INFO, not WARNING

## Related

Closes BUG-020, BUG-021 from 2026-05-27 session.

## SDD skip rationale

Sub-20 LOC bug fixes with obvious cause (PowerShell parameter set incompatibility + missing hash comparison). Neither touches a public contract, adds/removes a dependency, or requires architectural decisions. SDD skip per AGENTS.md criteria.
