### PR TITLE
fix(spec-gate): exclude docs/**/*.md from production LOC count

### DIFF
--- a/scripts/check-spec-gate.sh
+++ b/scripts/check-spec-gate.sh
@@ -93,6 +93,7 @@ _excluded() {
     local path="$1"
     local base="${path##*/}"
     case "$path" in
+        docs/*.md) return 0 ;;   # doc-only (ADRs, lessons, runbooks): prose, not production
         tests/*|specs/archive/*) return 0 ;;
         *generated*) return 0 ;;
     esac

--- a/tests/check-spec-gate.bats
+++ b/tests/check-spec-gate.bats
@@ -124,6 +124,23 @@ _commit() {
     [ "$status" -eq 0 ]
 }
 
+@test "excludes docs/**/*.md from LOC count (doc-only ADR/lesson/runbook)" {
+    mkdir -p docs/adr
+    printf 'line %d\n' {1..200} > docs/adr/adr-999-example.md
+    _commit "doc-only ADR"
+    run "$SCRIPTS_DIR/check-spec-gate.sh" --base-ref main --head-ref feature
+    [ "$status" -eq 0 ]
+}
+
+@test "does NOT exclude non-markdown under docs/ (a script still counts)" {
+    mkdir -p docs
+    printf 'line %d\n' {1..60} > docs/example.sh
+    _commit "script under docs counts as production"
+    run "$SCRIPTS_DIR/check-spec-gate.sh" --base-ref main --head-ref feature
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Discipline Gate"* ]]
+}
+
 @test "excludes lockfiles from LOC count" {
     printf 'line %d\n' {1..200} > package-lock.json
     _commit "lockfile bump"


### PR DESCRIPTION
## Problem

The spec-gate counts `docs/**` as production diff, so a doc-only ADR over 50 lines trips it (e.g. #200, an ADR of 71 lines). Doc-only changes are already exempt per AGENTS.md's SDD skip-list, so the only escape was a `skip-sdd` label on every ADR PR — which trains the reflex to apply `skip-sdd` and erodes the gate.

## Fix

Exclude `docs/*.md` in `_excluded()` (a `case` glob, so it covers any depth under `docs/`). Aligns with the already-excluded `CHANGELOG.md`. Markdown-only: a hypothetical script under `docs/` still counts as production.

## Tests (incident -> guard)

- `excludes docs/**/*.md from LOC count` — a 200-line doc-only ADR no longer trips the gate.
- `does NOT exclude non-markdown under docs/` — a script under `docs/` still counts.

Unblocks #200 (ADR-016) without a `skip-sdd` workaround once merged + rebased.
