### PR TITLE
chore(hermes): register Hermes overlay + re-home pattern-loader skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 > **Single Source of Truth for AI coding agents in this repo.**
 >
-> Claude Code, OpenCode, Copilot, Cursor, Codex, and Antigravity all read this file as their canonical system prompt. Per-agent files in `ai/<agent>/` and `.github/` are thin pointers that delegate here, retaining only agent-specific extensions. See [`docs/adr/adr-009-multi-agent-runtime.md`](docs/adr/adr-009-multi-agent-runtime.md) for the rationale.
+> Claude Code, OpenCode, Copilot, Cursor, Codex, and Antigravity all read this file as their canonical system prompt. Per-agent files in `ai/<agent>/` and `.github/` are thin pointers that delegate here, retaining only agent-specific extensions. **Hermes** is the exception: a remote ops agent that does not clone this repo, so it reads a self-contained subset from the vault constitution `80_agents/hermes-nan/AGENTS.md`, which defers back here as the canonical authority. See [`docs/adr/adr-009-multi-agent-runtime.md`](docs/adr/adr-009-multi-agent-runtime.md) for the rationale.
 
 ## Identity
 
@@ -76,6 +76,7 @@ Concrete model identifiers per tier live in the agent-specific overlay files:
 - `ai/opencode/opencode.jsonc` — OpenCode (TUI `/models` picker; `qq` / `qf` wrappers for quick-questions)
 - `ai/agy/AGY.md` — Antigravity CLI (agy) (per-prompt `--model` flag)
 - `ai/copilot/copilot-instructions.md` — GitHub Copilot CLI v2 (TBD; concrete schema pending AI-017/AI-018 audit)
+- `ai/hermes/AGENTS.md` — Hermes (Nous Research) remote ops agent (NaN catalog: `deepseek-v4-flash` interactive, `qwen3.6` async; provisioned by `ai/hermes/setup.sh`, reads the vault not this repo)
 
 Model names rotate; tier semantics are stable. When a provider releases a new flagship or sunsets a tier, edit ONLY the relevant overlay — `AGENTS.md` does not need a corresponding patch.
 

--- a/harness/skills/pattern-loader/SKILL.md
+++ b/harness/skills/pattern-loader/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: pattern-loader
+description: Use when a task matches a known workflow pattern in vault/00_meta/patterns/. Searches the pattern catalog, loads the most relevant pattern, and applies it. Ensures agents always use the latest version of patterns without caching stale copies in memory.
+---
+
+# Pattern Loader
+
+## Overview
+
+When a task matches a known workflow pattern, load it from the vault pattern catalog instead of guessing. This ensures agents always use the latest version of patterns without caching stale copies in memory.
+
+**Core principle:** Patterns live in the vault. Agents load them on demand. Never cache pattern content in long-term memory — always re-read from vault to stay current.
+
+## When to use
+
+- A task matches a known pattern name or category (e.g., "backup", "debug", "spec", "handoff")
+- Manu says "use the [pattern-name] pattern"
+- A workflow feels familiar but you're not sure of the exact steps
+- Starting a session and you want to check which patterns are relevant
+
+## When to skip
+
+- The task is trivial and doesn't need a pattern
+- You already know the exact steps from recent memory (e.g., just did this task 2 hours ago)
+- No matching pattern exists in the catalog
+
+## The protocol
+
+### Step 1 — Search the pattern catalog
+
+Prefer Hive MCP — it is path-agnostic and always reads the live vault:
+
+```
+vault_search(project="_meta", query="<keyword>", scope="patterns")
+```
+
+If Hive is unavailable, fall back to a file search against your local vault
+clone. The clone path is environment-specific, so resolve it from your
+environment instead of hardcoding it (`$VAULT_PATH` on Manu's workstations,
+defaulting to `~/Projects/knowledge`; `$HERMES_VAULT_PATH` on the Hermes box):
+
+```bash
+grep -rli "<keyword>" "${VAULT_PATH:-$HOME/Projects/knowledge}/00_meta/patterns/" 2>/dev/null
+```
+
+### Step 2 — Match and load
+
+Read the most relevant pattern file(s). Each pattern has frontmatter:
+
+```yaml
+---
+id: pattern-backup
+type: pattern
+status: active
+created: "2026-05-14"
+tags: [backup, ops, infrastructure]
+---
+```
+
+Use the `tags` and `id` to determine relevance. Read the full content.
+
+### Step 3 — Apply the pattern
+
+Follow the pattern's steps exactly. If the pattern has sections like:
+
+- **Overview** — context and intent
+- **When to use** — trigger conditions
+- **Steps** — numbered procedure
+- **Pitfalls** — common mistakes to avoid
+- **Verification** — how to confirm success
+
+Follow all sections in order. Do not skip pitfalls.
+
+### Step 4 — Log which pattern was used
+
+Add a brief note to the current session record:
+
+```
+Pattern applied: pattern-<name>.md
+```
+
+This is for audit trail — not for long-term memory.
+
+### Step 5 — Cache only if frequent
+
+If the same pattern is used >1x/week, cache it in memory (not in vault). Otherwise, always re-read from vault.
+
+## Pattern categories
+
+The pattern catalog is organized by category. Use these as search hints:
+
+| Category | What it covers | Examples |
+|----------|---------------|----------|
+| `pattern-backup` | Backup procedures, restore, verification | Full backup, selective restore, test-restore |
+| `pattern-debug-*` | Debugging methodologies | Systematic debugging, hardware debug, session debug |
+| `pattern-spec-*` | Spec-Driven Development | SDD flow, spec init, spec archive, adversarial review |
+| `pattern-git-*` | Git workflows | Worktrees, clean history, safe force |
+| `pattern-security-*` | Security procedures | Credential handling, audit, threat modeling |
+| `pattern-decision-*` | Decision persistence | ADR format, decision logging, crystallization |
+| `pattern-agent-*` | Agent workflows | Handoff, delegation, session start, pattern loader |
+| `pattern-dev-*` | Development workflows | TDD, test-driven, planning, execution |
+| `pattern-ops-*` | Operations | Server setup, monitoring, incident response |
+
+## Pitfalls
+
+- **Don't guess the pattern name** — search first, match second
+- **Don't cache patterns in long-term memory** — they change, cached versions become stale
+- **Don't skip pitfalls** — they exist for a reason
+- **Don't apply a pattern that doesn't fully match** — partial application causes bugs
+- **Don't assume a pattern exists** — if no match, say so and proceed without it
+
+## Verification
+
+After applying a pattern:
+
+1. Re-read the pattern's **Verification** section
+2. Execute the verification steps
+3. Report results to Manu
+4. If verification fails, log it as a lesson in `clients/` or `sessions/`
+
+## References
+
+- Pattern catalog: `vault/00_meta/patterns/`
+- Pattern format: see any file in `00_meta/patterns/pattern-*.md`
+- Related: `00_meta/skills/verification-before-completion/SKILL.md` (always verify after applying)

--- a/specs/HERMES-001-add-hermes-agent/verification.md
+++ b/specs/HERMES-001-add-hermes-agent/verification.md
@@ -9,19 +9,20 @@ created: "2026-05-31"
 
 Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior). Filled during implementation.
 
-- [ ] AC1 (shellcheck + bash -n + zsh -n clean) -> commit `<hash>` / `features.json` f1
-- [ ] AC2 (idempotent, second run no-op) -> commit `<hash>` / test `hermes-setup.bats: idempotent`
-- [ ] AC3 (fail fast on missing uv / token) -> commit `<hash>` / test `hermes-setup.bats: fail fast`
-- [ ] AC4 (AGENTS.md thin pointer) -> commit `<hash>` / `features.json` f4
-- [ ] AC5 (local-deploy surface untouched) -> commit `<hash>` / `features.json` f5
-- [ ] AC6 (vault SSOT consistent, validate.sh green) -> vault-side run of `validate.sh`
+- [x] AC1 (shellcheck + bash -n + zsh -n clean) -> Track A, PR #195 / `tests/hermes-setup.bats`
+- [x] AC2 (idempotent, second run no-op) -> Track A, PR #195 / test `hermes-setup.bats: idempotent`
+- [x] AC3 (fail fast on missing uv / token) -> Track A, PR #195 / test `hermes-setup.bats: fail fast`
+- [x] AC4 (AGENTS.md thin pointer) -> Track A, PR #195 / `ai/hermes/AGENTS.md`
+- [x] AC5 (local-deploy surface untouched) -> Track A, PR #195 (setup.sh never wired into setup-linux)
+- [x] AC6 (vault SSOT consistent, validate.sh green) -> Track B, vault master `8b3c299`: `validate.sh` exits 0 ("Vault SSOT consistent"). Curated `80_agents/hermes-nan/` against the reconciled provisioning reality.
 
 ## Test status
 
-- Test suite: `<command> -> <output / coverage %>`
-- Manual smoke test (remote): `setup.sh` run twice on the NaN box — what was exercised, what was observed
-- Vault-side: `bash 80_agents/hermes-nan/scripts/validate.sh -> <output>`
-- No regressions in existing test suite: yes / no (if no, document)
+- Test suite: `tests/hermes-setup.bats` -> 11 green (Track A, PR #195).
+- Manual smoke test (remote): `setup.sh` run twice on the NaN box (Track A) — idempotent, second run a no-op.
+- Vault-side: `HERMES_VAULT_PATH=<checkout> bash 80_agents/hermes-nan/scripts/validate.sh` -> exit 0, "Vault SSOT consistent"; 10 SSOT files pass with frontmatter, constitution names its write zone, 3 warnings are box-runtime advisories (expected off-box).
+- Follow-ups (this PR, #196): registered `ai/hermes/AGENTS.md` in the root overlay matrix; re-homed the `pattern-loader` skill off the `/tmp/hermes-vault` hardcode (vault source fixed on knowledge master; harness record regenerated). Opencode command-count test bumped 18 -> 19 for the new skill.
+- No regressions in existing test suite: yes (after the count bump).
 
 ## Decisions made during implementation
 

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -317,11 +317,11 @@ setup() {
     # Post-SDD-008: setup-linux.sh runs compile-harness.sh --deploy, which renders
     # each committed vault skill record whose targets[] includes opencode to a
     # command .md. The container has no vault, so --refresh is skipped and --deploy
-    # uses the committed records (23 skills, 5 Claude-only opt out -> 18 commands).
+    # uses the committed records (24 skills, 5 Claude-only opt out -> 19 commands).
     [ -d "$HOME/.config/opencode/commands" ]
     local count
     count=$(find "$HOME/.config/opencode/commands" -maxdepth 1 -name '*.md' | wc -l)
-    [ "$count" -eq 18 ]  # 17 -> 18: HANDOFF-001 added the /handoff skill (targets all agents)
+    [ "$count" -eq 19 ]  # 18 -> 19: pattern-loader skill re-homed from vault (no targets: -> all agents)
     # Spot check: audit.md present (portable), creating-skills.md absent (targets:[claude]).
     [ -f "$HOME/.config/opencode/commands/audit.md" ]
     [ ! -f "$HOME/.config/opencode/commands/creating-skills.md" ]


### PR DESCRIPTION
HERMES-001 follow-ups (#195 merged): register the Hermes overlay in AGENTS.md (notes Hermes does not clone this repo; reads the vault constitution which defers to root, ADR-009) and re-home the pattern-loader skill (regenerated from the fixed vault source; drops the /tmp/hermes-vault hardcode, prefers Hive vault_search, env-resolves the fallback path). compile-harness --check OK; pre-commit passed. Vault-side source fix went to knowledge master directly.
