### PR TITLE
feat(IDEAS-001): machine-local shell override files (.zshrc.local / .bashrc.local)

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -178,3 +178,9 @@ alias project-init="$HOME/.claude/init-project.sh"
 
 # Dotfiles scripts on PATH
 export PATH="$HOME/.dotfiles/scripts:$PATH"
+
+# ==========================
+# Machine-local overrides (IDEAS-001) — sourced LAST so a machine-specific tweak
+# can override anything above. NON-SENSITIVE config only; secrets use the age
+# system (sensitive/*.secret.age). See .bashrc.local.example. (gitignored)
+[ -r "$HOME/.bashrc.local" ] && [ -f "$HOME/.bashrc.local" ] && . "$HOME/.bashrc.local"

--- a/.bashrc.local.example
+++ b/.bashrc.local.example
@@ -1,0 +1,16 @@
+# ~/.bashrc.local — machine-local bash overrides (IDEAS-001).
+#
+# Copy to ~/.bashrc.local and uncomment what you need. This file is gitignored
+# and sourced LAST by .bashrc, so it can override aliases/exports/prompt above.
+#
+# NON-SENSITIVE config only. Secrets (API keys, tokens) belong in the age system
+# (sensitive/*.secret.age + sensitive/env-mapping.conf), NEVER here.
+
+# Host-specific PATH prepend (a tool installed by hand on this box only):
+# export PATH="$HOME/Applications/some-tool/bin:$PATH"
+
+# VM- or laptop-only alias:
+# alias k=kubectl
+
+# Work-only, non-secret environment variable:
+# export HTTP_PROXY="http://proxy.corp.local:8080"

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ Thumbs.db
 .env.development
 .env.staging
 
+# Machine-local shell overrides (IDEAS-001) — non-sensitive, per-machine
+.zshrc.local
+.bashrc.local
+
 # Development tools
 node_modules/
 *.log

--- a/.zshrc
+++ b/.zshrc
@@ -134,3 +134,9 @@ alias project-init="$HOME/.claude/init-project.sh"
 
 # Dotfiles scripts on PATH
 export PATH="$HOME/.dotfiles/scripts:$PATH"
+
+# ==========================
+# Machine-local overrides (IDEAS-001) — sourced LAST so a machine-specific tweak
+# can override anything above. NON-SENSITIVE config only; secrets use the age
+# system (sensitive/*.secret.age). See .zshrc.local.example. (gitignored)
+[ -r "$HOME/.zshrc.local" ] && [ -f "$HOME/.zshrc.local" ] && . "$HOME/.zshrc.local"

--- a/.zshrc.local.example
+++ b/.zshrc.local.example
@@ -1,0 +1,16 @@
+# ~/.zshrc.local — machine-local zsh overrides (IDEAS-001).
+#
+# Copy to ~/.zshrc.local and uncomment what you need. This file is gitignored
+# and sourced LAST by .zshrc, so it can override aliases/exports/prompt above.
+#
+# NON-SENSITIVE config only. Secrets (API keys, tokens) belong in the age system
+# (sensitive/*.secret.age + sensitive/env-mapping.conf), NEVER here.
+
+# Host-specific PATH prepend (a tool installed by hand on this box only):
+# export PATH="$HOME/Applications/some-tool/bin:$PATH"
+
+# VM- or laptop-only alias:
+# alias k=kubectl
+
+# Work-only, non-secret environment variable:
+# export HTTP_PROXY="http://proxy.corp.local:8080"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ secrets_list                        # List all secrets and status
 secrets_check                       # Validate mapping integrity
 ```
 
+### Machine-local overrides
+
+Non-sensitive, per-machine shell config (a host-only `PATH` prepend, a VM-only alias) goes in `~/.zshrc.local` / `~/.bashrc.local` — gitignored, sourced **last** so it can override anything above. Copy from the committed `.zshrc.local.example` / `.bashrc.local.example`.
+
+> **`.local` is not for secrets.** API keys, tokens and credentials always go through the age system above (`sensitive/*.secret.age` + `env-mapping.conf`), never a `.local` file.
+
 ### AI Tools
 
 ```bash

--- a/specs/IDEAS-001-local-override/proposal.md
+++ b/specs/IDEAS-001-local-override/proposal.md
@@ -1,7 +1,7 @@
 ---
 id: "IDEAS-001-local-override"
 type: spec
-status: draft
+status: active
 created: "2026-05-25"
 tags: [spec, proposal, ideas-001, shell, dotfiles-survey, tier-1]
 template_version: "1.0"

--- a/specs/IDEAS-001-local-override/verification.md
+++ b/specs/IDEAS-001-local-override/verification.md
@@ -3,48 +3,31 @@ tags: [spec, verification, ideas-001]
 created: "2026-05-25"
 ---
 
-# Verification - IDEAS-001-local-override
+# Verification — IDEAS-001-local-override
 
-> Status: skeleton. Populated by the implementation PR on the feature branch (not this research worktree).
+```bash
+~/.local/bin/bats tests/local-override.bats        # 6/6
+zsh -n .zshrc && bash -n .bashrc                    # rc files parse
+```
 
-## Evidence
+| AC | Evidence |
+|---|---|
+| `.zshrc` ends with guarded source of `~/.zshrc.local` | bats "as the last non-blank line" ✅ |
+| `.bashrc` ends with guarded source of `~/.bashrc.local` | bats "as the last non-blank line" ✅ |
+| `.gitignore` includes both local files | bats ".gitignore excludes both" ✅ |
+| `.zshrc.local.example` + `.bashrc.local.example` with use-cases | bats "example files exist…" ✅ |
+| present → sourced (zsh + bash) | bats "guard sources … when present" ✅ |
+| absent → graceful no-op (zsh + bash) | bats "guard is a graceful no-op" ✅ |
+| doc: `.local` vs age system | added under README "Machine-local overrides" (repo `.claude/CLAUDE.md` is gitignored → README is the tracked home; spec's own completeness note allows "README and/or") ✅ |
+| drift detector passes after deployment | **deferred** — verified post-merge + redeploy (drift compares deployed-vs-repo; expected drift until `setup-linux.sh` re-runs). CI has no user `$HOME`, so not gated there. |
 
-| # | Criterion | Evidence |
-|---|---|---|
-| 1 | `.zshrc` ends with conditional source of `$HOME/.zshrc.local` | _pending_ |
-| 2 | `.bashrc` ends with conditional source of `$HOME/.bashrc.local` | _pending_ |
-| 3 | `.gitignore` includes `.zshrc.local` and `.bashrc.local` | _pending_ |
-| 4 | `.zshrc.local.example` and `.bashrc.local.example` exist with ≥2 use-cases each | _pending_ |
-| 5 | Bats: zsh sources local file when present | _pending_ |
-| 6 | Bats: zsh no-ops cleanly when local file absent | _pending_ |
-| 7 | Bats: same coverage for bash | _pending_ |
-| 8 | Drift detector exit 0 post-deploy | _pending_ |
+Note on test design: the functional ACs exercise the guard's semantics in an
+isolated subshell rather than sourcing the full `.zshrc` (which pulls in plugins
+/ tools and is environment-fragile in CI). The structural test proves the real
+rc carries the exact guarded line as its last statement; together they are
+equivalent to "sourcing rc honors the override" without the fragility.
 
-## Test status
+## Out of scope (tracked)
 
-- Test suite: `bats tests/local-override.bats` → _pending_
-- Manual smoke test: `echo 'export TEST=1' > ~/.zshrc.local && zsh -ic 'echo $TEST'` should print `1` — _pending_
-- No regressions in existing test suite (`bats tests/*.bats`): _pending_
-
-## Decisions made during implementation
-
-_Populated during implementation. Likely topics:_
-
-- Should `.local` files load before or after the `load-secrets.sh` invocation? Recommendation: AFTER, so `.local` can override secret-derived env vars if needed.
-- Exact insertion location vs end-of-file when there's a trailing newline / heredoc / etc.
-- Whether to add `.shellrc.local` (R3 open question — currently deferred).
-
-## Promotion candidates
-
-Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
-
-- [ ] Lesson for `10_projects/dotfiles/90-lessons.md`? Likely **yes** — meta-lesson on "non-sensitive machine-local vs sensitive: don't conflate". Candidate body: "The `.local` override pattern complements (not replaces) the age secrets system. age = secrets, .local = non-sensitive machine-local config. Keeping the two systems orthogonal prevents users from drifting toward putting API keys in `.local`."
-- [ ] ADR-worthy decision for `10_projects/dotfiles/30-architecture/adr-XXX.md`? **Probably no** — small mechanism, not architectural.
-- [ ] New pattern candidate for `00_meta/patterns/`? **Maybe** — `pattern-rc-local-override` if other projects adopt; defer until recurrence detected.
-
-## Archive checklist
-
-- [ ] `proposal.md` frontmatter set to `status: archived`
-- [ ] Folder moved: `specs/IDEAS-001-local-override/` → `specs/archive/IDEAS-001-local-override/`
-- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
-- [ ] Promotions above executed (if any)
+- **IDEAS-001b** — Windows `profile.ps1` equivalent (`Test-Path` idiom). Windows session.
+- `.shellrc.local` cross-shell file — deferred to user feedback (proposal R3).

--- a/tests/local-override.bats
+++ b/tests/local-override.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+# IDEAS-001: machine-local override files (.zshrc.local / .bashrc.local).
+# Verifies the mechanism's STRUCTURE (guarded source present + last) and the
+# GUARD semantics (present -> sourced, absent -> graceful no-op) in both shells.
+# We do not source the full rc (env-fragile in CI); the structural test proves
+# the real rc carries the exact line, the functional test proves its logic.
+
+setup() {
+    REPO="$BATS_TEST_DIRNAME/.."
+    TMP="/tmp/bats_localoverride_$$_${BATS_TEST_NUMBER:-0}"
+    mkdir -p "$TMP"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+@test ".zshrc sources ~/.zshrc.local (guarded) as the last non-blank line" {
+    last="$(grep -vE '^[[:space:]]*$' "$REPO/.zshrc" | tail -1)"
+    [[ "$last" == *'.zshrc.local'* ]]
+    [[ "$last" == *'-r '* ]]
+    [[ "$last" == *'-f '* ]]
+}
+
+@test ".bashrc sources ~/.bashrc.local (guarded) as the last non-blank line" {
+    last="$(grep -vE '^[[:space:]]*$' "$REPO/.bashrc" | tail -1)"
+    [[ "$last" == *'.bashrc.local'* ]]
+    [[ "$last" == *'-r '* ]]
+    [[ "$last" == *'-f '* ]]
+}
+
+@test "guard sources the local file when present (zsh + bash)" {
+    printf 'export TEST_IDEAS001_LOCAL=42\n' > "$TMP/rc.local"
+    for sh in zsh bash; do
+        command -v "$sh" >/dev/null 2>&1 || continue
+        out="$("$sh" -c '[ -r "$1" ] && [ -f "$1" ] && . "$1"; printf "%s" "${TEST_IDEAS001_LOCAL:-unset}"' _ "$TMP/rc.local")"
+        [ "$out" = "42" ]
+    done
+}
+
+@test "guard is a graceful no-op when the local file is absent (zsh + bash)" {
+    for sh in zsh bash; do
+        command -v "$sh" >/dev/null 2>&1 || continue
+        run "$sh" -c '[ -r "$1" ] && [ -f "$1" ] && . "$1"; printf "ok"' _ "$TMP/missing.local"
+        [ "$status" -eq 0 ]
+        [ "$output" = "ok" ]
+    done
+}
+
+@test "example files exist with commented use-cases + the secrets warning" {
+    [ -f "$REPO/.zshrc.local.example" ]
+    [ -f "$REPO/.bashrc.local.example" ]
+    grep -q '^#' "$REPO/.zshrc.local.example"
+    grep -q '^#' "$REPO/.bashrc.local.example"
+    grep -qi 'age system' "$REPO/.zshrc.local.example"
+    grep -qi 'age system' "$REPO/.bashrc.local.example"
+}
+
+@test ".gitignore excludes both local override files" {
+    grep -qx '.zshrc.local' "$REPO/.gitignore"
+    grep -qx '.bashrc.local' "$REPO/.gitignore"
+}


### PR DESCRIPTION
## Why

Machine-specific shell config (a host-only `PATH`, a VM-only alias, a work-only non-secret env var) forces a bad choice in versioned `.zshrc`/`.bashrc`: commit private state, or fork the dotfiles per machine. The age system is for **secrets**, not non-sensitive local tweaks. Both mathiasbynens (`.extra`) and holman (`*.local`) solve this with a gitignored file sourced last.

## What

- Trailing **guarded** source in `.zshrc` and `.bashrc`, as the last non-blank line: `[ -r … ] && [ -f … ] && . …` — purely additive, graceful no-op when the file is absent.
- `.gitignore`: `.zshrc.local` + `.bashrc.local`.
- Committed `.zshrc.local.example` / `.bashrc.local.example` with use-cases + a prominent "**not for secrets**" warning.
- README "Machine-local overrides" section documenting `.local` vs the age system (repo `.claude/CLAUDE.md` is gitignored, so README is the tracked home — the spec allows "README and/or").

## Verification

- `tests/local-override.bats` → 6/6: structural (guarded source is the last line in both rc files), functional (present → sourced, absent → no-op, in **both** zsh and bash), example + gitignore presence.
- `zsh -n .zshrc` / `bash -n .bashrc` clean.

Spec: `specs/IDEAS-001-local-override/` (active). Out of scope, tracked: **IDEAS-001b** (Windows `profile.ps1` equivalent), `.shellrc.local` cross-shell file (deferred per proposal R3). Drift-detector AC is post-deploy/local (CI has no `$HOME`).