### PR TITLE
chore(CHORE-002): reconcile docs/placement policy in AGENTS.md + /handoff repo-docs sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,10 +225,10 @@ Stop generation and warn if you detect:
 
 ## "Neural Hive" Protocol (The Loop)
 
-**CORE PRINCIPLE:** Code lives in Git. Knowledge lives in the vault — `~/Projects/knowledge/` (Linux/macOS) or `%USERPROFILE%\Projects\knowledge\` (Windows).
+**CORE PRINCIPLE:** Code lives in Git. **Knowledge placement depends on the project model** (Standing Order #2): a repo's build/operate docs — ADRs (`docs/adr/`), runbooks, troubleshooting — live in that repo's `docs/`; the vault (`~/Projects/knowledge/` Linux/macOS, `%USERPROFILE%\Projects\knowledge\` Windows) holds the cross-project brain, AI memory, and personal/methodology lessons. Patterns: `pattern-knowledge-placement`, `pattern-platform-governance`.
 **LANGUAGE:** All Vault content MUST be in English.
-**COMMIT POLICY:** Agents NEVER commit. Stage changes only.
-**NEVER** create `docs/`, `TODO.md` or `CHANGELOG.md` inside the repo.
+**COMMIT POLICY:** Default to staging changes only; **commit / push / open PRs only when the user asks** (this preserves the guardrail while fitting workflows — like this repo's PR-per-feature flow — that routinely commit on request).
+**REPO DOCS:** Repos on the knowledge-placement model keep `docs/` (with `docs/adr/`) in-repo and may keep a root `CHANGELOG.md`. This **supersedes the older blanket "never create `docs/`" stance** (closes CHORE-002). Still avoid ad-hoc `TODO.md` — tasks live in `specs/` + the backlog.
 
 ### Phase 1: Context Sync (Read First)
 

--- a/harness/skills/handoff/SKILL.md
+++ b/harness/skills/handoff/SKILL.md
@@ -36,11 +36,15 @@ OVERWRITE the `## Session Handoff` section (the first section after the H1) of t
 
 Rules: OVERWRITE entirely (never append); dense but bounded (~8 lines — handoff, not journal); convert relative dates to absolute. **Path:** the project's auto-memory `MEMORY.md`, which is junctioned into `vault/10_projects/<repo>/memory/` — so any agent can write it. This is the only place strategic continuity prose lives (the rest of `MEMORY.md` stays index-only).
 
-### 2. Vault hygiene (Standing Order #3 — in-session, never "later")
+### 2. Knowledge & documentation sync (Standing Order #3 — in-session, never "later")
 
+**Vault knowledge:**
 - Tick completed tasks in `vault/10_projects/<repo>/11-tasks.md` (`[ ]` -> `[x]` + ✓ date + PR link). Keep the file guard-green (one ticket = one entry — see SDD-012 `check-backlog-integrity.sh`).
-- Capture any non-obvious lesson in `90-lessons.md` (Context / Problem / Solution / Tags).
-- New architectural decision -> `30-architecture/adr-XXX.md`. Recurring pattern -> `00_meta/patterns/`.
+- Capture any non-obvious lesson in `90-lessons.md` (Context / Problem / Solution / Tags). New architectural decision -> an ADR; recurring pattern -> `00_meta/patterns/`.
+
+**Repo documentation (keep it reflecting the latest state):**
+- If the session changed behavior, structure, commands, public contracts, or setup, update the repo docs that describe them: `README.md` and the repo's `docs/` (ADRs, runbooks, troubleshooting) for repos on the knowledge-placement model. ADRs in this repo live in `docs/adr/`.
+- **Scope = this session's deltas, NOT a full audit.** A complete README/docs reconciliation is a dedicated task (e.g. an `AUDIT-*` ticket), not something every handoff redoes — the goal here is simply that docs do not drift behind the code the session just changed.
 
 ### 3. Repo / worktree / branch state
 


### PR DESCRIPTION
Reconciles the AGENTS.md "Neural Hive" section, which contradicted its own Standing Orders #2/#3 and reality.

## Contradictions fixed
- "Knowledge lives in the vault" (absolute) vs Standing Order #2 (placement model) + reality (`docs/adr/` has 13 ADRs).
- "NEVER create `docs/`...`CHANGELOG.md`" vs the repo having both + the place-knowledge model (KPM-001). **Closes #130 (CHORE-002).**
- "Agents NEVER commit" vs the actual PR-per-feature workflow → softened to "commit only when the user asks" (keeps the guardrail).

## Also
- Extends the `/handoff` skill (step 2) to keep repo docs (`README` + `docs/`) reflecting session deltas — scoped to deltas, not a full audit.

## SDD skip rationale
Policy/doc reconciliation closing a tracked ticket (CHORE-002); no new feature/contract, <50 LOC. Parity tests (`agents-md.bats`, `docs-drift.bats`) green.