### PR TITLE
fix(SDD-012): match backlog guard by full ticket id (advisory NOTE for number reuse)

### DIFF
--- a/scripts/check-backlog-integrity.sh
+++ b/scripts/check-backlog-integrity.sh
@@ -4,25 +4,30 @@
 #
 # A hand-maintained `11-tasks.md` accumulates drift when the same ticket lives in
 # two places (e.g. a sprint overview + a detailed list) that fall out of sync:
-# the count inflates and ticks go stale (an ID shows `[ ]` in one view, `[x]` in
-# another, or is `[ ]` everywhere despite being merged). This guard enforces the
-# structural invariant that prevents it: ONE ticket = ONE entry.
+# the count inflates and ticks go stale (an id shows `[ ]` in one view, `[x]` in
+# another). This guard enforces the structural invariant that prevents it:
+# ONE ticket = ONE entry.
 #
 # Per file it flags:
-#   - DUPLICATE      a ticket ID on 2+ entry lines
-#   - CONTRADICTION  a ticket ID marked BOTH open ([ ]/[~]/[-]) and done ([x])
+#   - DUPLICATE      the same FULL ticket id on 2+ entry lines (true drift)
+#   - CONTRADICTION  the same FULL id marked BOTH open ([ ]/[~]/[-]) and done ([x])
+#   - NOTE           one ticket NUMBER reused by different full ids — advisory
+#                    only, NOT a failure (two distinct tickets sharing a number)
 #
-# Ticket IDs are `[A-Z]+-[0-9]+` with an optional single-letter sub-id suffix
-# (WIN-002 vs WIN-002a are distinct, not duplicates). No Obsidian dependency —
-# pure text parsing, safe in CI and fixture tests. Sibling of check-md-escapes.sh
-# (SDD-006); see specs/SDD-012-tasks-integrity-guard/.
+# Identity is the FULL bold id between ** ** (so BUG-020-pwsh-profile is distinct
+# from BUG-020-splitpath, and WIN-002 from WIN-002a). Matching by full id catches
+# genuine "same ticket listed twice" drift without false-positiving two different
+# tickets that merely share a number — the latter is reported as an advisory NOTE
+# (renumbering archived tickets would desync them from their PR/commit history).
+# No Obsidian dependency — pure text parsing, safe in CI and fixture tests.
+# Sibling of check-md-escapes.sh (SDD-006); see SDD-012-tasks-integrity-guard.
 #
 # Usage:
 #   check-backlog-integrity.sh <tasks-file>...
 #
 # Exit:
-#   0  clean
-#   1  one or more files have duplicate IDs / status contradictions
+#   0  clean (or only advisory NOTEs)
+#   1  one or more files have duplicate full ids / status contradictions
 #   2  usage error / missing file
 
 set -euo pipefail
@@ -30,9 +35,10 @@ set -euo pipefail
 if [ "$#" -eq 0 ]; then
     cat >&2 <<'EOF'
 Usage: check-backlog-integrity.sh <tasks-file>...
-  Flags, per file: duplicate ticket IDs (same ID on 2+ entry lines) and status
-  contradictions (same ID marked both [ ] and [x]). One ticket = one entry.
-  See specs/SDD-012-tasks-integrity-guard/ (sibling of SDD-006 check-md-escapes).
+  Flags, per file: duplicate FULL ticket ids (same id on 2+ entry lines) and
+  status contradictions (same id marked both [ ] and [x]). One ticket = one
+  entry. Number reuse across different tickets is an advisory NOTE, not a
+  failure. See SDD-012-tasks-integrity-guard (sibling of SDD-006 check-md-escapes).
 Exit: 0 clean | 1 issues found | 2 usage / missing file
 EOF
     exit 2
@@ -45,30 +51,52 @@ for f in "$@"; do
         exit 2
     fi
 
-    # Extract "<status-char>\t<ticket-id>" per checkbox entry line. The greedy
-    # [a-z]? keeps WIN-002a whole while leaving WIN-002 intact before a "-slug".
-    out="$(sed -nE 's/^- \[([ xX~-])\] \*\*([A-Z]+-[0-9]+[a-z]?).*/\1	\2/p' "$f" \
-        | awk -F'\t' '
-            {
-                id=$2; st=$1
-                count[id]++
-                if (st=="x" || st=="X") done_[id]=1; else open_[id]=1
-                if (!(id in seen)) { seen[id]=1; order[++n]=id }
-            }
-            END {
-                for (i=1; i<=n; i++) {
-                    id=order[i]
-                    if (count[id] >= 2) {
-                        if (done_[id] && open_[id])
-                            printf "  CONTRADICTION: %s — %d entries, marked BOTH open and done\n", id, count[id]
-                        else
-                            printf "  DUPLICATE: %s — %d entries\n", id, count[id]
-                    }
+    # All parsing in awk (no sed): the full id is the bold token between ** **,
+    # the status char is column 4 ("- [X] ..."). DUPLICATE/CONTRADICTION key off
+    # the full id; the number prefix only drives the advisory NOTE.
+    out="$(awk '
+        /^- \[[ xX~-]\] \*\*[^*]+\*\*/ {
+            line = $0
+            st = substr(line, 4, 1)
+            s = line; sub(/^[^*]*\*\*/, "", s)
+            fid = s; sub(/\*\*.*$/, "", fid)
+            count[fid]++
+            if (st == "x" || st == "X") done_[fid] = 1; else open_[fid] = 1
+            if (!(fid in seen)) { seen[fid] = 1; order[++n] = fid }
+            num = fid
+            if (match(num, /^[A-Z]+-[0-9]+/)) {
+                num = substr(num, 1, RLENGTH)
+                if (!((num SUBSEP fid) in spair)) {
+                    spair[num SUBSEP fid] = 1
+                    ncount[num]++
+                    nex[num] = nex[num] (ncount[num] > 1 ? ", " : "") fid
+                    if (!(num in snum)) { snum[num] = 1; norder[++m] = num }
                 }
-            }')"
+            }
+        }
+        END {
+            for (i = 1; i <= n; i++) {
+                fid = order[i]
+                if (count[fid] >= 2) {
+                    if (done_[fid] && open_[fid])
+                        printf "  CONTRADICTION: %s — %d entries, marked BOTH open and done\n", fid, count[fid]
+                    else
+                        printf "  DUPLICATE: %s — %d entries\n", fid, count[fid]
+                }
+            }
+            for (i = 1; i <= m; i++) {
+                num = norder[i]
+                if (ncount[num] > 1)
+                    printf "  NOTE: number %s reused by %d different tickets (%s) — advisory, not drift\n", num, ncount[num], nex[num]
+            }
+        }
+    ' "$f")" || true
 
     if [ -n "$out" ]; then
         printf '%s:\n%s\n' "$f" "$out"
+    fi
+    # Only DUPLICATE / CONTRADICTION are hard failures; NOTE (number reuse) is advisory.
+    if printf '%s\n' "$out" | grep -qE 'DUPLICATE|CONTRADICTION'; then
         issues=$((issues + 1))
     fi
 done
@@ -76,9 +104,10 @@ done
 if [ "$issues" -gt 0 ]; then
     cat >&2 <<EOF
 
-$issues file(s) have backlog-integrity issues (duplicate IDs / status contradictions).
-One ticket = one entry — consolidate the file so each ID appears once with a single
-status. See AGENTS.md "incident -> guard" and specs/SDD-012-tasks-integrity-guard/.
+$issues file(s) have backlog-integrity issues (duplicate full ids / status contradictions).
+One ticket = one entry — consolidate so each full id appears once with a single status.
+(NOTE lines about number reuse are advisory, not failures.)
+See AGENTS.md "incident -> guard" and specs/archive/SDD-012-tasks-integrity-guard/.
 EOF
     exit 1
 fi

--- a/tests/check-backlog-integrity.bats
+++ b/tests/check-backlog-integrity.bats
@@ -35,6 +35,17 @@ EOF
     echo "$output" | grep -q 'ENGINE-001'
 }
 
+@test "full-id: same NUMBER, different slug -> exit 0 + advisory NOTE (not drift)" {
+    cat > "$TMP/collide.md" <<'EOF'
+- [x] **BUG-020-pwsh-profile-corruption-heal**: fixed via #122
+- [x] **BUG-020-splitpath-literalpath-parent**: a DIFFERENT bug, fixed via #124
+EOF
+    run "$SCRIPT" "$TMP/collide.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qi 'NOTE'
+    echo "$output" | grep -q 'BUG-020'
+}
+
 @test "AC2 contradiction: same ID both [ ] and [x] -> exit 1, flagged as contradiction" {
     cat > "$TMP/contra.md" <<'EOF'
 - [ ] **POLISH-004-bundle**: still open in the sprint overview


### PR DESCRIPTION
## What

Refines the SDD-012 backlog-integrity guard to match by **full ticket id** (the bold token between `** **`) instead of just the number. Follow-up to #183.

**Why:** the number-only match false-positives two *different* tickets that share a number (e.g. `BUG-020-pwsh-profile-corruption-heal` #122 vs `BUG-020-splitpath-literalpath-parent` #124). Forcing those to "deduplicate" would mean renumbering archived tickets, desyncing them from their PR/commit history. The real drift the guard must catch is the *same* ticket listed twice with diverging status — that's a same-full-id event.

## Behavior

- `DUPLICATE` / `CONTRADICTION` now key off the **full id** → catch genuine drift, ignore number-coincidence.
- New `NOTE`: a number reused by different full ids is reported as **advisory** (does NOT fail) — surfaces the (real but historical) number-reuse without blocking.
- `WIN-002` vs `WIN-002a` still distinct (full id). Parsing moved fully into awk (no sed/tab; portable).

## Verification

- `bats tests/check-backlog-integrity.bats` → `1..7` ok (new test: same number + different slug → exit 0 + NOTE).
- `shellcheck` + `bash -n` clean.
- Real `11-tasks.md`: the 9 number-collisions (BUG-019/020/021/022, REFACTOR-001, WIN-001/002, IDEAS-001/007) now surface as `NOTE` (advisory); genuine same-full-id drift still hard-fails. The file goes green after the (separate) consolidation removes the same-full-id overview duplicates.

## SDD skip rationale

Small single-file refinement (+test) of the just-merged guard from the **archived** spec `specs/archive/SDD-012-tasks-integrity-guard/` — no new public contract, no new spec warranted. Discovered while consolidating the backlog the guard was built to protect.
