### PR TITLE
docs(MEMORY-001): ADR-014 cross-agent session-memory bridge + spec scaffold

### DIFF
--- a/docs/adr/adr-014-cross-agent-session-memory-bridge.md
+++ b/docs/adr/adr-014-cross-agent-session-memory-bridge.md
@@ -1,0 +1,63 @@
+---
+id: "ADR-014-cross-agent-session-memory-bridge"
+type: adr
+status: accepted
+owner: manu
+date: "2026-05-31"
+extends: [adr-013-agent-artifact-deploy-engine]
+tags: [architecture, decision, session-memory, continuity, cross-agent, dotfiles, harness-001, memory-001]
+created: "2026-05-31"
+---
+
+# ADR-014: Cross-agent session-memory bridge
+
+> Drives `MEMORY-001` (GH [#117](https://github.com/mlorentedev/dotfiles/issues/117)); builds on `HANDOFF-001` (the `/handoff` skill) and the SDD-008 deploy engine (ADR-013).
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-31
+
+## Context
+
+`HANDOFF-001` made the session handoff a cross-agent `/handoff` skill, but two gaps remain. (1) **No durable history**: `/handoff` *overwrites* the `## Session Handoff` block in `MEMORY.md` — only the latest session survives; there is no per-session record to look back on. (2) **No auto-trigger and no non-Claude continuity**: the handoff fires only when an agent follows the AGENTS.md instruction, and `MEMORY.md` is Claude's auto-memory — other agents (OpenCode, agy, Copilot) have no continuity sink at all. `MEMORY-001` is the bridge that closes both gaps.
+
+The enabling fact that shapes the design: **Claude Code exposes a reliable `SessionEnd` hook** (verified) — it fires once at session termination (reasons: `clear`/`resume`/`logout`/…), delivers JSON on stdin (`session_id`, `transcript_path`, `cwd`, `hook_event_name`), and can run a shell command. So an *automatic* session-end capture is viable, at least for Claude. The other agents' session-end surfaces are not yet confirmed (and partly Windows-empirical).
+
+## Decision Drivers
+
+- Durable, append-only continuity that survives across sessions and agents.
+- Reuse `/handoff` (HANDOFF-001) — one procedure, two invocation paths (auto + manual), no second schema.
+- Don't bet the architecture on session-end hooks every agent may not have.
+- Cross-OS (bash + PowerShell), and CI-testable without the private vault.
+
+## Considered Options
+
+1. **Per-agent auto session-end hook + manual fallback** (CHOSEN). Each agent triggers `/handoff` at session end via its native session-end hook where one is confirmed reliable; agents without one fall back to the manual `/handoff` instruction already in AGENTS.md.
+2. **Manual-only `/handoff`.** Rejected — it wastes Claude's confirmed `SessionEnd` capability and leaves continuity dependent on the agent remembering.
+3. **A daemon / filesystem watcher.** Rejected — added moving part, no clean "session boundary" signal, cross-OS service complexity.
+
+## Decision
+
+Adopt a **cross-agent session-memory bridge** with three parts:
+
+1. **Append-only session store.** Each session writes a record `vault/00_meta/sessions/<YYYY-MM-DD>-<project>-<agent>.md` using the `/handoff` schema (`Last task` / `Decisions` / `Open threads` / `Next action`) plus frontmatter (`session_id`, `agent`, `project`, `date`). This is the durable **history**; the `MEMORY.md` `## Session Handoff` block remains the **latest** snapshot. The two are complementary, not redundant.
+2. **Trigger = native session-end hook where reliable, manual `/handoff` otherwise.** Claude wires its confirmed `SessionEnd` hook (in `settings.json`) to `scripts/session-handoff.sh`. Agents without a confirmed reliable session-end hook use the manual `/handoff` instruction (unchanged). Per-agent hook wiring for OpenCode / agy / Copilot is **empirical validation, tracked separately, non-blocking** on this ADR.
+3. **The bridge script `scripts/session-handoff.sh` (+ `.ps1`).** Reads the hook payload (`session_id`, `transcript_path`) from stdin, decides whether the session was non-trivial, and writes/updates the session record + the `MEMORY.md` block. Cross-OS; unit-testable against a fixture payload (no vault needed in CI).
+
+## Consequences
+
+- **Positive.** Claude gets automatic, durable session records immediately (SessionEnd is confirmed). `/handoff` is the single shared procedure both the auto-hook and the manual path invoke — no schema fork. The session store gives true cross-agent continuity once each agent's trigger is wired. The bridge is fixture-testable, so CI covers the logic without the private vault.
+- **Negative / risks.** (a) Non-Claude agents stay manual until their session-end surfaces are validated — partial coverage at first (tracked, acceptable). (b) `SessionEnd` fires on `clear`/`resume` too, so the bridge must gate on "was meaningful work done?" to avoid noise records. (c) An append-only store grows; periodic archival of `00_meta/sessions/` is a future hygiene task, not a blocker.
+- **Follow-up.** `MEMORY-001` implements parts 1–3 for Claude (Linux first); per-agent hook validation (OpenCode/agy/Copilot, some Windows-empirical) and session-store archival are downstream tickets.
+
+## References
+
+- `HANDOFF-001` — the `/handoff` skill (the shared procedure this bridge auto-invokes). `vault/00_meta/skills/handoff/SKILL.md`.
+- ADR-013 — agent-artifact deploy engine (how the hook + script deploy cross-OS).
+- Claude Code `SessionEnd` hook (verified capability: once-per-session, stdin JSON payload with `session_id` + `transcript_path`).
+- `claude-mem` — precedent for session-hook capture (conversation flow), complementary to this crystallized-continuity store.
+- `00_meta/patterns/pattern-decision-persistence.md`; GH [#117](https://github.com/mlorentedev/dotfiles/issues/117) (MEMORY-001).

--- a/specs/MEMORY-001-cross-agent-session-bridge/proposal.md
+++ b/specs/MEMORY-001-cross-agent-session-bridge/proposal.md
@@ -1,0 +1,51 @@
+---
+id: "MEMORY-001-cross-agent-session-bridge"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-05-31"
+tags: [spec, proposal, session-memory, continuity, cross-agent, adr-014, harness-001]
+template_version: "1.0"
+---
+
+# MEMORY-001-cross-agent-session-bridge
+
+> **Naming**: file lives at `<repo>/specs/MEMORY-001-cross-agent-session-bridge/proposal.md`. Implements **ADR-014** (`docs/adr/adr-014-cross-agent-session-memory-bridge.md`).
+
+## Why
+
+<!-- from 11-tasks.md: ([#117](https://github.com/mlorentedev/dotfiles/issues/117)) — Cross-Agent Session Memory Bridge dotfiles-side. **Dotfiles deliverables:** (a) `session-end` hook for opencode + AGY + copilot; (b) `dotfiles/scripts/session-handoff.sh` reads hook payload, writes to `00_meta/sessions/`; (c) cross-OS test parity. **Depends_on:** ADR (now ADR-014), SDD-008. -->
+
+`HANDOFF-001` made the handoff a cross-agent `/handoff` skill, but it only *overwrites* the `## Session Handoff` block in `MEMORY.md` (latest-only) and fires only when an agent follows the instruction — there is no durable per-session history and no continuity for non-Claude agents. ADR-014 ratified the bridge design; this spec builds its **Linux/Claude core**: an append-only session-record store plus an automatic capture wired to Claude's confirmed `SessionEnd` hook, reusing the `/handoff` schema. Per-agent triggers for OpenCode/agy/Copilot (some Windows-empirical) are explicit follow-ups.
+
+## What
+
+1. **Append-only session store**: a record `vault/00_meta/sessions/<YYYY-MM-DD>-<project>-<agent>.md` per non-trivial session, with frontmatter (`session_id`, `agent`, `project`, `date`) + the `/handoff` body (`Last task` / `Decisions` / `Open threads` / `Next action`). Durable history; complements `MEMORY.md`'s latest snapshot.
+2. **Bridge script `scripts/session-handoff.sh`**: reads the Claude `SessionEnd` JSON payload (`session_id`, `transcript_path`, `cwd`) from stdin, decides whether the session was non-trivial, and writes the session record (+ optionally refreshes the `MEMORY.md` block). No-ops cleanly on trivial sessions.
+3. **Claude `SessionEnd` hook** wired in `ai/claude/settings.json` → `session-handoff.sh`, deployed by setup (the merge policy already manages `hooks`).
+4. **Cross-OS + fixture-tested**: a `.ps1` mirror stub (parity) and a bats test driving `session-handoff.sh` with a fixture `SessionEnd` payload — no vault/Obsidian needed in CI.
+
+## Out of scope
+
+- **Per-agent session-end hooks for OpenCode / agy / Copilot** — their session-end surfaces are unconfirmed and partly Windows-empirical; tracked as downstream tickets (ADR-014 follow-up). Those agents keep the manual `/handoff` path meanwhile.
+- **Session-store archival / rotation** — `00_meta/sessions/` grows append-only; pruning is a later hygiene task.
+- **Changing the `/handoff` schema or the `MEMORY.md` format** — reused as-is.
+
+## Risks / open questions
+
+- **`SessionEnd` fires on `clear`/`resume` too** → noise records. **Mitigation:** the bridge gates on "was meaningful work done?" (e.g. transcript length / a marker) before writing.
+- **Cross-OS payload parsing** (bash `jq` vs PowerShell `ConvertFrom-Json`). **Mitigation:** parity test with the same fixture payload on both; ADR-013 already establishes the jq/ConvertFrom-Json dual approach.
+- **Writing to the vault from a hook** while the vault may be mid-sync. **Mitigation:** append a new file (not edit a shared one) to avoid races; obsidian-git commits it.
+
+## Acceptance criteria
+
+- [ ] **AC1 — bridge writes a record**: `scripts/session-handoff.sh` fed a fixture `SessionEnd` JSON payload writes `00_meta/sessions/<date>-<project>-claude.md` with the frontmatter + `/handoff` sections. **Verify:** bats fixture.
+- [ ] **AC2 — trivial-session no-op**: a fixture payload representing a trivial session writes no record (exit 0, no file). **Verify:** bats fixture.
+- [ ] **AC3 — Claude hook wired**: `ai/claude/settings.json` registers a `SessionEnd` hook invoking `session-handoff.sh`; the settings merge policy preserves it. **Verify:** grep settings template + bats parity assert.
+- [ ] **AC4 — cross-OS parity**: `session-handoff.ps1` exists with the same contract; a Pester/bats parity assert covers the fixture payload. **Verify:** parity test.
+
+## References
+
+- **ADR-014** `docs/adr/adr-014-cross-agent-session-memory-bridge.md` (the ratified design this implements)
+- `HANDOFF-001` — the `/handoff` skill + schema reused here
+- ADR-013 — deploy engine + the jq/ConvertFrom-Json cross-OS pattern
+- GH [#117](https://github.com/mlorentedev/dotfiles/issues/117); epic HARNESS-001 [#162](https://github.com/mlorentedev/dotfiles/issues/162)

--- a/specs/MEMORY-001-cross-agent-session-bridge/tasks.md
+++ b/specs/MEMORY-001-cross-agent-session-bridge/tasks.md
@@ -1,0 +1,34 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-05-13"
+---
+
+# Tasks - MEMORY-001-cross-agent-session-bridge
+
+> TDD order. Implements ADR-014. This PR ships the **ADR + spec (design)**; the implementation tasks below execute in a follow-up.
+
+## Setup
+
+- [x] Vault gate entry (MEMORY-001-mirror) in `11-tasks.md`
+- [x] **ADR-014** written + ratified (`docs/adr/adr-014-cross-agent-session-memory-bridge.md`)
+- [x] `proposal.md` complete; acceptance criteria testable
+
+## Implementation (follow-up — TDD)
+
+- [ ] Write failing bats: `session-handoff.sh` fed a fixture `SessionEnd` payload writes `00_meta/sessions/<date>-<project>-claude.md` (AC1)
+- [ ] Implement `scripts/session-handoff.sh`: parse stdin JSON (`jq`), gate on non-trivial, render the session record from the `/handoff` schema → green (AC1)
+- [ ] bats: trivial-session payload → no record written (AC2)
+- [ ] Wire the Claude `SessionEnd` hook in `ai/claude/settings.json` → `session-handoff.sh`; extend the settings merge policy assert (AC3)
+- [ ] `scripts/session-handoff.ps1` parity stub + cross-OS fixture parity assert (AC4)
+
+## Closing
+
+- [ ] Every AC covered by a test
+- [ ] `features.json` present
+- [ ] `verification.md` filled
+- [ ] PR opened referencing this spec folder
+
+## Follow-up tickets (downstream, per ADR-014)
+
+- [ ] Per-agent session-end hooks: OpenCode (`opencode.jsonc`), agy (`~/.gemini/settings.json`), Copilot — each needs its session-end surface validated (some Windows-empirical).
+- [ ] `00_meta/sessions/` archival / rotation hygiene.

--- a/specs/MEMORY-001-cross-agent-session-bridge/verification.md
+++ b/specs/MEMORY-001-cross-agent-session-bridge/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-05-13"
+---
+
+# Verification - MEMORY-001-cross-agent-session-bridge
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for `<area>/90-lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for `<area>/30-architecture/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/MEMORY-001-cross-agent-session-bridge/` -> `specs/archive/MEMORY-001-cross-agent-session-bridge/`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
## What

Ships **ADR-014 (cross-agent session-memory bridge)** — the ratified design for MEMORY-001 — plus the **MEMORY-001 spec scaffold**. This PR is design-only; the implementation (the bridge script + hook + tests) is a tracked follow-up.

## The decision (ADR-014)

`HANDOFF-001` made the handoff a cross-agent `/handoff` skill, but it only *overwrites* `MEMORY.md` (latest-only) and fires manually. ADR-014 closes the gap with a three-part bridge:

1. **Append-only session store** `vault/00_meta/sessions/<date>-<project>-<agent>.md` (the `/handoff` schema) — durable history, complementing `MEMORY.md`'s latest snapshot.
2. **Trigger = native session-end hook where reliable, manual `/handoff` otherwise.** Claude's **`SessionEnd` hook is confirmed** (fires once at session end, stdin JSON with `session_id` + `transcript_path`) → an automatic capture is viable. OpenCode/agy/Copilot session-end surfaces are unconfirmed → manual fallback, validated downstream.
3. **Bridge `scripts/session-handoff.sh`** parses the payload, gates on non-trivial, writes the record. Fixture-testable (no vault in CI).

Options rejected: manual-only (wastes the confirmed `SessionEnd`), daemon/watcher (complexity, no clean boundary).

## Verification

- ADR-014 follows the repo `docs/adr/` format (Context / Drivers / Options / Decision / Consequences / References); user-ratified.
- Spec `specs/MEMORY-001-cross-agent-session-bridge/` scaffolded (proposal + tasks plan), gated on the existing `MEMORY-001-mirror` backlog entry.

## Follow-up (the implementation, per the spec tasks)

`session-handoff.sh` + the Claude `SessionEnd` hook + bats fixture tests (Linux/Claude core first); then per-agent hooks (OpenCode/agy/Copilot, some Windows-empirical).
