### PR TITLE
feat(MEMORY-001): session-handoff.sh bridge — archive /handoff to 00_meta/sessions (ADR-014)

### DIFF
--- a/scripts/session-handoff.sh
+++ b/scripts/session-handoff.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# session-handoff.sh — MEMORY-001 cross-agent session bridge (implements ADR-014).
+#
+# Wired to Claude Code's `SessionEnd` hook. Reads the hook JSON on stdin and
+# ARCHIVES the `## Session Handoff` block that the /handoff skill wrote into the
+# project's MEMORY.md into an append-only record:
+#     $VAULT_PATH/00_meta/sessions/<date>-<project>-claude.md
+# The agent authors the handoff (via /handoff, with reasoning); this hook only
+# persists it as durable cross-session history.
+#
+# Resilience contract: a session-end hook must NEVER crash a session. Every
+# trivial / missing / malformed input is a clean no-op (exit 0, no file).
+#
+# Usage: session-handoff.sh        (SessionEnd JSON payload on stdin)
+
+VAULT_PATH="${VAULT_PATH:-$HOME/Projects/knowledge}"
+
+# 1. Read the payload; empty stdin -> no-op.
+payload="$(cat 2>/dev/null)"
+[ -n "$payload" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+# 2. Extract cwd + session_id (graceful on malformed JSON).
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null)"
+sid="$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null)"
+[ -n "$cwd" ] || exit 0
+project="$(basename "$cwd")"
+
+# 3. Locate the project's MEMORY.md; absent -> no-op.
+memory="$VAULT_PATH/10_projects/$project/memory/MEMORY.md"
+[ -f "$memory" ] || exit 0
+
+# 4. Extract the `## Session Handoff` block (from after the heading to the next
+#    `## ` heading or EOF). Empty/whitespace block -> trivial session, no-op.
+block="$(awk '
+    /^## Session Handoff[[:space:]]*$/ { cap=1; next }
+    cap && /^## / { exit }
+    cap { print }
+' "$memory")"
+[ -n "$(printf '%s' "$block" | tr -d '[:space:]')" ] || exit 0
+
+# 5. Append a durable, timestamped session record.
+date="$(date -u +%Y-%m-%d)"
+out_dir="$VAULT_PATH/00_meta/sessions"
+mkdir -p "$out_dir" 2>/dev/null || exit 0
+out="$out_dir/$date-$project-claude.md"
+
+{
+    printf -- '---\n'
+    printf 'id: "session-%s-%s-claude"\n' "$date" "$project"
+    printf 'type: session\n'
+    printf 'session_id: %s\n' "${sid:-unknown}"
+    printf 'agent: claude\n'
+    printf 'project: %s\n' "$project"
+    printf 'date: "%s"\n' "$date"
+    printf 'tags: [session, handoff, %s]\n' "$project"
+    printf -- '---\n\n'
+    printf '# Session %s — %s (claude)\n\n' "$date" "$project"
+    printf '%s\n' "$block"
+} > "$out" 2>/dev/null || exit 0
+
+exit 0

--- a/specs/MEMORY-001-cross-agent-session-bridge/features.json
+++ b/specs/MEMORY-001-cross-agent-session-bridge/features.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "MEMORY-001-cross-agent-session-bridge-f1",
+    "behavior": "AC1/AC2 — session-handoff.sh archives the MEMORY.md handoff block into 00_meta/sessions/ from a SessionEnd payload, and is a resilient no-op on trivial/missing/empty input",
+    "verification": "~/.local/bin/bats tests/session-handoff.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "MEMORY-001-cross-agent-session-bridge-f2",
+    "behavior": "session-handoff.sh is lint-clean",
+    "verification": "~/.local/bin/shellcheck scripts/session-handoff.sh",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/MEMORY-001-cross-agent-session-bridge/tasks.md
+++ b/specs/MEMORY-001-cross-agent-session-bridge/tasks.md
@@ -13,13 +13,13 @@ created: "2026-05-13"
 - [x] **ADR-014** written + ratified (`docs/adr/adr-014-cross-agent-session-memory-bridge.md`)
 - [x] `proposal.md` complete; acceptance criteria testable
 
-## Implementation (follow-up — TDD)
+## Implementation (TDD)
 
-- [ ] Write failing bats: `session-handoff.sh` fed a fixture `SessionEnd` payload writes `00_meta/sessions/<date>-<project>-claude.md` (AC1)
-- [ ] Implement `scripts/session-handoff.sh`: parse stdin JSON (`jq`), gate on non-trivial, render the session record from the `/handoff` schema → green (AC1)
-- [ ] bats: trivial-session payload → no record written (AC2)
-- [ ] Wire the Claude `SessionEnd` hook in `ai/claude/settings.json` → `session-handoff.sh`; extend the settings merge policy assert (AC3)
-- [ ] `scripts/session-handoff.ps1` parity stub + cross-OS fixture parity assert (AC4)
+- [x] Failing bats `tests/session-handoff.bats` (fixture `SessionEnd` payload) → RED (AC1)
+- [x] `scripts/session-handoff.sh`: parse stdin JSON (`jq`), locate the project MEMORY.md, **archive its `## Session Handoff` block** to `00_meta/sessions/<date>-<project>-claude.md`; resilient no-op on trivial/missing/malformed input → GREEN (AC1). *(Design: the agent authors via /handoff; the hook persists — see ADR-014.)*
+- [x] bats: no handoff block / no MEMORY.md / empty stdin → no record, clean exit (AC2)
+- [ ] **(next increment — deploy plumbing)** Wire the Claude `SessionEnd` hook in `ai/claude/settings.json` + the setup merge policy (placeholder substitution + `.hooks.SessionEnd` merge, cross-OS `setup-{linux,windows}`) + settings-template assert (AC3)
+- [ ] **(next increment)** `scripts/session-handoff.ps1` Windows port + Pester parity (AC4)
 
 ## Closing
 

--- a/specs/MEMORY-001-cross-agent-session-bridge/verification.md
+++ b/specs/MEMORY-001-cross-agent-session-bridge/verification.md
@@ -5,38 +5,34 @@ created: "2026-05-13"
 
 # Verification - MEMORY-001-cross-agent-session-bridge
 
+> This PR delivers the **Linux/Claude bridge core** (the script + tests). AC3 (hook deploy wiring) + AC4 (Windows port) are the tracked next increment.
+
 ## Evidence
 
-Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
-
-- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+- [x] **AC1 — archives the handoff block** → `tests/session-handoff.bats` test 1: a fixture `SessionEnd` payload + a `MEMORY.md` with a `## Session Handoff` block → `00_meta/sessions/<date>-myproj-claude.md` written, carrying `session_id` + the block content, excluding the index-only tail.
+- [x] **AC2 — trivial no-op** → tests 2/3/4: no handoff block / no `MEMORY.md` / empty stdin → no record, exit 0. A session-end hook never crashes a session.
+- [ ] **AC3 — Claude SessionEnd hook wired** → NEXT increment (settings.json + cross-OS setup merge policy). Design: `__SESSION_END_COMMAND__` placeholder + `.hooks.SessionEnd` merge, mirroring the SessionStart wiring.
+- [ ] **AC4 — Windows parity** → NEXT increment (`session-handoff.ps1` + Pester).
 
 ## Test status
 
-- Test suite: `<command> -> <output / coverage %>`
-- Manual smoke test: what was exercised, what was observed
-- No regressions in existing test suite: yes / no (if no, document)
+- `~/.local/bin/bats tests/session-handoff.bats` → `1..4` all `ok`.
+- `~/.local/bin/shellcheck scripts/session-handoff.sh` + `bash -n` → clean.
 
 ## Decisions made during implementation
 
-Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
-
--
--
+- **The hook archives; the agent authors.** `session-handoff.sh` does NOT synthesize the handoff (that needs the agent's reasoning) — it copies the `## Session Handoff` block that `/handoff` wrote into `MEMORY.md` into a timestamped append-only record. Clean separation, and fixture-testable without a real session (ADR-014).
+- **Resilience over strictness.** No `set -e`; every missing/malformed/trivial input is a clean `exit 0`. A `SessionEnd` hook that errors would surface noise at the worst moment.
+- **Scoped delivery.** The deploy wiring (settings.json + setup merge, cross-OS) is SDD-002-sensitive plumbing; shipped as a separate next increment rather than rushed into the bridge PR.
 
 ## Promotion candidates
 
-Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
-
-- [ ] Lesson for `<area>/90-lessons.md`? <yes / no - one line of what>
-- [ ] ADR-worthy decision for `<area>/30-architecture/adr-XXX.md`? <yes / no - one line of what>
-- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+- [ ] Lesson? **no** — standard hook-bridge; ADR-014 captures the design.
+- [ ] ADR-worthy? **no** — ADR-014 already covers it.
+- [ ] Pattern? **no**.
 
 ## Archive checklist
 
-- [ ] `proposal.md` frontmatter set to `status: archived`
-- [ ] Folder moved: `specs/MEMORY-001-cross-agent-session-bridge/` -> `specs/archive/MEMORY-001-cross-agent-session-bridge/`
-- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
-- [ ] Promotions above executed (if any)
+- [ ] AC3 + AC4 increments landed (then this spec is complete)
+- [ ] `proposal.md` -> `status: archived`; folder moved to `specs/archive/`
+- [ ] Vault `11-tasks.md` MEMORY-001 ticked with PR links

--- a/tests/session-handoff.bats
+++ b/tests/session-handoff.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+# MEMORY-001: session-handoff.sh — the Claude SessionEnd bridge (ADR-014).
+# It ARCHIVES the `## Session Handoff` block that /handoff wrote into a project's
+# MEMORY.md into an append-only record under 00_meta/sessions/. The agent reasons
+# (via /handoff); the hook persists. Fixture-driven — no real vault, CI-safe.
+
+setup() {
+    REPO="$BATS_TEST_DIRNAME/.."
+    SCRIPT="$REPO/scripts/session-handoff.sh"
+    VAULT="$(mktemp -d)"
+    PROJ_PARENT="$(mktemp -d)"
+    PROJ="$PROJ_PARENT/myproj"
+    mkdir -p "$PROJ" "$VAULT/00_meta/sessions" "$VAULT/10_projects/myproj/memory"
+    export VAULT_PATH="$VAULT"
+    PAYLOAD="$VAULT/payload.json"
+}
+
+teardown() { rm -rf "$VAULT" "$PROJ_PARENT"; }
+
+write_payload() {
+    printf '{"session_id":"%s","cwd":"%s","hook_event_name":"SessionEnd","reason":"clear"}' "$1" "$PROJ" > "$PAYLOAD"
+}
+
+@test "AC1: archives the MEMORY.md handoff block into a session record" {
+    cat > "$VAULT/10_projects/myproj/memory/MEMORY.md" <<'EOF'
+# Memory
+## Session Handoff
+> Updated: 2026-05-31
+**Last task:** built the thing
+**Next action:** ship it
+## Other
+index-only stuff
+EOF
+    write_payload sess-123
+    run bash -c "'$SCRIPT' < '$PAYLOAD'"
+    [ "$status" -eq 0 ]
+    rec="$(find "$VAULT/00_meta/sessions" -name '*-myproj-claude.md')"
+    [ -n "$rec" ]
+    grep -q 'session_id: sess-123' "$rec"
+    grep -q 'built the thing' "$rec"
+    # only the handoff block is archived, not the index-only tail
+    ! grep -q 'index-only stuff' "$rec"
+}
+
+@test "AC2: no handoff block in MEMORY.md -> no record (trivial no-op)" {
+    printf '# Memory\n## Index\nstuff\n' > "$VAULT/10_projects/myproj/memory/MEMORY.md"
+    write_payload sess-1
+    run bash -c "'$SCRIPT' < '$PAYLOAD'"
+    [ "$status" -eq 0 ]
+    [ -z "$(find "$VAULT/00_meta/sessions" -name '*.md')" ]
+}
+
+@test "AC2b: no MEMORY.md at all -> clean exit, no record" {
+    write_payload sess-1
+    run bash -c "'$SCRIPT' < '$PAYLOAD'"
+    [ "$status" -eq 0 ]
+    [ -z "$(find "$VAULT/00_meta/sessions" -name '*.md' 2>/dev/null)" ]
+}
+
+@test "usage: no stdin payload / empty -> clean no-op (never crashes a session)" {
+    run bash -c "printf '' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Implements the **Linux/Claude core** of the cross-agent session-memory bridge (ADR-014, spec MEMORY-001).

## What
`scripts/session-handoff.sh` is wired (next increment) to Claude's `SessionEnd` hook. It reads the hook JSON, locates the project's `MEMORY.md`, and **archives the `## Session Handoff` block** that `/handoff` wrote into an append-only record `00_meta/sessions/<date>-<project>-claude.md`.

**Design (ADR-014):** the agent authors the handoff (via `/handoff`, with reasoning); the hook only persists it as durable history. Resilient: every trivial/missing/malformed input is a clean no-op — a session-end hook must never crash a session.

## Verification
- `bats tests/session-handoff.bats` -> `1..4` ok (archive + 3 no-op cases)
- `shellcheck` + `bash -n` clean

## Scope
AC1/AC2 (the bridge logic) ship here. **AC3** (settings.json + cross-OS setup merge wiring) and **AC4** (Windows `.ps1` + Pester) are the tracked next increment — deploy plumbing that touches the SDD-002 settings-merge, kept as a separate focused PR.

Spec: `specs/MEMORY-001-cross-agent-session-bridge/`. Implements ADR-014.