### PR TITLE
fix(init-spec): accept sub-id feature-ids (SDD-012b / WIN-002a)

### DIFF
--- a/scripts/init-spec.sh
+++ b/scripts/init-spec.sh
@@ -48,9 +48,13 @@ if [[ -z "$FEATURE_ID" ]]; then
 fi
 
 # --- Validate id ---
-if [[ ! "$FEATURE_ID" =~ ^([A-Z]+-[0-9]+(-[a-z0-9-]+)?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+)$ ]]; then
+# The optional single letter after the number ([a-z]?) admits the sub-id
+# convention (SDD-012b, WIN-002a) that check-backlog-integrity.sh already treats
+# as a distinct ticket. Without it, init-spec rejected ids the rest of the system
+# accepts — sibling defect to BUG-024 in the same vault-gate.
+if [[ ! "$FEATURE_ID" =~ ^([A-Z]+-[0-9]+[a-z]?(-[a-z0-9-]+)?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+)$ ]]; then
     printf '[ERROR] Invalid feature-id: %s\n' "$FEATURE_ID" >&2
-    printf '        Expected: TICKET-NNN[-slug] (e.g. AI-001-ollama-public) or YYYY-MM-DD-slug\n' >&2
+    printf '        Expected: TICKET-NNN[letter][-slug] (e.g. AI-001-ollama-public, SDD-012b-guard) or YYYY-MM-DD-slug\n' >&2
     exit 1
 fi
 

--- a/tests/init-spec.bats
+++ b/tests/init-spec.bats
@@ -45,6 +45,24 @@ teardown() {
     [ -f "$MAINREPO/specs/TEST-001-foo/proposal.md" ]
 }
 
+@test "accepts a sub-id feature-id (SDD-012b / WIN-002a convention)" {
+    # Sibling of BUG-024: the regex rejected sub-ids that check-backlog-integrity.sh
+    # treats as distinct tickets. A trailing single letter on the number is valid.
+    printf -- '- [ ] **TEST-002a-subid** sub-id backlog entry\n' \
+        >> "$VAULT/10_projects/canonrepo/11-tasks.md"
+    cd "$MAINREPO"
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-002a-subid
+    [ "$status" -eq 0 ]
+    [ -f "$MAINREPO/specs/TEST-002a-subid/proposal.md" ]
+}
+
+@test "still rejects a malformed feature-id (no ticket number)" {
+    cd "$MAINREPO"
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" notaticket
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid feature-id"* ]]
+}
+
 @test "BUG-024: scaffolds from a linked worktree (vault-gate resolves canonical name)" {
     git -C "$MAINREPO" worktree add -q "$TMP/canonrepo-feature" -b feature
     cd "$TMP/canonrepo-feature"


### PR DESCRIPTION
## Why

`init-spec.sh`'s feature-id regex was `[A-Z]+-[0-9]+(-[a-z0-9-]+)?` — it required a **dash** before any suffix. So the sub-id convention (`NNNa`/`NNNb`) that `check-backlog-integrity.sh` (SDD-012) already treats as a **distinct ticket** (`WIN-002` vs `WIN-002a`) was rejected at the gate. The two halves of the vault-gate disagreed on what a valid id is — a sibling defect to BUG-024.

Found in practice: scaffolding `SDD-012b-merged-open-reconciliation-guard` failed with `Invalid feature-id`, forcing a manual spec scaffold.

## What

- Add an optional single letter after the ticket number: `[A-Z]+-[0-9]+[a-z]?(-[a-z0-9-]+)?`. `SDD-012`, `SDD-012b`, `WIN-002a`, `AI-001-ollama-public` all valid; date form unchanged.
- Updated the error hint to show the sub-id form.

## Guard (incident → guard)

`tests/init-spec.bats` gains:
- a **sub-id acceptance** test (`TEST-002a-subid` scaffolds, exit 0), and
- a **malformed-id rejection** test (`notaticket` → exit 1) so the regex cannot silently regress in either direction.

## Verification

- `bats tests/init-spec.bats` → 7/7
- `shellcheck` clean; `bash -n` clean
- Under 50 LOC production diff → no spec required.