### PR TITLE
feat(HANDOFF-001): cross-agent /handoff skill (vault SSOT + AGENTS.md trigger)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,7 @@ Stop generation and warn if you detect:
 * **Strategy (`10-roadmap.md`):** ONLY if a major milestone is completed.
 * **Lessons:** Append to `90-lessons.md` using the Lesson Template.
 * **Promotion:** If the solution is generic, create `00_meta/patterns/pattern-<topic>.md`.
+* **Session handoff (at session end):** run the **`/handoff`** skill — the complete, cross-agent checklist (continuity block in `MEMORY.md` + the vault hygiene above + repo/worktree/branch state + artifact/PR summary + a concrete next action). SSOT: `00_meta/skills/handoff/SKILL.md`. Skip only for trivial sessions.
 
 For the full session taxonomy and document placement table, query `00_meta/patterns/workflow-protocol.md`.
 

--- a/ai/claude/CLAUDE.md
+++ b/ai/claude/CLAUDE.md
@@ -8,24 +8,9 @@
 
 Self-maintaining knowledge across sessions. Zero manual intervention required.
 
-### Session Handoff (MANDATORY at session end)
+### Session Handoff
 
-At the END of every session where meaningful work was done, OVERWRITE the `## Session Handoff` section in `MEMORY.md`. This MUST be the first section after the H1 heading.
-
-**Fields (in this exact order, overwrite the entire section):**
-
-- `> Updated: YYYY-MM-DD`
-- `**Last task:** [1-line what was worked on]`
-- `**Decisions:** [key decisions, or "None"]`
-- `**Open threads:** [unfinished work, or "None"]`
-- `**Next action:** [concrete first step for next session]`
-
-Rules:
-
-- OVERWRITE entirely each session. Never append.
-- Max 8 lines. Handoff, not journal.
-- Skip if session was trivial (quick question, no state change).
-- Exception to MEMORY.md "index-only" rule: this section holds ephemeral continuity data.
+Session handoff is a **cross-agent `/handoff` skill** — SSOT at `00_meta/skills/handoff/SKILL.md`, with an always-on trigger in `AGENTS.md`. At the END of any non-trivial session, run it. For Claude, the continuity block it overwrites (`## Session Handoff`, the first section after the H1) lives in this project's auto-memory `MEMORY.md`. The skill is the source of truth for the full checklist (continuity block + vault hygiene + repo/worktree state + artifact summary + next action) — don't duplicate it here.
 
 ### Auto-Crystallize
 

--- a/harness/skills/handoff/SKILL.md
+++ b/harness/skills/handoff/SKILL.md
@@ -1,0 +1,73 @@
+---
+id: handoff-skill
+type: skill
+status: active
+created: "2026-05-31"
+name: handoff
+description: Run a complete, standardized session handoff at session end (or on demand). Triggers on /handoff, "do handoff", "haz handoff", "wrap up the session", "session handoff", "close out the session". Updates the MEMORY.md continuity block, then vault hygiene (tick tasks, capture lessons), repo/worktree/branch state verification, an artifact/PR summary, and a concrete next action. Cross-agent via AGENTS.md indirection.
+allowed-tools: [Bash, Read, Edit, Write, mcp__hive__vault_query, mcp__hive__vault_search, mcp__hive__vault_write, mcp__hive__vault_patch]
+---
+
+# Handoff Workflow
+
+> A complete, repeatable session handoff. Any agent, any session: "do handoff" runs the SAME checklist, so the next session (or a different agent) resumes with zero context loss.
+> **Core principle:** the handoff is a *checklist*, not just a memory write. The always-on trigger ("at session end, run the handoff") lives in `AGENTS.md`; this skill is the SSOT for WHAT the handoff does.
+
+## When to use
+
+- `/handoff` explicitly, or "do handoff" / "haz handoff" / "wrap up the session".
+- Automatically at the END of any session where meaningful work was done (per the `AGENTS.md` trigger).
+
+## When to SKIP
+
+- Trivial session: a quick question, no state change, nothing committed. A handoff would be noise. (Mirrors the `MEMORY.md` "skip if trivial" rule.)
+
+## The handoff checklist (run in order)
+
+### 1. Continuity block — `## Session Handoff` in `MEMORY.md`
+
+OVERWRITE the `## Session Handoff` section (the first section after the H1) of the project's `MEMORY.md` with these fields, in this exact order:
+
+- `> Updated: YYYY-MM-DD`
+- `**Last task:** [what was worked on, with PR/commit refs]`
+- `**Decisions:** [durable decisions, or "None"]`
+- `**Open threads:** [unfinished work + who owns each, or "None"]`
+- `**Next action:** [concrete first step for the next session]`
+
+Rules: OVERWRITE entirely (never append); dense but bounded (~8 lines — handoff, not journal); convert relative dates to absolute. **Path:** the project's auto-memory `MEMORY.md`, which is junctioned into `vault/10_projects/<repo>/memory/` — so any agent can write it. This is the only place strategic continuity prose lives (the rest of `MEMORY.md` stays index-only).
+
+### 2. Vault hygiene (Standing Order #3 — in-session, never "later")
+
+- Tick completed tasks in `vault/10_projects/<repo>/11-tasks.md` (`[ ]` -> `[x]` + ✓ date + PR link). Keep the file guard-green (one ticket = one entry — see SDD-012 `check-backlog-integrity.sh`).
+- Capture any non-obvious lesson in `90-lessons.md` (Context / Problem / Solution / Tags).
+- New architectural decision -> `30-architecture/adr-XXX.md`. Recurring pattern -> `00_meta/patterns/`.
+
+### 3. Repo / worktree / branch state
+
+- No uncommitted work left dangling — or explicitly named in **Open threads** (never silently).
+- Worktrees for MERGED PRs removed; their branches deleted; `git fetch --prune` gone refs.
+- Every PR opened this session linked (number + merged/open state) in the handoff.
+
+### 4. Artifact summary
+
+List what the session produced: PRs (number + state), key commit hashes, files created/changed, vault entries added/ticked.
+
+### 5. Next action
+
+One concrete first step for the next session — actionable, not vague ("merge #185 then build X", not "continue").
+
+### 6. Verification (preferred)
+
+Tests/lints green; nothing claimed done-when-not. If something is incomplete, it belongs in **Open threads** with its owner — report outcomes faithfully.
+
+## Cross-OS / cross-agent notes
+
+- Step 1 targets the vault-junctioned `MEMORY.md` path, writable by every agent — so the handoff is portable today, before MEMORY-001 (the cross-agent session bridge) lands. Non-Claude agents write the same path directly.
+- Steps 2-6 are agent-agnostic (vault + git).
+- Path joining: never hardcode `/` or `\`; use platform-appropriate joining.
+
+## References
+
+- Trigger (always-on): `AGENTS.md` — "at session end, run the handoff".
+- Continuity-schema origin: the former Claude-only "Session Handoff (MANDATORY)" rule, now a pointer in `ai/claude/CLAUDE.md` (no duplication).
+- Related: `MEMORY-001` (cross-agent session bridge), `00_meta/patterns/pattern-decision-persistence.md`, SDD-011 (the two-surface skill+trigger pattern this mirrors).

--- a/specs/HANDOFF-001-cross-agent-handoff-skill/features.json
+++ b/specs/HANDOFF-001-cross-agent-handoff-skill/features.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "HANDOFF-001-cross-agent-handoff-skill-f1",
+    "behavior": "AC2 — AGENTS.md carries the always-on /handoff trigger and ai/claude/CLAUDE.md is reduced to a pointer (no duplicated 5-field detail)",
+    "verification": "grep -q '`/handoff`' AGENTS.md && grep -q 'skills/handoff' ai/claude/CLAUDE.md && ! grep -q '\\*\\*Last task:\\*\\* \\[1-line' ai/claude/CLAUDE.md",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HANDOFF-001-cross-agent-handoff-skill-f2",
+    "behavior": "AC3 — the committed record renders and compile-harness --check reports no drift",
+    "verification": "grep -q '^name: handoff' harness/skills/handoff/SKILL.md && ./scripts/compile-harness.sh --check",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HANDOFF-001-cross-agent-handoff-skill-f3",
+    "behavior": "AC3 — /handoff deploys cross-agent (claude + opencode + agy) carrying its checklist",
+    "verification": "~/.local/bin/bats tests/skills-pipeline.bats",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/HANDOFF-001-cross-agent-handoff-skill/proposal.md
+++ b/specs/HANDOFF-001-cross-agent-handoff-skill/proposal.md
@@ -1,0 +1,52 @@
+---
+id: "HANDOFF-001-cross-agent-handoff-skill"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-05-31"
+tags: [spec, proposal, cross-agent, handoff, skill, harness-001, sdd-011-sibling]
+template_version: "1.0"
+---
+
+# HANDOFF-001-cross-agent-handoff-skill
+
+> **Naming**: file lives at `<repo>/specs/HANDOFF-001-cross-agent-handoff-skill/proposal.md`.
+
+## Why
+
+<!-- from 11-tasks.md: *(P2, queued 2026-05-31, GH TBD, cross-agent, SDD-required)*: Promote the session "handoff" from a Claude-only rule (a `~/.claude/CLAUDE.md` directive to overwrite `MEMORY.md`'s `## Session Handoff`) into a **cross-agent `/handoff` skill**, so "do handoff" runs the same complete checklist in any agent. **Two-surface design (mirrors [[SDD-011-agent-side-spec-trigger]]):** (1) detail = vault skill `00_meta/skills/handoff/SKILL.md`; (2) trigger = a short always-on line in `AGENTS.md`. **Done when:** `/handoff` skill exists in vault + deploys to all agents (`compile-harness.sh --check` green), AGENTS.md trigger added, CLAUDE.md rule reduced to a pointer. **Anti-scope:** don't change the `MEMORY.md` schema. Part of HARNESS-001. -->
+
+Today the session handoff is a Claude-only rule in `ai/claude/CLAUDE.md` that does one thing: overwrite the `## Session Handoff` block in `MEMORY.md`. It is neither complete (no vault hygiene / repo-state / artifact-summary steps) nor portable (other agents — opencode, agy, copilot — have no handoff at all). The user wants to tell ANY session "do handoff" and get the SAME complete result, so continuity does not depend on which agent ran the session. This promotes the handoff into a real cross-agent skill on the existing SDD-008 pipeline — the same two-surface pattern SDD-011 used.
+
+## What
+
+After this PR:
+
+1. **A `/handoff` skill is the SSOT** at `vault/00_meta/skills/handoff/SKILL.md` — a complete, ordered checklist: (1) overwrite the `## Session Handoff` continuity block in `MEMORY.md` (the 5 fields), (2) vault hygiene (tick `11-tasks.md`, capture lessons), (3) repo/worktree/branch state verification, (4) artifact/PR summary, (5) concrete next action, (6) verification.
+2. **It deploys cross-agent** through the SDD-008 pipeline: `compile-harness.sh --refresh` regenerates the committed record `harness/skills/handoff/`; `--deploy` renders it to `~/.claude/skills/handoff`, `~/.config/opencode/commands/handoff.md`, `~/.gemini/{skills,prompts}`; `--check` stays green. So `/handoff` (or "do handoff") works in Claude, OpenCode, and agy.
+3. **`AGENTS.md` carries the always-on trigger** (Phase 3 / Knowledge Crystallization): "at session end, run the `/handoff` skill", pointing to the skill — cross-agent, no checklist duplicated.
+4. **The Claude-only rule becomes a pointer**: `ai/claude/CLAUDE.md`'s "Session Handoff" section is reduced to a short pointer to the skill (the 5-field detail is no longer duplicated there).
+
+## Out of scope
+
+- **The cross-agent session-memory bridge** (writing continuity for non-Claude agents to `00_meta/sessions/`) — that is MEMORY-001. Until it lands, the skill targets the vault-junctioned `MEMORY.md` path, which any agent can write.
+- **Changing the `MEMORY.md` schema** (the 5 fields, the index-only rule) — unchanged; the skill consumes it as-is.
+- **Auto-invoking the handoff** (a session-end hook that runs it without the agent deciding) — the trigger is an instruction, not automation; a hook is a separate follow-up.
+
+## Risks / open questions
+
+- **Continuity path portability.** The `MEMORY.md` is Claude's auto-memory, junctioned into the vault. **Mitigation:** the skill references the vault-junctioned path, writable by any agent; full cross-agent continuity is MEMORY-001 (out of scope, noted).
+- **Two-surface drift** (AGENTS.md trigger vs skill detail). **Mitigation:** AGENTS.md + CLAUDE.md carry only a pointer; the checklist lives once, in the skill (verified by AC2).
+
+## Acceptance criteria
+
+- [ ] **AC1 — skill is the SSOT**: `vault/00_meta/skills/handoff/SKILL.md` exists with the ordered checklist (continuity block + vault hygiene + repo/worktree state + artifact summary + next action). **Verify:** grep the steps.
+- [ ] **AC2 — trigger + pointer, no duplication**: `AGENTS.md` Phase 3 instructs running `/handoff` at session end and points to the skill; `ai/claude/CLAUDE.md` "Session Handoff" is reduced to a pointer (the 5-field list no longer duplicated there). **Verify:** grep AGENTS.md trigger + assert CLAUDE.md no longer lists the 5 fields.
+- [ ] **AC3 — deploys cross-agent, no drift**: after `compile-harness.sh --refresh`, the committed record `harness/skills/handoff/SKILL.md` exists and `--check` exits 0; bats asserts `/handoff` deploys to claude + opencode + agy carrying its checklist. **Verify:** `--check` + `tests/skills-pipeline.bats`.
+- [ ] **AC4 — minimal, scoped diff**: `--refresh` changes only the handoff record (plus the hand-authored AGENTS.md/CLAUDE.md edits); no other skill record churns. **Verify:** `git diff --stat`.
+
+## References
+
+- Sibling pattern: `specs/archive/SDD-011-agent-side-spec-trigger/` (two-surface skill + always-on trigger)
+- Pipeline: `00_meta/patterns/pattern-cross-agent-skill-pipeline.md` (SDD-008)
+- Continuity origin: the former `ai/claude/CLAUDE.md` "Session Handoff (MANDATORY)" rule
+- Epic: HARNESS-001 ([#162](https://github.com/mlorentedev/dotfiles/issues/162)); related MEMORY-001 (cross-agent session bridge)

--- a/specs/HANDOFF-001-cross-agent-handoff-skill/tasks.md
+++ b/specs/HANDOFF-001-cross-agent-handoff-skill/tasks.md
@@ -1,0 +1,35 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-05-13"
+---
+
+# Tasks - HANDOFF-001-cross-agent-handoff-skill
+
+> TDD order. One task = one focused commit.
+
+## Setup
+
+- [x] Vault gate entry HANDOFF-001 in `11-tasks.md` (committed 58c5bed)
+- [x] Branch `feat/handoff-001-cross-agent-skill` off origin/main (no parallel session → primary checkout, no worktree)
+- [x] `proposal.md` complete; acceptance criteria testable
+
+## Implementation
+
+- [x] Author the SSOT skill `vault/00_meta/skills/handoff/SKILL.md` — the ordered checklist (continuity block + vault hygiene + repo/worktree state + artifact summary + next action + verification) (AC1)
+- [x] Add the always-on trigger to `AGENTS.md` Phase 3 (Knowledge Crystallization) pointing to the skill (AC2)
+- [x] Reduce `ai/claude/CLAUDE.md` "Session Handoff" to a pointer — drop the duplicated 5-field detail (AC2)
+- [x] `compile-harness.sh --refresh` → regenerate record `harness/skills/handoff/`; `--check` green; minimal diff (AC3, AC4)
+- [x] bats: `/handoff` deploys cross-agent (claude + opencode + agy) carrying its checklist (AC3)
+
+## Closing
+
+- [x] Every AC covered by a test/check
+- [x] `features.json` present with non-vacuous verification commands
+- [x] `--check` + bats green; no unrelated changes (diff = skill record + AGENTS.md + CLAUDE.md + spec + test)
+- [x] `verification.md` filled
+- [ ] PR opened referencing this spec folder
+
+## Follow-up (separate)
+
+- [ ] MEMORY-001 cross-agent session bridge (continuity for non-Claude agents → `00_meta/sessions/`).
+- [ ] Optional: a session-end hook that auto-invokes `/handoff` (today the trigger is an instruction, not automation).

--- a/specs/HANDOFF-001-cross-agent-handoff-skill/verification.md
+++ b/specs/HANDOFF-001-cross-agent-handoff-skill/verification.md
@@ -1,0 +1,37 @@
+---
+tags: [spec, verification, templates]
+created: "2026-05-13"
+---
+
+# Verification - HANDOFF-001-cross-agent-handoff-skill
+
+## Evidence
+
+- [x] **AC1 — skill is the SSOT** → `vault/00_meta/skills/handoff/SKILL.md` carries the ordered checklist (6 steps: continuity block / vault hygiene / repo-worktree state / artifact summary / next action / verification).
+- [x] **AC2 — trigger + pointer, no duplication** → `grep` of `AGENTS.md` Phase 3 shows the `/handoff` trigger (count 1); `ai/claude/CLAUDE.md` no longer lists the 5-field detail (count 0) and points to `skills/handoff` (count 1).
+- [x] **AC3 — deploys cross-agent, no drift** → `compile-harness.sh --refresh` produced `harness/skills/handoff/`; `--check` → `[check] OK: no harness drift`; `tests/skills-pipeline.bats` test #4 asserts `/handoff` deploys to `.claude/skills/handoff`, `.config/opencode/commands/handoff.md`, `.gemini/skills/handoff` carrying `## Session Handoff`.
+- [x] **AC4 — minimal scoped diff** → `git status` after refresh: `AGENTS.md`, `ai/claude/CLAUDE.md` (hand edits) + new `harness/skills/handoff/` + spec folder; no other skill record changed.
+
+## Test status
+
+- `~/.local/bin/bats tests/skills-pipeline.bats` → `1..7` all `ok` (HANDOFF-001 is test #4).
+- `./scripts/compile-harness.sh --check` → `[check] OK: no harness drift`.
+- No regressions: the 6 pre-existing pipeline asserts still pass alongside the new one.
+
+## Decisions made during implementation
+
+- **Two-surface, mirrors SDD-011.** Detail (checklist) single-sourced in the vault skill; `AGENTS.md` (always-on, cross-agent) + `ai/claude/CLAUDE.md` (Claude overlay) carry only a pointer. The handoff fires for any agent, not just Claude.
+- **Continuity path = vault-junctioned `MEMORY.md`.** Any agent can write it, so the handoff is portable today; full cross-agent continuity (non-Claude session records) is MEMORY-001, out of scope.
+- **Built in the primary checkout (no worktree).** No parallel session was active — per the corrected worktree rule, a branch in `~/Projects/dotfiles` was the right call.
+
+## Promotion candidates
+
+- [ ] Lesson? **no** — third application of the two-surface skill+trigger pattern (SDD-011 already captured it); nothing new.
+- [ ] ADR-worthy? **no**.
+- [ ] Pattern candidate? **no** — folds into `pattern-cross-agent-skill-pipeline`.
+
+## Archive checklist
+
+- [ ] `proposal.md` → `status: archived`
+- [ ] Folder moved to `specs/archive/HANDOFF-001-cross-agent-handoff-skill/`
+- [ ] Vault `11-tasks.md` HANDOFF-001 ticked with PR link

--- a/tests/skills-pipeline.bats
+++ b/tests/skills-pipeline.bats
@@ -50,6 +50,17 @@ teardown() { cd / || true; rm -rf "$FAKEHOME"; }
     ! grep -q '^name:' "$FAKEHOME/.gemini/prompts/spec.md"   # frontmatter stripped
 }
 
+@test "HANDOFF-001: /handoff deploys cross-agent (claude + opencode + agy) with its checklist" {
+    run env HOME="$FAKEHOME" "$SCRIPT" --deploy
+    [ "$status" -eq 0 ]
+    [ -f "$FAKEHOME/.claude/skills/handoff/SKILL.md" ]
+    grep -q '^name: handoff' "$FAKEHOME/.claude/skills/handoff/SKILL.md"
+    [ -f "$FAKEHOME/.config/opencode/commands/handoff.md" ]
+    [ -f "$FAKEHOME/.gemini/skills/handoff/SKILL.md" ]
+    # the continuity-block checklist survives the vault -> record -> render chain
+    grep -q '## Session Handoff' "$FAKEHOME/.claude/skills/handoff/SKILL.md"
+}
+
 @test "AC8 smoke: a Claude-only skill is NOT exposed to opencode/agy" {
     run env HOME="$FAKEHOME" "$SCRIPT" --deploy
     [ "$status" -eq 0 ]

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -317,11 +317,11 @@ setup() {
     # Post-SDD-008: setup-linux.sh runs compile-harness.sh --deploy, which renders
     # each committed vault skill record whose targets[] includes opencode to a
     # command .md. The container has no vault, so --refresh is skipped and --deploy
-    # uses the committed records (22 skills, 5 Claude-only opt out -> 17 commands).
+    # uses the committed records (23 skills, 5 Claude-only opt out -> 18 commands).
     [ -d "$HOME/.config/opencode/commands" ]
     local count
     count=$(find "$HOME/.config/opencode/commands" -maxdepth 1 -name '*.md' | wc -l)
-    [ "$count" -eq 17 ]
+    [ "$count" -eq 18 ]  # 17 -> 18: HANDOFF-001 added the /handoff skill (targets all agents)
     # Spot check: audit.md present (portable), creating-skills.md absent (targets:[claude]).
     [ -f "$HOME/.config/opencode/commands/audit.md" ]
     [ ! -f "$HOME/.config/opencode/commands/creating-skills.md" ]


### PR DESCRIPTION
## What

Promotes the session **handoff** from a Claude-only rule into a **cross-agent `/handoff` skill**, so "do handoff" runs the same complete checklist in any agent (Claude, OpenCode, agy). Same two-surface pattern as SDD-011.

**Before:** `ai/claude/CLAUDE.md` had a Claude-only rule that did one thing — overwrite the `## Session Handoff` block in `MEMORY.md`. Not complete, not portable.

## How (two surfaces, SSOT-preserving)

- **Detail (SSOT):** `vault/00_meta/skills/handoff/SKILL.md` — the ordered checklist: (1) continuity block in `MEMORY.md` (5 fields), (2) vault hygiene (tick `11-tasks.md`, capture lessons), (3) repo/worktree/branch state, (4) artifact/PR summary, (5) next action, (6) verification. Regenerated into the committed record `harness/skills/handoff/` and deployed cross-agent by the SDD-008 pipeline.
- **Trigger (always-on):** `AGENTS.md` Phase 3 (Knowledge Crystallization) instructs running `/handoff` at session end, pointing to the skill.
- **`ai/claude/CLAUDE.md`** "Session Handoff" reduced to a pointer — the 5-field detail is no longer duplicated.

## Acceptance criteria

- [x] **AC1** skill is the SSOT (ordered checklist in the vault skill)
- [x] **AC2** AGENTS.md trigger + CLAUDE.md pointer, no duplication (grep: trigger=1, 5-field-list=0, points-to-skill=1)
- [x] **AC3** deploys cross-agent, no drift (`--check` OK; bats #4 asserts `/handoff` → claude + opencode + agy carrying its checklist)
- [x] **AC4** minimal diff (only the handoff record + the AGENTS.md/CLAUDE.md edits; no other skill record churns)

## Verification

- `bats tests/skills-pipeline.bats` → `1..7` ok (HANDOFF-001 = #4)
- `compile-harness.sh --check` → `[check] OK: no harness drift`

## SDD

- Spec: `specs/HANDOFF-001-cross-agent-handoff-skill/`
- Sibling: `specs/archive/SDD-011-agent-side-spec-trigger/` (two-surface skill + trigger)
- Epic: HARNESS-001 (#162); related MEMORY-001 (cross-agent session bridge, out of scope here)

## Note on the vault

The skill SSOT lives in the private vault (`00_meta/skills/handoff/SKILL.md`, on `master`) — not in this diff. The committed record here is a faithful render of it, gated offline by `--check`.
