### PR TITLE
fix: section-12 drift checks work under the copy-deploy model

### DIFF
--- a/scripts/compile-harness.sh
+++ b/scripts/compile-harness.sh
@@ -56,7 +56,9 @@ EOF
 # is exactly where setup + healthcheck invoke --check / --deploy. (The previous
 # `git rev-parse --show-toplevel` was CWD-dependent and errored on the non-git
 # copy, which was the root cause of the section-12 drift false-fail.)
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
+# HARNESS_REPO_ROOT overrides this — the test harness points the real script at a
+# throwaway fixture tree, the same explicit-override idiom as VAULT_PATH below.
+REPO_ROOT="${HARNESS_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)}"
 MANIFEST="$REPO_ROOT/harness/manifest.json"
 RECORD_DIR="$REPO_ROOT/harness/enforced"
 VAULT_PATH="${VAULT_PATH:-$HOME/Projects/knowledge}"

--- a/scripts/compile-harness.sh
+++ b/scripts/compile-harness.sh
@@ -50,16 +50,20 @@ EOF
 }
 
 # --- locate repo + inputs ---
-if ! REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
-    printf '[ERROR] not in a git repo\n' >&2
-    exit 1
-fi
+# Resolve the repo/deploy root from the script's own location: CWD-independent
+# and deploy-model-independent. Correct in a git checkout, a linked worktree, and
+# the non-git deploy copy (~/.dotfiles, ADR-012 copy-deploy) alike — and the copy
+# is exactly where setup + healthcheck invoke --check / --deploy. (The previous
+# `git rev-parse --show-toplevel` was CWD-dependent and errored on the non-git
+# copy, which was the root cause of the section-12 drift false-fail.)
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
 MANIFEST="$REPO_ROOT/harness/manifest.json"
 RECORD_DIR="$REPO_ROOT/harness/enforced"
 VAULT_PATH="${VAULT_PATH:-$HOME/Projects/knowledge}"
 
 require_tools() {
     command -v jq >/dev/null 2>&1 || { printf '[ERROR] jq is required\n' >&2; exit 2; }
+    [ -f "$MANIFEST" ] || { printf '[ERROR] manifest not found: %s (run from the repo or a complete deploy)\n' "$MANIFEST" >&2; exit 2; }
 }
 
 # --- helpers ---

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -415,11 +415,12 @@ else
 fi
 
 # Harness override drift (ENGINE-001): generated blocks vs their source-of-record.
-# Offline (no vault); run from the repo so git resolves regardless of CWD.
-# --check also validates that every committed skill record (SDD-008) renders
-# cleanly, so this one gate covers both the override blocks and the skill records.
+# Offline (no vault). compile-harness resolves its own root from the script's
+# location, so this works from the non-git deploy copy too — no CWD juggling.
+# --check also validates every committed skill record (SDD-008) renders cleanly,
+# so this one gate covers both the override blocks and the skill records.
 if [ -x "$SCRIPT_DIR/compile-harness.sh" ]; then
-    if ( cd "$DOTFILES_DIR" && "$SCRIPT_DIR/compile-harness.sh" --check ) >/dev/null 2>&1; then
+    if "$SCRIPT_DIR/compile-harness.sh" --check >/dev/null 2>&1; then
         pass "harness blocks + skill records match their source-of-record (no drift)"
     else
         fail "harness/skill drift (run: $SCRIPT_DIR/compile-harness.sh --refresh, then re-deploy)"
@@ -431,15 +432,21 @@ fi
 # Skill deployment integrity (SDD-008, AC1): deployed skills MUST be regular
 # copies, never symlinks/junctions (the BUG-100 fragility class). --check above
 # verifies the records render; this asserts the on-machine deploy is symlink-free.
+# Deployed skill paths MUST be regular hard copies, never symlinks (BUG-100 /
+# ADR-012). The invariant is intentionally strict — ANY symlink here is fragile
+# (a dangling/foreign link breaks discovery), so we surface all of them. Report
+# every offending path (not just the first) so cleanup is one pass.
 _skill_dirs=""
 for _d in "$HOME/.claude/skills" "$HOME/.config/opencode/commands" "$HOME/.gemini/skills" "$HOME/.gemini/prompts"; do
     [ -d "$_d" ] && _skill_dirs="$_skill_dirs $_d"
 done
 if [ -n "$_skill_dirs" ]; then
-    # shellcheck disable=SC2086
-    _skill_link="$(find $_skill_dirs -type l 2>/dev/null | head -1)"
-    if [ -n "$_skill_link" ]; then
-        fail "deployed skill path is a symlink (run: $SCRIPT_DIR/compile-harness.sh --deploy): $_skill_link"
+    # shellcheck disable=SC2086  # _skill_dirs is an intentional space-separated list
+    _skill_links="$(find $_skill_dirs -type l 2>/dev/null)"
+    if [ -n "$_skill_links" ]; then
+        fail "deployed skill path(s) are symlinks (must be hard copies — BUG-100):"
+        printf '%s\n' "$_skill_links" | sed 's|^|        |'
+        printf '        Fix: ours -> %s/compile-harness.sh --deploy; foreign/dangling -> remove the link.\n' "$SCRIPT_DIR"
     else
         pass "deployed skills are regular copies (no symlinks in skill paths)"
     fi

--- a/tests/compile-harness-rootresolve.bats
+++ b/tests/compile-harness-rootresolve.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+# Regression guard: compile-harness.sh must resolve its repo/deploy root from the
+# script's own location (not `git rev-parse`), so --check / --deploy work from the
+# NON-GIT deploy copy (~/.dotfiles, ADR-012 copy-deploy) — that is where setup and
+# healthcheck (section 12) invoke them. Requiring a git repo there false-failed.
+
+setup() {
+    REPO="$BATS_TEST_DIRNAME/.."
+    TMP="$(mktemp -d)"
+}
+
+teardown() { rm -rf "$TMP"; }
+
+@test "compile-harness --check works from a non-git copy (root resolved from SCRIPT_DIR)" {
+    # Assemble a complete, NON-git copy of exactly what --check reads.
+    mkdir -p "$TMP/scripts" "$TMP/ai/claude"
+    cp "$REPO/scripts/compile-harness.sh" "$TMP/scripts/"
+    cp "$REPO/AGENTS.md" "$TMP/"
+    cp "$REPO/ai/claude/CLAUDE.md" "$TMP/ai/claude/"
+    cp -r "$REPO/harness" "$TMP/"
+    [ ! -d "$TMP/.git" ]   # genuinely not a git repo
+
+    # Run from an unrelated CWD to prove root resolution is CWD-independent.
+    run bash -c "cd / && '$TMP/scripts/compile-harness.sh' --check"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'no harness drift'
+}
+
+@test "compile-harness without its harness/ dir fails gracefully (no crash)" {
+    mkdir -p "$TMP/scripts"
+    cp "$REPO/scripts/compile-harness.sh" "$TMP/scripts/"
+    run bash -c "cd / && '$TMP/scripts/compile-harness.sh' --check"
+    [ "$status" -ne 0 ]   # missing manifest -> clean non-zero, not a stack trace
+}

--- a/tests/compile-harness.bats
+++ b/tests/compile-harness.bats
@@ -29,6 +29,11 @@ EOF
     git init -q -b main
     git config user.email t@t; git config user.name t; git config commit.gpgsign false
 
+    # Point the real script at this fixture tree (the script defaults to its own
+    # SCRIPT_DIR — the live repo — so without this every mode would operate on the
+    # real harness/ instead of the fixture). Inherited by every `run` below.
+    export HARNESS_REPO_ROOT="$REPO"
+
     cat > "$REPO/harness/manifest.json" <<'EOF'
 { "version": 1, "vault_subpath": "00_meta/patterns",
   "enforced": [ { "id": "demo", "source": "test-pattern.md#1-demo-rule" } ],
@@ -110,7 +115,7 @@ run_refresh() { run env VAULT_PATH="$VAULT" "$SCRIPT" --refresh; }
 }
 
 @test "AC1: healthcheck.sh asserts deployed skills are symlink-free (SDD-008)" {
-    grep -q 'deployed skill path is a symlink' "$BATS_TEST_DIRNAME/../scripts/healthcheck.sh"
+    grep -qF 'deployed skill path(s) are symlinks' "$BATS_TEST_DIRNAME/../scripts/healthcheck.sh"
     grep -qF '.claude/skills' "$BATS_TEST_DIRNAME/../scripts/healthcheck.sh"
     grep -qF '.config/opencode/commands' "$BATS_TEST_DIRNAME/../scripts/healthcheck.sh"
 }


### PR DESCRIPTION
Fixes the two section-12 "Repo <-> Deploy-Dir Drift" healthcheck FAILs from `setup-linux`. Both were exposed by the copy-deploy model (ADR-012 made `~/.dotfiles` a plain non-git copy).

## FAIL 1 - harness/skill drift
`compile-harness.sh --check` required a git repo (`git rev-parse`), but the healthcheck runs it from the non-git `~/.dotfiles` -> `[ERROR] not in a git repo` -> false-fail.
**Fix:** resolve the root from the script's own location (CWD- and deploy-model-independent) - works in a checkout, a linked worktree, and the non-git copy alike. Removed the vestigial `cd "$DOTFILES_DIR"`. `--check/--deploy/--refresh` now fail loudly on a missing manifest (was a silent pass).

## FAIL 2 - deployed skill is a symlink (`~/.claude/skills/find-skills`)
A REAL issue, correctly caught: `find-skills` was a **dangling** symlink (-> a removed 3-Feb `~/.agents` leftover). Resolved by removing the broken symlink (runtime). The check stays **strict** - all deployed skill paths must be hard copies (BUG-100); now reports every offender with an ours/foreign fix hint. (An attempt to scope the check to "our" skills was reverted - it would have hidden the real dangling symlink, contradicting the all-hard-copies invariant.)

## Verification
- `bats tests/compile-harness-rootresolve.bats`: --check works from a non-git copy + fails gracefully without a manifest.
- `skills-pipeline.bats` + `claude-settings-template.bats` green; `shellcheck` + `bash -n` clean.