### PR TITLE
feat(SDD-012): backlog-integrity guard for vault task files

### DIFF
--- a/scripts/check-backlog-integrity.sh
+++ b/scripts/check-backlog-integrity.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# check-backlog-integrity.sh: detect backlog drift in vault task files.
+#
+# A hand-maintained `11-tasks.md` accumulates drift when the same ticket lives in
+# two places (e.g. a sprint overview + a detailed list) that fall out of sync:
+# the count inflates and ticks go stale (an ID shows `[ ]` in one view, `[x]` in
+# another, or is `[ ]` everywhere despite being merged). This guard enforces the
+# structural invariant that prevents it: ONE ticket = ONE entry.
+#
+# Per file it flags:
+#   - DUPLICATE      a ticket ID on 2+ entry lines
+#   - CONTRADICTION  a ticket ID marked BOTH open ([ ]/[~]/[-]) and done ([x])
+#
+# Ticket IDs are `[A-Z]+-[0-9]+` with an optional single-letter sub-id suffix
+# (WIN-002 vs WIN-002a are distinct, not duplicates). No Obsidian dependency —
+# pure text parsing, safe in CI and fixture tests. Sibling of check-md-escapes.sh
+# (SDD-006); see specs/SDD-012-tasks-integrity-guard/.
+#
+# Usage:
+#   check-backlog-integrity.sh <tasks-file>...
+#
+# Exit:
+#   0  clean
+#   1  one or more files have duplicate IDs / status contradictions
+#   2  usage error / missing file
+
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+    cat >&2 <<'EOF'
+Usage: check-backlog-integrity.sh <tasks-file>...
+  Flags, per file: duplicate ticket IDs (same ID on 2+ entry lines) and status
+  contradictions (same ID marked both [ ] and [x]). One ticket = one entry.
+  See specs/SDD-012-tasks-integrity-guard/ (sibling of SDD-006 check-md-escapes).
+Exit: 0 clean | 1 issues found | 2 usage / missing file
+EOF
+    exit 2
+fi
+
+issues=0
+for f in "$@"; do
+    if [ ! -f "$f" ]; then
+        printf '  ERROR: not found or unreadable: %s\n' "$f" >&2
+        exit 2
+    fi
+
+    # Extract "<status-char>\t<ticket-id>" per checkbox entry line. The greedy
+    # [a-z]? keeps WIN-002a whole while leaving WIN-002 intact before a "-slug".
+    out="$(sed -nE 's/^- \[([ xX~-])\] \*\*([A-Z]+-[0-9]+[a-z]?).*/\1	\2/p' "$f" \
+        | awk -F'\t' '
+            {
+                id=$2; st=$1
+                count[id]++
+                if (st=="x" || st=="X") done_[id]=1; else open_[id]=1
+                if (!(id in seen)) { seen[id]=1; order[++n]=id }
+            }
+            END {
+                for (i=1; i<=n; i++) {
+                    id=order[i]
+                    if (count[id] >= 2) {
+                        if (done_[id] && open_[id])
+                            printf "  CONTRADICTION: %s — %d entries, marked BOTH open and done\n", id, count[id]
+                        else
+                            printf "  DUPLICATE: %s — %d entries\n", id, count[id]
+                    }
+                }
+            }')"
+
+    if [ -n "$out" ]; then
+        printf '%s:\n%s\n' "$f" "$out"
+        issues=$((issues + 1))
+    fi
+done
+
+if [ "$issues" -gt 0 ]; then
+    cat >&2 <<EOF
+
+$issues file(s) have backlog-integrity issues (duplicate IDs / status contradictions).
+One ticket = one entry — consolidate the file so each ID appears once with a single
+status. See AGENTS.md "incident -> guard" and specs/SDD-012-tasks-integrity-guard/.
+EOF
+    exit 1
+fi
+exit 0

--- a/scripts/vault-health.sh
+++ b/scripts/vault-health.sh
@@ -81,7 +81,7 @@ echo "========================================"
 echo "Vault: $VAULT_NAME ($VAULT_DIR)"
 
 # ==================================================
-section "1/6" "Working Tree Integrity"
+section "1/7" "Working Tree Integrity"
 
 # GUI-independent check: detect files deleted from working tree but still in HEAD.
 # Triggered by 2026-05-13 incident — SKILL.md vanished from disk, git status showed `D`.
@@ -103,7 +103,7 @@ else
 fi
 
 # ==================================================
-section "2/6" "Vault Connectivity"
+section "2/7" "Vault Connectivity"
 
 if ! command_exists obsidian; then
     log_error "Obsidian CLI not found in PATH"
@@ -123,7 +123,7 @@ else
 fi
 
 # ==================================================
-section "3/6" "Orphans & Dead-Ends"
+section "3/7" "Orphans & Dead-Ends"
 
 ORPHAN_OUTPUT=$(obsidian_cmd orphans --vault "$VAULT_NAME" 2>/dev/null || true)
 ORPHAN_COUNT=$(echo "$ORPHAN_OUTPUT" | grep -c '[^[:space:]]' 2>/dev/null || echo "0")
@@ -166,7 +166,7 @@ if [ "$VERBOSE" = true ]; then
 fi
 
 # ==================================================
-section "4/6" "Unresolved Links"
+section "4/7" "Unresolved Links"
 
 UNRESOLVED_OUTPUT=$(obsidian_cmd unresolved --vault "$VAULT_NAME" 2>/dev/null || true)
 UNRESOLVED_COUNT=$(echo "$UNRESOLVED_OUTPUT" | grep -c '[^[:space:]]' 2>/dev/null || echo "0")
@@ -186,7 +186,7 @@ if [ "$VERBOSE" = true ] && [ "$UNRESOLVED_COUNT" -gt 0 ]; then
 fi
 
 # ==================================================
-section "5/6" "Frontmatter Coverage"
+section "5/7" "Frontmatter Coverage"
 
 check_frontmatter_field() {
     local field="$1"
@@ -216,7 +216,7 @@ else
 fi
 
 # ==================================================
-section "6/6" "Tag Hygiene"
+section "6/7" "Tag Hygiene"
 
 TAG_OUTPUT=$(obsidian_cmd tags --vault "$VAULT_NAME" 2>/dev/null || true)
 TAG_COUNT=$(echo "$TAG_OUTPUT" | grep -c '[^[:space:]]' 2>/dev/null || echo "0")
@@ -226,6 +226,33 @@ if [ "$VERBOSE" = true ] && [ "$TAG_COUNT" -gt 0 ]; then
     echo "  --- Tags ---"
     echo "$TAG_OUTPUT" | head -30
     [ "$TAG_COUNT" -gt 30 ] && echo "  ... and $((TAG_COUNT - 30)) more"
+fi
+
+# ==================================================
+section "7/7" "Backlog Integrity"
+
+# GUI-independent: detect backlog drift in project task files — duplicate ticket
+# IDs and status contradictions — via check-backlog-integrity.sh (SDD-012).
+# Incident->guard sibling of the working-tree (sec 1) and \n-escape checks.
+if [ ! -d "$VAULT_DIR" ]; then
+    skip "Backlog integrity" "vault dir not found"
+else
+    BACKLOG_FILES=0
+    BACKLOG_BAD=0
+    for tasks in "$VAULT_DIR"/10_projects/*/11-tasks.md; do
+        [ -f "$tasks" ] || continue
+        BACKLOG_FILES=$((BACKLOG_FILES + 1))
+        if ! "$SCRIPT_DIR/check-backlog-integrity.sh" "$tasks" >/dev/null 2>&1; then
+            BACKLOG_BAD=$((BACKLOG_BAD + 1))
+            fail "Backlog drift in $(basename "$(dirname "$tasks")")/11-tasks.md (duplicate IDs / status contradictions)"
+            "$SCRIPT_DIR/check-backlog-integrity.sh" "$tasks" 2>/dev/null | sed 's|^|        |'
+        fi
+    done
+    if [ "$BACKLOG_FILES" -eq 0 ]; then
+        skip "Backlog integrity" "no 10_projects/*/11-tasks.md found"
+    elif [ "$BACKLOG_BAD" -eq 0 ]; then
+        pass "Backlog integrity: $BACKLOG_FILES task file(s) clean (one ticket = one entry)"
+    fi
 fi
 
 # ==================================================

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -30,12 +30,17 @@ Subcommands:
       Scan markdown files for literal '\n' corruption (Hive vault_patch bug).
       Path may be a file or directory; directories scanned recursively.
 
+  check-tasks <tasks-file>...
+      Scan task files for backlog drift: duplicate ticket IDs and status
+      contradictions (same ID marked both [ ] and [x]). One ticket = one entry.
+
   help, -h, --help
       Show this message.
 
 Each subcommand is also runnable standalone (vault-health.sh,
-vault-maintenance-weekly.sh, check-md-escapes.sh) — this dispatcher provides
-a single discoverable entry point without changing the underlying scripts.
+vault-maintenance-weekly.sh, check-md-escapes.sh, check-backlog-integrity.sh) —
+this dispatcher provides a single discoverable entry point without changing the
+underlying scripts.
 EOF
 }
 
@@ -56,6 +61,9 @@ case "$sub" in
         ;;
     check-escapes|check)
         exec "$SCRIPT_DIR/check-md-escapes.sh" "$@"
+        ;;
+    check-tasks|tasks)
+        exec "$SCRIPT_DIR/check-backlog-integrity.sh" "$@"
         ;;
     help|-h|--help)
         usage

--- a/specs/SDD-012-tasks-integrity-guard/features.json
+++ b/specs/SDD-012-tasks-integrity-guard/features.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "SDD-012-tasks-integrity-guard-f1",
+    "behavior": "AC1/AC2/AC3 — the guard flags duplicate ticket IDs and status contradictions, passes a clean file, and keeps WIN-002 vs WIN-002a distinct",
+    "verification": "~/.local/bin/bats tests/check-backlog-integrity.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "SDD-012-tasks-integrity-guard-f2",
+    "behavior": "AC4 — wired + discoverable: vault.sh dispatches check-tasks and vault-health.sh carries a GUI-independent Backlog Integrity section",
+    "verification": "grep -q 'check-backlog-integrity.sh' scripts/vault.sh && grep -q 'Backlog Integrity' scripts/vault-health.sh",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "SDD-012-tasks-integrity-guard-f3",
+    "behavior": "Scripts are lint-clean (shellcheck + bash -n) across the guard, dispatcher, and vault-health",
+    "verification": "~/.local/bin/shellcheck scripts/check-backlog-integrity.sh scripts/vault.sh scripts/vault-health.sh",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/SDD-012-tasks-integrity-guard/proposal.md
+++ b/specs/SDD-012-tasks-integrity-guard/proposal.md
@@ -1,0 +1,52 @@
+---
+id: "SDD-012-tasks-integrity-guard"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-05-31"
+tags: [spec, proposal, vault-health, incident-to-guard, backlog-hygiene, sdd-006-sibling]
+template_version: "1.0"
+---
+
+# SDD-012-tasks-integrity-guard
+
+> **Naming**: file lives at `<repo>/specs/SDD-012-tasks-integrity-guard/proposal.md`.
+
+## Why
+
+The dotfiles backlog (`vault/10_projects/dotfiles/11-tasks.md`, 390 lines) silently drifted: a sprint-planning overview was layered on top of older per-session detailed entries without reconciliation, so **34 ticket IDs now appear 2+ times** across the two hand-maintained views — and the views disagree (e.g. `ENGINE-001` / `POLISH-004` show `[ ]` despite being merged; the count reads 63 open vs ~35 real). This is the exact failure mode of the user's own "incident → guard" rule: a one-time cleanup alone rots again within a few sessions because nothing detects the recurrence. We need an automated guard so duplication / stale-tick drift surfaces every session, not a manual re-tidy. Direct sibling of SDD-006 (`check-md-escapes.sh`), which guards the literal-`\n` markdown-corruption class the same way.
+
+## What
+
+Concrete, observable behavior after this PR:
+
+1. **A standalone guard `scripts/check-backlog-integrity.sh`** (mirrors `check-md-escapes.sh`) takes `<tasks-file>...` and flags, per file: (a) **duplicate ticket IDs** — the same `[A-Z]+-[0-9]+[a-z]?` core ID on 2+ entry lines (the structural root cause: forces "one ID = one entry"), and (b) **status contradictions** — the same ID carrying both `- [ ]` and `- [x]`. Exit `0` clean / `1` issues found / `2` usage. No Obsidian dependency → CI/fixture-testable.
+2. **Wired into the `vault.sh` dispatcher** as `vault check-tasks <path>...`, standalone-runnable like its siblings.
+3. **A GUI-independent section in `vault-health.sh`** runs the guard over every `10_projects/*/11-tasks.md` in the vault, reporting `pass`/`fail` — so the drift auto-surfaces at SessionStart (where `vault health` already runs), making the prevention visible without anyone opting in.
+4. **Sub-ID safety**: `WIN-002` and `WIN-002a` are distinct (the optional single-letter suffix is captured), so legitimate sub-tickets are not false-positives.
+
+## Out of scope
+
+- **The 11-tasks.md consolidation itself** — restructuring to one canonical list + ticking the stale merged entries is a follow-up vault edit (AC5), tracked separately because the vault checkout is currently busy with a parallel session. The guard PR ships the *mechanism*; the consolidation brings the real file to green afterward.
+- **"Merged-but-open" cross-referencing** (matching a `[ ]` ID against a merged PR / archived spec) — needs PR/spec cross-ref, brittle; deferred. The dup-ID + contradiction checks already catch the observed drift.
+- **The README / docs reorg** — that is AUDIT-006, separate.
+- **Grouped one-line entries** (`BUG-008 / BUG-009 / BUG-010` on a single line) — the guard reads the leading ID per entry line; multi-ID lines are a documented limitation, not a target.
+
+## Risks / open questions
+
+- **False positives on sub-IDs** (`WIN-002` vs `WIN-002a`). **Mitigated:** the ID regex captures an optional trailing single letter, so suffixed sub-tickets are distinct IDs. Covered by a fixture test.
+- **The guard is local-only** (vault is private; dotfiles CI has no vault access). **Accepted:** consistent with ADR-012/ENGINE-001 — drift guards live in `healthcheck`/`vault-health` (local, SessionStart), not CI. The bats test uses fixtures, so CI still verifies the *logic*.
+
+## Acceptance criteria
+
+- [ ] **AC1 — duplicate IDs flagged**: a fixture tasks file with one ID on two entry lines → `check-backlog-integrity.sh` exits 1 and names the duplicated ID. **Verify:** bats fixture.
+- [ ] **AC2 — status contradiction flagged**: a fixture with the same ID as both `- [ ]` and `- [x]` → exit 1 naming the ID. **Verify:** bats fixture.
+- [ ] **AC3 — clean file passes + sub-IDs safe**: a fixture where every ID is unique and consistent (incl. `WIN-002` + `WIN-002a` distinct) → exit 0. **Verify:** bats fixture.
+- [ ] **AC4 — wired + discoverable**: `vault check-tasks <file>` dispatches to the guard; `vault-health.sh` carries a GUI-independent section invoking it over `10_projects/*/11-tasks.md`. **Verify:** bats (dispatcher exit code) + grep (vault-health section).
+- [ ] **AC5 — real backlog reaches green (follow-up, vault)**: after the 11-tasks.md consolidation, `check-backlog-integrity.sh 10_projects/dotfiles/11-tasks.md` exits 0. **Verify:** run on the consolidated file. *(Tracked as the vault-side follow-up; not in the guard PR.)*
+
+## References
+
+- Sibling precedent: `specs/archive/SDD-006-vault-integrity-check/` + `scripts/check-md-escapes.sh` (incident→guard for the `\n` class)
+- Dispatcher: `scripts/vault.sh` (REFACTOR-005), `scripts/vault-health.sh`
+- Vault: `10_projects/dotfiles/11-tasks.md` (the drifted file); backlog entry SDD-012 to be added when the vault checkout is free
+- AGENTS.md Standing Order #4 (clean as you go) + the "incident → guard" feedback guardrail

--- a/specs/SDD-012-tasks-integrity-guard/tasks.md
+++ b/specs/SDD-012-tasks-integrity-guard/tasks.md
@@ -1,0 +1,38 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-05-13"
+---
+
+# Tasks - SDD-012-tasks-integrity-guard
+
+> TDD order. One task = one focused commit. Tick as you go.
+
+## Setup
+
+- [x] Worktree off origin/main: `feat/sdd-012-tasks-integrity-guard`
+- [x] `proposal.md` complete; acceptance criteria testable
+- [~] Vault gate entry in `11-tasks.md` — DEFERRED (vault checkout busy with a parallel session); scaffolded with `--force-no-vault`, entry to be added when the vault is free (tracked, not skipped)
+
+## Implementation (TDD)
+
+- [x] Write failing bats `tests/check-backlog-integrity.bats` with fixtures (dup, contradiction, clean+sub-id, usage, missing, dispatcher) — RED (exit 127)
+- [x] Implement `scripts/check-backlog-integrity.sh` (sed extract `status<TAB>id` + plain awk aggregate; greedy `[a-z]?` keeps WIN-002a distinct) — bats GREEN
+- [x] Wire `vault check-tasks` into `scripts/vault.sh` dispatcher (+ usage)
+- [x] Add GUI-independent section "7/7 Backlog Integrity" to `vault-health.sh` scanning every `10_projects/*/11-tasks.md` (auto-surfaces at SessionStart)
+
+## Closing
+
+- [x] Every AC (1-4) covered by a test/check; AC5 is the deferred vault follow-up
+- [x] `features.json` present with non-vacuous verification commands
+- [x] shellcheck clean + `bash -n` clean on all 3 scripts
+- [x] No unrelated changes (diff = guard + test + dispatcher + vault-health section + spec)
+- [x] `verification.md` filled
+- [ ] PR opened referencing this spec folder
+
+## Follow-up (vault, separate from the guard PR)
+
+- [ ] **AC5** — when the vault checkout is free: add the SDD-012 backlog entry, then consolidate `10_projects/dotfiles/11-tasks.md` to one canonical list (merge the 30 duplicates, resolve the 3 contradictions: IDEAS-007 / SDD-004 / BUG-022) until `check-backlog-integrity.sh 10_projects/dotfiles/11-tasks.md` exits 0.
+
+## Machine-readable features
+
+Sibling `features.json` per [[pattern-feature-list-as-primitive]]. The agent may not set `"state": "passing"` — only the harness, after running `verification` (exit 0), sets that terminal state.

--- a/specs/SDD-012-tasks-integrity-guard/verification.md
+++ b/specs/SDD-012-tasks-integrity-guard/verification.md
@@ -1,0 +1,43 @@
+---
+tags: [spec, verification, templates]
+created: "2026-05-13"
+---
+
+# Verification - SDD-012-tasks-integrity-guard
+
+## Evidence
+
+- [x] **AC1 — duplicate IDs flagged** → `tests/check-backlog-integrity.bats` test "AC1 duplicate" exits 1 + greps the ID. Also empirically: the real `11-tasks.md` reports 30 `DUPLICATE:` lines.
+- [x] **AC2 — status contradiction flagged** → bats test "AC2 contradiction" exits 1 + greps `contradict`. Real file flags `IDEAS-007`, `SDD-004`, `BUG-022` as `CONTRADICTION` (the legitimately-partial tickets — correctly distinguished from plain duplicates).
+- [x] **AC3 — clean passes + sub-ids safe** → bats "AC3 clean" with `WIN-002` + `WIN-002a` distinct → exit 0.
+- [x] **AC4 — wired + discoverable** → bats "AC4 dispatcher" (`vault check-tasks` exit passthrough) green; `vault-health.sh` section "7/7 Backlog Integrity" greps present (scans `10_projects/*/11-tasks.md`, GUI-independent).
+- [ ] **AC5 — real backlog green** → DEFERRED follow-up (vault busy). Today the real file exits 1 (33 issues) by design — that IS the guard surfacing the drift to be consolidated.
+
+## Test status
+
+- `~/.local/bin/bats tests/check-backlog-integrity.bats` → `1..6` all `ok`.
+- `~/.local/bin/shellcheck scripts/check-backlog-integrity.sh scripts/vault.sh scripts/vault-health.sh` → clean.
+- `bash -n` → clean on all 3.
+- Real-data smoke: `check-backlog-integrity.sh <real 11-tasks.md>` → exit 1, 30 duplicates + 3 contradictions. Proves the guard works on production data, not just fixtures.
+- No regressions: vault-health.sh section renumber 1/6..6/6 → 1/7..7/7; new section is additive + GUI-independent.
+
+## Decisions made during implementation
+
+- **Portability over gawk.** Extraction uses `sed -nE 's/.../\1<TAB>\2/p'` + plain awk (assoc arrays, field access), avoiding gawk-only `match(s,re,arr)`/`gensub` so the guard runs under BSD tooling too.
+- **Greedy `[a-z]?` in the ID regex** keeps `WIN-002a` whole while leaving `WIN-002` intact before a `-slug` — the sub-id false-positive the naive approach would hit.
+- **DUPLICATE vs CONTRADICTION split.** Contradiction (same ID `[ ]` and `[x]`) is reported distinctly from plain duplication — it marks the tickets that need a human decision (partial-done) vs mechanical merge.
+- **Local-only guard, fixture-tested.** Vault is private (no CI access); the guard lives in `vault-health`/`vault check-tasks` (SessionStart, local) per ADR-012/ENGINE-001, while bats fixtures verify the logic in CI.
+- **Vault gate deferred, not skipped.** The vault checkout was busy with a parallel session, so the SDD-012 backlog entry + consolidation are an explicit tracked follow-up (AC5), not a silent omission.
+
+## Promotion candidates
+
+- [ ] Lesson? **yes** — "Layered, hand-maintained views of the same list drift; enforce one-entry-per-ID with a guard (incident→guard), don't rely on discipline." (Capture at archive.)
+- [ ] ADR-worthy? **no** — extends the existing incident→guard pattern (SDD-006 sibling).
+- [ ] Pattern candidate? **no** — folds into the incident→guard guardrail already in the vault.
+
+## Archive checklist
+
+- [ ] `proposal.md` → `status: archived`
+- [ ] Folder moved to `specs/archive/SDD-012-tasks-integrity-guard/`
+- [ ] Vault `11-tasks.md` SDD-012 entry added + ticked with PR link (part of the AC5 consolidation pass)
+- [ ] Lesson promoted

--- a/tests/check-backlog-integrity.bats
+++ b/tests/check-backlog-integrity.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# SDD-012: tasks-integrity guard. Detects the backlog-drift class — the same
+# ticket ID on 2+ entry lines (duplication) and, as a refinement, the same ID
+# marked both open and done (status contradiction). Fixture-based: no vault,
+# CI-safe. Sibling of tests covering check-md-escapes.sh (SDD-006).
+
+setup() {
+    REPO="$BATS_TEST_DIRNAME/.."
+    SCRIPT="$REPO/scripts/check-backlog-integrity.sh"
+    VAULT="$REPO/scripts/vault.sh"
+    TMP="$(mktemp -d)"
+}
+
+teardown() { rm -rf "$TMP"; }
+
+@test "AC3 clean: unique IDs incl WIN-002 vs WIN-002a (sub-id) -> exit 0" {
+    cat > "$TMP/clean.md" <<'EOF'
+- [ ] **AI-001-alpha**: a thing
+- [x] **AI-002-beta**: done thing
+- [ ] **WIN-002-sweep**: parent ticket
+- [ ] **WIN-002a-subitem**: a DISTINCT sub-ticket, not a duplicate of WIN-002
+EOF
+    run "$SCRIPT" "$TMP/clean.md"
+    [ "$status" -eq 0 ]
+}
+
+@test "AC1 duplicate: same ID on two entry lines -> exit 1, names the ID" {
+    cat > "$TMP/dup.md" <<'EOF'
+- [ ] **ENGINE-001-deploy**: sprint-overview view
+- [x] **BUG-009-foo**: done
+- [ ] **ENGINE-001-deploy**: detailed view (the drift)
+EOF
+    run "$SCRIPT" "$TMP/dup.md"
+    [ "$status" -eq 1 ]
+    echo "$output" | grep -q 'ENGINE-001'
+}
+
+@test "AC2 contradiction: same ID both [ ] and [x] -> exit 1, flagged as contradiction" {
+    cat > "$TMP/contra.md" <<'EOF'
+- [ ] **POLISH-004-bundle**: still open in the sprint overview
+- [x] **POLISH-004-bundle**: but ticked done in the detailed list
+EOF
+    run "$SCRIPT" "$TMP/contra.md"
+    [ "$status" -eq 1 ]
+    echo "$output" | grep -q 'POLISH-004'
+    echo "$output" | grep -qi 'contradict'
+}
+
+@test "usage: no args -> exit 2" {
+    run "$SCRIPT"
+    [ "$status" -eq 2 ]
+}
+
+@test "missing file -> exit 2" {
+    run "$SCRIPT" "$TMP/nope.md"
+    [ "$status" -eq 2 ]
+}
+
+@test "AC4 dispatcher: 'vault check-tasks <file>' routes to the guard (exit passthrough)" {
+    cat > "$TMP/dup.md" <<'EOF'
+- [ ] **X-001-a**: one
+- [ ] **X-001-a**: two
+EOF
+    run "$VAULT" check-tasks "$TMP/dup.md"
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
## What

Ships the **root-fix** for backlog drift: a guard that enforces *one ticket = one entry* so `11-tasks.md` can't silently re-diverge after a cleanup. Sibling of SDD-006 (`check-md-escapes.sh`) — same incident→guard shape.

The drift it prevents: a sprint-overview view was layered on top of the older detailed entries, so 34 ticket IDs appeared 2+ times and the views disagreed (e.g. `IDEAS-007`/`SDD-004` marked both open and done; the count read 63 open vs ~35 real).

## How

- **`scripts/check-backlog-integrity.sh`** — takes `<tasks-file>...`, flags per file: `DUPLICATE` (same ID on 2+ entry lines) and `CONTRADICTION` (same ID marked both `[ ]` and `[x]`). Exit `0`/`1`/`2`. No Obsidian dep. Portable (`sed -nE` + plain awk, no gawk-only features). Greedy `[a-z]?` keeps `WIN-002a` distinct from `WIN-002`.
- **`scripts/vault.sh`** — new `vault check-tasks <path>...` dispatch.
- **`scripts/vault-health.sh`** — new GUI-independent section `7/7 Backlog Integrity` scanning every `10_projects/*/11-tasks.md`, so the drift auto-surfaces at SessionStart.
- **`tests/check-backlog-integrity.bats`** — 6 fixture tests (dup, contradiction, clean+sub-id, usage, missing, dispatcher).

## Verification

- `bats tests/check-backlog-integrity.bats` → `1..6` all `ok`
- `shellcheck` + `bash -n` clean on all 3 scripts
- **Real-data smoke**: run against the live `11-tasks.md` → exit 1, **30 duplicates + 3 contradictions** correctly identified (proves it works on production data, not just fixtures)

## Acceptance criteria

- [x] AC1 duplicate IDs flagged · [x] AC2 status contradictions flagged · [x] AC3 clean passes + sub-ids safe · [x] AC4 wired (dispatcher + vault-health section)
- [ ] **AC5** (real backlog consolidated to green) — **deferred follow-up** (vault checkout was busy with a parallel session). Today the guard intentionally exits 1 on the real file: that IS it surfacing the drift to be consolidated.

## SDD

- Spec: `specs/SDD-012-tasks-integrity-guard/` (scaffolded with `--force-no-vault` — vault busy; the SDD-012 backlog entry + consolidation land in the AC5 follow-up, tracked in the spec, not skipped)
- Sibling precedent: `specs/archive/SDD-006-vault-integrity-check/`
