### PR TITLE
docs(HARNESS-001): umbrella spec + ADR-013 agent-artifact deploy engine

### DIFF
--- a/docs/adr/adr-001-skill-based-ai-workflow.md
+++ b/docs/adr/adr-001-skill-based-ai-workflow.md
@@ -11,6 +11,8 @@ owner: manu
 
 # ADR-001: Custom Skills Over BMAD Framework
 
+> **Supersession proposed by [ADR-013](adr-013-agent-artifact-deploy-engine.md)** (status: `proposed` — not yet in effect). ADR-013 generalizes skill deploy into a manifest-driven agent-artifact engine of which skills are one consumer. This ADR remains `accepted` until ADR-013 is accepted.
+
 ## Context
 
 The dotfiles project needed a complete product development pipeline for AI-assisted workflows. Two approaches were evaluated:

--- a/docs/adr/adr-008-skills-ecosystem-overhaul.md
+++ b/docs/adr/adr-008-skills-ecosystem-overhaul.md
@@ -7,6 +7,8 @@ created: "2026-03-29"
 
 # ADR-008: Skills Ecosystem Overhaul
 
+> **Supersession proposed by [ADR-013](adr-013-agent-artifact-deploy-engine.md)** (status: `proposed` — not yet in effect). ADR-013 subsumes the skills ecosystem into a manifest-driven agent-artifact deploy engine. This ADR remains `accepted` until ADR-013 is accepted.
+
 ## Status: Accepted
 
 ## Date: 2026-03-29

--- a/docs/adr/adr-013-agent-artifact-deploy-engine.md
+++ b/docs/adr/adr-013-agent-artifact-deploy-engine.md
@@ -1,0 +1,60 @@
+---
+id: "ADR-013-agent-artifact-deploy-engine"
+type: adr
+status: proposed
+owner: manu
+date: "2026-05-28"
+supersedes: [adr-001-skill-based-ai-workflow, adr-008-skills-ecosystem-overhaul]
+extends: [adr-012-deploy-strategy-copy-with-drift-assertion]
+tags: [architecture, decision, deploy, harness, cross-agent, dotfiles, harness-001]
+created: "2026-05-28"
+---
+
+# ADR-013: Agent-artifact deploy engine (manifest-driven, generate-and-commit)
+
+> Proposed by epic HARNESS-001 (`specs/HARNESS-001-unified-cross-agent-harness/`, GH [#162](https://github.com/mlorentedev/dotfiles/issues/162)). **Status `proposed`** — supersession of ADR-001/008 takes effect only when this ADR is accepted (PR-1 of the engine lands).
+
+## Status
+
+Proposed
+
+## Date
+
+2026-05-28
+
+## Context
+
+The repo deploys several *kinds* of AI-agent artifact — behavioural instructions (`AGENTS.md`, `CLAUDE.md`, `AGY.md`, Copilot), enforced `00_meta/patterns` rules, skills/commands, and MCP config — and each kind currently has its own bespoke, per-agent deploy path. ADR-001 chose custom `SKILL.md` files deployed by a glob loop; ADR-008 overhauled the skills ecosystem; both are **skill-specific** and say nothing about instructions, patterns, or MCP config. ADR-012 fixed the *mechanism* (atomic copy + drift assertion, not symlinks) but not the *source-of-truth-to-N-targets fan-out*.
+
+The gap surfaced as a real regression: the no-attribution policy (#156) silently disappeared from the deployed instructions because **nothing propagates `00_meta/patterns` into the files agents read**, and agent harness defaults override absent rules at runtime. This is structural, not a one-off — every artifact kind repeats the deploy decision ad-hoc, so the SSOT promise breaks without detection until the next incident. External precedent (`ruler`, AGENTS.md standard) converges on one answer: a declarative manifest that compiles a single source into per-agent artifacts and **commits** them.
+
+## Decision
+
+Adopt a single **agent-artifact deploy engine**:
+
+1. **One declarative manifest** (lean format: JSON — parsed by `jq` on Linux + native `ConvertFrom-Json` on Windows, no new dependency) describes every agent: `kind` (`native` AGENTS.md reader | `pointer`+overlay), source path(s), overlay, and target deploy path.
+2. **Cross-OS compiler** (`compile-harness.sh` + `compile-harness.ps1`) reads the manifest, concatenates shared + overlay by precedence, and emits per-agent artifacts. Every generated file carries a `<!-- GENERATED FROM <source> — DO NOT EDIT -->` source-marker.
+3. **Generate-and-commit** (not symlink, not render-on-demand): generated artifacts are committed, building on ADR-012's copy-deploy. This is what lets CI verify them — the dotfiles CI has zero visibility into the private vault.
+4. **Enforced patterns**: `00_meta/patterns/*.md` with frontmatter `enforce: true` compile into a generated override block in the deployed instructions (the #156 attribution case at minimum).
+5. **CI drift + contradiction guard** fails on hand-edited artifacts (run-twice-and-diff) or instructions contradicting an enforced pattern.
+
+Skills (SDD-008), the `.agent/<id>/` registry (IDEAS-007), and work/personal mode (#159) become **consumers** of this engine rather than independent deploy paths.
+
+## Consequences
+
+**Positive**
+
+- One place defines the source→target contract; a rule added once is enforced across all agents and both OSes.
+- Drift and silent-override regressions (the #156 class) become CI failures, not surprises.
+- New agents are a manifest entry + (if `pointer`) an overlay, not a new bespoke deploy script.
+
+**Negative / costs**
+
+- Bootstrap depends on the vault clone being present for source content (reuse SDD-008's setup-time preflight).
+- The compiler must assert line-cap invariants post-compile (`ai/claude/CLAUDE.md` ≤ 80, `ai/agy/AGY.md` ≤ 50) or concatenation can silently breach them.
+- Full engine exceeds the ~300-LOC atomic-PR limit → delivered as a PR sequence (tracer-bullet first; see the epic `tasks.md`).
+
+**Supersession**
+
+- Supersedes ADR-001 (custom skills workflow) and ADR-008 (skills ecosystem overhaul): both are subsumed by the generalized engine, of which skills are one consumer. Effective on acceptance.
+- Extends ADR-012 (copy + drift assertion): the engine is generate-and-commit on top of that copy substrate.

--- a/specs/HARNESS-001-unified-cross-agent-harness/proposal.md
+++ b/specs/HARNESS-001-unified-cross-agent-harness/proposal.md
@@ -1,0 +1,80 @@
+---
+id: "HARNESS-001-unified-cross-agent-harness"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-05-28"
+tags: [spec, proposal, harness-001, epic, cross-agent, cross-os, deploy-engine, ruler]
+template_version: "1.0"
+---
+
+# HARNESS-001-unified-cross-agent-harness
+
+> **Epic / umbrella spec.** Owns the shared *deploy-engine core* and the cross-agent architecture; the four consumers (SDD-008, IDEAS-007, #156, #159) implement verticals on top and each carries its own spec + atomic PR. Tracker: GH [#162](https://github.com/mlorentedev/dotfiles/issues/162).
+
+## Why
+
+The no-attribution policy regressed **silently** (#156): nothing propagates `00_meta/patterns` rules into the instruction files agents actually read at session start, and agent harness defaults override them at runtime. That is not a one-off — it is the symptom of a missing pipeline. Today every agent artifact (instructions, enforced patterns, skills, MCP config) is deployed ad-hoc and per-agent (symlink here, mechanical copy there, hand-edit elsewhere), so the SSOT promise breaks without anyone noticing until the next incident. We need **one deploy engine** that compiles every agent artifact from a single declarative manifest, commits the generated output, and is guarded by CI against drift — so a rule added once is enforced everywhere, deterministically, across Claude / OpenCode / Antigravity (`agy`) / Copilot / Pi and across Linux / Windows. Vault: `10_projects/dotfiles/11-tasks.md` (HARNESS-001 epic).
+
+## What
+
+Observable behavior after the epic completes (engine first, then consumers):
+
+1. **Declarative manifest** at repo root (`harness/manifest.json` — format TBD, see Risks) defines, per agent: `kind` (`native` AGENTS.md reader | `pointer`+overlay), source path(s), overlay file, and target deploy path.
+2. **Cross-OS compiler** — `compile-harness.sh` + `compile-harness.ps1` read the manifest and emit per-agent artifacts (`~/.claude/CLAUDE.md`, repo `AGENTS.md` pointers, `.github/copilot-instructions.md`, `ai/agy/AGY.md`, opencode), each carrying a `<!-- GENERATED FROM <source> — DO NOT EDIT -->` marker. **Generated artifacts are committed** (so CI and vault-less machines work).
+3. **Precedence concatenation** — shared `AGENTS.md` subset + per-agent overlay, applied in declared order. Pi/OpenCode consume `AGENTS.md` natively; Claude/agy/Copilot get pointer + overlay.
+4. **Enforced patterns** — any `00_meta/patterns/*.md` with frontmatter `enforce: true` is injected as a generated `## Overrides of harness defaults` block into the deployed Claude + AGENTS instructions (attribution at minimum, the #156 case).
+5. **CI drift + contradiction guard** — a workflow re-runs the compiler and fails if committed artifacts differ (hand-edit / forgot-to-recompile), or if a deployed instruction contradicts an enforced pattern.
+6. **Consumers ride the engine** — skills (SDD-008), the `.agent/<id>/` registry (IDEAS-007), and work/personal SSOT mode (#159) deploy through the same compiler; no bespoke per-artifact deploy survives.
+7. **Cross-OS + invariant parity** — bats (Linux) + PSScriptAnalyzer/Pester (Windows) cover the compiler; line-cap invariants hold post-compile (`ai/claude/CLAUDE.md` ≤ 80 lines, `ai/agy/AGY.md` ≤ 50 lines).
+
+## Engine vs consumers
+
+The umbrella owns the **engine**; everything else is a consumer with its own spec, ID, and atomic PR.
+
+| Layer | Owner | Deliverable |
+|---|---|---|
+| **Engine core** | **this spec (HARNESS-001)** | manifest + schema, `compile-harness.{sh,ps1}`, source-markers, precedence concat, committed artifacts, drift/contradiction CI guard, ADR-013 |
+| Skills vertical | SDD-008 (#141) | skill SSOT → per-agent skill artifacts *through the engine* (existing spec stays skill-specific) |
+| Harness structure | IDEAS-007 (#103) | `.agent/<id>/INSTRUCT.md` + agent registry (`native` \| `pointer`) consumed by the manifest |
+| Enforced patterns | #156 | `enforce: true` propagation + CI contradiction guard; restores no-attribution for real |
+| Work/personal mode | #159 | switch knowledge SSOT (vault vs repo `docs/` + Project) by repo type, via the manifest |
+
+## Out of scope
+
+Siblings tracked separately — **not** children of this engine:
+
+- Pi coding-agent install (#161, separate sprint).
+- DevOps CLI-over-MCP + scoped permissions profile (#160).
+- Cross-agent session-memory bridge (#117) and subagents-as-vault-artifact (#118).
+- MCP-config manifest unification (#163) — adjacent; may reuse the manifest later, tracked on its own.
+- The *content* of each consumer (skills migration, `.agent/` registry entries, work/personal switch logic) — those live in the child specs; this epic ships only the engine core + umbrella architecture.
+
+## Risks / open questions
+
+- **🟡 Manifest format** — TOML (`ruler` precedent) vs YAML vs JSON. **Lean: JSON**, parsed by `jq` (Linux) + native `ConvertFrom-Json` (Windows) — no new dependency, supports the nested per-agent records, boring tech (Decision Hierarchy #3/#4). Lock at PR-1 start.
+- **🟡 PR decomposition** — the full engine exceeds the ~300-LOC atomic-PR limit. Mitigation: **PR-1 = attribution tracer-bullet** (the smallest payload — one `enforce: true` pattern — driven through the *entire* pipeline: manifest → marker → compile → commit → drift CI), then one atomic PR per consumer. Recorded in `tasks.md`.
+- **🟢 CI-without-vault-access** — RESOLVED by committing generated artifacts (ruler model). The dotfiles CI has zero visibility into the private `mlorentedev/knowledge` repo; committed output is what CI diffs.
+- **🟡 Bootstrap dependency** — the compiler needs the vault clone present for source content. Reuse SDD-008's setup-time preflight (exit 2 + actionable message) rather than inventing a new check.
+- **🟡 Line-cap invariants** — `ai/claude/CLAUDE.md` ≤ 80 (opencode.bats #34) and `ai/agy/AGY.md` ≤ 50 MUST be asserted *post-compile*, or CI fails. Concatenation can silently blow these.
+- **🔴 Tooling bug found this session (separate ticket)** — `init-spec.sh` vault-gate false-negatives inside git worktrees: `REPO_NAME=$(basename "$REPO_ROOT")` resolves to `<repo>-<feature>`, not the canonical repo name. Bypassed here with `--force-no-vault` (entry exists under canonical `dotfiles`). Needs its own BUG ticket + bats guard per the incident→guard rule.
+
+## Acceptance criteria
+
+Epic-level outcomes. Each child spec additionally carries its own testable ACs; these gate the *engine*.
+
+- [ ] **AC1** — Declarative manifest exists with a schema; `compile-harness.{sh,ps1}` parse it and fail with a clear error on a malformed manifest.
+- [ ] **AC2** — Linux and Windows compilers produce equivalent artifacts for the same manifest (cross-OS parity test green).
+- [ ] **AC3** — Every generated artifact carries a `<!-- GENERATED FROM <source> — DO NOT EDIT -->` marker and is committed to the repo.
+- [ ] **AC4** — CI drift guard fails when any generated artifact is hand-edited without recompiling (run-twice-and-diff).
+- [ ] **AC5** — The no-attribution rule (#156 Exhibit A) appears in deployed `CLAUDE.md` + `AGENTS.md` as a generated override block, sourced from an `enforce: true` pattern — not hand-maintained.
+- [ ] **AC6** — SDD-008 skills are produced by this engine; no bespoke skill-deploy path remains.
+- [ ] **AC7** — Post-compile, `ai/claude/CLAUDE.md` ≤ 80 lines and `ai/agy/AGY.md` ≤ 50 lines (asserted in CI).
+- [ ] **AC8** — ADR-013 recorded (supersedes adr-001 + adr-008, extends adr-012); child-spec index + dependency graph present in `tasks.md`.
+
+## References
+
+- Vault: `10_projects/dotfiles/11-tasks.md` (HARNESS-001 epic anchor)
+- Tracker: GH [#162](https://github.com/mlorentedev/dotfiles/issues/162) (epic); consumers [#141](https://github.com/mlorentedev/dotfiles/issues/141), [#103](https://github.com/mlorentedev/dotfiles/issues/103), [#156](https://github.com/mlorentedev/dotfiles/issues/156), [#159](https://github.com/mlorentedev/dotfiles/issues/159)
+- ADR: `docs/adr/adr-013-agent-artifact-deploy-engine.md` (this epic); builds on `docs/adr/adr-012-deploy-strategy-copy-with-drift-assertion.md`, `adr-009-multi-agent-runtime.md`, `adr-010-agent-harness-parity.md`; supersedes `adr-001-skill-based-ai-workflow.md`, `adr-008-skills-ecosystem-overhaul.md`
+- Child spec: `specs/SDD-008-skill-pipeline/`, `specs/IDEAS-007-cross-provider-agent-harness/`
+- External: `ruler` (https://github.com/intellectronica/ruler) — manifest + generate-and-commit precedent; AGENTS.md standard (https://github.com/agentsmd/agents.md)

--- a/specs/HARNESS-001-unified-cross-agent-harness/tasks.md
+++ b/specs/HARNESS-001-unified-cross-agent-harness/tasks.md
@@ -1,0 +1,54 @@
+---
+tags: [spec, tasks, harness-001, epic]
+created: "2026-05-28"
+---
+
+# Tasks - HARNESS-001-unified-cross-agent-harness
+
+> **Epic coordination, not a single PR's TDD list.** This umbrella ships as a *sequence* of atomic PRs. Each implementation PR has its own `specs/<id>/` with a real TDD `tasks.md`. The order below is the dependency graph; freeze it once PR-1 starts `implementing`.
+
+## Setup
+
+- [x] Vault epic anchor added to `10_projects/dotfiles/11-tasks.md` (HARNESS-001)
+- [x] Worktree `feat/harness-001-spec` off `origin/main`
+- [x] `proposal.md` complete; engine-vs-consumer boundary drawn (engine owned here)
+- [ ] ADR-013 stub drafted (`docs/adr/adr-013-agent-artifact-deploy-engine.md`, `status: proposed`)
+- [ ] Manifest format locked (lean: JSON) — resolve at PR-1 kickoff, not here
+
+## PR sequence (the work)
+
+> Tracer-bullet first: smallest payload through the whole pipeline, then scale by consumer. Every PR ≤ ~300 LOC production diff.
+
+- [ ] **PR-1 — Engine core (attribution tracer-bullet)** *(this epic's engine; own spec to be split from SDD-008 or new ENGINE id)*
+  - [ ] Define `harness/manifest.json` + schema (one agent: Claude; one enforced pattern: no-attribution)
+  - [ ] `compile-harness.sh`: parse manifest → inject `## Overrides of harness defaults` block w/ source-marker into deployed `CLAUDE.md` + `AGENTS.md` → commit artifact
+  - [ ] bats: malformed manifest fails; generated marker present; line-cap ≤ 80 assertion
+  - [ ] CI drift guard (run-twice-and-diff) fails on hand-edit
+  - [ ] Satisfies epic AC1, AC3, AC4, AC5 (Claude path), partial AC7
+- [ ] **PR-2 — Windows parity** `compile-harness.ps1` + Pester/PSScriptAnalyzer; cross-OS equivalence test → AC2
+- [ ] **PR-3 — All pointer agents** extend manifest to agy + Copilot (`pointer`+overlay) and OpenCode/Pi (`native`); AGY ≤ 50 assertion → completes AC7
+- [ ] **PR-4 — SDD-008 consumer** rewire skill deploy through the engine (skill spec stays skill-specific) → AC6
+- [ ] **PR-5 — IDEAS-007 consumer** `.agent/<id>/INSTRUCT.md` + registry consumed by the manifest
+- [ ] **PR-6 — #156 consumer** full `enforce: true` propagation + contradiction guard; remove contradictory vault carve-outs
+- [ ] **PR-7 — #159 consumer** work/personal SSOT mode switch in the manifest
+
+## Dependency graph
+
+```
+PR-1 engine core ──┬─> PR-2 win parity ─> PR-3 all agents ──┬─> PR-4 SDD-008
+                   │                                         ├─> PR-5 IDEAS-007
+                   └─────────────────────────────────────── ├─> PR-6 #156
+                                                             └─> PR-7 #159
+```
+
+## Closing (epic)
+
+- [ ] All seven PRs merged; each child spec archived under `specs/archive/`
+- [ ] Every epic acceptance criterion (AC1–AC8) has matching evidence in `verification.md`
+- [ ] ADR-013 promoted from `proposed` → `accepted`; adr-001/008 carry supersede pointers
+- [ ] Vault HARNESS-001 anchor ticked with the closing PR link
+- [ ] `verification.md` filled in
+
+## Machine-readable features
+
+Epic-level `features.json` maps the engine ACs to executable checks (sibling file). For an umbrella, most features become checkable only as PRs land; entries stay `pending` until their PR sets evidence. **Pass-state gating:** only the harness may set `"state": "passing"` after capturing exit 0. Per [[pattern-feature-list-as-primitive]].

--- a/specs/HARNESS-001-unified-cross-agent-harness/verification.md
+++ b/specs/HARNESS-001-unified-cross-agent-harness/verification.md
@@ -1,0 +1,46 @@
+---
+tags: [spec, verification, harness-001, epic]
+created: "2026-05-28"
+---
+
+# Verification - HARNESS-001-unified-cross-agent-harness
+
+> **Epic in `draft`.** No implementation merged yet; evidence is filled in as each PR in the sequence lands. This file is the running ledger that gates archive.
+
+## Evidence
+
+Map every epic acceptance criterion to the PR that proves it.
+
+- [ ] AC1 (manifest + schema parse, fail on malformed) -> PR-1 `<hash>` / test `<name>`
+- [ ] AC2 (Linux/Windows compiler parity) -> PR-2 `<hash>` / test `<name>`
+- [ ] AC3 (source-marker + committed artifacts) -> PR-1 `<hash>` / test `<name>`
+- [ ] AC4 (CI drift guard fails on hand-edit) -> PR-1 `<hash>` / test `<name>`
+- [ ] AC5 (no-attribution override block generated from enforce:true) -> PR-1 `<hash>` / test `<name>`
+- [ ] AC6 (SDD-008 skills produced by engine) -> PR-4 `<hash>` / test `<name>`
+- [ ] AC7 (line caps ≤80 / ≤50 asserted) -> PR-1 + PR-3 `<hash>` / test `<name>`
+- [ ] AC8 (ADR-013 recorded; child index present) -> this PR `<hash>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>` (per PR; do NOT run `bats tests/*.bats` headless — session-start-config.bats #14 hangs on real Obsidian, see #167; run targeted files)
+- Manual smoke test: `<what was exercised>`
+- No regressions in existing test suite: `<yes / no>`
+
+## Decisions made during implementation
+
+- Engine core lives in the umbrella spec; SDD-008 stays skill-specific and becomes the first consumer (decision 2026-05-28).
+- New ADR goes to repo `docs/adr/adr-013` (KPM-001: dotfiles' own ADRs live in the repo, not the vault), superseding the repo copies of adr-001/008.
+- Manifest format lean: JSON (`jq` + `ConvertFrom-Json`, no new dep). To be confirmed at PR-1.
+
+## Promotion candidates
+
+- [ ] Lesson for `90-lessons.md`? yes — "tracer-bullet a deploy pipeline on its smallest enforced payload to de-risk cross-OS compile parity before scaling to N artifacts" (capture when PR-1 lands).
+- [ ] ADR-worthy decision? yes — ADR-013 (authored as part of this epic, not deferred).
+- [ ] New pattern candidate for `00_meta/patterns/`? Maybe — "manifest-driven agent-artifact deploy (generate-and-commit)" if it recurs beyond dotfiles. Defer until a 2nd project needs it.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/HARNESS-001-unified-cross-agent-harness/` -> `specs/archive/HARNESS-001-unified-cross-agent-harness/`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
## Summary

Scaffolds the umbrella spec for the **HARNESS-001** epic (#162) — *one deploy engine, four consumers* — following the three-layer proposal lifecycle (vault ticket → spec → issue).

## Contents

- `specs/HARNESS-001-unified-cross-agent-harness/{proposal,tasks,verification}.md` — the **engine core is owned by the umbrella**; SDD-008 stays skill-specific and becomes the *first consumer*. Includes 8 epic acceptance criteria, the tracer-bullet PR sequence, and the dependency graph.
- `docs/adr/adr-013-agent-artifact-deploy-engine.md` (`status: proposed`) — manifest-driven, generate-and-commit deploy engine. **Supersedes** ADR-001 + ADR-008 (effective on acceptance); **extends** ADR-012 (copy + drift assertion).
- Supersession-pending pointers added to ADR-001 and ADR-008 (status unchanged until ADR-013 is accepted).

## Key decisions

- **Manifest format lean: JSON** (`jq` on Linux + native `ConvertFrom-Json` on Windows — no new dependency, boring tech). To be locked at PR-1.
- **PR-1 = engine core as an attribution tracer-bullet** (#156 slice): smallest payload driven through the full pipeline (manifest → source-marker → compile → commit → drift CI), then one atomic PR per consumer.

## Notes

- Doc-only: spec + ADRs. No production code or shell scripts changed; the `specs/HARNESS-001-.../` folder satisfies the SDD discipline gate.
- Vault epic ticket recorded in `10_projects/dotfiles/11-tasks.md`.
