### PR TITLE
feat(SDD-012b): merged-but-open backlog reconciliation guard

### DIFF
--- a/scripts/check-backlog-merged.sh
+++ b/scripts/check-backlog-merged.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# check-backlog-merged.sh: detect "merged-but-open" backlog drift in vault task files.
+#
+# Semantic sibling of check-backlog-integrity.sh (SDD-012). That guard catches
+# STRUCTURAL drift (one id on 2+ lines, an id marked both [ ] and [x]). It cannot
+# catch the SEMANTIC class: a `- [ ]` entry whose work is already shipped — a
+# stale-merged tick is perfectly well-formed text. This guard closes that gap,
+# implementing the cross-reference SDD-012 deferred as "merged-but-open".
+#
+# Done-signal (v1): an ARCHIVED SPEC for the entry's FULL id —
+# `<repo>/specs/archive/<full-id>/`. The SDD lifecycle archives a spec at merge
+# (see pattern-three-layer-proposal-lifecycle), so its presence is a reliable,
+# local, network-free "this shipped" marker. Keyed on the FULL id (the bold
+# token between ** **), NOT the bare ticket number — that is what dodges the
+# number-reuse trap (dotfiles has had two BUG-024s, two HERMES-002s, etc.).
+#
+# Matching merged PRs by number is intentionally OUT OF SCOPE here: PR titles
+# cite the number, not the slug, so the match is heuristic and number-reuse makes
+# it noisy. That stays a manual/advisory step — see pattern-verify-against-
+# source-of-truth.md "Automating the Reconciliation". This guard ships the
+# reliable, zero-false-positive half.
+#
+# ADVISORY by contract: a finding is a "verify + tick" candidate, not proof.
+# vault-health.sh treats a non-zero exit as a WARN, not a failure.
+#
+# Usage:
+#   check-backlog-merged.sh <tasks-file> [--repo <repo-dir>]
+#     <tasks-file>   a vault 11-tasks.md
+#     --repo <dir>   repo holding specs/archive/. Default: inferred from the
+#                    tasks path — <vault>/10_projects/<proj>/11-tasks.md maps to
+#                    $HOME/Projects/<proj> (the workstation convention).
+#
+# Exit:
+#   0  clean (no stale-open candidates, or repo not found -> nothing to check)
+#   1  one or more open entries have an archived spec (likely done -> verify+tick)
+#   2  usage error / tasks file missing
+
+set -euo pipefail
+
+TASKS=""
+REPO=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --repo) REPO="${2:-}"; shift 2 ;;
+        -h|--help)
+            cat <<'EOF'
+Usage: check-backlog-merged.sh <tasks-file> [--repo <repo-dir>]
+  Flags open `- [ ]` entries whose FULL ticket id has an archived spec
+  (<repo>/specs/archive/<id>/) — work shipped but the tick is stale.
+  --repo defaults to $HOME/Projects/<proj> inferred from the tasks path.
+  Advisory: findings are "verify + tick" candidates, not failures.
+Exit: 0 clean | 1 stale-open candidates | 2 usage / missing file
+EOF
+            exit 0 ;;
+        -*) printf '  ERROR: unknown option: %s\n' "$1" >&2; exit 2 ;;
+        *)
+            if [ -z "$TASKS" ]; then TASKS="$1"; shift
+            else printf '  ERROR: only one tasks-file accepted\n' >&2; exit 2; fi ;;
+    esac
+done
+
+if [ -z "$TASKS" ]; then
+    cat >&2 <<'EOF'
+Usage: check-backlog-merged.sh <tasks-file> [--repo <repo-dir>]
+  Flags open `- [ ]` entries whose FULL ticket id has an archived spec
+  (<repo>/specs/archive/<id>/) — i.e. the work shipped but the tick is stale.
+  Advisory: findings are "verify + tick" candidates. See SDD-012b and
+  pattern-verify-against-source-of-truth.md.
+Exit: 0 clean | 1 stale-open candidates | 2 usage / missing file
+EOF
+    exit 2
+fi
+
+if [ ! -f "$TASKS" ]; then
+    printf '  ERROR: not found or unreadable: %s\n' "$TASKS" >&2
+    exit 2
+fi
+
+# Infer the repo from the tasks-file path when not given explicitly.
+# <vault>/10_projects/<proj>/11-tasks.md -> $HOME/Projects/<proj>
+if [ -z "$REPO" ]; then
+    proj="$(basename "$(dirname "$TASKS")")"
+    REPO="$HOME/Projects/$proj"
+fi
+
+# No repo -> no archived specs to cross-reference. Advisory skip, exit clean:
+# the guard's job is to FLAG drift, not to fail when it cannot look.
+if [ ! -d "$REPO/specs/archive" ]; then
+    printf '  SKIP: no %s/specs/archive — nothing to cross-reference\n' "$REPO" >&2
+    exit 0
+fi
+
+# Collect OPEN entries' FULL ids. Open = status char ' ', '~', or '-'
+# (not 'x'/'X'). The full id is the bold token between the first ** ** pair,
+# mirroring check-backlog-integrity.sh's identity rule.
+open_ids="$(awk '
+    /^- \[[ ~-]\] \*\*[^*]+\*\*/ {
+        s = $0; sub(/^[^*]*\*\*/, "", s)
+        id = s;  sub(/\*\*.*$/, "", id)
+        print id
+    }
+' "$TASKS")"
+
+candidates=0
+while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    if [ -d "$REPO/specs/archive/$id" ]; then
+        printf '  STALE-OPEN: %s — archived spec exists (specs/archive/%s/); verify + tick [x]\n' "$id" "$id"
+        candidates=$((candidates + 1))
+    fi
+done <<EOF
+$open_ids
+EOF
+
+if [ "$candidates" -gt 0 ]; then
+    cat >&2 <<EOF
+
+$candidates open entr$([ "$candidates" -eq 1 ] && echo y || echo ies) in $TASKS have an archived spec — the work likely shipped but the
+backlog tick is stale. Verify against git/PR history and mark [x] with the PR link.
+Advisory only (archived spec is a strong but not absolute signal). See
+pattern-verify-against-source-of-truth.md "Automating the Reconciliation".
+EOF
+    exit 1
+fi
+exit 0

--- a/scripts/vault-health.sh
+++ b/scripts/vault-health.sh
@@ -253,6 +253,17 @@ else
     elif [ "$BACKLOG_BAD" -eq 0 ]; then
         pass "Backlog integrity: $BACKLOG_FILES task file(s) clean (one ticket = one entry)"
     fi
+
+    # Semantic drift (advisory): open [ ] entries whose work already shipped
+    # (full id has an archived spec) via check-backlog-merged.sh (SDD-012b).
+    # WARN, not fail — the signal is strong but the tick is a human/agent action.
+    for tasks in "$VAULT_DIR"/10_projects/*/11-tasks.md; do
+        [ -f "$tasks" ] || continue
+        if ! merged_out="$("$SCRIPT_DIR/check-backlog-merged.sh" "$tasks" 2>/dev/null)"; then
+            warn "Stale-merged ticks in $(basename "$(dirname "$tasks")")/11-tasks.md — work shipped, tick still [ ]:"
+            printf '%s\n' "$merged_out" | sed 's|^|        |'
+        fi
+    done
 fi
 
 # ==================================================

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -34,11 +34,17 @@ Subcommands:
       Scan task files for backlog drift: duplicate ticket IDs and status
       contradictions (same ID marked both [ ] and [x]). One ticket = one entry.
 
+  check-merged <tasks-file> [--repo <dir>]
+      Flag open [ ] entries whose work already shipped: full ticket id has an
+      archived spec under <repo>/specs/archive/. Advisory ("verify + tick"), not
+      a failure. --repo defaults to $HOME/Projects/<proj> from the tasks path.
+
   help, -h, --help
       Show this message.
 
 Each subcommand is also runnable standalone (vault-health.sh,
-vault-maintenance-weekly.sh, check-md-escapes.sh, check-backlog-integrity.sh) —
+vault-maintenance-weekly.sh, check-md-escapes.sh, check-backlog-integrity.sh,
+check-backlog-merged.sh) —
 this dispatcher provides a single discoverable entry point without changing the
 underlying scripts.
 EOF
@@ -64,6 +70,9 @@ case "$sub" in
         ;;
     check-tasks|tasks)
         exec "$SCRIPT_DIR/check-backlog-integrity.sh" "$@"
+        ;;
+    check-merged|merged)
+        exec "$SCRIPT_DIR/check-backlog-merged.sh" "$@"
         ;;
     help|-h|--help)
         usage

--- a/specs/SDD-012b-merged-open-reconciliation-guard/proposal.md
+++ b/specs/SDD-012b-merged-open-reconciliation-guard/proposal.md
@@ -1,0 +1,57 @@
+---
+id: "SDD-012b-merged-open-reconciliation-guard"
+type: spec
+status: active
+created: "2026-06-01"
+tags: [spec, proposal, vault-health, incident-to-guard, backlog-hygiene, sdd-012-followup]
+template_version: "1.0"
+---
+
+# SDD-012b-merged-open-reconciliation-guard
+
+> **Naming**: file lives at `<repo>/specs/SDD-012b-merged-open-reconciliation-guard/proposal.md`.
+
+## Why
+
+<!-- from 11-tasks.md: implement SDD-012's deferred "merged-but-open" cross-reference -->
+
+SDD-012 (`check-backlog-integrity.sh`) guards **structural** backlog drift — one id on two lines, an id marked both `[ ]` and `[x]`. It explicitly deferred the **semantic** class as out of scope: a `- [ ]` entry whose work has *already shipped*. A stale-merged tick is perfectly well-formed text, so the structural guard cannot see it. On 2026-06-01 a single dotfiles reconciliation sweep found **four** such entries — `BUG-022`, `BUG-023`, `BUG-024`, `SDD-009` — all merged weeks earlier, all still `[ ]`, all passing `check-backlog-integrity.sh`. `session_briefing` reads the vault, so these surfaced as phantom open work and nearly caused duplicate implementation. This is the exact failure mode of [[pattern-verify-against-source-of-truth]]: the doc drifts from the repo, and "reconcile manually" rots because nothing detects recurrence. The principle is canonized; this ships its mechanical enforcement.
+
+## What
+
+Concrete, observable behavior after this PR:
+
+1. **A standalone guard `scripts/check-backlog-merged.sh`** (sibling of `check-backlog-integrity.sh`) takes a `<tasks-file>` and flags each open `- [ ]`/`[~]`/`[-]` entry whose **FULL ticket id** (the bold token between `** **`) has an archived spec at `<repo>/specs/archive/<id>/`. Exit `0` clean / `1` candidates found / `2` usage. The done-signal is the SDD lifecycle's own archival marker (per [[pattern-three-layer-proposal-lifecycle]]) — local, network-free, CI/fixture-testable.
+2. **Full-id keying** (not the bare number): `SDD-009-opencode-deploy-time-secrets` matches its archive; `SDD-009-some-other-ticket` does not. This is what dodges the **number-reuse** trap (dotfiles has had two `BUG-024`s and two `HERMES-002`s). Sub-ids (`WIN-002a`) resolve distinctly.
+3. **Repo inference**: `<vault>/10_projects/<proj>/11-tasks.md` → `$HOME/Projects/<proj>`, overridable with `--repo`. Generalizes to every project, not just dotfiles.
+4. **Wired into `vault.sh`** as `vault check-merged <file>`, standalone-runnable like its siblings.
+5. **A GUI-independent advisory line in `vault-health.sh`** runs the guard over every `10_projects/*/11-tasks.md` and reports findings via `warn` (yellow, not a failure) — so stale-merged ticks auto-surface at SessionStart for **whatever agent opens the next session**, turning the "verify against source of truth" discipline into a backstop no one has to remember.
+
+## Out of scope
+
+- **Merged-PR / commit cross-referencing** (matching a `[ ]` id against `gh`/`git log`). PR titles cite the *number*, not the slug, so the match is heuristic and number-reuse makes it noisy. Stays a manual/advisory step (documented in the pattern). The archived-spec signal ships the reliable, zero-false-positive half — the same scoping discipline SDD-012 used.
+- **Auto-ticking** the stale entries. The guard flags; a human/agent verifies against git and ticks with the PR link. Closing the loop is a deliberate action, not an automated mutation of the SSOT.
+- **Fixing `init-spec.sh`'s id regex** so it accepts sub-ids like `SDD-012b` (it currently rejects them — a sibling defect to BUG-024, found while scaffolding this very spec). Separate concern, separate PR.
+- **Multi-id lines** (`BUG-008 / BUG-009 / BUG-010` on one line): the guard reads the leading id per entry line — a documented limitation inherited from SDD-012, not a target.
+
+## Risks / open questions
+
+- **Archived spec ≠ absolute proof of merge** (a spec could be archived prematurely). **Mitigated:** the guard is advisory (`warn`/exit-1-as-warn), output says "verify + tick", and the human confirms against git. False positives cost one `git log`, not a wrong mutation.
+- **Bug/direct-fix tickets have no spec** (BUG-022/023/024 were not caught automatically — only SDD-009 was). **Accepted:** the spec'd class is the recurring, highest-volume drift; the bug class is covered by the pattern's manual procedure + the structural guard. Honest partial coverage beats a brittle full-coverage heuristic.
+- **Guard is local-only** (vault is private; dotfiles CI has no vault access). **Accepted:** consistent with ADR-012 / SDD-012 / ENGINE-001 — drift guards live in `vault-health` (local, SessionStart), not CI. The bats tests use fixtures, so CI still verifies the *logic*.
+
+## Acceptance criteria
+
+- [ ] **AC1 — stale-open flagged**: an open entry whose full id has `specs/archive/<id>/` → exit 1, names the id. **Verify:** bats fixture.
+- [ ] **AC2 — ticked + no-spec pass**: `[x]` entries and `[ ]` entries without an archive → exit 0. **Verify:** bats fixtures.
+- [ ] **AC3 — full-id keyed**: a different ticket sharing a number is NOT flagged; sub-ids (`WIN-002a`) resolve distinctly. **Verify:** bats fixtures.
+- [ ] **AC4 — repo inference + skip**: path→repo inference works; missing `specs/archive` → advisory skip exit 0; missing tasks file → exit 2. **Verify:** bats fixtures.
+- [ ] **AC5 — wired + discoverable**: `vault check-merged <file>` dispatches; `vault-health.sh` carries a GUI-independent advisory section invoking it over `10_projects/*/11-tasks.md` as `warn`. **Verify:** dispatcher run + grep of vault-health section.
+- [ ] **AC6 — live backlog green**: after the 2026-06-01 reconciliation, `check-backlog-merged.sh` on the real `10_projects/dotfiles/11-tasks.md` exits 0. **Verify:** run on the live file (done at build time: exit 0).
+
+## References
+
+- Sibling precedent: `specs/archive/SDD-012-tasks-integrity-guard/` + `scripts/check-backlog-integrity.sh` (the structural half this completes)
+- Canonized in: `pattern-verify-against-source-of-truth.md` §"Automating the Reconciliation"; merge-time step of `pattern-three-layer-proposal-lifecycle`
+- Dispatcher: `scripts/vault.sh` (REFACTOR-005), `scripts/vault-health.sh` section 7
+- Incident: the 2026-06-01 sweep (BUG-022/023/024 + SDD-009 stale-merged); AGENTS.md "incident → guard"

--- a/specs/SDD-012b-merged-open-reconciliation-guard/tasks.md
+++ b/specs/SDD-012b-merged-open-reconciliation-guard/tasks.md
@@ -1,0 +1,12 @@
+# SDD-012b — Tasks (TDD order)
+
+- [x] Write `tests/check-backlog-merged.bats` fixtures (fake repo + `specs/archive/<id>/`) — failing first.
+- [x] Implement `scripts/check-backlog-merged.sh`: parse open full-ids (awk), cross-reference `specs/archive/<id>/`, advisory exit 0/1/2.
+- [x] Full-id keying + sub-id (`WIN-002a`) distinctness — bats AC3.
+- [x] Repo inference (`<vault>/10_projects/<proj>` → `$HOME/Projects/<proj>`) + `--repo` override + missing-specs skip — bats AC4.
+- [x] Wire `vault.sh` dispatcher: `check-merged|merged` case + usage + standalone list.
+- [x] Wire `vault-health.sh` section 7: advisory `warn` over `10_projects/*/11-tasks.md`.
+- [x] `shellcheck` clean (script + vault.sh + vault-health.sh); `bash -n` clean.
+- [x] `bats tests/check-backlog-merged.bats` green (11/11); no regression in `check-backlog-integrity.bats`.
+- [x] Run on live `10_projects/dotfiles/11-tasks.md` → exit 0 (AC6).
+- [ ] Archive this spec post-merge → `specs/archive/SDD-012b-merged-open-reconciliation-guard/`; tick the vault `11-tasks.md` entry `[x]` with the PR link (dogfooding the guard).

--- a/specs/SDD-012b-merged-open-reconciliation-guard/verification.md
+++ b/specs/SDD-012b-merged-open-reconciliation-guard/verification.md
@@ -1,0 +1,28 @@
+# SDD-012b — Verification
+
+Run from the repo root (or the worktree).
+
+```bash
+# Logic (CI-safe, fixture-based)
+~/.local/bin/shellcheck scripts/check-backlog-merged.sh scripts/vault.sh scripts/vault-health.sh
+~/.local/bin/bats tests/check-backlog-merged.bats          # AC1–AC4: 11/11
+~/.local/bin/bats tests/check-backlog-integrity.bats       # no regression in the sibling
+
+# Wiring (AC5)
+./scripts/vault.sh check-merged ~/Projects/knowledge/10_projects/dotfiles/11-tasks.md --repo ~/Projects/dotfiles
+grep -n 'check-backlog-merged' scripts/vault-health.sh     # advisory section present
+
+# Live backlog (AC6) — expect exit 0 after the 2026-06-01 reconciliation
+./scripts/check-backlog-merged.sh ~/Projects/knowledge/10_projects/dotfiles/11-tasks.md ; echo "exit=$?"
+```
+
+| AC | Check | Result at build (2026-06-01) |
+|---|---|---|
+| AC1 | stale-open flagged, names id | ✅ bats |
+| AC2 | ticked / no-spec pass | ✅ bats |
+| AC3 | full-id keyed; `WIN-002a` distinct | ✅ bats |
+| AC4 | repo inference + skip + missing-file | ✅ bats |
+| AC5 | `vault check-merged` dispatch + vault-health `warn` | ✅ dispatch exit 0; grep present |
+| AC6 | live `11-tasks.md` exit 0 | ✅ exit 0 |
+
+Self-test summary: shellcheck clean · 11/11 new bats · 6/6 sibling bats · dispatcher routes · live file clean.

--- a/tests/check-backlog-merged.bats
+++ b/tests/check-backlog-merged.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-backlog-merged.sh — the "merged-but-open" backlog guard
+# (SDD-012b). Semantic sibling of check-backlog-integrity.bats (SDD-012, structural).
+# The done-signal is an archived spec keyed on the FULL ticket id.
+
+setup() {
+    SCRIPTS_DIR="$BATS_TEST_DIRNAME/../scripts"
+    GUARD="$SCRIPTS_DIR/check-backlog-merged.sh"
+    TMP="/tmp/bats_mergedguard_$$_${BATS_TEST_NUMBER:-0}"
+    mkdir -p "$TMP"
+
+    # fake repo with an archived-specs tree
+    REPO="$TMP/repo"
+    mkdir -p "$REPO/specs/archive/SDD-009-opencode-deploy-time-secrets"
+    mkdir -p "$REPO/specs/archive/WIN-002a-vault-health-sh-inverted-check"
+
+    TASKS="$TMP/11-tasks.md"
+}
+
+teardown() {
+    cd / || true
+    rm -rf "$TMP"
+}
+
+@test "flags an open entry whose full id has an archived spec" {
+    printf -- '- [ ] **SDD-009-opencode-deploy-time-secrets** still open here\n' > "$TASKS"
+    run "$GUARD" "$TASKS" --repo "$REPO"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"STALE-OPEN: SDD-009-opencode-deploy-time-secrets"* ]]
+    [[ "$output" == *"archived spec exists"* ]]
+}
+
+@test "clean when the same id is already ticked [x]" {
+    printf -- '- [x] **SDD-009-opencode-deploy-time-secrets** done\n' > "$TASKS"
+    run "$GUARD" "$TASKS" --repo "$REPO"
+    [ "$status" -eq 0 ]
+}
+
+@test "clean when an open entry has NO archived spec" {
+    printf -- '- [ ] **AI-020-gemini-empirical-validation** genuinely open\n' > "$TASKS"
+    run "$GUARD" "$TASKS" --repo "$REPO"
+    [ "$status" -eq 0 ]
+}
+
+@test "full-id keyed: a different ticket sharing a number is NOT flagged" {
+    # archive has SDD-009-opencode...; an open SDD-009-something-else must not match
+    printf -- '- [ ] **SDD-009-some-other-ticket** distinct full id\n' > "$TASKS"
+    run "$GUARD" "$TASKS" --repo "$REPO"
+    [ "$status" -eq 0 ]
+}
+
+@test "sub-id (WIN-002a) resolves distinctly from its parent number" {
+    printf -- '- [ ] **WIN-002a-vault-health-sh-inverted-check** sub-id\n' > "$TASKS"
+    run "$GUARD" "$TASKS" --repo "$REPO"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WIN-002a-vault-health-sh-inverted-check"* ]]
+}
+
+@test "open statuses [~] and [-] are also checked" {
+    printf -- '- [~] **SDD-009-opencode-deploy-time-secrets** in progress\n' > "$TASKS"
+    run "$GUARD" "$TASKS" --repo "$REPO"
+    [ "$status" -eq 1 ]
+}
+
+@test "multiple stale-open entries are all reported and counted" {
+    {
+        printf -- '- [ ] **SDD-009-opencode-deploy-time-secrets** a\n'
+        printf -- '- [ ] **WIN-002a-vault-health-sh-inverted-check** b\n'
+        printf -- '- [ ] **AI-020-gemini-empirical-validation** c\n'
+    } > "$TASKS"
+    run "$GUARD" "$TASKS" --repo "$REPO"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"SDD-009-opencode-deploy-time-secrets"* ]]
+    [[ "$output" == *"WIN-002a-vault-health-sh-inverted-check"* ]]
+    # AI-020 has no archived spec -> not flagged
+    [[ "$output" != *"AI-020"* ]]
+}
+
+@test "no repo / no specs/archive -> advisory skip, exit 0" {
+    printf -- '- [ ] **SDD-009-opencode-deploy-time-secrets** open\n' > "$TASKS"
+    run "$GUARD" "$TASKS" --repo "$TMP/nonexistent-repo"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SKIP"* ]]
+}
+
+@test "missing tasks file -> exit 2" {
+    run "$GUARD" "$TMP/does-not-exist.md" --repo "$REPO"
+    [ "$status" -eq 2 ]
+}
+
+@test "no argument -> usage, exit 2" {
+    run "$GUARD"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "repo inference: <vault>/10_projects/<proj>/11-tasks.md -> \$HOME/Projects/<proj>" {
+    # Build a path the inference will map to our fake repo via HOME override.
+    FAKE_HOME="$TMP/home"
+    mkdir -p "$FAKE_HOME/Projects/repo/specs/archive/SDD-009-opencode-deploy-time-secrets"
+    VAULTTASKS="$TMP/vault/10_projects/repo/11-tasks.md"
+    mkdir -p "$(dirname "$VAULTTASKS")"
+    printf -- '- [ ] **SDD-009-opencode-deploy-time-secrets** open\n' > "$VAULTTASKS"
+    run env HOME="$FAKE_HOME" "$GUARD" "$VAULTTASKS"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"STALE-OPEN: SDD-009-opencode-deploy-time-secrets"* ]]
+}


### PR DESCRIPTION
## Why

SDD-012 (`check-backlog-integrity.sh`) guards **structural** backlog drift — one id on two lines, an id marked both `[ ]` and `[x]`. It explicitly deferred the **semantic** class: a `- [ ]` entry whose work already shipped. A stale-merged tick is well-formed text, so the structural guard cannot see it.

A single reconciliation sweep on 2026-06-01 found **four** such entries — `BUG-022`, `BUG-023`, `BUG-024`, `SDD-009` — merged weeks earlier, still `[ ]`, all passing the structural guard. `session_briefing` reads the vault, so these surfaced as phantom open work and nearly caused duplicate implementation. Incident → guard.

## What

`scripts/check-backlog-merged.sh` flags each open `[ ]`/`[~]`/`[-]` entry whose **FULL ticket id** has an archived spec at `<repo>/specs/archive/<id>/` (the SDD lifecycle's own "this shipped" marker — local, network-free).

- **Full-id keyed**, never the bare number → ticket-number reuse (two `BUG-024`s, two `HERMES-002`s) never false-matches; sub-ids (`WIN-002a`) resolve distinctly.
- **Repo inference**: `<vault>/10_projects/<proj>/11-tasks.md` → `~/Projects/<proj>`, `--repo` override.
- **Advisory** contract (exit 0/1/2): a finding is a "verify + tick" candidate, not proof.
- Wired into `vault.sh` (`vault check-merged`) and `vault-health.sh` (as a `warn`, runs at SessionStart for every agent).

Matching merged PRs by number stays out of scope (heuristic; number-reuse noise) — same scoping discipline SDD-012 used. The archived-spec signal ships the reliable, zero-false-positive half. Canonized in `pattern-verify-against-source-of-truth.md` §"Automating the Reconciliation".

## Verification

- `bats tests/check-backlog-merged.bats` → 11/11 (AC1–AC4)
- `bats tests/check-backlog-integrity.bats` → no regression
- `shellcheck` clean (script + vault.sh + vault-health.sh)
- `vault check-merged` dispatches; live `10_projects/dotfiles/11-tasks.md` exits 0 (AC6)

Spec: `specs/SDD-012b-merged-open-reconciliation-guard/` (active → satisfies spec-gate).