### PR TITLE
fix(init-spec): canonical repo name for vault-gate in worktrees (BUG-024)

### DIFF
--- a/scripts/init-spec.sh
+++ b/scripts/init-spec.sh
@@ -69,7 +69,12 @@ if ! REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
     printf '[ERROR] Not in a git repo. cd into a repo first.\n' >&2
     exit 1
 fi
-REPO_NAME="$(basename "$REPO_ROOT")"
+# Canonical repo name = basename of the MAIN worktree. In a linked git worktree,
+# --show-toplevel points at the worktree dir (e.g. "dotfiles-harness"), not the
+# repo, which would break the vault project lookup below (10_projects/<repo>/).
+# --git-common-dir always resolves to the main repo's .git, so its parent dir is
+# the canonical repo root. (BUG-024)
+REPO_NAME="$(basename "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")")"
 SPEC_DIR="$REPO_ROOT/specs/$FEATURE_ID"
 
 # --- No clobber ---

--- a/tests/init-spec.bats
+++ b/tests/init-spec.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# Tests for scripts/init-spec.sh — spec scaffolder + vault-gate.
+# Regression guard for BUG-024: the vault-gate must resolve the CANONICAL repo
+# name (not the worktree dir basename), so init-spec works from a git worktree.
+
+setup() {
+    SCRIPTS_DIR="$BATS_TEST_DIRNAME/../scripts"
+    TMP="/tmp/bats_initspec_$$_${BATS_TEST_NUMBER:-0}"
+    mkdir -p "$TMP"
+
+    # --- fake vault with the three spec templates ---
+    VAULT="$TMP/vault"
+    mkdir -p "$VAULT/00_meta/templates"
+    printf '# proposal\n\n## Why\n' > "$VAULT/00_meta/templates/spec-proposal.md"
+    printf '# tasks\n' > "$VAULT/00_meta/templates/spec-tasks.md"
+    printf '# verification\n' > "$VAULT/00_meta/templates/spec-verification.md"
+
+    # --- main repo; canonical name = "canonrepo" ---
+    MAINREPO="$TMP/canonrepo"
+    mkdir -p "$MAINREPO"
+    cd "$MAINREPO" || exit 1
+    git init -q -b main
+    git config user.email test@test
+    git config user.name test
+    git config commit.gpgsign false
+    echo seed > seed.txt
+    git add -A
+    git commit -q -m seed
+
+    # --- vault backlog for the CANONICAL project name ---
+    mkdir -p "$VAULT/10_projects/canonrepo"
+    printf -- '- [ ] **TEST-001-foo** demo backlog entry\n' \
+        > "$VAULT/10_projects/canonrepo/11-tasks.md"
+}
+
+teardown() {
+    cd / || true
+    rm -rf "$TMP"
+}
+
+@test "scaffolds in a plain clone (backward compatible)" {
+    cd "$MAINREPO"
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-001-foo
+    [ "$status" -eq 0 ]
+    [ -f "$MAINREPO/specs/TEST-001-foo/proposal.md" ]
+}
+
+@test "BUG-024: scaffolds from a linked worktree (vault-gate resolves canonical name)" {
+    git -C "$MAINREPO" worktree add -q "$TMP/canonrepo-feature" -b feature
+    cd "$TMP/canonrepo-feature"
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-001-foo
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Vault context found"* ]]
+    # spec files land in the WORKTREE, not the main repo
+    [ -f "$TMP/canonrepo-feature/specs/TEST-001-foo/proposal.md" ]
+    [ ! -e "$MAINREPO/specs/TEST-001-foo" ]
+}
+
+@test "vault-gate still fails (exit 3) when the entry is genuinely missing" {
+    cd "$MAINREPO"
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-999-missing
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"No vault entry"* ]]
+}
+
+@test "vault-gate missing-entry from a worktree also fails (no false-positive from the fix)" {
+    git -C "$MAINREPO" worktree add -q "$TMP/canonrepo-feature" -b feature
+    cd "$TMP/canonrepo-feature"
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-999-missing
+    [ "$status" -eq 3 ]
+}
+
+@test "--force-no-vault bypasses the gate from a worktree" {
+    git -C "$MAINREPO" worktree add -q "$TMP/canonrepo-feature" -b feature
+    cd "$TMP/canonrepo-feature"
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-777-bypass --force-no-vault
+    [ "$status" -eq 0 ]
+    [ -f "$TMP/canonrepo-feature/specs/TEST-777-bypass/proposal.md" ]
+}


### PR DESCRIPTION
## Summary

`scripts/init-spec.sh` false-negatived its vault-gate inside **any git worktree**: `REPO_NAME=$(basename "$REPO_ROOT")` resolved to the worktree directory (`<repo>-<feature>`), so it looked for `10_projects/<repo>-<feature>/11-tasks.md` and exited 3 even when a valid backlog entry existed under the canonical project.

Discovered while scaffolding **HARNESS-001** (#162) in a worktree — bypassed there with `--force-no-vault`. This blocks friction-free worktree-based SDD (the standard flow).

## Fix

Resolve the canonical repo name from the shared `--git-common-dir` (always the main repo's `.git`), while keeping `--show-toplevel` for the spec **output** path (the current worktree). The two were wrongly conflated — identical in a plain clone, divergent in a worktree.

## Guard (incident → guard)

`tests/init-spec.bats` — 5 cases: plain-clone backward compat, the BUG-024 worktree regression, gate still fails on a genuinely-missing entry (clone + worktree), and `--force-no-vault` bypass.

## Verification

- `bash -n` + shellcheck: clean
- `bats tests/init-spec.bats`: 5/5 pass

## SDD

Bug fix < 20 LOC production diff, obvious cause → Skip-SDD per AGENTS.md (tests excluded from the gate). Vault ticket: **BUG-024**.
