### PR TITLE
feat(opencode): add Xiaomi MiMo V2.5 to the NaN model catalog

### DIFF
--- a/ai/opencode/opencode.jsonc
+++ b/ai/opencode/opencode.jsonc
@@ -79,6 +79,14 @@
             "input": ["text", "image"],
             "output": ["text"]
           }
+        },
+        "mimo-v2.5": {
+          "name": "Xiaomi MiMo V2.5",
+          "contextWindow": 500000,
+          "modalities": {
+            "input": ["text", "image", "audio"],
+            "output": ["text"]
+          }
         }
         // Non-chat NaN models (qwen3-embedding, kokoro TTS, whisper STT) are
         // intentionally NOT listed here: opencode's modality schema only allows

--- a/tests/opencode.bats
+++ b/tests/opencode.bats
@@ -125,8 +125,8 @@ setup() {
     grep -qE '"model":\s*"nan/qwen3.6"' "$OPENCODE_CFG"
 }
 
-@test "opencode.jsonc exposes 3 chat NaN models (non-chat models intentionally excluded — opencode schema rejects 'embedding' modality)" {
-    for m in deepseek-v4-flash qwen3.6 gemma4; do
+@test "opencode.jsonc exposes 4 chat NaN models (non-chat models intentionally excluded — opencode schema rejects 'embedding' modality)" {
+    for m in deepseek-v4-flash qwen3.6 gemma4 mimo-v2.5; do
         grep -qE "\"$m\":" "$OPENCODE_CFG" || { echo "missing chat model $m" >&2; false; }
     done
     # Non-chat models must NOT appear (would break config load)


### PR DESCRIPTION
## What

Adds `mimo-v2.5` (Xiaomi MiMo V2.5) to the `nan` provider catalog in `ai/opencode/opencode.jsonc`: 500K context, multimodal input (`text`/`image`/`audio`), text output.

- `audio` input is **schema-valid** — opencode's modality set is `{text, audio, image, video, pdf}` (per the existing in-file note); only `embedding` is rejected. No config-load risk.
- Bumps `tests/opencode.bats` NaN chat-model check **3 → 4** (adds `mimo-v2.5` to the presence loop + updates the description) so the count cannot silently drift.

## Verification

- `bats tests/opencode.bats` → 39/39 (test 24 now asserts the 4 chat models incl. mimo-v2.5).

Small config addition; under the spec-gate LOC threshold.