### PR TITLE
feat(SKILLS-001): vendor 5 cross-agent DevOps skills via the deploy engine

### DIFF
--- a/harness/skills/ATTRIBUTION.md
+++ b/harness/skills/ATTRIBUTION.md
@@ -1,0 +1,24 @@
+# Vendored skill attribution (SKILLS-001)
+
+Some skills in the cross-agent skill pipeline are **vendored** (adapted) from external,
+permissively-licensed open-source repositories. The editable source of truth lives in the
+vault (`00_meta/skills/<name>/SKILL.md`); these `harness/skills/<name>/` records are the
+committed, generated snapshots (see the repo README / ADR-013 "generate-and-commit").
+
+For each vendored skill we vendor **only the `SKILL.md`** (adapted for our pipeline and
+trimmed of broken sibling/reference links). The upstream `references/` deep-dive files are
+**not** copied — consult the source repo for those. Full license texts live in each source
+repository; this file is the NOTICE-equivalent that preserves attribution as the licenses require.
+
+| Skill | Source repo | Upstream skill | License | Copyright |
+|-------|-------------|----------------|---------|-----------|
+| `terraform` | [antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill) | terraform-skill | Apache-2.0 | © 2026 Anton Babenko |
+| `helm` | [laurigates/claude-plugins](https://github.com/laurigates/claude-plugins) | helm-chart-development | MIT | © 2026 Lauri Gates |
+| `mcp-builder` | [anthropics/skills](https://github.com/anthropics/skills) | mcp-builder | Apache-2.0 | © 2026 Anthropic, PBC |
+| `golang-pro` | [jeffallan/claude-skills](https://github.com/jeffallan/claude-skills) | golang-pro | MIT | © 2025 Jeff Allan |
+| `async-python-patterns` | [wshobson/agents](https://github.com/wshobson/agents) | async-python-patterns | MIT | © 2024 Seth Hobson |
+
+All sources verified by reading the repository `LICENSE` file at vendor time (2026-06-03).
+Apache-2.0 and MIT both permit redistribution with attribution; this file plus the per-skill
+footer satisfy the notice requirement. If a skill is updated upstream, re-vendor the `SKILL.md`
+into the vault source and re-run `compile-harness.sh --refresh`.

--- a/harness/skills/async-python-patterns/SKILL.md
+++ b/harness/skills/async-python-patterns/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: async-python-patterns
+description: Master Python asyncio, concurrent programming, and async/await patterns for high-performance applications. Use when building async APIs, concurrent systems, or I/O-bound applications requiring non-blocking operations.
+source: https://github.com/wshobson/agents (async-python-patterns)
+license: MIT
+---
+
+# Async Python Patterns
+
+Implementing asynchronous Python with asyncio and async/await for high-performance, non-blocking systems.
+
+## When to use
+
+Async web APIs (FastAPI, aiohttp, Sanic); concurrent I/O (DB, file, network); concurrent web scraping; real-time apps (WebSocket, chat); processing many independent tasks; async microservice communication; optimizing I/O-bound workloads; async background tasks and queues.
+
+## Sync vs async decision guide
+
+| Use case | Approach |
+|----------|----------|
+| Many concurrent network/DB calls | `asyncio` |
+| CPU-bound computation | `multiprocessing` or a thread pool |
+| Mixed I/O + CPU | offload CPU work with `asyncio.to_thread()` |
+| Simple scripts, few connections | sync (simpler to debug) |
+| Web APIs with high concurrency | async frameworks (FastAPI, aiohttp) |
+
+**Key rule:** stay fully sync or fully async within a call path. Mixing creates hidden blocking.
+
+> **Modern structured concurrency (3.11+):** prefer `asyncio.TaskGroup` over bare `gather` for supervised tasks, and `asyncio.timeout()` over `wait_for` where available — they cancel siblings on failure and compose cleanly.
+
+## Core concepts
+
+- **Event loop** — single-threaded cooperative scheduler; runs coroutines, handles I/O without blocking.
+- **Coroutines** — `async def` functions that can pause/resume at `await`.
+- **Tasks** — scheduled coroutines running concurrently (`asyncio.create_task`).
+- **Futures** — low-level eventual results.
+- **Async context managers / iterators** — `async with` / `async for` for resource cleanup and async streams.
+
+## Patterns
+
+```python
+import asyncio
+
+# 1. Basic async/await
+async def fetch_data(url: str) -> dict:
+    await asyncio.sleep(1)        # simulate I/O
+    return {"url": url, "data": "result"}
+
+# 2. Concurrent execution
+async def fetch_all(ids: list[int]) -> list[dict]:
+    return await asyncio.gather(*(fetch_one(i) for i in ids))
+
+# 3. Task management
+async def main():
+    t1 = asyncio.create_task(work("a", 2))
+    t2 = asyncio.create_task(work("b", 1))
+    return await asyncio.gather(t1, t2)
+
+# 4. Error handling — collect, don't crash the batch
+async def process(ids: list[int]):
+    results = await asyncio.gather(*(safe(i) for i in ids), return_exceptions=True)
+    ok = [r for r in results if not isinstance(r, Exception)]
+    return ok
+
+# 5. Timeout
+async def with_timeout():
+    try:
+        return await asyncio.wait_for(slow(5), timeout=2.0)
+    except asyncio.TimeoutError:
+        return None
+```
+
+## Common pitfalls
+
+- **Forgetting `await`** → you get a coroutine object, nothing runs.
+- **Blocking the loop** with `time.sleep()` / sync I/O → use `await asyncio.sleep()` / async libs, or `asyncio.to_thread()`.
+- **Not handling `CancelledError`** → catch, clean up, and re-raise to propagate cancellation.
+- **Calling `await` from a sync function** → use `asyncio.run()` at the boundary.
+
+## Testing async code
+
+```python
+import pytest, asyncio
+
+@pytest.mark.asyncio
+async def test_fetch():
+    assert await fetch_data("https://api.example.com") is not None
+
+@pytest.mark.asyncio
+async def test_timeout():
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(slow(5), timeout=1.0)
+```
+
+## Deep-dive topics (apply from memory; full reference file upstream)
+
+Async context managers, async iterators/generators, producer–consumer with `asyncio.Queue`, `asyncio.Semaphore` rate limiting, async locks/synchronization, real-world apps (aiohttp scraping, async DB, WebSocket servers), and performance (connection pools, batching, avoiding blocking ops).
+
+---
+*Vendored from [wshobson/agents](https://github.com/wshobson/agents) `async-python-patterns` (MIT, © 2024 Seth Hobson). Adapted for the cross-agent skill pipeline; the advanced `references/details.md` remains upstream. See `harness/skills/ATTRIBUTION.md`.*

--- a/harness/skills/golang-pro/SKILL.md
+++ b/harness/skills/golang-pro/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: golang-pro
+description: Idiomatic Go for concurrency (goroutines, channels, select), microservices (gRPC/REST), generics, interfaces, robust error handling, and pprof performance work. Use when building Go applications requiring concurrent programming, microservices architecture, or high-performance systems; for goroutines, channels, generics, gRPC, CLIs, benchmarks, or table-driven tests.
+source: https://github.com/jeffallan/claude-skills (golang-pro)
+license: MIT
+---
+
+# Golang Pro
+
+Senior Go developer with deep expertise in Go 1.21+, concurrent programming, and cloud-native microservices. Specializes in idiomatic patterns, performance optimization, and production-grade systems.
+
+## Core Workflow
+
+1. **Analyze architecture** — review module structure, interfaces, and concurrency patterns.
+2. **Design interfaces** — small, focused interfaces with composition.
+3. **Implement** — idiomatic Go with proper error handling and context propagation; run `go vet ./...` before proceeding.
+4. **Lint & validate** — `golangci-lint run`; fix all reported issues before proceeding.
+5. **Optimize** — profile with pprof, write benchmarks, eliminate allocations.
+6. **Test** — table-driven tests with `-race`, fuzzing, 80%+ coverage; confirm the race detector passes before committing.
+
+## Core Pattern: goroutine with context cancellation + error propagation
+
+```go
+// worker runs until ctx is cancelled or an error occurs.
+// Errors are returned via errCh; the caller must drain it.
+func worker(ctx context.Context, jobs <-chan Job, errCh chan<- error) {
+    for {
+        select {
+        case <-ctx.Done():
+            errCh <- fmt.Errorf("worker cancelled: %w", ctx.Err())
+            return
+        case job, ok := <-jobs:
+            if !ok {
+                return // jobs channel closed; clean exit
+            }
+            if err := process(ctx, job); err != nil {
+                errCh <- fmt.Errorf("process job %v: %w", job.ID, err)
+                return
+            }
+        }
+    }
+}
+
+func runPipeline(ctx context.Context, jobs []Job) error {
+    ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+    defer cancel()
+
+    jobCh := make(chan Job, len(jobs))
+    errCh := make(chan error, 1)
+    go worker(ctx, jobCh, errCh)
+
+    for _, j := range jobs {
+        jobCh <- j
+    }
+    close(jobCh)
+
+    select {
+    case err := <-errCh:
+        return err
+    case <-ctx.Done():
+        return fmt.Errorf("pipeline timed out: %w", ctx.Err())
+    }
+}
+```
+
+Key properties: bounded goroutine lifetime via `ctx`, error propagation with `%w`, no goroutine leak on cancellation.
+
+## Constraints
+
+### MUST
+- Run gofmt and golangci-lint on all code.
+- Add `context.Context` to all blocking operations.
+- Handle every error explicitly (no naked `_` discards without justification).
+- Write table-driven tests with subtests; run the race detector (`-race`).
+- Document all exported functions, types, and packages.
+- Use `X | Y` union constraints for generics (Go 1.18+).
+- Propagate errors with `fmt.Errorf("...: %w", err)`.
+
+### MUST NOT
+- Ignore errors or use `panic` for normal error handling.
+- Create goroutines without clear lifecycle management or context cancellation.
+- Use reflection without a performance justification.
+- Hardcode configuration (use functional options or env vars).
+
+## Deep-dive topics (apply from memory; full reference files live upstream)
+
+| Topic | When |
+|-------|------|
+| Concurrency | goroutines, channels, select, sync primitives |
+| Interfaces | interface design, io.Reader/Writer, composition |
+| Generics | type parameters, constraints, generic patterns |
+| Testing | table-driven tests, benchmarks, fuzzing |
+| Project structure | module layout, internal packages, go.mod |
+
+## Output template
+
+When implementing Go features, provide: (1) interface definitions (contracts first), (2) implementation files with proper package structure, (3) a test file with table-driven tests, (4) a brief note on the concurrency patterns used.
+
+---
+*Vendored from [jeffallan/claude-skills](https://github.com/jeffallan/claude-skills) `golang-pro` (MIT, © 2025 Jeff Allan). Adapted for the cross-agent skill pipeline; deep-dive `references/` files remain upstream. See `harness/skills/ATTRIBUTION.md`.*

--- a/harness/skills/helm/SKILL.md
+++ b/harness/skills/helm/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: helm
+description: Create, test, and package Helm charts — Chart.yaml, templates, _helpers.tpl, dependencies/subcharts, lint/template/dry-run, and repo/OCI publishing. Use when the user mentions Helm charts, helm lint/template/package, or Kubernetes packaging.
+source: https://github.com/laurigates/claude-plugins (helm-chart-development)
+license: MIT
+---
+
+# Helm Chart Development
+
+Create, test, and package custom Helm charts with best practices for maintainability and reusability. (This skill covers chart *authoring*; release install/upgrade, multi-env values overrides, and deployment debugging are separate concerns.)
+
+## Chart creation & structure
+
+```bash
+helm create mychart    # scaffolds Chart.yaml, values.yaml, charts/, templates/ (+ _helpers.tpl, tests/), .helmignore
+```
+
+**Chart.yaml essentials:**
+```yaml
+apiVersion: v2          # Helm 3
+name: mychart
+version: 0.1.0          # chart version (SemVer)
+appVersion: "1.0.0"     # app version
+type: application       # application | library
+dependencies:
+  - name: postgresql
+    version: "12.1.9"
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
+```
+
+## Validation & testing
+
+```bash
+helm lint ./mychart --strict                                   # warnings as errors
+helm template myrelease ./mychart --values values.yaml         # render locally
+helm template myrelease ./mychart --show-only templates/deployment.yaml --validate
+helm install myrelease ./mychart --dry-run --debug             # server-side validation
+# chart tests (helm.sh/hook: test pods):
+helm install myrelease ./mychart -n test && helm test myrelease -n test --logs && helm uninstall myrelease -n test
+```
+
+Chart test pod (`templates/tests/test-connection.yaml`) uses annotations `"helm.sh/hook": test` and `"helm.sh/hook-delete-policy": hook-succeeded,hook-failed`.
+
+## Template helpers (`_helpers.tpl`)
+
+```yaml
+{{- define "mychart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{- define "mychart.labels" -}}
+helm.sh/chart: {{ include "mychart.chart" . }}
+{{ include "mychart.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+```
+
+## Dependencies / subcharts
+
+```bash
+helm dependency update ./mychart    # download per Chart.yaml -> Chart.lock
+helm dependency build ./mychart     # build from existing Chart.lock
+```
+Configure subchart values under the dependency's key in the parent `values.yaml` (e.g. `postgresql: { auth: {...}, primary: { persistence: { size: 10Gi } } }`). Use `condition:` to toggle and `file://../common-library` for local deps.
+
+## Packaging & distribution
+
+```bash
+helm package ./mychart --dependency-update --destination ./dist/
+helm repo index ./repo/
+helm push mychart-0.1.0.tgz oci://registry.example.com/charts   # Helm 3.8+ OCI
+```
+
+## Agentic cheat-sheet
+
+| Context | Command |
+|---------|---------|
+| Lint (strict) | `helm lint ./mychart --strict` |
+| Render one template | `helm template myapp ./mychart --show-only templates/deployment.yaml` |
+| Dry-run validation | `helm install myapp ./mychart --dry-run --debug 2>&1 \| head -100` |
+| Package | `helm package ./mychart --dependency-update` |
+
+References: [Helm charts](https://helm.sh/docs/topics/charts/) · [Best practices](https://helm.sh/docs/chart_best_practices/) · [Template guide](https://helm.sh/docs/chart_template_guide/) · [chart-testing](https://github.com/helm/chart-testing). The upstream skill bundles a deeper `REFERENCE.md` (values/schema/testing detail).
+
+---
+*Vendored from [laurigates/claude-plugins](https://github.com/laurigates/claude-plugins) `helm-chart-development` (MIT, © 2026 Lauri Gates). Adapted for the cross-agent skill pipeline; the companion `REFERENCE.md` remains upstream. See `harness/skills/ATTRIBUTION.md`.*

--- a/harness/skills/mcp-builder/SKILL.md
+++ b/harness/skills/mcp-builder/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: mcp-builder
+description: Guide for creating high-quality MCP (Model Context Protocol) servers that let LLMs interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, in Python (FastMCP) or Node/TypeScript (MCP SDK).
+source: https://github.com/anthropics/skills (mcp-builder)
+license: Apache-2.0
+---
+
+# MCP Server Development Guide
+
+Create MCP servers that enable LLMs to interact with external services through well-designed tools. Quality is measured by how well the server enables LLMs to accomplish real-world tasks.
+
+## High-level workflow (4 phases)
+
+### Phase 1 — Research & planning
+- **API coverage vs workflow tools:** balance comprehensive endpoint coverage with specialized workflow tools. When uncertain, prioritize comprehensive API coverage.
+- **Naming & discoverability:** clear, action-oriented names with consistent prefixes (`github_create_issue`, `github_list_repos`).
+- **Context management:** concise tool descriptions; support filtering/pagination; return focused, relevant data.
+- **Actionable errors:** guide the agent toward a fix with specific next steps.
+- **Study the protocol:** start at `https://modelcontextprotocol.io/sitemap.xml`, fetch pages with a `.md` suffix for markdown. Review architecture, transports (streamable HTTP, stdio), and tool/resource/prompt definitions.
+- **Recommended stack:** TypeScript SDK (strong typing, good model support); streamable HTTP + stateless JSON for remote servers, stdio for local.
+
+### Phase 2 — Implementation
+- **Project structure:** per the language guide (TS: package.json/tsconfig; Python: module layout + deps).
+- **Core infrastructure:** authenticated API client, error-handling helpers, response formatting (JSON/Markdown), pagination.
+- **Per tool:**
+  - *Input schema* — Zod (TS) or Pydantic (Python); constraints + clear descriptions + examples.
+  - *Output schema* — define `outputSchema` where possible; return `structuredContent`.
+  - *Implementation* — async I/O, actionable errors, pagination; return both text and structured data.
+  - *Annotations* — `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`.
+
+### Phase 3 — Review & test
+- Review for DRY, consistent error handling, full type coverage, clear descriptions.
+- **TypeScript:** `npm run build`; test with `npx @modelcontextprotocol/inspector`.
+- **Python:** `python -m py_compile your_server.py`; test with MCP Inspector.
+
+### Phase 4 — Evaluations
+Create ~10 evaluation questions that are **independent, read-only, complex (multi-tool), realistic, verifiable (single string-comparable answer), and stable**. Process: inspect tools → explore data (read-only) → generate questions → verify answers yourself. Output as XML:
+
+```xml
+<evaluation>
+  <qa_pair>
+    <question>...complex, realistic, multi-tool question...</question>
+    <answer>3</answer>
+  </qa_pair>
+</evaluation>
+```
+
+## Key SDK references (fetch on demand)
+- Python SDK: `https://raw.githubusercontent.com/modelcontextprotocol/python-sdk/main/README.md`
+- TypeScript SDK: `https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/README.md`
+
+The upstream skill bundles four reference files (Python/FastMCP guide, Node/TS guide, MCP best practices, evaluation harness with runnable scripts) — consult them for complete worked examples.
+
+---
+*Vendored from [anthropics/skills](https://github.com/anthropics/skills) `mcp-builder` (Apache-2.0, © 2026 Anthropic, PBC). Adapted for the cross-agent skill pipeline; the `reference/` + `scripts/` bundles remain upstream. See `harness/skills/ATTRIBUTION.md`.*

--- a/harness/skills/terraform/SKILL.md
+++ b/harness/skills/terraform/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: terraform
+description: Use when writing, reviewing, or debugging Terraform/OpenTofu modules, tests, CI, scans, or state ops — diagnoses the failure mode (identity churn, secret exposure, blast radius, CI drift, compliance, state corruption, provider-upgrade risk, testing blind spots) with version-aware guards, then generates fixes.
+source: https://github.com/antonbabenko/terraform-skill (terraform-skill)
+license: Apache-2.0
+---
+
+# Terraform / OpenTofu
+
+Diagnose first, then fix. Every response states runtime assumptions, identifies the risk category, proposes remediation with tradeoffs, gives validation commands, and includes rollback notes for destructive changes.
+
+## Response contract
+1. **Assumptions & version floor** — `terraform` vs `tofu`, version, providers, state backend, criticality.
+2. **Risk category addressed** — one of the failure modes below.
+3. **Remediation & tradeoffs** — what was chosen, what was traded off.
+4. **Validation plan** — exact commands (`fmt -check`, `validate`, `plan -out`, policy checks).
+5. **Rollback notes** — undo procedure + evidence retention for state-mutating changes.
+
+## Failure-mode routing
+| Category | Symptoms |
+|----------|----------|
+| Identity churn | addresses shift, `count` index churn, missing `moved` blocks |
+| Secret exposure | secrets in defaults/state/logs/CI |
+| Blast radius | oversized stacks, shared prod/non-prod state |
+| CI drift | local plan ≠ CI plan, unpinned versions |
+| Compliance gaps | no policy stage, no approval, no evidence |
+| Testing blind spots | plan-only validation of computed/set values |
+| State corruption | stuck lock, backend migration, drift |
+| Provider upgrade/lifecycle | breaking bumps; `removed` blocks for retiring resources |
+| Bootstrap misuse | `null_resource` + `local-exec`/`remote-exec` |
+
+## Module hierarchy & layout
+resource → resource module → infrastructure module → composition. Keep modules small, single-responsibility. Separate environments from modules; use `examples/` as docs *and* test fixtures.
+```
+environments/  modules/  examples/
+my-module/: README.md main.tf variables.tf outputs.tf versions.tf examples/{minimal,complete}/ tests/module_test.tftest.hcl
+```
+**Naming:** descriptive resource names; reserve `this` for genuine singletons; context-prefixed variables; standard files. **Block order:** resource = `count`/`for_each` → args → `tags` → `depends_on` → `lifecycle`; variable = `description` → `type` → `default` → `validation` → `nullable` → `sensitive`.
+
+## count vs for_each
+| Scenario | Use |
+|----------|-----|
+| Boolean create/don't | `count = cond ? 1 : 0` |
+| Items may reorder/remove | `for_each = toset(list)` |
+| Reference by key / named | `for_each = map` |
+
+**Never use a list index as long-lived identity** — removing a middle element reshuffles every later address.
+
+## Testing decision matrix
+| Situation | Approach | Tools |
+|-----------|----------|-------|
+| Quick syntax | static | `validate`, `fmt` |
+| Pre-commit | static + lint | `tflint`, `trivy`, `checkov` |
+| 1.6+, simple logic | native | `terraform test` |
+| Pre-1.6 / Go expertise | integration | Terratest |
+| Security/compliance | policy-as-code | OPA, Sentinel |
+| Cost-sensitive | mock providers (1.7+) | native + mocks |
+
+Native test rules (1.6+): `command = plan` for input-derived values; `command = apply` for computed values (ARNs, generated names) and set-type nested blocks (cannot be `[0]`-indexed — use `for` expressions or materialize via apply).
+
+## State management
+**Never local state in teams/prod.** Use a remote backend (locking, encryption, versioning, audit):
+```hcl
+terraform {
+  backend "s3" {
+    bucket = "my-tf-state"
+    key    = "prod/vpc/terraform.tfstate"
+    region = "us-east-1"
+    encrypt      = true
+    use_lockfile = true   # native S3 locking, 1.10+ (else dynamodb_table)
+  }
+}
+```
+Organize per-environment + per-component (hybrid). Split state when different teams/cadences or >500 resources; combine when tightly coupled and <100.
+
+## Version management
+| Component | Strategy | Example |
+|-----------|----------|---------|
+| Runtime | pin minor | `required_version = "~> 1.9"` |
+| Providers | pin major | `version = "~> 5.0"` |
+| Modules (prod) | pin exact | `version = "5.1.2"` |
+Commit `.terraform.lock.hcl`. Keep provider/runtime upgrades in a separate PR from functional changes.
+
+## Security & compliance
+Run `trivy config .` and `checkov -d .`. **Don't** store secrets in variables/`.tfvars`, use the default VPC, skip encryption, open SGs to `0.0.0.0/0`, or use inline `ingress`/`egress`. **Do** source secrets from cloud secret managers, use `write_only`/`*_wo` args (1.11+), dedicated VPCs, least-privilege SGs, separate `aws_vpc_security_group_{ingress,egress}_rule`. Note: `sensitive = true` masks display only — the value still lives in state.
+
+## CI/CD
+Stages: **validate → test → plan → apply** (with environment protection). Apply the **reviewed plan artifact** (don't re-run `plan` in the apply job). Mock providers on PR validation; real-cloud integration only on main/scheduled; tag + auto-clean test resources.
+
+## Modern features (verify the runtime floor before emitting)
+`try()` 0.13+ · `nullable=false` 1.1+ · `moved` 1.1+ · `optional()` defaults 1.3+ · `import` blocks 1.5+ · `check` 1.5+ · native `test` 1.6+ · mock providers 1.7+ · `removed` 1.7+ · cross-variable validation 1.9+ · S3 native lock 1.10+ · `write_only` 1.11+. Both Terraform and OpenTofu (1.6+) are supported.
+
+The upstream skill bundles eight `references/*.md` deep-dives (testing, modules, CI/CD, security, state, code patterns, LSP, quick-reference) — consult them for full worked examples.
+
+---
+*Vendored from [antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill) (Apache-2.0, © 2026 Anton Babenko). Adapted for the cross-agent skill pipeline; the `references/` deep-dives remain upstream. See `harness/skills/ATTRIBUTION.md`.*

--- a/harness/skills/vault-sync/SKILL.md
+++ b/harness/skills/vault-sync/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: vault-sync
+description: "Vault git synchronization protocol: pull before read, pull --rebase before write, push after write. Handles divergence, conflict resolution, and recovery. Follow this whenever interacting with the knowledge vault."
+---
+
+# Vault Sync Protocol
+
+## Overview
+
+The knowledge vault is a git repository shared across multiple agents (Claude Code, OpenCode, Hermes Agent) and humans (Manu via Obsidian). Concurrent writes are the norm, not the exception. This protocol ensures safe synchronization without data loss or force pushes.
+
+**Core principle:** The vault is always evolving. Never assume your local copy is up to date. Sync before every read, every write, and every push.
+
+## The Iron Law
+
+```
+PULL BEFORE READ  |  PULL --REBASE BEFORE WRITE  |  PUSH AFTER WRITE
+```
+
+- **Skip pull before read?** You read stale data. Decision based on stale data.
+- **Skip pull --rebase before write?** Push gets rejected. You have to unwind.
+- **Skip push after write?** The vault diverges from remote. Next agent starts behind.
+
+There is no shortcut. Do all three, every time.
+
+## When to use
+
+- **Every** vault interaction — whether reading, writing, or searching
+- Before starting a session that will use vault data
+- After any vault write (file create, edit, delete)
+- When Hive MCP returns stale or inconsistent data
+- When `vault_health` reports divergence between local and remote
+
+## When to skip
+
+- Read-only operations on the local vault that do NOT need to be current (rare — almost always sync first)
+- Emergency operations where the vault is inaccessible and you're writing to /tmp/ for later manual sync
+
+## The protocol
+
+### Phase 1 — Pull before read
+
+```bash
+# Before ANY read, search, or query on the vault:
+cd /tmp/hermes-vault && git pull --rebase
+```
+
+This ensures you're working with the latest state. If the vault has been modified by another agent or by Obsidian sync, you pick up those changes immediately.
+
+**Why --rebase?** It keeps history linear. Merge commits in the vault create noise and complicate history bisection.
+
+### Phase 2 — Pull --rebase before write
+
+```bash
+# Before ANY write, edit, or delete on the vault:
+cd /tmp/hermes-vault && git pull --rebase
+```
+
+Even if you just pulled in Phase 1, another agent may have pushed since then. Pull again immediately before writing to minimize the chance of a non-fast-forward rejection.
+
+### Phase 3 — Write using Hive MCP (preferred)
+
+```python
+# Use Hive tools for vault operations:
+# vault_write, vault_patch, vault_create
+# Hive auto-commits with message "vault: ..."
+```
+
+Hive's auto-commit integrates cleanly with git history. No manual `git add`/`git commit` needed.
+
+### Phase 3b — Native write (fallback)
+
+```bash
+# Only when Hive MCP is unavailable:
+# 1. Make changes via Write / Edit / patch
+# 2. Stage and commit manually:
+cd /tmp/hermes-vault && git add -A && git commit -m "vault: <description>"
+```
+
+Always use the `vault:` prefix to match Hive's convention.
+
+### Phase 4 — Push after write
+
+```bash
+cd /tmp/hermes-vault && git push
+```
+
+If the push is rejected (non-fast-forward), proceed to Phase 5.
+
+### Phase 5 — Divergence recovery
+
+If `git push` fails with a non-fast-forward error:
+
+```bash
+# 1. Pull --rebase to reapply your commits on top of remote
+cd /tmp/hermes-vault && git pull --rebase
+
+# 2. Resolve any conflicts
+# 3. Push again
+git push
+```
+
+**Never use `git push --force` or `git push --force-with-lease` on the vault.** Force pushes rewrite history and corrupt the shared timeline. If rebase fails due to conflicts:
+
+1. Use `git status` to identify conflicted files
+2. Resolve each conflict manually
+3. `git add <resolved-file>` for each
+4. `git rebase --continue`
+5. `git push`
+
+If you cannot resolve a conflict (e.g., large auto-generated file), escalate to Manu.
+
+## Error handling matrix
+
+| Symptom | Cause | Action |
+|---------|-------|--------|
+| `push rejected (non-fast-forward)` | Remote has commits you don't | `git pull --rebase`, then push |
+| `pull --rebase fails with conflicts` | Same file changed in both | Manual conflict resolution |
+| `Could not resolve host` | Network down | Cache changes locally, retry later |
+| `fatal: not a git repository` | Vault not cloned | Run setup.sh or git clone |
+| `Permission denied (publickey)` | Wrong remote URL or no SSH key | Use HTTPS with token |
+| `remote: Invalid username or password` | Token expired or invalid | Ask Manu for new token |
+| `hint: diverged branches` | rebase detected divergence | Run `git pull --rebase` again, should auto-resolve |
+
+## Conflict resolution
+
+When `git pull --rebase` produces merge conflicts:
+
+1. **Identify conflicted files:**
+   ```bash
+   git status
+   # Look for files under "both modified" or "Unmerged paths"
+   ```
+
+2. **Resolve each conflict:**
+   - Open the file and find `<<<<<<<`, `=======`, `>>>>>>>` markers
+   - Decide which version to keep (or merge both)
+   - Remove the conflict markers
+   - Save the file
+
+3. **Mark as resolved:**
+   ```bash
+   git add <file>
+   ```
+
+4. **Continue rebase:**
+   ```bash
+   git rebase --continue
+   ```
+
+5. **If stuck:**
+   ```bash
+   # Abort the rebase and restore original state
+   git rebase --abort
+   # Then escalate to Manu
+   ```
+
+## Automatic sync via Hive MCP
+
+When using Hive MCP tools (`vault_write`, `vault_patch`, `vault_create`):
+
+- Hive handles git commit automatically (message format: `vault: ...`)
+- Hive does NOT auto-push. You must still run Phase 4 (push) after Hive operations.
+- Hive does NOT auto-pull. You must still run Phase 1-2 before Hive operations.
+
+**Reasoning:** Push and pull require network access and may fail. Hive defers those to you so you can handle retries and divergence.
+
+## Pitfalls
+
+- **Assuming your local copy is current.** It's not. Another agent or Obsidian sync may have pushed since your last pull.
+- **Skipping pull before read.** Stale data leads to bad decisions.
+- **Forgetting to push after write.** Your changes exist only on this machine. If the server dies, they're gone.
+- **Using git push --force.** This is a shared repo. Force push destroys history. Never.
+- **Multiple writes without intervening pushes.** Batch your writes, but push after each logical batch. Don't accumulate 10 commits and push once — that maximizes the chance of divergence.
+- **Committing when Hive already auto-committed.** Double commits duplicate history. Check `git status` first.
+
+## Verification
+
+After completing the sync cycle:
+
+1. Confirm remote is up-to-date:
+   ```bash
+   cd /tmp/hermes-vault && git status
+   # Should say: "Your branch is up to date with 'origin/master'."
+   ```
+
+2. Confirm no uncommitted changes:
+   ```bash
+   git status --porcelain
+   # Should be empty
+   ```
+
+3. Confirm last commit message matches vault convention:
+   ```bash
+   git log -1 --oneline
+   # Should start with "vault:"
+   ```
+
+## Related
+
+- `00_meta/patterns/pattern-hive-first-vault-access.md` — when to use Hive vs. native tools
+- `00_meta/skills/verification-before-completion/SKILL.md` — verify before claiming completion
+- `00_meta/skills/handoff/SKILL.md` — session handoff includes vault sync status

--- a/specs/SKILLS-001-vendor-devops-skills/proposal.md
+++ b/specs/SKILLS-001-vendor-devops-skills/proposal.md
@@ -1,0 +1,65 @@
+---
+id: "SKILLS-001-vendor-devops-skills"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-03"
+tags: [spec, proposal, harness-001, skills, skills-sh, vendoring, cross-agent]
+template_version: "1.0"
+---
+
+# SKILLS-001-vendor-devops-skills
+
+> **HARNESS-001 consumer 3 (GH [#158](https://github.com/mlorentedev/dotfiles/issues/158)).** Vendor a curated, license-clean set of DevOps/IaC skills from the skills.sh ecosystem into the vault skill SSOT, so they deploy cross-agent through the existing engine (SDD-008) — not a bespoke per-skill copy.
+
+## Why
+
+skills.sh is a package manager (Vercel) for agent skills (`SKILL.md` = frontmatter + markdown), distributed from GitHub repos via `npx skills add <owner/repo>`. Several skills map to the user's stack (Terraform/Helm/Kubernetes, Go, async Python, MCP authoring) and should be available to **every** agent (Claude/OpenCode/agy/Copilot), through the unified deploy engine.
+
+The repo already has the engine (vault `00_meta/skills/` → `compile-harness.sh --refresh` → committed `harness/skills/` records → `--deploy` per agent). SKILLS-001 just adds source skills to the SSOT; they then flow through the pipeline with zero new machinery.
+
+## What
+
+Observable result:
+
+1. **Five vendored skills** added to the vault SSOT (`00_meta/skills/<name>/SKILL.md`) and refreshed into committed `harness/skills/` records, deploying to all agents via the existing matrix:
+   - `terraform` — antonbabenko/terraform-skill (**Apache-2.0**)
+   - `helm` — laurigates/claude-plugins · helm-chart-development (**MIT**)
+   - `mcp-builder` — anthropics/skills · mcp-builder (**Apache-2.0**, official Anthropic)
+   - `golang-pro` — jeffallan/claude-skills (**MIT**)
+   - `async-python-patterns` — wshobson/agents (**MIT**)
+2. **License attribution** — `harness/skills/ATTRIBUTION.md` (NOTICE-equivalent) + a per-skill footer citing source/license/copyright. Only each `SKILL.md` is vendored; upstream `references/` deep-dives are left upstream (linked, not copied).
+3. **Drift fixed in passing** — `--refresh` also generated the missing `vault-sync` record (it was in the vault SSOT but lacked a committed record). Folded in, noted.
+4. **CI green** — `compile-harness.sh --check` validates the new records offline; bats suite passes.
+
+## Audit (avoided duplication — issue requirement)
+
+Of the issue's 10 candidates, **3 were dropped as duplicates** of existing skills (audit-first): `architecture-patterns` (≈ `architecture-session`), `skill-development` (≈ `creating-skills`), `python-testing-patterns` (≈ `test` / `test-driven-development`). The 3 terraform candidates (module-library / style-guide / test) collapse into one comprehensive `terraform` skill. `frontend-design` is already present as a plugin.
+
+## Out of scope
+
+- **Vendoring upstream `references/` deep-dive files.** Only `SKILL.md` per skill; the self-contained guidance is the deliverable, depth links to upstream.
+- **Windows deploy parity validation.** The skill records are OS-agnostic markdown; `compile-harness.ps1 --deploy` renders them on Windows unchanged. Empirical Windows validation is batched into the dedicated Windows session.
+- **`npx skills` runtime integration.** Rejected: it lives outside the vault→engine SSOT model (the issue explicitly wants engine deploy, not a bespoke per-machine npx step).
+
+## Risks / open questions
+
+- **🟡 License compliance in a public repo.** MIT + Apache-2.0 both allow redistribution with attribution; `ATTRIBUTION.md` + per-skill footer preserve copyright + license + source link. We do not copy full LICENSE texts (they live upstream) — acceptable for adapted docs; tighten by copying license files if the repo later needs strict NOTICE.
+- **🟡 Upstream drift.** Vendored copies can age vs upstream. Mitigation: each record marks its source; re-vendor + `--refresh` to update. No auto-sync (would couple us to external repos).
+- **🟢 No engine change.** Skills are auto-discovered from the vault `skills.vault_subpath`; no `manifest.json` edit needed.
+
+## Acceptance criteria
+
+- [ ] **AC1** — 5 skills exist in vault `00_meta/skills/` with valid `name`+`description` frontmatter (schema-passing).
+- [ ] **AC2** — `compile-harness.sh --refresh` generates `harness/skills/<name>` records for all 5 (+ vault-sync drift-fix); committed.
+- [ ] **AC3** — `compile-harness.sh --check` exits 0 ("no harness drift").
+- [ ] **AC4** — `harness/skills/ATTRIBUTION.md` lists every vendored skill's source/license/copyright; each `SKILL.md` carries a footer citing it.
+- [ ] **AC5** — Audit documented: 3 dropped duplicates + the terraform 3→1 collapse.
+- [ ] **AC6** — Vault skill sources committed to vault `master`; harness records + spec + attribution shipped via dotfiles PR (closes #158).
+- [ ] **AC7** — HARNESS-001 epic (#162) consumer-3 (#158) ticked on merge.
+
+## References
+
+- Issue: GH [#158](https://github.com/mlorentedev/dotfiles/issues/158); epic [#162](https://github.com/mlorentedev/dotfiles/issues/162).
+- Engine: `scripts/compile-harness.sh`, `harness/manifest.json`, SDD-008 / ADR-013.
+- skills.sh ecosystem: <https://skills.sh>, <https://skills-registry.dev>.
+- Sources: antonbabenko/terraform-skill, laurigates/claude-plugins, anthropics/skills, jeffallan/claude-skills, wshobson/agents (see `harness/skills/ATTRIBUTION.md`).

--- a/specs/SKILLS-001-vendor-devops-skills/tasks.md
+++ b/specs/SKILLS-001-vendor-devops-skills/tasks.md
@@ -1,0 +1,36 @@
+---
+id: "SKILLS-001-vendor-devops-skills"
+type: tasks
+status: draft
+created: "2026-06-03"
+template_version: "1.0"
+---
+
+# SKILLS-001 — Tasks
+
+## T1 — Audit (avoid duplication) ✅
+- [x] Compare the 10 issue candidates against the 25 existing vault skills.
+- [x] Drop 3 duplicates (architecture-patterns, skill-development, python-testing-patterns); collapse terraform 3→1.
+
+## T2 — Source + license due-diligence ✅
+- [x] Identify a permissive (MIT/Apache-2.0) source repo per skill; verify each by reading its LICENSE.
+- [x] terraform=Apache-2.0, helm=MIT, mcp-builder=Apache-2.0, golang-pro=MIT, async-python-patterns=MIT.
+
+## T3 — Vendor into the vault SSOT ✅
+- [x] Write `00_meta/skills/<name>/SKILL.md` for all 5 (clean frontmatter name+description+source+license; body adapted; broken `references/` links neutralized; attribution footer).
+
+## T4 — Refresh + validate ✅
+- [x] `compile-harness.sh --refresh` → committed `harness/skills/` records (+ vault-sync drift-fix).
+- [x] `compile-harness.sh --check` → exit 0, "no harness drift".
+
+## T5 — Attribution ✅
+- [x] `harness/skills/ATTRIBUTION.md` NOTICE table (source/license/copyright per skill).
+
+## T6 — Commit + PR
+- [ ] Vault: commit the 5 `00_meta/skills/*` sources to vault `master` (direct, per vault discipline).
+- [ ] dotfiles: PR with the 6 new `harness/skills/` records + ATTRIBUTION.md + spec. `Closes #158`. No AI attribution; English; no phase refs.
+- [ ] Verify CI green (test/lint/spec-gate/integration).
+
+## T7 — Close-out
+- [ ] Tick HARNESS-001 epic (#162) consumer-3 (#158) on merge.
+- [ ] (optional) Deploy locally: `setup` to render the new skills into ~/.claude/skills, ~/.config/opencode/commands, etc.

--- a/specs/SKILLS-001-vendor-devops-skills/verification.md
+++ b/specs/SKILLS-001-vendor-devops-skills/verification.md
@@ -1,0 +1,30 @@
+---
+id: "SKILLS-001-vendor-devops-skills"
+type: verification
+status: draft
+created: "2026-06-03"
+template_version: "1.0"
+---
+
+# SKILLS-001 — Verification
+
+| AC | How verified | Evidence |
+|---|---|---|
+| AC1 | 5 vault `SKILL.md` exist with name+description; `--check` validates frontmatter against the schema. | ls + --check |
+| AC2 | `--refresh` produced `harness/skills/{terraform,helm,mcp-builder,golang-pro,async-python-patterns,vault-sync}`. | git status (6 new dirs) |
+| AC3 | `compile-harness.sh --check` → exit 0, "no harness drift". | command output |
+| AC4 | `harness/skills/ATTRIBUTION.md` lists all 5 sources; each SKILL.md ends with a source/license footer. | grep |
+| AC5 | Audit recorded in proposal (3 dropped dupes + terraform 3→1). | proposal.md |
+| AC6 | Vault `master` commit SHA (5 sources) + dotfiles PR (records+attribution+spec) closing #158. | git log / gh pr |
+| AC7 | Epic #162 #158 checkbox `[x]` after merge. | gh issue view |
+
+## License due-diligence (per source, read at vendor time 2026-06-03)
+- terraform — antonbabenko/terraform-skill — Apache-2.0 (LICENSE read).
+- helm — laurigates/claude-plugins — MIT (LICENSE read).
+- mcp-builder — anthropics/skills — Apache-2.0 (per-skill LICENSE.txt read).
+- golang-pro — jeffallan/claude-skills — MIT (LICENSE read).
+- async-python-patterns — wshobson/agents — MIT (LICENSE read).
+All permit redistribution with attribution; ATTRIBUTION.md + per-skill footer preserve the notice.
+
+## Anti-scope confirmation
+Upstream `references/` deep-dives NOT copied (linked upstream). No `manifest.json` change (skills auto-discovered). Windows deploy parity deferred to the batched Windows session (records are OS-agnostic markdown).

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -317,11 +317,11 @@ setup() {
     # Post-SDD-008: setup-linux.sh runs compile-harness.sh --deploy, which renders
     # each committed vault skill record whose targets[] includes opencode to a
     # command .md. The container has no vault, so --refresh is skipped and --deploy
-    # uses the committed records (24 skills, 5 Claude-only opt out -> 19 commands).
+    # uses the committed records (30 skills, 5 Claude-only opt out -> 25 commands).
     [ -d "$HOME/.config/opencode/commands" ]
     local count
     count=$(find "$HOME/.config/opencode/commands" -maxdepth 1 -name '*.md' | wc -l)
-    [ "$count" -eq 19 ]  # 18 -> 19: pattern-loader skill re-homed from vault (no targets: -> all agents)
+    [ "$count" -eq 25 ]  # 19 -> 25: SKILLS-001 vendored terraform/helm/mcp-builder/golang-pro/async-python-patterns + vault-sync drift-fix (all no targets: -> all agents)
     # Spot check: audit.md present (portable), creating-skills.md absent (targets:[claude]).
     [ -f "$HOME/.config/opencode/commands/audit.md" ]
     [ ! -f "$HOME/.config/opencode/commands/creating-skills.md" ]


### PR DESCRIPTION
## Summary

**HARNESS-001 consumer 3 (#158).** Vendors a curated, license-clean set of DevOps/IaC skills from the skills.sh ecosystem into the vault skill SSOT, so they deploy cross-agent (Claude/OpenCode/agy/Copilot) through the existing engine — no bespoke per-skill copy.

| Skill | Source | License |
|---|---|---|
| `terraform` | antonbabenko/terraform-skill | Apache-2.0 |
| `helm` | laurigates/claude-plugins · helm-chart-development | MIT |
| `mcp-builder` | anthropics/skills · mcp-builder | Apache-2.0 (official Anthropic) |
| `golang-pro` | jeffallan/claude-skills | MIT |
| `async-python-patterns` | wshobson/agents | MIT |

## Audit first (issue requirement — avoid duplication)

Of the 10 candidates, **3 dropped as duplicates** of existing skills: `architecture-patterns` (≈ architecture-session), `skill-development` (≈ creating-skills), `python-testing-patterns` (≈ test / test-driven-development). The 3 terraform candidates collapse into one comprehensive `terraform` skill.

## How it flows (no engine change)

Source written to the **vault** (`00_meta/skills/<name>/SKILL.md`, committed to vault master) → `compile-harness.sh --refresh` → committed `harness/skills/` records (this PR) → `--deploy` renders per agent. Skills are auto-discovered; no `manifest.json` edit.

## Also in this PR

- `harness/skills/ATTRIBUTION.md` — NOTICE-equivalent (source/license/copyright per skill); each `SKILL.md` carries a footer. Only `SKILL.md` vendored — upstream `references/` deep-dives linked, not copied.
- **Drift fix:** `--refresh` also generated the previously-missing `vault-sync` record.
- Spec: `specs/SKILLS-001-vendor-devops-skills/`.

## Verification

- `compile-harness.sh --check` → exit 0, "no harness drift".
- Full dotfiles bats suite green via pre-commit.
- License of every source verified by reading its LICENSE at vendor time.

Closes #158
Refs #162 (HARNESS-001 epic — consumer 3, last consumer)