### PR TITLE
feat(SDD-011): agent-side proactive Skip-SDD trigger for /spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,6 +379,8 @@ Before creating ANY branch for code changes in this repo, evaluate against `patt
 6. Fill `verification.md` with evidence (commit hashes, test outputs, smoke results)
 7. On merge: move folder to `specs/archive/<feature-id>/` and tick the vault entry with the PR link
 
+**Proactive proposal (agent-side).** Do not wait to be asked. While scoping work in conversation, if you detect any trigger above, apply the Skip-SDD heuristic yourself and **propose `/spec init <feature-id>`** — stating which trigger fired and the checks you ran, then let the user decide. The full activation rule (the checks, the proposal wording, when NOT to propose, and the once-per-change debounce) is the SSOT in the `/spec` skill's **"Agent-Side Activation Rule"** section (`00_meta/skills/spec/SKILL.md`); do not duplicate it here.
+
 **Banned phrases when planning work in this session:**
 
 - "I'll do vault hygiene later"

--- a/harness/skills/spec/SKILL.md
+++ b/harness/skills/spec/SKILL.md
@@ -27,6 +27,48 @@ allowed-tools: [Bash, Read, Edit, Write, mcp__hive__vault_query, mcp__hive__vaul
 - Strategic planning across milestones -> use `/writing-plans`.
 - If you cannot point to ANY vault entry justifying this spec (backlog, ADR, roadmap) — don't run the skill yet; first crystallize the work in the vault.
 
+---
+
+## Agent-Side Activation Rule
+
+> **Proactive mode.** The subcommands below are *reactive* — they run when a human types `/spec …`. This rule makes the agent *proactive*: when work is being scoped in conversation and a Discipline Gate trigger is met, the agent applies the Skip-SDD heuristic itself and PROPOSES `/spec init <id>` — it does not wait to be asked. The always-on trigger that primes this behavior lives in `AGENTS.md` ("Discipline Gate"); this section is the SSOT for *how* the agent decides and *how* it phrases the proposal.
+
+### Checks the agent runs
+
+When a change is being planned or has just been described, silently evaluate it against the Discipline Gate triggers (authoritative list: `AGENTS.md` → "Discipline Gate (NON-NEGOTIABLE)" / `pattern-spec-driven-development.md` → "Trigger Criteria"):
+
+1. **Size** — does the change look like ~50–300+ LOC of production diff (excluding tests, generated files, lockfiles)?
+2. **Public contract** — does it touch an API, CLI flag, exported type, alias name, file path, deployed config schema, or *agent behavior*?
+3. **Dependency** — does it add or remove a dependency?
+4. **Multi-PR** — is it the first step of a multi-PR sequence?
+5. **Socratic** — does it warrant a Socratic Guardrail pause (architecture, schema design, concurrency, breaking change)?
+
+If ANY trigger fires AND none of the "When NOT to propose" conditions hold → propose a spec.
+
+### How to phrase the proposal
+
+Surface a short, skippable proposal that states the evidence — don't just assert. Template:
+
+> This looks like a Discipline-Gate trigger: **<which trigger(s) fired>** (e.g. "~120 LOC + touches a deployed config schema"). I ran the Skip-SDD checks — it does **not** qualify for skip. Propose `/spec init <feature-id>` before writing code? (id from the vault backlog, or a new `11-tasks.md` entry.)
+
+- **List the checks you ran**, not just the verdict — the evidence is the value (mirrors the Model-Tier "the proposal IS the value" rule in `AGENTS.md`).
+- **Offer, don't impose.** The human decides. If they decline, proceed without the spec and do not re-propose for the same change.
+- **Suggest the id.** Derive `<feature-id>` from an existing vault entry if one matches; otherwise propose creating the 1-line `11-tasks.md` entry first (the vault gate).
+
+### When NOT to propose
+
+Silence is correct when ANY of these hold — proposing here is noise:
+
+- **Trivial change** per the Skip-SDD list: typo, comment-only, mechanical rename, doc-only, or an obvious bugfix <20 LOC.
+- **Already inside an active spec** — `specs/<id>/` exists for this work; just keep implementing and ticking `tasks.md`.
+- **User already declined** a spec for this change in the current thread (once-per-change debounce — do not nag).
+- **Pure exploration / question** — no change is being committed yet.
+- **Emergency / hotfix** the user has explicitly fast-tracked.
+
+When unsure whether a change crosses the threshold, ASK rather than assume (`AGENTS.md`: "When in doubt, ASK the user") — a one-line "want a spec for this?" is cheaper than either a missed spec or an unwanted one.
+
+---
+
 ## Environment (resolve once per invocation)
 
 - `$VAULT_PATH` — env var. Cross-OS default `$HOME/Projects/knowledge` (Linux/macOS) or `%USERPROFILE%\Projects\knowledge` (Windows).

--- a/specs/SDD-011-agent-side-spec-trigger/features.json
+++ b/specs/SDD-011-agent-side-spec-trigger/features.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "SDD-011-agent-side-spec-trigger-f1",
+    "behavior": "AC2 — AGENTS.md Discipline Gate carries an always-on proactive-proposal trigger that points to the skill's Agent-Side Activation Rule without duplicating the checklist",
+    "verification": "grep -q 'Proactive proposal (agent-side)' AGENTS.md && grep -q 'Agent-Side Activation Rule' AGENTS.md",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "SDD-011-agent-side-spec-trigger-f2",
+    "behavior": "AC3 — the committed record harness/skills/spec/SKILL.md reflects the new section and compile-harness.sh --check reports no drift",
+    "verification": "grep -q '^## Agent-Side Activation Rule' harness/skills/spec/SKILL.md && ./scripts/compile-harness.sh --check",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "SDD-011-agent-side-spec-trigger-f3",
+    "behavior": "AC4 — after --deploy to a throwaway HOME, the rendered Claude skill and OpenCode command for /spec both carry the Agent-Side Activation Rule heading",
+    "verification": "~/.local/bin/bats tests/skills-pipeline.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "SDD-011-agent-side-spec-trigger-f4",
+    "behavior": "AC1 — the vault SSOT 00_meta/skills/spec/SKILL.md defines the Agent-Side Activation Rule (checks, proposal format, when-not-to-propose)",
+    "verification": "grep -q '^## Agent-Side Activation Rule' \"${VAULT_PATH:-$HOME/Projects/knowledge}/00_meta/skills/spec/SKILL.md\"",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/SDD-011-agent-side-spec-trigger/proposal.md
+++ b/specs/SDD-011-agent-side-spec-trigger/proposal.md
@@ -1,0 +1,57 @@
+---
+id: "SDD-011-agent-side-spec-trigger"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-05-31"
+tags: [spec, proposal, sdd-008-followup, agent-behavior, skill-content, harness-001]
+template_version: "1.0"
+---
+
+# SDD-011-agent-side-spec-trigger
+
+> **Naming**: file lives at `<repo>/specs/SDD-011-agent-side-spec-trigger/proposal.md`. `SDD-011-agent-side-spec-trigger` is `YYYY-MM-DD-<slug>` or `<TICKET-NN>`.
+
+## Why
+
+<!-- from 11-tasks.md: *(P1, queued 2026-05-30, cross-agent, SDD-required, spec: `specs/SDD-011-agent-side-spec-trigger/`)*: Deferred sub-task of [[SDD-008-skill-pipeline]] (proposal §What #5 — NOT shipped in PR #179, which delivered only the deploy pipeline). Make the agent apply the Skip-SDD heuristic *itself* and proactively propose `/spec init <id>` when it detects a non-trivial change mid-conversation (a Discipline Gate trigger is met), instead of waiting for the human to ask. **Two-surface design (SSOT-preserving):** (1) a detailed "Agent-Side Activation Rule" section in `vault/00_meta/skills/spec/SKILL.md` — the checks the agent runs, the proposal format, and when NOT to propose; (2) a short always-on trigger + pointer in `AGENTS.md` Discipline Gate so the behavior can fire *before* `/spec` is invoked (the skill body only loads on invocation, so the always-on file must carry the trigger). Propagated to the committed record via `compile-harness.sh --refresh`; `--check` green. **Done when:** record reflects the new section, a bats assert proves it deploys, PR references archived SDD-008 + epic HARNESS-001 #162. **Anti-scope:** empirical validation that agents apply the heuristic correctly across N sessions is observational (already carved out in SDD-008 Out-of-scope). Part of HARNESS-001 #162. -->
+
+Today the SDD Discipline Gate is enforced *reactively*: the rules live in `AGENTS.md`, CI fails post-hoc on un-spec'd PRs, and the `/spec` skill only runs once a human types `/spec init`. The agent never volunteers a spec — so the human carries the whole burden of noticing "this change is now non-trivial; it needs a spec" at exactly the right moment. That moment is easy to miss mid-flow, which is precisely how scope creep and un-specced 200-LOC PRs happen. SDD-008's proposal (§What #5) called for closing this gap by making the agent apply the Skip-SDD heuristic itself and propose `/spec init` proactively; SDD-008 shipped only the deploy pipeline, leaving this behavior unbuilt. This spec ships it.
+
+## What
+
+Concrete, observable behavior changes after this PR:
+
+1. **The `/spec` skill gains an "Agent-Side Activation Rule"** (in the vault SSOT `00_meta/skills/spec/SKILL.md`). It defines: (a) the checks the agent runs against the Discipline Gate when work is being scoped in conversation, (b) the exact shape of a proactive proposal (state which trigger fired + the checks run + the suggested `/spec init <id>`), and (c) explicit "when NOT to propose" guardrails (trivial change, already inside an active spec, user already declined this session).
+2. **`AGENTS.md` Discipline Gate carries a short always-on trigger** instructing agents to apply that heuristic proactively and surface the proposal *before* `/spec` is invoked, pointing at the skill section for the detail (no rule body duplicated — the always-on file is a trigger + pointer, the skill is the SSOT of the detail).
+3. **The change propagates deterministically** to every agent through the existing SDD-008 pipeline: `compile-harness.sh --refresh` regenerates the committed record `harness/skills/spec/SKILL.md`; `--deploy` renders it to each agent's native path; `--check` stays green (offline drift gate).
+4. **Observable as agent-initiated spec proposals** in transcripts where the human previously had to initiate — the agent says "this looks like a Discipline-Gate trigger (≈X LOC / public contract); I ran the Skip-SDD checks; propose `/spec init <id>`?" unprompted.
+
+## Out of scope
+
+Things this PR explicitly does NOT include.
+
+- **Empirical validation** that agents actually apply the heuristic correctly across N real sessions — observational work, already carved out in SDD-008's Out-of-scope.
+- **Redefining the Skip-SDD criteria / trigger thresholds** — those remain owned by `AGENTS.md` Discipline Gate + `pattern-spec-driven-development.md`. This PR references them; it does not change the thresholds.
+- **New PowerShell/Windows logic** — the rule is content carried by the existing cross-OS pipeline; no `Deploy-SkillRecord` or setup-script change is required. Windows consumes the regenerated record like any other skill.
+
+## Risks / open questions
+
+- **Over-triggering (annoyance) vs under-triggering (uselessness).** A proactive proposer that fires on every two-line edit is worse than silence. **Mitigation (in-scope):** the rule ships explicit "when NOT to propose" guardrails and a once-per-thread debounce (don't re-propose for the same change after a decline). Not a blocker.
+- **Two-surface drift.** The trigger (AGENTS.md, always-on) and the detail (skill, on-demand) could drift. **Mitigation:** AGENTS.md carries only a one-line trigger + pointer, never a copy of the checks — SSOT stays in the skill. Verified by an acceptance criterion asserting the pointer exists and the detailed checklist lives only in the skill.
+- **Record counted by spec-gate.** `harness/skills/*` is not matched by the gate's `*generated*` exclusion, so the regenerated record counts toward diff LOC. **Resolved:** this spec folder satisfies the gate regardless of LOC (SPEC_TOUCHED=1).
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [ ] **AC1 — Rule in vault SSOT**: `vault/00_meta/skills/spec/SKILL.md` contains an `## Agent-Side Activation Rule` section that names (a) the checks the agent runs, (b) the proposal format, (c) when NOT to propose. **Verify:** grep the three sub-parts in the skill file.
+- [ ] **AC2 — Always-on trigger + pointer, no duplication**: `AGENTS.md` Discipline Gate instructs agents to proactively propose `/spec init` and points to the skill's Agent-Side Activation Rule; the detailed checklist is NOT duplicated in AGENTS.md. **Verify:** grep AGENTS.md for the proactive-trigger sentence + skill pointer.
+- [ ] **AC3 — Deterministic propagation, no drift**: after `compile-harness.sh --refresh`, the committed record `harness/skills/spec/SKILL.md` contains `Agent-Side Activation Rule`, and `compile-harness.sh --check` exits 0. **Verify:** grep record + `--check` exit code.
+- [ ] **AC4 — Deploys to agents**: after `compile-harness.sh --deploy` to a throwaway HOME, the rendered Claude skill and OpenCode command for `spec` both carry the `Agent-Side Activation Rule` heading. **Verify:** bats assert in `tests/skills-pipeline.bats`.
+
+## References
+
+- Vault: `10_projects/dotfiles/11-tasks.md` (SDD-011 backlog entry)
+- Parent (archived): `specs/archive/SDD-008-skill-pipeline/proposal.md` §What #5 (original trigger wording) + §Out-of-scope (empirical-validation carve-out)
+- Related patterns: `00_meta/patterns/pattern-cross-agent-skill-pipeline.md` (the deploy pipeline), `00_meta/patterns/pattern-spec-driven-development.md` (the Discipline Gate this extends)
+- Epic: HARNESS-001 unified cross-agent harness ([#162](https://github.com/mlorentedev/dotfiles/issues/162))

--- a/specs/SDD-011-agent-side-spec-trigger/tasks.md
+++ b/specs/SDD-011-agent-side-spec-trigger/tasks.md
@@ -1,0 +1,37 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-05-13"
+---
+
+# Tasks - SDD-011-agent-side-spec-trigger
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+
+## Setup
+
+- [x] Branch created from main: `feat/sdd-011-agent-side-spec-trigger` (worktree-isolated)
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions" (all three resolved/mitigated in-scope)
+
+## Implementation
+
+- [x] Add SDD-011 vault-gate entry to `vault/10_projects/dotfiles/11-tasks.md` (the vault gate `init-spec.sh` enforces)
+- [x] Author the `## Agent-Side Activation Rule` section in vault SSOT `00_meta/skills/spec/SKILL.md` — the checks the agent runs, the proposal format, and the "when NOT to propose" guardrails + once-per-change debounce (AC1)
+- [x] Add the always-on proactive trigger + pointer to `AGENTS.md` Discipline Gate, with `do not duplicate it here` to keep the detail single-sourced in the skill (AC2)
+- [x] Regenerate the committed record via `compile-harness.sh --refresh`; confirm minimal diff (only `harness/skills/spec/SKILL.md`) and `--check` green (AC3)
+- [x] Add a bats regression assert that the deployed `/spec` (claude + opencode) carries the rule heading — guards against a future record regen from a SKILL.md missing the section (AC4)
+
+## Closing
+
+- [x] Every acceptance criterion from `proposal.md` is covered by at least one test/check
+- [x] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [x] Lint passes (no shell scripts modified; `--check` + bats green)
+- [x] No unrelated changes in the diff (no scope creep) — verified `git diff --stat` = AGENTS.md + record only
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.

--- a/specs/SDD-011-agent-side-spec-trigger/verification.md
+++ b/specs/SDD-011-agent-side-spec-trigger/verification.md
@@ -1,0 +1,41 @@
+---
+tags: [spec, verification, templates]
+created: "2026-05-13"
+---
+
+# Verification - SDD-011-agent-side-spec-trigger
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof.
+
+- [x] **AC1** (rule in vault SSOT) -> `00_meta/skills/spec/SKILL.md` `## Agent-Side Activation Rule` with the three sub-parts (Checks the agent runs / How to phrase the proposal / When NOT to propose). Committed to vault `master` as `e2931be`.
+- [x] **AC2** (always-on trigger + pointer, no duplication) -> `AGENTS.md` Discipline Gate: `**Proactive proposal (agent-side).**` paragraph pointing to the skill's `"Agent-Side Activation Rule"` with explicit `do not duplicate it here`. `grep` confirms the trigger sentence + skill pointer; the checklist is NOT copied into AGENTS.md.
+- [x] **AC3** (deterministic propagation, no drift) -> `compile-harness.sh --refresh` regenerated `harness/skills/spec/SKILL.md` (+42, line 32 `## Agent-Side Activation Rule`); `git diff --stat` minimal (AGENTS.md + record only, no other skill records or enforced blocks); `compile-harness.sh --check` -> `[check] OK: no harness drift`.
+- [x] **AC4** (deploys to agents) -> `tests/skills-pipeline.bats` test `SDD-011: deployed /spec carries the Agent-Side Activation Rule (claude + opencode)` greps the heading in both `~/.claude/skills/spec/SKILL.md` and `~/.config/opencode/commands/spec.md` after `--deploy`.
+
+## Test status
+
+- Test suite: `~/.local/bin/bats tests/skills-pipeline.bats` -> `1..6` all `ok` (the SDD-011 assert is test #2).
+- Offline drift gate: `./scripts/compile-harness.sh --check` -> `[check] OK: no harness drift`.
+- Manual smoke: `--refresh` from an isolated vault worktree pinned at the source commit produced a minimal `AGENTS.md (+2)` + `harness/skills/spec/SKILL.md (+42)` diff; no unintended record/enforced-block churn.
+- No regressions: yes — the 5 pre-existing skills-pipeline asserts still pass alongside the new one.
+
+## Decisions made during implementation
+
+- **Two-surface design.** The detailed rule is single-sourced in the `/spec` skill (loads on invocation); `AGENTS.md` (always-on) carries only the trigger + a pointer. Rationale: the proactive proposal must fire BEFORE `/spec` is invoked, so the trigger has to live in the always-loaded instructions, while SSOT of the detail stays in the skill. Pointer says `do not duplicate it here` to lock the boundary.
+- **Test is a regression guard, not strict red-green.** The change is prose-in-a-skill, not algorithmic; the bats assert guards against a future record regen from a SKILL.md missing the section (incident -> guard).
+- **Vault commit recovery.** The vault commit first landed on a parallel feature branch (`rfd-001/pdf-modifier-mcp`) because another session had staged work checked out; recovered by cherry-picking onto `master` (`e2931be`) from an isolated worktree, without touching the active checkout. The record for this PR was regenerated from an isolated detached worktree at the source commit, so the dotfiles diff never depended on the vault checkout state.
+
+## Promotion candidates
+
+- [ ] Lesson for `90-lessons.md`? **yes** — "Don't commit to a shared vault that has another session's staged work checked out; use an isolated `git worktree` to read/operate on a specific commit." (Capture at archive.)
+- [ ] ADR-worthy decision? **no** — the two-surface (always-on trigger + on-demand detail) pattern is already implied by ENGINE-001/SDD-008; no new ADR.
+- [ ] New pattern candidate for `00_meta/patterns/`? **no** — folds into the existing `pattern-cross-agent-skill-pipeline.md`.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/SDD-011-agent-side-spec-trigger/` -> `specs/archive/SDD-011-agent-side-spec-trigger/`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (the lesson)

--- a/tests/skills-pipeline.bats
+++ b/tests/skills-pipeline.bats
@@ -32,6 +32,16 @@ teardown() { cd / || true; rm -rf "$FAKEHOME"; }
     [ ! -L "$FAKEHOME/.config/opencode/commands/spec.md" ]
 }
 
+@test "SDD-011: deployed /spec carries the Agent-Side Activation Rule (claude + opencode)" {
+    run env HOME="$FAKEHOME" "$SCRIPT" --deploy
+    [ "$status" -eq 0 ]
+    # The agent-side proactive trigger must survive the vault -> record -> render
+    # chain; if the record is regenerated from a SKILL.md missing the section, the
+    # proactive /spec proposal behavior silently regresses. Guard both renders.
+    grep -q '^## Agent-Side Activation Rule' "$FAKEHOME/.claude/skills/spec/SKILL.md"
+    grep -q '^## Agent-Side Activation Rule' "$FAKEHOME/.config/opencode/commands/spec.md"
+}
+
 @test "AC8 smoke: agy gets /spec as a native skill + a flat prompt" {
     run env HOME="$FAKEHOME" "$SCRIPT" --deploy
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## What

Ships the **agent-side proactive Skip-SDD trigger** for `/spec`: agents now apply the Skip-SDD heuristic *themselves* and **propose `/spec init <id>`** when they detect a Discipline-Gate trigger mid-conversation, instead of waiting for a human to ask.

This is the deferred sub-task of **SDD-008** (proposal §What #5). SDD-008 (#179) shipped only the deploy pipeline; this PR adds the skill-content behavior it carved out.

## Design — two-surface, SSOT-preserving

The proactive proposal must fire *before* `/spec` is invoked, but the skill body only loads *on* invocation. So the behavior is split without duplicating it:

- **Detail (SSOT):** a new `## Agent-Side Activation Rule` section in the vault `00_meta/skills/spec/SKILL.md` — the checks the agent runs, the proposal format, and the "when NOT to propose" guardrails + once-per-change debounce. Regenerated into the committed record `harness/skills/spec/SKILL.md` via `compile-harness.sh --refresh`.
- **Trigger (always-on):** a short `**Proactive proposal (agent-side).**` paragraph in the `AGENTS.md` Discipline Gate that points at the skill section and explicitly says `do not duplicate it here`.

## Acceptance criteria

- [x] **AC1** — vault SSOT `spec/SKILL.md` defines the rule (checks / proposal format / when-not). *(vault `master` `e2931be`; private repo, not in this diff)*
- [x] **AC2** — `AGENTS.md` carries the always-on trigger + pointer, no checklist duplication
- [x] **AC3** — committed record reflects the section and `compile-harness.sh --check` reports no drift
- [x] **AC4** — `tests/skills-pipeline.bats` asserts the deployed `/spec` (claude + opencode) carries the rule heading

## Verification

- `~/.local/bin/bats tests/skills-pipeline.bats` → `1..6` all `ok` (SDD-011 assert is #2)
- `./scripts/compile-harness.sh --check` → `[check] OK: no harness drift`
- `git diff --stat` minimal: `AGENTS.md (+2)` + `harness/skills/spec/SKILL.md (+42)` — no other record/enforced-block churn

## SDD

- Spec: `specs/SDD-011-agent-side-spec-trigger/` (proposal + tasks + verification + features.json)
- Parent (archived): `specs/archive/SDD-008-skill-pipeline/` §What #5
- Epic: HARNESS-001 unified cross-agent harness (#162)

## Note on the vault

The vault is the SSOT and a separate private repo, so the skill-content change is not in this diff — it lives on vault `master` (`e2931be`). The record here is a faithful render of it, gated offline by `--check`.
