### PR TITLE
test(agy): re-point Shared-Skills parity check to the SDD-008 deploy engine

### DIFF
--- a/tests/antigravity.bats
+++ b/tests/antigravity.bats
@@ -54,12 +54,16 @@ setup() {
     grep -qF 'Obsidian vault not found at' "$DOTFILES_DIR/setup-windows.ps1"
 }
 
-@test "setup-windows.ps1 syncs Shared Skills to ~/.gemini/skills (closes 0-skills-on-Windows bug)" {
-    # setup-linux.sh:398-419 deploys to ~/.gemini/skills (Shared path); parity
-    # was missing on Windows -> agy displayed "0 skills". This test locks the
-    # cross-OS parity.
-    grep -qF 'Synced Shared Skills to' "$DOTFILES_DIR/setup-windows.ps1"
-    grep -qF 'sharedSkillsDir' "$DOTFILES_DIR/setup-windows.ps1"
+@test "setup-windows.ps1 deploys agy skills via the SDD-008 engine (closes 0-skills-on-Windows bug, cross-OS parity)" {
+    # SDD-008 (#179) replaced the per-agent sharedSkillsDir sync with the unified
+    # render-at-deploy engine (Deploy-SkillRecord on Windows, compile-harness
+    # --deploy on Linux). The old 'Synced Shared Skills to' / 'sharedSkillsDir'
+    # literals are gone from both setups. From a Linux box we cannot run the
+    # Windows setup, so we static-check that the Windows script still wires up
+    # agy skill deployment: it invokes Deploy-SkillRecord and provisions the
+    # gemini skills dir. This locks the cross-OS parity at the live mechanism.
+    grep -qF 'Deploy-SkillRecord' "$DOTFILES_DIR/setup-windows.ps1"
+    grep -qF "GeminiHome 'skills'" "$DOTFILES_DIR/setup-windows.ps1"
 }
 
 @test "ai/agy/AGY.md H1 is '# AGY.md' (regression: GEMINI.md->AGY.md rename completeness)" {


### PR DESCRIPTION
## What

The antigravity parity test (`tests/antigravity.bats`) asserted `setup-windows.ps1` contained the literals `'Synced Shared Skills to'` and `'sharedSkillsDir'`. SDD-008 (#179) replaced the per-agent skill sync with the unified render-at-deploy engine (`Deploy-SkillRecord` on Windows, `compile-harness.sh --deploy` on Linux) and **removed those literals from both setup scripts**.

## Why

The test was a false negative: it **passed in CI** (the whole `antigravity.bats` suite skips when `agy` is absent) but **failed on any machine with `agy` installed**, because it checked for strings that no longer exist. It asserted dead implementation detail, not the real invariant.

## Fix

Re-point the static parity proxy (we can't run the Windows setup from Linux, so we grep its script) to the live mechanism: assert `setup-windows.ps1` invokes `Deploy-SkillRecord` and provisions the gemini skills dir. The cross-OS parity invariant ("agy gets its skills, not 0") is preserved; only the implementation coupling changes.

## Evidence

- Before: `not ok — grep 'Synced Shared Skills to' failed` (on an `agy` box)
- After: `ok 6 — setup-windows.ps1 deploys agy skills via the SDD-008 engine`
- Full suite: **16/16 green**, no regression.

Test-only change (no production diff); Skip-SDD applies (obvious cause, locks an existing invariant).