### PR TITLE
feat(hermes): add remote agent provisioning + safety net

### DIFF
--- a/ai/hermes/AGENTS.md
+++ b/ai/hermes/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md (Hermes)
+
+> **SYSTEM META-INSTRUCTION:** Target agent: Hermes Agent (Nous Research), a
+> remote ops agent on NaN infrastructure (Debian 13), reachable via Telegram.
+>
+> **First, read `AGENTS.md` at the repo root** — the canonical SSOT for behaviour
+> rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop,
+> MCP usage, Operational Rules). This file holds only Hermes-specific notes on top.
+>
+> If `AGENTS.md` is missing from the current context, default to the canonical
+> version at `~/Projects/dotfiles/AGENTS.md` (Linux/macOS) or
+> `%USERPROFILE%\Projects\dotfiles\AGENTS.md` (Windows).
+
+## Runtime brain lives in the vault, not in this checkout
+
+Hermes does **not** clone the dotfiles repo. It is provisioned remotely by
+`ai/hermes/setup.sh` (curled once) and reads its operating knowledge from the
+vault. This file is documentation in the dotfiles repo (per-agent overlay,
+ADR-009 parity with `ai/agy/AGY.md`); Hermes's live constitution and SSOT are:
+
+- **Constitution:** `80_agents/hermes-nan/AGENTS.md` (operating law: write-zone,
+  sync discipline, bootstrap protocol).
+- **Identity + structure map:** `80_agents/hermes-nan/00-context.md`.
+- **Shared patterns:** `00_meta/patterns/` — loaded on demand via the
+  `pattern-loader` skill.
+
+## Hermes-specific rules (on top of root `AGENTS.md`)
+
+- **Write zone.** Hermes commits **only** within `80_agents/hermes-nan/` (the
+  autonomous-agent commit policy, PR #189). It has read access to the whole
+  vault — that cross-project brain is the value — but never writes outside its
+  workspace.
+- **Language.** Chat with Manu in **Spanish from Spain**; **all** vault content
+  (files, commit messages) in **English**.
+- **Vault access.** Hive MCP via `uvx hive-vault`, pointed at the persistent
+  clone (`$HERMES_VAULT_PATH`, default `~/.local/state/hermes/vault`).
+- **Secrets.** `GITHUB_TOKEN_KNOWLEDGE` lives in `~/.hermes/.env` (chmod 600) —
+  never in chat or vault. Hermes diverges from the dotfiles age-secrets model by
+  design (the remote box has neither the dotfiles repo nor the age key).
+- **Provisioning.** `ai/hermes/setup.sh` is idempotent and non-interactive; it
+  does not touch the local-deploy surface and is never wired into `setup-linux`.
+
+## Model Tier (per root `AGENTS.md` "Model Selection")
+
+- **Default:** `deepseek-v4-flash` (NaN endpoint) — interactive ops.
+- **Async / cron:** `qwen3.6` — scheduled, multilingual jobs.
+
+Model identifiers reflect the NaN catalog; verify availability in the Hermes
+runtime if a listed model is rejected.

--- a/ai/hermes/setup.sh
+++ b/ai/hermes/setup.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# ai/hermes/setup.sh — remote provisioner for the Hermes agent (HERMES-001).
+#
+# Hermes is a remote ops agent (Debian 13 on NaN infra, Telegram gateway). This
+# script is NOT the Hermes product installer (that is Nous Research's
+# `curl … install.sh` + `hermes setup --portal`); it layers the vault/Hive
+# integration on top of an already-installed Hermes. A fresh box curls this.
+#
+# Properties: idempotent, non-interactive (safe under `curl … | bash`). It runs
+# as root on the NaN box and MAY apt-install the `cron` package if absent. It
+# touches NONE of the local-deploy surface (setup-linux.sh, setup-windows.ps1,
+# mcp-servers.json).
+#
+# Seams (env overrides; mirror the repo's VAULT_PATH / HARNESS_REPO_ROOT idiom):
+#   HERMES_HOME         dir for ~/.hermes config + secrets   (default ~/.hermes)
+#   HERMES_VAULT_PATH   persistent vault clone               (default ~/.local/state/hermes/vault)
+#   HERMES_VAULT_REPO   vault git remote                     (default knowledge repo)
+#   HERMES_VAULT_BRANCH vault default branch                 (default master)
+#   HERMES_SETUP_DRY_RUN=1  skip network/system mutations (tests)
+#
+# Secrets: GITHUB_TOKEN_KNOWLEDGE comes from the environment or $HERMES_HOME/.env
+# (never from sensitive/ — the remote box has neither the dotfiles repo nor the
+# age key). The token is needed to clone the private vault and to push to
+# 80_agents/. See specs/HERMES-001-add-hermes-agent/proposal.md.
+
+set -euo pipefail
+
+# --- Config (env-overridable seams) ---
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_VAULT_PATH="${HERMES_VAULT_PATH:-$HOME/.local/state/hermes/vault}"
+HERMES_VAULT_REPO="${HERMES_VAULT_REPO:-https://github.com/mlorentedev/knowledge.git}"
+HERMES_VAULT_BRANCH="${HERMES_VAULT_BRANCH:-master}"
+DRY_RUN="${HERMES_SETUP_DRY_RUN:-0}"
+
+AGENT_DIR_REL="80_agents/hermes-nan"
+
+log() { printf '[hermes-setup] %s\n' "$*"; }
+die() { printf '[hermes-setup] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# Git invocation that supplies the token via a credential helper sourcing
+# $HERMES_HOME/.env at call time, so the token never lands in .git/config. Used
+# for the first clone (ensure_hermes_home populates .env before this runs).
+git_token() {
+    git -c "credential.helper=!f(){ . $HERMES_HOME/.env 2>/dev/null; echo username=x-access-token; echo \"password=\$GITHUB_TOKEN_KNOWLEDGE\"; };f" "$@"
+}
+
+# --- 1. Prerequisites (fail fast) ---
+check_prereqs() {
+    command -v uv >/dev/null 2>&1 || die "uv not found. Install: https://docs.astral.sh/uv/"
+
+    # Token: environment wins; otherwise source $HERMES_HOME/.env; otherwise fail.
+    if [ -z "${GITHUB_TOKEN_KNOWLEDGE:-}" ] && [ -f "$HERMES_HOME/.env" ]; then
+        # shellcheck disable=SC1091
+        . "$HERMES_HOME/.env"
+    fi
+    [ -n "${GITHUB_TOKEN_KNOWLEDGE:-}" ] || \
+        die "GITHUB_TOKEN_KNOWLEDGE required (set in the environment or $HERMES_HOME/.env)"
+    log "prerequisites ok (uv present, token resolved)"
+}
+
+# --- 2. ~/.hermes home + secrets file ---
+ensure_hermes_home() {
+    mkdir -p "$HERMES_HOME"
+    chmod 700 "$HERMES_HOME"
+    env_file="$HERMES_HOME/.env"
+    if [ ! -f "$env_file" ]; then
+        : > "$env_file"
+    fi
+    chmod 600 "$env_file"
+    # Persist the token only if not already recorded (idempotent).
+    if ! grep -q '^GITHUB_TOKEN_KNOWLEDGE=' "$env_file" 2>/dev/null; then
+        printf 'GITHUB_TOKEN_KNOWLEDGE=%s\n' "$GITHUB_TOKEN_KNOWLEDGE" >> "$env_file"
+        log "recorded GITHUB_TOKEN_KNOWLEDGE in $env_file"
+    fi
+}
+
+# --- 3. Hive MCP launcher ---
+install_hive() {
+    if [ "$DRY_RUN" = 1 ]; then
+        log "[dry-run] would: uv tool install --upgrade hive-vault"
+        return 0
+    fi
+    uv tool install --upgrade hive-vault
+    log "hive-vault installed/updated"
+}
+
+# --- 3.5 Preflight: verify the token actually reaches the vault remote ---
+# Fail BEFORE any heavy mutation (clone, package install) rather than half-
+# provisioning, so a bad/expired token is a clean abort, not a wedged box.
+check_vault_access() {
+    if [ "$DRY_RUN" = 1 ]; then
+        log "[dry-run] would: verify vault remote access with the token"
+        return 0
+    fi
+    if ! git_token ls-remote --heads "$HERMES_VAULT_REPO" >/dev/null 2>&1; then
+        die "cannot reach vault remote ($HERMES_VAULT_REPO) with the provided token — check scope/expiry"
+    fi
+    log "vault remote reachable, token valid"
+}
+
+# --- 4. Vault clone (persistent path, idempotent) ---
+ensure_vault_clone() {
+    mkdir -p "$(dirname "$HERMES_VAULT_PATH")"
+    if [ -d "$HERMES_VAULT_PATH/.git" ]; then
+        if [ "$DRY_RUN" = 1 ]; then
+            log "[dry-run] would: git -C $HERMES_VAULT_PATH pull --ff-only"
+        else
+            git_token -C "$HERMES_VAULT_PATH" pull --ff-only --quiet
+            log "vault updated at $HERMES_VAULT_PATH"
+        fi
+    else
+        if [ "$DRY_RUN" = 1 ]; then
+            log "[dry-run] would: git clone $HERMES_VAULT_REPO -> $HERMES_VAULT_PATH"
+        else
+            git_token clone --branch "$HERMES_VAULT_BRANCH" "$HERMES_VAULT_REPO" "$HERMES_VAULT_PATH"
+            log "vault cloned to $HERMES_VAULT_PATH"
+        fi
+    fi
+    if [ -d "$HERMES_VAULT_PATH/.git" ]; then
+        # Strip any token embedded in the remote URL (the existing box has
+        # https://x-access-token:***@github.com/...). The credential helper
+        # below supplies the token instead, keeping it out of .git/config.
+        if git -C "$HERMES_VAULT_PATH" remote get-url origin 2>/dev/null | grep -q '@'; then
+            git -C "$HERMES_VAULT_PATH" remote set-url origin "$HERMES_VAULT_REPO"
+            log "stripped embedded token from origin remote URL"
+        fi
+        # Persistent credential helper that sources $HERMES_HOME/.env at call
+        # time — works for the cron/non-interactive post-commit push too.
+        git -C "$HERMES_VAULT_PATH" config credential.helper \
+            "!f(){ . $HERMES_HOME/.env 2>/dev/null; echo username=x-access-token; echo \"password=\$GITHUB_TOKEN_KNOWLEDGE\"; };f"
+    fi
+}
+
+# --- 5. Vault SSOT bootstrap (ensure the agent workspace context exists) ---
+ensure_agent_workspace() {
+    ctx="$HERMES_VAULT_PATH/$AGENT_DIR_REL/00-context.md"
+    if [ -d "$HERMES_VAULT_PATH/.git" ] && [ ! -f "$ctx" ]; then
+        log "warning: $AGENT_DIR_REL/00-context.md missing in vault (agent will bootstrap it)"
+    fi
+    # Ensure-local only: we do NOT commit here. The agent commits in its own flow
+    # (write-only 80_agents/ per the commit policy).
+}
+
+# --- 6. Vault sync mechanism: robust cron pull + post-commit auto-push ---
+
+# Robust auto-pull wrapper: aborts a conflicted rebase instead of leaving the
+# clone wedged (a junior agent cannot recover a half-rebased repo). Paths are
+# baked in because cron jobs run with no environment.
+write_sync_script() {
+    sync_script="$HERMES_HOME/vault-pull.sh"
+    cat > "$sync_script" <<EOF
+#!/bin/sh
+# hermes-managed: robust vault auto-pull (abort rebase on conflict, never wedge)
+cd "$HERMES_VAULT_PATH" || exit 0
+if ! git pull --rebase --quiet 2>/dev/null; then
+    git rebase --abort 2>/dev/null || true
+    printf '%s vault pull conflict; rebase aborted\n' "\$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$HERMES_HOME/sync.log"
+fi
+EOF
+    chmod +x "$sync_script"
+}
+
+ensure_sync() {
+    # The cron PACKAGE may be absent on a minimal Debian box. Install it if so
+    # (the box runs as root). The crontab ENTRY itself is userspace.
+    if ! command -v crontab >/dev/null 2>&1; then
+        if [ "$DRY_RUN" = 1 ]; then
+            log "[dry-run] would: apt-get install -y cron"
+        elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq && apt-get install -y cron
+            log "installed cron package"
+        else
+            log "warning: crontab not found and apt-get unavailable; skipping cron setup"
+            return 0
+        fi
+    fi
+
+    write_sync_script
+    cron_line="*/5 * * * * $HERMES_HOME/vault-pull.sh"
+    if [ "$DRY_RUN" = 1 ]; then
+        log "[dry-run] would: install crontab entry + start cron"
+    else
+        # Rebuild the crontab: drop the stale pre-HERMES-001 inline /tmp pull
+        # line and any prior wrapper entry, then add exactly one wrapper entry.
+        # Idempotent: the end state is identical on every run.
+        new_crontab="$(crontab -l 2>/dev/null | grep -vF 'cd /tmp/hermes-vault && git pull' | grep -vF "$HERMES_HOME/vault-pull.sh" || true)"
+        { printf '%s\n' "$new_crontab"; printf '%s\n' "$cron_line"; } | grep -v '^[[:space:]]*$' | crontab -
+        log "ensured vault-pull crontab entry (single; stale /tmp entry removed)"
+        if command -v service >/dev/null 2>&1; then
+            service cron start >/dev/null 2>&1 || true
+        fi
+    fi
+
+    # Post-commit auto-push hook (idempotent; marker-guarded).
+    hook="$HERMES_VAULT_PATH/.git/hooks/post-commit"
+    if [ -d "$HERMES_VAULT_PATH/.git" ]; then
+        if [ ! -f "$hook" ] || ! grep -q 'hermes-managed' "$hook" 2>/dev/null; then
+            cat > "$hook" <<EOF
+#!/bin/sh
+# hermes-managed: auto-push after every commit
+exec git push --quiet origin $HERMES_VAULT_BRANCH 2>&1
+EOF
+            chmod +x "$hook"
+            log "installed post-commit auto-push hook"
+        fi
+    fi
+}
+
+# --- 7. Mechanical guardrails (Hermes commits via git CLI, so hooks fire) ---
+# A junior agent needs a hard boundary, not an instruction. These local hooks
+# live in Hermes's clone only (never tracked, never cloned) and cannot be
+# bypassed by a normal commit/push.
+install_guardrails() {
+    [ -d "$HERMES_VAULT_PATH/.git" ] || return 0
+    hooks="$HERMES_VAULT_PATH/.git/hooks"
+    mkdir -p "$hooks"
+
+    # pre-commit: reject any staged path outside the agent workspace, and any
+    # token-like content (defense in depth even within the zone).
+    cat > "$hooks/pre-commit" <<EOF
+#!/bin/sh
+# hermes-managed: write-zone + secret guard (HERMES-001)
+zone="$AGENT_DIR_REL/"
+outside=\$(git diff --cached --name-only | grep -v "^\$zone" || true)
+if [ -n "\$outside" ]; then
+    echo "pre-commit: refusing commit touching paths outside \$zone:" >&2
+    echo "\$outside" >&2
+    exit 1
+fi
+if git diff --cached -U0 | grep -qE '(ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|AGE-SECRET-KEY-1|AKIA[0-9A-Z]{16})'; then
+    echo "pre-commit: refusing commit with token-like content" >&2
+    exit 1
+fi
+exit 0
+EOF
+    chmod +x "$hooks/pre-commit"
+
+    # pre-push: reject non-fast-forward (force) pushes that rewrite history.
+    cat > "$hooks/pre-push" <<'EOF'
+#!/bin/sh
+# hermes-managed: reject non-fast-forward (force) pushes (HERMES-001)
+z=0000000000000000000000000000000000000000
+while read -r _lref lsha _rref rsha; do
+    [ "$lsha" = "$z" ] && continue
+    [ "$rsha" = "$z" ] && continue
+    if ! git merge-base --is-ancestor "$rsha" "$lsha" 2>/dev/null; then
+        echo "pre-push: refusing non-fast-forward (force) push" >&2
+        exit 1
+    fi
+done
+exit 0
+EOF
+    chmod +x "$hooks/pre-push"
+    log "installed write-zone + secret + no-force guardrails"
+}
+
+# --- 8. Register the Hive MCP server with Hermes (native CLI) ---
+# Hermes exposes `hermes mcp add`; we do NOT hand-edit config.yaml (which lives
+# at /hermes-home/config.yaml and holds the product's own provider config).
+# Idempotent via `hermes mcp list`. Non-fatal: the agent operates over git today.
+register_hive_mcp() {
+    hermes_bin="${HERMES_BIN:-}"
+    if [ -z "$hermes_bin" ]; then
+        if command -v hermes >/dev/null 2>&1; then
+            hermes_bin="hermes"
+        elif [ -x /opt/hermes/.venv/bin/hermes ]; then
+            hermes_bin="/opt/hermes/.venv/bin/hermes"
+        fi
+    fi
+    if [ -z "$hermes_bin" ]; then
+        log "warning: hermes binary not found; skipping Hive MCP registration"
+        return 0
+    fi
+    if [ "$DRY_RUN" = 1 ]; then
+        log "[dry-run] would: $hermes_bin mcp add hive --command uvx --args hive-vault --env HIVE_VAULT_PATH=$HERMES_VAULT_PATH"
+        return 0
+    fi
+    if "$hermes_bin" mcp list 2>/dev/null | grep -qi hive; then
+        log "Hive MCP already registered"
+        return 0
+    fi
+    # hive-vault reads HIVE_VAULT_PATH from its env; hermes injects it at start.
+    if "$hermes_bin" mcp add hive --command uvx --args hive-vault \
+        --env "HIVE_VAULT_PATH=$HERMES_VAULT_PATH"; then
+        log "registered Hive MCP server (HIVE_VAULT_PATH=$HERMES_VAULT_PATH)"
+    else
+        log "warning: 'hermes mcp add hive' failed"
+    fi
+}
+
+main() {
+    check_prereqs
+    ensure_hermes_home
+    check_vault_access
+    install_hive
+    ensure_vault_clone
+    ensure_agent_workspace
+    ensure_sync
+    install_guardrails
+    register_hive_mcp
+    log "done. vault: $HERMES_VAULT_PATH | home: $HERMES_HOME"
+}
+
+main "$@"

--- a/specs/HERMES-001-add-hermes-agent/features.json
+++ b/specs/HERMES-001-add-hermes-agent/features.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "HERMES-001-add-hermes-agent-f1",
+    "behavior": "ai/hermes/setup.sh passes shellcheck and parses clean under bash -n and zsh -n",
+    "verification": "shellcheck ai/hermes/setup.sh && bash -n ai/hermes/setup.sh && zsh -n ai/hermes/setup.sh",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HERMES-001-add-hermes-agent-f2",
+    "behavior": "setup.sh is idempotent: run twice under the dry-run/stub seam, both exit 0, second run is a no-op",
+    "verification": "bats tests/hermes-setup.bats -f idempotent",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HERMES-001-add-hermes-agent-f3",
+    "behavior": "setup.sh fails fast with non-zero exit and a clear message when uv or GITHUB_TOKEN_KNOWLEDGE is missing",
+    "verification": "bats tests/hermes-setup.bats -f 'fail fast'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HERMES-001-add-hermes-agent-f4",
+    "behavior": "ai/hermes/AGENTS.md is a thin pointer to root AGENTS.md and the vault constitution",
+    "verification": "grep -qi 'AGENTS.md' ai/hermes/AGENTS.md && grep -qi 'hermes-nan' ai/hermes/AGENTS.md",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HERMES-001-add-hermes-agent-f5",
+    "behavior": "setup.sh modifies none of setup-linux.sh, setup-windows.ps1, mcp-servers.json",
+    "verification": "! grep -qE 'setup-linux\\.sh|setup-windows\\.ps1|mcp-servers\\.json' ai/hermes/setup.sh",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HERMES-001-add-hermes-agent-f6",
+    "behavior": "vault SSOT is consistent: 80_agents/hermes-nan/scripts/validate.sh passes against the real folder (vault-side)",
+    "verification": "bash \"$HOME/Projects/knowledge/80_agents/hermes-nan/scripts/validate.sh\"",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HERMES-001-add-hermes-agent-f7",
+    "behavior": "safety net: preflight aborts on unreachable vault remote; auto-pull wrapper aborts a conflicted rebase",
+    "verification": "bats tests/hermes-setup.bats -f 'preflight|sync wrapper'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HERMES-001-add-hermes-agent-f8",
+    "behavior": "mechanical write-zone: pre-commit rejects paths outside 80_agents/hermes-nan and token-like content; pre-push forbids force-push (pending commit-path confirmation)",
+    "verification": "bats tests/hermes-setup.bats -f guardrail",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/HERMES-001-add-hermes-agent/proposal.md
+++ b/specs/HERMES-001-add-hermes-agent/proposal.md
@@ -1,0 +1,95 @@
+---
+id: "HERMES-001-add-hermes-agent"
+status: draft # draft | implementing | verifying | archived
+created: "2026-05-31"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# HERMES-001: Add Hermes agent
+
+> **Naming**: file lives at `<repo>/specs/HERMES-001-add-hermes-agent/proposal.md`.
+
+## Why
+
+<!-- from 11-tasks.md: *(P1, queued 2026-05-31, GH [#193](https://github.com/mlorentedev/dotfiles/issues/193), SDD-required — spec to be defined together next session)*: Add **Hermes Agent** (remote ops agent on NaN infra, via Telegram — <https://hermes-agent.nousresearch.com/docs>) as a new agent in the dotfiles ecosystem. **Proposed deliverables:** (a) `ai/hermes/AGENTS.md` — thin pointer to root `AGENTS.md` (per ADR-009); explains Hermes is a REMOTE infra agent (Debian 13, full system access, built-in skills github/email/mcp/cron), uses Hive MCP `uvx hive-vault`, writes to `vault/80_agents/Hermes-NaN/`, speaks Spanish-from-Spain. (b) `ai/hermes/setup.sh` — minimal, idempotent, non-interactive, NO sudo/apt, does NOT touch `setup-linux.sh`/`mcp-servers.json`: verify `uv` + `$GITHUB_TOKEN_KNOWLEDGE` (exit 1 if missing), `uv tool install --upgrade hive-vault`, clone/pull vault to `/tmp/hermes-vault`, ensure `80_agents/Hermes-NaN/_index.md`, generate `~/.hermes/config.yaml` (MCP hive, `HIVE_VAULT_PATH` env, no hardcoded path) + `~/.hermes/.env` (token). **Fit analysis (2026-05-31):** ✓ strong fit — (1) cross-agent SSOT pointer pattern (ADR-009); (2) **FIRST concrete consumer of the `80_agents/` autonomous-agent commit-policy shipped in PR #189** (autonomous agents commit only in `80_agents/`) — validates that policy with a real case; (3) reuses `hive-vault` like claude/agy. **NEW pattern:** Hermes is REMOTE + SELF-provisioning (runs its own setup.sh on remote infra), deliberately NOT wired into `setup-linux` — a coherent extension, not a local-deploy agent. **Open design Qs for the spec:** (1) **vault trust boundary** — cloning the FULL private vault to remote `/tmp` exposes all AI-memory/lessons to NaN infra; decide full-clone vs scoped/`80_agents`-only access; (2) **secrets divergence** — token-in-`.env` vs the age-secrets model (justified for remote; document it); (3) idempotence test approach (bats? remote-only?) + confirm `ai/hermes/` location. **Process:** define spec together next session → `specs/HERMES-001-add-hermes-agent/` → implement. Part of the multi-agent runtime (ADR-009 / HARNESS-001 [#162](https://github.com/mlorentedev/dotfiles/issues/162) family). -->
+
+Hermes is a remote ops agent (Debian 13 on NaN infrastructure, Telegram gateway, 24/7) that already operates and self-documents its state in the vault under `80_agents/hermes-nan/`. Today its provisioning exists only as prose the agent wrote about itself, and that prose has already drifted from reality (a `validate.sh` that checks filenames the folder no longer uses, a constitution file referenced everywhere but absent, a vault clone living in ephemeral `/tmp` whose loss takes the auto-push hook with it). A fresh box therefore cannot be brought up reproducibly. This spec makes the agent reproducible and self-replicating: a versioned, idempotent `ai/hermes/setup.sh` plus a thin `ai/hermes/AGENTS.md` pointer in dotfiles, backed by a curated, internally consistent SSOT in `80_agents/hermes-nan/`. It is also the first concrete consumer of the `80_agents/` autonomous-agent commit policy (PR #189) and extends the cross-agent SSOT model (ADR-009).
+
+## What
+
+After this change, observable behavior that did not exist before:
+
+1. **A new `ai/hermes/` overlay exists in dotfiles**, mirroring the per-agent convention (`ai/agy/`, `ai/nan/`, `ai/claude/`):
+   - `ai/hermes/AGENTS.md` — a thin pointer (ADR-009 parity) to the root `AGENTS.md` for shared rules **and** to the vault constitution (`80_agents/hermes-nan/AGENTS.md`) for the agent-specific operating law. It is documentation in the dotfiles repo; it is NOT Hermes's runtime brain (Hermes reads the vault, not the dotfiles checkout).
+   - `ai/hermes/setup.sh` — the remote provisioner, the entry point a fresh box curls.
+   - the dotfiles-side mirror of the cross-agent `pattern-loader` skill (today untracked in the working tree) is brought under version control as part of Hermes's contract.
+
+2. **`setup.sh`, run on a fresh Debian 13 box, provisions the agent end-to-end** and is safe to re-run (idempotent, non-interactive). In one invocation it:
+   - verifies prerequisites: `uv` present; `GITHUB_TOKEN_KNOWLEDGE` available from the environment or `~/.hermes/.env` (fail fast, non-zero exit, clear message if either is missing);
+   - installs/updates the Hive MCP launcher: `uv tool install --upgrade hive-vault`;
+   - clones (first run) or `git pull --ff-only` (subsequent runs) the private vault to a **persistent** path `$HERMES_VAULT_PATH` (default `~/.local/state/hermes/vault`), using a git credential helper that reads the token from `~/.hermes/.env` (token never persisted in `.git/config`);
+   - installs the vault-sync mechanism: a userspace `crontab` pull entry and a `post-commit` auto-push hook (installing the `cron` package via `apt-get` only if absent — the box runs as root);
+   - ensures `~/.hermes/.env` (the token), strips any token embedded in the vault remote URL, and registers the Hive MCP server via the native `hermes mcp add` CLI (idempotent; the product config at `/hermes-home/config.yaml` is left to the product, never hand-edited);
+   - installs mechanical guardrails into Hermes's clone — a `pre-commit` hook (write-zone + secret-scan) and a `pre-push` hook (no force-push);
+   - ensures `~/.hermes/.env` (chmod 600) and runs the vault's `validate.sh` as a final smoke check.
+
+3. **The agent's vault SSOT (`80_agents/hermes-nan/`) is internally consistent and replication-ready**: `validate.sh` matches the real numbered filenames, the canonical workspace name is `hermes-nan` throughout, the vault constitution (`AGENTS.md`) exists, and the bootstrap/recovery docs (`00-context.md`, `20-servers.md`, `13-config.md`, `14-env-variables.md`) describe the reconciled `setup.sh` (persistent path, apt-if-absent, marker-patched config). Every curation change updates the structure map the agent reads (`00-context.md`) and leaves a `sessions/` record so the junior agent re-discovers the new state.
+
+4. **`setup.sh` touches none of the local-deploy surface**: not `setup-linux.sh`, not `setup-windows.ps1`, not `mcp-servers.json`. Hermes is remote and self-provisioning by design; it is deliberately not wired into the local bootstrap.
+
+5. **A mechanical safety net** wraps provisioning and the agent's vault writes — Hermes is a low-capability (junior) agent, so instruction-only boundaries are insufficient. It comprises: a preflight token/remote auth-check that aborts before any heavy mutation; an idempotent-by-construction script verified by a full two-run test; a robust auto-pull wrapper that aborts a conflicted rebase instead of wedging the clone; never force-pushing; and — once the commit path is confirmed (git CLI vs Hive MCP) — local `pre-commit`/`pre-push` hooks in Hermes's clone that reject writes outside `80_agents/hermes-nan/`, block token-like content, and forbid force-push.
+
+### Design decisions (resolved with the user, 2026-05-31)
+
+Several original ticket assumptions were revised during design; the divergence is intentional and recorded here for traceability.
+
+| Topic | Decision | Note vs. original ticket |
+|---|---|---|
+| Vault trust boundary | Full clone (read-all) + write-only `80_agents/hermes-nan/` enforced by instruction (PR #189). | Resolves open Q1. Read access is the point — the cross-project brain is the value. |
+| Write boundary nature | Soft, instruction-enforced. The token can push anywhere; only the agent's rules confine writes. Accepted, documented residual. | New, explicit. |
+| Secrets | `GITHUB_TOKEN_KNOWLEDGE` via env or `~/.hermes/.env` (chmod 600). **Not** the age-secrets system. | Resolves open Q2. Rationale: the remote box has neither the dotfiles repo nor the age master key, so age cannot serve it; the token is also needed to curl the bootstrap, before any local secret loader could run. |
+| Token → git | Credential helper that sources `~/.hermes/.env`; serves both the interactive clone and the cron/non-interactive post-commit push. Token never written to `.git/config`. | New (security). |
+| Vault clone path | Persistent `$HERMES_VAULT_PATH` (default `~/.local/state/hermes/vault`). | Revised from `/tmp/hermes-vault`. A durable bridge in ephemeral storage loses the auto-push hook on reboot — the agent's own recovery doc admits this fragility. |
+| cron package | `setup.sh` may `apt-get install` it if absent (idempotent; box is root). | Revised from "NO sudo/apt". Relaxing apt is what makes one-shot idempotent recovery possible. |
+| `setup.sh` scope | Full recovery protocol (clone/pull + hive-vault + crontab + post-commit hook + config patch + `.env` + final `validate.sh`). | Broader than the original bullet list, matching the agent's documented recovery steps. |
+| Hive MCP registration | Native `hermes mcp add` CLI (idempotent via `hermes mcp list`); no hand-edited YAML. | Revised after box probe: product config lives at `/hermes-home/config.yaml` and exposes a CLI — safer than patching YAML. |
+| Workspace registration | Ensure `00-context.md` (numbered convention); no `_index.md`. | Revised: the original `_index.md` does not match the folder convention. |
+| Idempotence test | bats with an injection seam (`HERMES_SETUP_DRY_RUN` + stubbed network/`uv`/`apt`/`crontab`), runs twice, asserts no-op on the second run. | Resolves open Q3. CI-enforceable in dotfiles. |
+| Canonical name | `hermes-nan` (lowercase). | Revised from `Hermes-NaN`. The live workspace already uses lowercase. |
+
+## Out of scope
+
+- **Installing the Hermes product itself** (`curl … install.sh` from Nous Research + `hermes setup --portal`). This spec layers vault integration on top of an already-installed Hermes.
+- **Model-provider / portal OAuth credentials** — owned by the Hermes portal, not by `setup.sh`.
+- **Wiring Hermes into `setup-linux.sh` / `setup-windows.ps1` / `mcp-servers.json`** — Hermes is remote and self-provisioning by design.
+- **Downstream agent capabilities** tracked separately in the agent's own backlog (`80_agents/hermes-nan/30-tasks.md`): Himalaya email (SETUP-003), Headscale/Tailscale auth (SETUP-005), Ansible (SETUP-004).
+
+## Risks / open questions
+
+The design questions are resolved (see table above). Residual risks to keep visible:
+
+- **Hive MCP env-passing flag.** Registration uses the native `hermes mcp add` CLI (product config at `/hermes-home/config.yaml`). One detail open: the flag to pass `HIVE_VAULT_PATH` to the hive-vault server (`hermes mcp add --help`) — without it the server may not locate the clone. Non-blocking: the agent operates over git today regardless of Hive.
+- **Idempotence-test seam fidelity.** The bats stubs (network/`uv`/`apt`/`crontab`/`git`) must exercise the real idempotence guards, not short-circuit them — a mock that always returns success would make the test green while hiding a non-idempotent `setup.sh`. The seam must let the second run observe the first run's side effects.
+- **Soft → hard write boundary.** The token can push anywhere in the vault repo; instructions alone are insufficient for a junior agent. Planned hardening (AC8): local `pre-commit`/`pre-push` hooks in Hermes's clone that mechanically reject out-of-zone writes, secret-like content, and force-push. **Gated on confirming Hermes commits via the git CLI** (so hooks fire) vs. the Hive MCP (which may bypass them) — if bypassed, enforcement moves to the Hive scope/server side. Residual beyond that: branch protection / pre-receive hook.
+- **Cross-repo scope.** This work spans two repos (dotfiles + vault). The dotfiles CI can only gate the dotfiles track; the vault-curation track is verified by running `validate.sh` against the real vault, recorded in `verification.md`.
+
+## Acceptance criteria
+
+- [ ] **AC1** — `ai/hermes/setup.sh` passes `shellcheck` and parses clean under both `bash -n` and `zsh -n` (repo shell-compat standard).
+- [ ] **AC2** — `ai/hermes/setup.sh` is idempotent: a bats test runs it twice under the dry-run/stub seam; both runs exit 0 and the second run produces no changes (no duplicate cron entry, no clobbered `config.yaml`, `.env` untouched).
+- [ ] **AC3** — `ai/hermes/setup.sh` fails fast (non-zero exit + clear message) when `uv` is absent or `GITHUB_TOKEN_KNOWLEDGE` is unavailable (neither env nor `~/.hermes/.env`).
+- [ ] **AC4** — `ai/hermes/AGENTS.md` exists and is a thin pointer to root `AGENTS.md` and the vault constitution, consistent with the `ai/agy/AGY.md` parity pattern (ADR-009).
+- [ ] **AC5** — `setup.sh` modifies none of `setup-linux.sh`, `setup-windows.ps1`, `mcp-servers.json` (asserted by a guard in the test).
+- [ ] **AC6** (vault track) — `80_agents/hermes-nan/scripts/validate.sh` passes against the real folder (filename checks match the numbered files); the canonical name `hermes-nan` and the vault constitution `AGENTS.md` are present and consistent. Verified vault-side, recorded in `verification.md`.
+- [ ] **AC7** — `setup.sh` preflight aborts (non-zero) when the token cannot reach the vault remote; the cron auto-pull wrapper aborts a conflicted rebase rather than wedging the clone. Both covered by `tests/hermes-setup.bats`.
+- [ ] **AC8** — mechanical write-zone enforcement in Hermes's clone (confirmed: Hermes commits via git CLI, so local hooks fire): a `pre-commit` hook rejects staged paths outside `80_agents/hermes-nan/` and token-like content; a `pre-push` hook forbids non-fast-forward (force) pushes. Covered by four functional tests in `tests/hermes-setup.bats`.
+
+## References
+
+- Vault: `10_projects/dotfiles/11-tasks.md` (HERMES-001 backlog entry); `80_agents/hermes-nan/` (the agent's live SSOT)
+- GitHub: issue [#193](https://github.com/mlorentedev/dotfiles/issues/193)
+- ADR: `docs/adr/adr-009-multi-agent-runtime.md` (cross-agent SSOT); ADR-012 (deploy = copy/patch, not symlink — the marker-patch idiom)
+- Policy: PR #189 (`80_agents/` autonomous-agent commit policy)
+- Family: HARNESS-001 / issue [#162](https://github.com/mlorentedev/dotfiles/issues/162) (multi-agent runtime)
+- Product: <https://hermes-agent.nousresearch.com/docs>

--- a/specs/HERMES-001-add-hermes-agent/tasks.md
+++ b/specs/HERMES-001-add-hermes-agent/tasks.md
@@ -1,0 +1,71 @@
+---
+tags: [spec, tasks]
+created: "2026-05-31"
+---
+
+# Tasks - HERMES-001-add-hermes-agent
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> Two tracks. **Track A (dotfiles)** ships in this PR and is gated by dotfiles CI. **Track B (vault curation)** is staged in the vault and verified vault-side (`validate.sh`); it is not gated by dotfiles CI.
+
+## Setup
+
+- [ ] Branch created from main: `feat/add-hermes-agent`
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No blocking open questions left in `proposal.md` "Risks / open questions" (the Hermes config-schema risk blocks only the config-patch task — sequence it after verification)
+
+## Track A — dotfiles (this PR, TDD order)
+
+- [ ] Bring the untracked `pattern-loader` skill under version control at its canonical dotfiles location (decide `ai/skills/` vs `harness/skills/`); fix its hardcoded `/tmp/hermes-vault` to `$HERMES_VAULT_PATH`
+- [ ] Write failing bats: `setup.sh` fails fast (non-zero + message) when `uv` missing OR `GITHUB_TOKEN_KNOWLEDGE` absent (AC3)
+- [ ] Write failing bats: `setup.sh` is idempotent under the dry-run/stub seam — run twice, both exit 0, second run is a no-op (AC2)
+- [ ] Write failing bats/guard: `setup.sh` references/modifies none of `setup-linux.sh`, `setup-windows.ps1`, `mcp-servers.json` (AC5)
+- [ ] Implement `ai/hermes/setup.sh` skeleton: arg/flag parse, `HERMES_SETUP_DRY_RUN` seam, prereq checks (`uv`, token via env/`~/.hermes/.env`) — make AC3 green
+- [ ] Implement clone/pull to `$HERMES_VAULT_PATH` via env-sourced credential helper (no token in `.git/config`) — idempotent (clone-if-absent-else-`pull --ff-only`)
+- [ ] Implement `uv tool install --upgrade hive-vault` (idempotent by `--upgrade`)
+- [ ] Implement vault-sync install: userspace `crontab` pull entry (insert-once) + `post-commit` auto-push hook; `apt-get install cron` only if absent
+- [ ] Implement `~/.hermes/.env` ensure (chmod 600; write only if var present and not already recorded) and `config.yaml` marker-patch stub
+- [ ] Refactor `setup.sh` for clarity; confirm `shellcheck` + `bash -n` + `zsh -n` clean (AC1) — make AC2/AC5 green
+- [ ] Write `ai/hermes/AGENTS.md` thin pointer (root `AGENTS.md` + vault constitution), parity with `ai/agy/AGY.md` (AC4)
+
+## Track A — safety net (junior agent: mechanical guardrails)
+
+- [x] Preflight token/remote auth-check: abort before any heavy mutation (AC7) + test
+- [x] Robust auto-pull wrapper (`vault-pull.sh`): abort conflicted rebase, never wedge (AC7) + test
+- [x] Full idempotence test (DRY_RUN=0, stubbed git/crontab): two runs no-op, no dupes (AC2)
+- [x] Block-2 confirmed: Hermes commits via git CLI (HOOKS FIRE) — git-hook enforcement is valid
+- [x] `pre-commit` hook: reject staged paths outside `80_agents/hermes-nan/` (AC8) + functional test
+- [x] `pre-commit` secret-scan: reject token-like content (AC8) + functional test
+- [x] `pre-push` hook: forbid non-fast-forward / force-push (AC8) + test
+
+## Track A — box-reality hardening (from the 2026-05-31 Hermes probe)
+
+- [x] Strip the token embedded in the vault remote URL (`x-access-token:***@`) — move it to the credential helper, out of `.git/config`
+- [x] Migrate the stale `/tmp/hermes-vault` inline cron line to the robust `vault-pull.sh` wrapper (single entry)
+- [x] Register Hive MCP via native `hermes mcp add` (replaces the YAML-patch plan; idempotent via `hermes mcp list`)
+- [ ] Confirm `hermes mcp add` env-passing flag so `HIVE_VAULT_PATH` reaches the hive-vault server (ask: `hermes mcp add --help`)
+
+## Track B — vault curation (staged in vault, verified by validate.sh)
+
+- [ ] Fix `80_agents/hermes-nan/scripts/validate.sh`: check the real numbered filenames (`10-memory.md`, `11-skills.md`, `12-cronjobs.md`, `13-config.md`, `20-servers.md`) and the persistent vault path
+- [ ] Create `80_agents/hermes-nan/AGENTS.md` (vault constitution): thin pointer to root `AGENTS.md` + Hermes operating law (write-zone, sync discipline, bootstrap protocol)
+- [ ] Reconcile naming to `hermes-nan` and Hive scope to `agents:hermes-nan` across the folder
+- [ ] Align bootstrap/recovery docs (`00-context.md`, `20-servers.md`, `13-config.md`, `14-env-variables.md`) to the reconciled `setup.sh` (persistent `$HERMES_VAULT_PATH`, apt-if-absent, marker-patched config, no `_index.md`)
+- [ ] Update the structure map in `00-context.md` and leave a `sessions/2026-05-31-*.md` record of the reorg so the agent re-discovers state
+- [ ] Run `validate.sh` against the real folder → exit 0 (AC6)
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test or vault-side check
+- [ ] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [ ] Lint passes: `shellcheck ai/hermes/setup.sh`; `bats` suite green
+- [ ] No unrelated changes in the diff (no scope creep); `setup-linux.sh` / `mcp-servers.json` untouched
+- [ ] `verification.md` filled in with evidence (commit hashes, test output, vault `validate.sh` result)
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+See sibling `features.json`. Each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence`.
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state.

--- a/specs/HERMES-001-add-hermes-agent/verification.md
+++ b/specs/HERMES-001-add-hermes-agent/verification.md
@@ -1,0 +1,47 @@
+---
+tags: [spec, verification]
+created: "2026-05-31"
+---
+
+# Verification - HERMES-001-add-hermes-agent
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior). Filled during implementation.
+
+- [ ] AC1 (shellcheck + bash -n + zsh -n clean) -> commit `<hash>` / `features.json` f1
+- [ ] AC2 (idempotent, second run no-op) -> commit `<hash>` / test `hermes-setup.bats: idempotent`
+- [ ] AC3 (fail fast on missing uv / token) -> commit `<hash>` / test `hermes-setup.bats: fail fast`
+- [ ] AC4 (AGENTS.md thin pointer) -> commit `<hash>` / `features.json` f4
+- [ ] AC5 (local-deploy surface untouched) -> commit `<hash>` / `features.json` f5
+- [ ] AC6 (vault SSOT consistent, validate.sh green) -> vault-side run of `validate.sh`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test (remote): `setup.sh` run twice on the NaN box — what was exercised, what was observed
+- Vault-side: `bash 80_agents/hermes-nan/scripts/validate.sh -> <output>`
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections. Routine choices belong in commit messages.
+
+- Original ticket assumptions revised during design (apt relaxed, `/tmp` -> persistent path, `_index.md` -> `00-context.md`) — full rationale table in `proposal.md`.
+- Box probe (2026-05-31) findings that shaped the implementation: (a) Hermes product config is at `/hermes-home/config.yaml`, not `~/.hermes/`, and exposes a native `hermes mcp add` CLI -> register Hive via CLI, not YAML patch; (b) Hermes commits via git CLI (pre-commit probe FIRED) -> write-zone/secret/no-force guardrails implemented as local git hooks; (c) the vault remote URL had the token embedded (`x-access-token:***@`) -> setup.sh strips it and relies on the credential helper; (d) the existing `/tmp/hermes-vault` inline pull cron is migrated to the robust `vault-pull.sh` wrapper.
+- Open: `hermes mcp add` env-passing flag for `HIVE_VAULT_PATH` (non-blocking).
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault.
+
+- [ ] Lesson for `dotfiles/90-lessons.md`? Likely yes — "a remote agent's self-authored bootstrap docs drift; curate them against reality as part of onboarding it as code" (and the `/tmp`-as-durable-bridge anti-pattern).
+- [ ] ADR-worthy decision? Likely yes — remote self-provisioning agent: full-clone read + instruction-enforced write boundary + secrets divergence from the age model. Candidate `docs/adr/` or `30-architecture/adr-XXX`.
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if it recurs — "remote agent provisioning via curl + vault SSOT" could generalize beyond Hermes.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/HERMES-001-add-hermes-agent/` -> `specs/archive/HERMES-001-add-hermes-agent/`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)

--- a/tests/hermes-setup.bats
+++ b/tests/hermes-setup.bats
@@ -1,0 +1,189 @@
+#!/usr/bin/env bats
+# Tests for ai/hermes/setup.sh — the Hermes remote provisioner (HERMES-001).
+#
+# Hermetic: setup.sh runs under a stub seam — redirected HERMES_HOME /
+# HERMES_VAULT_PATH (into the per-test tmpdir) and stubbed external commands
+# (uv/git/crontab) on a restricted PATH. The guardrail tests provision into a
+# REAL git repo (so the installed hooks can be exercised with real git), while
+# setup.sh itself still runs against the stubbed git for clone/pull.
+
+setup() {
+    DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    SETUP="$DOTFILES_DIR/ai/hermes/setup.sh"
+    export HERMES_HOME="$BATS_TEST_TMPDIR/dot-hermes"
+    export HERMES_VAULT_PATH="$BATS_TEST_TMPDIR/state/vault"
+    STUB="$BATS_TEST_TMPDIR/stub-bin"
+    mkdir -p "$STUB"
+}
+
+# Simple stub on PATH that succeeds and logs its argv.
+stub() {
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'printf "%%s\\n" "%s $*" >> "%s/calls.log"\n' "$1" "$BATS_TEST_TMPDIR"
+        printf 'exit 0\n'
+    } > "$STUB/$1"
+    chmod +x "$STUB/$1"
+}
+
+# git stub: ignores -c/-C options, dispatches on the subcommand. ls-remote
+# returns $GIT_STUB_LSREMOTE_RC (default 0) so the auth-check path is testable.
+stub_git() {
+    cat > "$STUB/git" <<'EOF'
+#!/usr/bin/env bash
+sub=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -c|-C) shift 2; continue ;;
+        -*) shift; continue ;;
+        *) sub="$1"; break ;;
+    esac
+done
+case "$sub" in
+    ls-remote) exit "${GIT_STUB_LSREMOTE_RC:-0}" ;;
+    *) exit 0 ;;
+esac
+EOF
+    chmod +x "$STUB/git"
+}
+
+# Stateful crontab stub: `-l` prints the store, `crontab -` installs from stdin.
+stub_crontab() {
+    export CRONTAB_STORE="$BATS_TEST_TMPDIR/crontab.store"
+    cat > "$STUB/crontab" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "-l" ]; then cat "$CRONTAB_STORE" 2>/dev/null; exit 0; fi
+cat > "$CRONTAB_STORE"
+EOF
+    chmod +x "$STUB/crontab"
+}
+
+# hermes CLI stub: logs argv to $HERMES_CALLS; `mcp list` prints nothing (so the
+# server is treated as unregistered and the add path runs).
+stub_hermes() {
+    cat > "$STUB/hermes" <<'EOF'
+#!/usr/bin/env bash
+printf 'hermes %s\n' "$*" >> "$HERMES_CALLS"
+exit 0
+EOF
+    chmod +x "$STUB/hermes"
+}
+
+# Provision into a REAL git repo so the installed hooks are exercisable with real
+# git; setup.sh runs with stubbed git/crontab/uv (no real network/cron).
+provision() {
+    stub uv; stub_git; stub_crontab
+    export GITHUB_TOKEN_KNOWLEDGE=dummy
+    git init -q "$HERMES_VAULT_PATH"
+    git -C "$HERMES_VAULT_PATH" config user.email t@t
+    git -C "$HERMES_VAULT_PATH" config user.name t
+    PATH="$STUB:/usr/bin:/bin" bash "$SETUP" >/dev/null 2>&1
+}
+
+@test "fail fast: non-zero exit + message when uv is missing" {
+    export HERMES_SETUP_DRY_RUN=1
+    export GITHUB_TOKEN_KNOWLEDGE=dummy   # isolate the uv check
+    PATH="$STUB:/usr/bin:/bin" run bash "$SETUP"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"uv"* ]]
+}
+
+@test "fail fast: non-zero exit + message when GITHUB_TOKEN_KNOWLEDGE is missing" {
+    export HERMES_SETUP_DRY_RUN=1
+    stub uv
+    unset GITHUB_TOKEN_KNOWLEDGE
+    PATH="$STUB:/usr/bin:/bin" run bash "$SETUP"   # HERMES_HOME has no .env
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GITHUB_TOKEN_KNOWLEDGE"* ]]
+}
+
+@test "preflight: aborts when the token cannot reach the vault remote" {
+    stub uv
+    stub_git
+    export GITHUB_TOKEN_KNOWLEDGE=dummy
+    export GIT_STUB_LSREMOTE_RC=1     # ls-remote fails -> token invalid/unreachable
+    mkdir -p "$HERMES_VAULT_PATH/.git/hooks"
+    PATH="$STUB:/usr/bin:/bin" run bash "$SETUP"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"cannot reach vault remote"* ]]
+}
+
+@test "guard: setup.sh touches none of the local-deploy surface (comments excluded)" {
+    ! grep -vE '^[[:space:]]*#' "$SETUP" | grep -qE 'setup-linux\.sh|setup-windows\.ps1|mcp-servers\.json'
+}
+
+@test "sync wrapper aborts a conflicted rebase (never wedges the clone)" {
+    export HERMES_SETUP_DRY_RUN=1
+    stub uv
+    export GITHUB_TOKEN_KNOWLEDGE=dummy
+    PATH="$STUB:/usr/bin:/bin" run bash "$SETUP"
+    [ "$status" -eq 0 ]
+    [ -x "$HERMES_HOME/vault-pull.sh" ]
+    grep -qF 'rebase --abort' "$HERMES_HOME/vault-pull.sh"
+}
+
+@test "idempotent (full, DRY_RUN=0): two real runs are a no-op — no dupes" {
+    stub uv
+    stub_git
+    stub_crontab
+    export GITHUB_TOKEN_KNOWLEDGE=dummy
+    mkdir -p "$HERMES_VAULT_PATH/.git/hooks"   # pretend the clone exists -> pull path
+
+    PATH="$STUB:/usr/bin:/bin" run bash "$SETUP"
+    [ "$status" -eq 0 ]
+    PATH="$STUB:/usr/bin:/bin" run bash "$SETUP"
+    [ "$status" -eq 0 ]
+
+    [ "$(grep -c '^GITHUB_TOKEN_KNOWLEDGE=' "$HERMES_HOME/.env")" -eq 1 ]
+    [ "$(stat -c '%a' "$HERMES_HOME/.env")" = "600" ]
+    [ "$(grep -c 'vault-pull.sh' "$CRONTAB_STORE")" -eq 1 ]
+    [ "$(grep -c 'hermes-managed' "$HERMES_VAULT_PATH/.git/hooks/post-commit")" -eq 1 ]
+    [ -x "$HERMES_HOME/vault-pull.sh" ]
+}
+
+@test "guardrail: pre-commit rejects a commit outside the write-zone" {
+    provision
+    [ -x "$HERMES_VAULT_PATH/.git/hooks/pre-commit" ]
+    mkdir -p "$HERMES_VAULT_PATH/00_meta"
+    echo x > "$HERMES_VAULT_PATH/00_meta/foo.md"
+    git -C "$HERMES_VAULT_PATH" add 00_meta/foo.md
+    run git -C "$HERMES_VAULT_PATH" commit -m "out of zone"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"80_agents"* || "$output" == *"outside"* ]]
+}
+
+@test "guardrail: pre-commit allows a commit inside the write-zone" {
+    provision
+    mkdir -p "$HERMES_VAULT_PATH/80_agents/hermes-nan/sessions"
+    echo ok > "$HERMES_VAULT_PATH/80_agents/hermes-nan/sessions/x.md"
+    git -C "$HERMES_VAULT_PATH" add 80_agents/hermes-nan/sessions/x.md
+    run git -C "$HERMES_VAULT_PATH" commit -m "in zone"
+    [ "$status" -eq 0 ]
+}
+
+@test "guardrail: pre-commit rejects token-like content inside the zone" {
+    provision
+    mkdir -p "$HERMES_VAULT_PATH/80_agents/hermes-nan"
+    printf 'leak: ghp_%s\n' "AbCdEfGh0123456789AbCdEfGhIj" > "$HERMES_VAULT_PATH/80_agents/hermes-nan/leak.md"
+    git -C "$HERMES_VAULT_PATH" add 80_agents/hermes-nan/leak.md
+    run git -C "$HERMES_VAULT_PATH" commit -m "leak"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"token-like"* ]]
+}
+
+@test "guardrail: pre-push hook installed and rejects non-fast-forward" {
+    provision
+    [ -x "$HERMES_VAULT_PATH/.git/hooks/pre-push" ]
+    grep -qF 'non-fast-forward' "$HERMES_VAULT_PATH/.git/hooks/pre-push"
+}
+
+@test "registers Hive MCP via hermes mcp add with HIVE_VAULT_PATH env" {
+    export HERMES_CALLS="$BATS_TEST_TMPDIR/hermes.calls"
+    stub uv; stub_git; stub_crontab; stub_hermes
+    export GITHUB_TOKEN_KNOWLEDGE=dummy
+    mkdir -p "$HERMES_VAULT_PATH/.git/hooks"
+    PATH="$STUB:/usr/bin:/bin" run bash "$SETUP"
+    [ "$status" -eq 0 ]
+    grep -qF 'mcp add hive' "$HERMES_CALLS"
+    grep -qF "HIVE_VAULT_PATH=$HERMES_VAULT_PATH" "$HERMES_CALLS"
+}


### PR DESCRIPTION
Implements **HERMES-001** (`specs/HERMES-001-add-hermes-agent/`). Adds Hermes — a remote ops agent (Debian 13 on NaN infra, Telegram gateway) — to the dotfiles ecosystem as a **self-provisioning, remote-only** agent. First concrete consumer of the `80_agents/` autonomous-agent commit policy (#189).

## What

- **`ai/hermes/setup.sh`** — idempotent, non-interactive remote provisioner (the script a fresh box curls). Prereq + token/remote auth-check; persistent vault clone at `~/.local/state/hermes/vault` via an env-sourced git credential helper (token never lands in `.git/config`); `uv tool install hive-vault`; robust auto-pull wrapper that aborts a conflicted rebase instead of wedging the clone; Hive MCP registration via the native `hermes mcp add --env HIVE_VAULT_PATH=...`.
- **Mechanical safety net** (Hermes is a junior agent; confirmed it commits via git CLI, so local hooks fire): a `pre-commit` hook rejecting any staged path outside `80_agents/hermes-nan/` and token-like content; a `pre-push` hook forbidding non-fast-forward (force) pushes.
- **`ai/hermes/AGENTS.md`** — thin pointer (ADR-009 parity) to root `AGENTS.md` + the vault constitution.
- **`tests/hermes-setup.bats`** — 11 tests: fail-fast, full idempotence (two real runs, no dupes), the four functional guardrail tests, Hive registration.

## Hardening from the live-box probe

- Strips a token embedded in the vault remote URL (`x-access-token:***@`) and relies on the credential helper instead.
- Migrates the stale `/tmp/hermes-vault` inline pull cron to the robust `vault-pull.sh` wrapper.
- Registers Hive via the product's native CLI (config lives at `/hermes-home/config.yaml`); no hand-edited YAML.

## Scope

`setup.sh` touches none of `setup-linux.sh`, `setup-windows.ps1`, or `mcp-servers.json`; Hermes is deliberately not wired into the local bootstrap. Vault-side curation (`validate.sh` fix, vault constitution, naming) is tracked separately and verified vault-side.

## Testing

`shellcheck` + `bash -n` + `zsh -n` clean; `bats tests/hermes-setup.bats` → 11/11.