### PR TITLE
fix(agents): restore no-attribution + English-only harness override (stopgap for #156)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,6 +398,14 @@ Standing Order #3 (vault hygiene) is **in-session, not 'later'**. Every "later" 
 
 ## Operational Rules (from past corrections)
 
+### Overrides of Harness Defaults (non-negotiable)
+
+These rules **counter agent harness defaults** that would otherwise silently win at runtime (e.g. a CLI whose default appends `Co-Authored-By` to commits). They are re-affirmed here because a default not explicitly overridden is the default that ships. Canonical source: `00_meta/patterns/pattern-git-workflow.md` §6–§7. *(Hand-maintained today; HARNESS-001 (#156) will generate this block from the pattern.)*
+
+* **No AI attribution.** No `Co-Authored-By` trailers, no "Generated with" / "🤖" footers, no bot-style emojis — in commits, PR descriptions, or issue comments. All git/GitHub artifacts must appear human-authored.
+* **English only** in git/GitHub artifacts: commit messages, branch names, PR/issue titles and bodies, and code comments. (Conversation with the user may be in any language; the durable record is English.)
+* **No internal phase/milestone references** in branch names, commit messages, or PR titles (e.g. `phase-3.1`). Phase tracking lives in the issue tracker, not in git history.
+
 ### Interaction Discipline
 
 * **Wait before acting.** Do not launch exploration, implementation, or autonomous tasks until the user has finished their prompt.

--- a/ai/claude/CLAUDE.md
+++ b/ai/claude/CLAUDE.md
@@ -53,6 +53,7 @@ For the full dual-memory protocol, query `00_meta/patterns/pattern-dual-memory.m
 
 ## Claude Code Tooling Notes
 
+* **No attribution / English-only (overrides Claude default).** Per `AGENTS.md` § Operational Rules → "Overrides of Harness Defaults": no `Co-Authored-By` / "Generated with" / 🤖 footers on commits, PRs, or issues; English only in git/GitHub artifacts — even when the harness default suggests otherwise.
 * **Skills.** `~/.claude/skills/<skill>/SKILL.md` auto-load via slash commands. Skill auto-loading is a Claude Code feature, not portable. Skill **content** is portable: `AI-012-opencode-commands-port` mechanically transforms each skill into an OpenCode command in `ai/opencode/commands/*.md`.
 * **TaskCreate / TaskUpdate / TaskList.** Use for non-trivial multi-step work (≥3 distinct steps). Mark `in_progress` BEFORE starting; mark `completed` immediately on finish. Don't batch updates.
 * **AskUserQuestion.** Use for branching decisions with 2-4 mutually exclusive options. Always include "(Recommended)" on the preferred option.


### PR DESCRIPTION
## What

Stopgap for #156 (Exhibit A): the no-attribution policy regressed out of the deployed agent instructions, so the Claude Code harness default (append `Co-Authored-By` / "Generated with" footer) was silently winning at runtime.

Restores the override in the two deployed surfaces:

- **`AGENTS.md`** § Operational Rules → new **"Overrides of Harness Defaults"** subsection (cross-agent): no AI attribution, English-only in git/GitHub artifacts, no internal phase/milestone references. Canonical source cited: `pattern-git-workflow` §6–§7.
- **`ai/claude/CLAUDE.md`** → **"Harness Default Overrides (read first)"** section restating the attribution + English-only rules where Claude reads them (the offending default is Claude Code's).

## Why a hand-maintained block (for now)

This is the **stopgap**. The durable fix is the HARNESS-001 enforced-patterns pipeline (#156): `00_meta/patterns` (`enforce: true`) → generated override block injected into each deployed config, with a CI drift/contradiction guard. The block is annotated as hand-maintained until that lands.

## Out of scope (follow-ups)

- Removing the two contradictory vault carve-outs (`00_meta/skills/CURRENT-STATE.md`, `feedback_pr_no_attribution.md`) — done directly in the vault (not a dotfiles change).
- Cross-agent generation of this block — #156.

## Verification

- 21 bats tests green (`agents-md`, `docs-drift`, `check-md-escapes` incl. repo-markdown-clean self-test).
- Deploy is copy-based (ADR-012); re-run `setup-{linux,windows}` to propagate to `~/.claude/CLAUDE.md` + `~/.config/opencode/AGENTS.md`.

Part of HARNESS-001 (#162). Refs #156.
