### PR TITLE
test(TEST-001): bats coverage for 3 untested scripts + fix bash printf bug

### DIFF
--- a/scripts/vault-maintenance-weekly.sh
+++ b/scripts/vault-maintenance-weekly.sh
@@ -18,11 +18,11 @@ mkdir -p "$LOG_DIR"
 {
     printf '=== Vault Maintenance: %s ===\n\n' "$(date)"
 
-    printf '--- knowledge-crystallize --all ---\n'
+    printf '%s\n' '--- knowledge-crystallize --all ---'
     "$SCRIPT_DIR/knowledge-crystallize.sh" --all 2>&1 || true
     printf '\n'
 
-    printf '--- vault-health ---\n'
+    printf '%s\n' '--- vault-health ---'
     "$SCRIPT_DIR/vault-health.sh" 2>&1 || true
     printf '\n'
 

--- a/tests/backup-secrets-to-usb.bats
+++ b/tests/backup-secrets-to-usb.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+# Tests for scripts/backup-secrets-to-usb.sh (TEST-001 / #128)
+#
+# NOTE: basic syntax + usage coverage for this script already lives in
+# tests/age-scripts.bats (it shares the age/secrets backup family). This file
+# adds the *failure-mode guard* coverage that age-scripts.bats does not have:
+# the three validation gates that exit non-zero BEFORE any copy happens, so
+# they are exercisable with no real USB, no real key, and no secret reads.
+#
+# We re-assert syntax here too so this file is self-contained as the canonical
+# per-script suite, but the load-bearing additions are the guard tests.
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    export SCRIPTS_DIR="$DOTFILES_DIR/scripts"
+    export BACKUP_SCRIPT="$SCRIPTS_DIR/backup-secrets-to-usb.sh"
+    TMP="$(mktemp -d)"
+}
+
+teardown() {
+    [ -n "${TMP:-}" ] && rm -rf "$TMP"
+}
+
+# --- Syntax (1 & 2) ---
+
+@test "backup-secrets-to-usb.sh valid bash syntax" {
+    bash -n "$BACKUP_SCRIPT"
+}
+
+@test "backup-secrets-to-usb.sh valid zsh syntax" {
+    if command -v zsh >/dev/null 2>&1; then
+        zsh -n "$BACKUP_SCRIPT"
+    else
+        skip "zsh not available"
+    fi
+}
+
+# --- Usage (3) ---
+
+@test "backup-secrets-to-usb.sh with no args prints usage and exits 1" {
+    run bash "$BACKUP_SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "backup-secrets-to-usb.sh usage documents the key.txt prerequisite" {
+    run bash "$BACKUP_SCRIPT"
+    [[ "$output" == *"key.txt must already exist in USB root"* ]]
+}
+
+# --- Failure-mode guards: the three validations, in order (4) ---
+# Each gate exits non-zero before any cp/mkdir, so no real secrets, USB, or
+# key material are touched. These are the seams age-scripts.bats omits.
+
+@test "backup-secrets-to-usb.sh exits with error when USB path does not exist" {
+    run bash "$BACKUP_SCRIPT" "$TMP/no-such-usb"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"USB path not found"* ]]
+}
+
+@test "backup-secrets-to-usb.sh exits with error when key.txt is missing on the USB" {
+    # USB path exists but has no key.txt => second gate fires.
+    usb="$TMP/usb"
+    mkdir -p "$usb"
+    run bash "$BACKUP_SCRIPT" "$usb"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"key.txt not found in USB"* ]]
+}
+
+@test "backup-secrets-to-usb.sh does not write anything to the USB when key.txt is missing" {
+    usb="$TMP/usb"
+    mkdir -p "$usb"
+    run bash "$BACKUP_SCRIPT" "$usb"
+    [ "$status" -ne 0 ]
+    # The guard must fire before the secrets/ dir is created on the USB.
+    [ ! -e "$usb/secrets" ]
+    [ ! -e "$usb/age-standalone.sh" ]
+}
+
+@test "backup-secrets-to-usb.sh key.txt guard also fires under zsh" {
+    if ! command -v zsh >/dev/null 2>&1; then
+        skip "zsh not available"
+    fi
+    usb="$TMP/usb"
+    mkdir -p "$usb"
+    run zsh "$BACKUP_SCRIPT" "$usb"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"key.txt not found in USB"* ]]
+}

--- a/tests/claude-mem-heal.bats
+++ b/tests/claude-mem-heal.bats
@@ -1,0 +1,205 @@
+#!/usr/bin/env bats
+# Tests for scripts/claude-mem-heal.sh (TEST-001 / #128)
+#
+# claude-mem-heal.sh idempotently repairs the thedotmack/claude-mem plugin
+# cache. It is sourceable: with CLAUDE_CONFIG_DIR pointed at an empty temp
+# dir the top-level heal loop is a no-op, so we can source the file and
+# exercise its pure-ish heal_* functions against fixtures -- no network, no
+# real ~/.claude mutation.
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    export SCRIPTS_DIR="$DOTFILES_DIR/scripts"
+    export HEAL_SCRIPT="$SCRIPTS_DIR/claude-mem-heal.sh"
+    # Sandbox: isolate every run from the real ~/.claude.
+    TMP="$(mktemp -d)"
+    export CLAUDE_CONFIG_DIR="$TMP/claude"
+    mkdir -p "$CLAUDE_CONFIG_DIR"
+}
+
+teardown() {
+    [ -n "${TMP:-}" ] && rm -rf "$TMP"
+}
+
+# --- Syntax (1 & 2) ---
+
+@test "claude-mem-heal.sh valid bash syntax" {
+    bash -n "$HEAL_SCRIPT"
+}
+
+@test "claude-mem-heal.sh valid zsh syntax" {
+    if command -v zsh >/dev/null 2>&1; then
+        zsh -n "$HEAL_SCRIPT"
+    else
+        skip "zsh not available"
+    fi
+}
+
+# --- Usage / invocation behavior (3) ---
+
+@test "claude-mem-heal.sh runs silently and exits 0 on a clean (empty) install" {
+    # No cache dir, no marketplace dirs => nothing to heal => silent, exit 0.
+    run "$HEAL_SCRIPT"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "claude-mem-heal.sh --verbose logs what it checked and exits 0" {
+    run "$HEAL_SCRIPT" --verbose
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[claude-mem-heal]"* ]]
+    [[ "$output" == *"no cache dir"* ]]
+}
+
+@test "claude-mem-heal.sh documents both invocation forms in header" {
+    grep -qF 'claude-mem-heal.sh           # silent unless something was healed' "$HEAL_SCRIPT"
+    grep -qF 'claude-mem-heal.sh --verbose # always log what was checked' "$HEAL_SCRIPT"
+}
+
+# --- Helper: source ONLY the function definitions, not the top-level heal
+# loop. The script ends in a bare `exit 0`, so sourcing it whole would kill
+# the bats test process; instead we materialize a function-only copy by
+# truncating at the top-level execution marker, then source that. The copy
+# is byte-identical to the original up to the cut, so the functions under
+# test are exactly the shipped ones.
+_source_heal() {
+    funcs="$TMP/heal-funcs.sh"
+    awk '/^# Heal every cached version/ { exit } { print }' \
+        "$HEAL_SCRIPT" > "$funcs"
+    # shellcheck disable=SC1090
+    . "$funcs"
+}
+
+# --- heal_mcp_json: idempotency + both broken-signature heals (4) ---
+
+@test "heal_mcp_json is a no-op on a missing target" {
+    _source_heal
+    run heal_mcp_json "$TMP/does-not-exist.json"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "heal_mcp_json converges: re-healing produces byte-identical output" {
+    # NOTE: heal_mcp_json is NOT skip-idempotent -- its own canonical output
+    # contains the v13 'sh'/'-c' + 'while IFS= read' signatures, so it rewrites
+    # on every pass. The property that actually holds (and matters) is
+    # CONVERGENCE: a second heal yields exactly the same bytes as the first.
+    _source_heal
+    f="$TMP/converge.mcp.json"
+    printf '%s\n' '{ "args": ["${_R%/}"] }' > "$f"
+    heal_mcp_json "$f"
+    first="$(cat "$f")"
+    heal_mcp_json "$f"
+    second="$(cat "$f")"
+    [ "$first" = "$second" ]
+    grep -qF 'head -n1' "$f"
+}
+
+@test "heal_mcp_json rewrites a v12.7.4 \${_R%/} broken file and logs the patch" {
+    _source_heal
+    broken="$TMP/v12.mcp.json"
+    # The literal ${_R%/} expansion is the v12.7.4 breakage signature.
+    before='{ "args": ["${_R%/}"] }'
+    printf '%s\n' "$before" > "$broken"
+    run heal_mcp_json "$broken"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"patched .mcp.json"* ]]
+    [[ "$output" == *"v12.7.4"* ]]
+    # The file was rewritten to the canonical race-free form: it changed, it
+    # carries the head -n1 discovery, and it is now a full mcpServers block.
+    [ "$(cat "$broken")" != "$before" ]
+    grep -qF 'head -n1' "$broken"
+    grep -qF '"mcpServers"' "$broken"
+}
+
+@test "heal_mcp_json rewrites a v13.x cascade file and logs the v13 patch" {
+    _source_heal
+    broken="$TMP/v13.mcp.json"
+    printf '%s\n' '{ "command": "sh", "args": ["-c", "while IFS= read"] }' > "$broken"
+    run heal_mcp_json "$broken"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"patched .mcp.json"* ]]
+    [[ "$output" == *"v13.x"* ]]
+    grep -qF 'head -n1' "$broken"
+}
+
+# --- heal_zod: guards before any npm side effect (4) ---
+
+@test "heal_zod is a no-op when package.json is absent" {
+    _source_heal
+    run heal_zod "$TMP/empty-plugin"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "heal_zod is a no-op when package.json declares no zod dep" {
+    _source_heal
+    pdir="$TMP/nozod"
+    mkdir -p "$pdir"
+    printf '%s\n' '{ "dependencies": { "left-pad": "^1.0.0" } }' > "$pdir/package.json"
+    run heal_zod "$pdir"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "heal_zod is a no-op when node_modules/zod already present (no npm call)" {
+    _source_heal
+    pdir="$TMP/haszod"
+    mkdir -p "$pdir/node_modules/zod"
+    printf '%s\n' '{ "dependencies": { "zod": "^4.3.6" } }' > "$pdir/package.json"
+    run heal_zod "$pdir"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# --- ensure_marketplace_compat_symlink: BUG-012 symlink seam (4) ---
+
+@test "ensure_marketplace_compat_symlink no-ops when actual marketplace is absent" {
+    _source_heal
+    run ensure_marketplace_compat_symlink
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ ! -e "$CLAUDE_CONFIG_DIR/plugins/marketplaces/thedotmack" ]
+}
+
+@test "ensure_marketplace_compat_symlink creates the legacy symlink when actual exists" {
+    _source_heal
+    actual="$CLAUDE_CONFIG_DIR/plugins/marketplaces/thedotmack-claude-mem"
+    mkdir -p "$actual"
+    run ensure_marketplace_compat_symlink
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"created legacy marketplace symlink"* ]]
+    [ -L "$CLAUDE_CONFIG_DIR/plugins/marketplaces/thedotmack" ]
+}
+
+@test "ensure_marketplace_compat_symlink is idempotent when legacy path already exists" {
+    _source_heal
+    actual="$CLAUDE_CONFIG_DIR/plugins/marketplaces/thedotmack-claude-mem"
+    legacy="$CLAUDE_CONFIG_DIR/plugins/marketplaces/thedotmack"
+    mkdir -p "$actual" "$legacy"
+    run ensure_marketplace_compat_symlink
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    # Pre-existing real dir must be left as-is, not replaced by a symlink.
+    [ -d "$legacy" ] && [ ! -L "$legacy" ]
+}
+
+# --- heal_hooks_json: idempotency on a healthy file (4) ---
+
+@test "heal_hooks_json no-ops on a missing target" {
+    _source_heal
+    run heal_hooks_json "$TMP/no-hooks.json"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "heal_hooks_json leaves a healthy hooks.json untouched" {
+    _source_heal
+    healthy="$TMP/healthy.hooks.json"
+    printf '%s\n' '{ "hooks": { "Stop": [] } }' > "$healthy"
+    before="$(cat "$healthy")"
+    run heal_hooks_json "$healthy"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ "$(cat "$healthy")" = "$before" ]
+}

--- a/tests/vault-maintenance-weekly.bats
+++ b/tests/vault-maintenance-weekly.bats
@@ -11,15 +11,13 @@
 #     COPY of the script placed next to stub siblings, with HOME redirected to
 #     a temp dir (no vault, no network, no notify-send dependency).
 #
-# COVERAGE GAP (documented, not papered over): the end-to-end run is exercised
-# under zsh only. Under bash (the script's declared shebang) the section-header
-# lines `printf '--- ... ---'` abort with "printf: --: invalid option" because
-# the format string begins with `--`; combined with `set -e` this aborts the
-# whole log block. That is a PRE-EXISTING portability defect in the script
-# (it violates the repo's bash+zsh rule), out of scope for TEST-001 which only
-# adds coverage. See the test report for the finding. The structural guards
-# below run shell-independently; the behavioral run uses zsh where the script
-# currently works.
+# The end-to-end run is exercised under BOTH zsh and bash. A pre-existing
+# portability defect surfaced while writing this coverage: the section-header
+# lines `printf '--- ... ---'` aborted under bash with "printf: --: invalid
+# option" (the format string begins with `--`), and with `set -e` killed the
+# whole log block — so the script only worked under zsh. Fixed in the same PR
+# (incident->guard) to `printf '%s\n' '--- ... ---'`; the bash behavioral test
+# below is the regression guard (it fails on the old script, passes on the fix).
 
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
@@ -112,6 +110,21 @@ EOF
     _prep_sandbox "all clean"
     run env HOME="$FAKE_HOME" PATH="$TMP:$PATH" zsh "$TMP/vault-maintenance-weekly.sh"
     [ "$status" -eq 0 ]
+    log="$FAKE_HOME/.local/share/vault-maintenance/latest.log"
+    grep -qF 'knowledge-crystallize --all' "$log"
+    grep -qF 'vault-health' "$log"
+    grep -qF '=== Done:' "$log"
+}
+
+@test "vault-maintenance-weekly.sh runs cleanly under bash — guards the printf '--' regression" {
+    # Regression guard: section headers used `printf '--- ... ---'`, which under
+    # bash abort with "printf: --: invalid option" and (set -e) kill the run before
+    # the sections write. Fixed to `printf '%s\n' '--- ... ---'`. This FAILS on the
+    # old script (sections + Done missing) and PASSES on the fix.
+    _prep_sandbox "all clean"
+    run env HOME="$FAKE_HOME" PATH="$TMP:$PATH" bash "$TMP/vault-maintenance-weekly.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"invalid option"* ]]
     log="$FAKE_HOME/.local/share/vault-maintenance/latest.log"
     grep -qF 'knowledge-crystallize --all' "$log"
     grep -qF 'vault-health' "$log"

--- a/tests/vault-maintenance-weekly.bats
+++ b/tests/vault-maintenance-weekly.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+# Tests for scripts/vault-maintenance-weekly.sh (TEST-001 / #128)
+#
+# This script is mostly side-effectful: it execs two sibling scripts
+# (knowledge-crystallize.sh --all, vault-health.sh), writes a log under
+# $HOME/.local/share, and fires a best-effort desktop notification. The real
+# maintenance run needs the Obsidian vault + every project, so we cannot unit
+# test it directly. Instead we:
+#   - assert syntax + structural guards on the real file, and
+#   - drive the real log-writing + issue-counting path end-to-end against a
+#     COPY of the script placed next to stub siblings, with HOME redirected to
+#     a temp dir (no vault, no network, no notify-send dependency).
+#
+# COVERAGE GAP (documented, not papered over): the end-to-end run is exercised
+# under zsh only. Under bash (the script's declared shebang) the section-header
+# lines `printf '--- ... ---'` abort with "printf: --: invalid option" because
+# the format string begins with `--`; combined with `set -e` this aborts the
+# whole log block. That is a PRE-EXISTING portability defect in the script
+# (it violates the repo's bash+zsh rule), out of scope for TEST-001 which only
+# adds coverage. See the test report for the finding. The structural guards
+# below run shell-independently; the behavioral run uses zsh where the script
+# currently works.
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    export SCRIPTS_DIR="$DOTFILES_DIR/scripts"
+    export MAINT_SCRIPT="$SCRIPTS_DIR/vault-maintenance-weekly.sh"
+    TMP="$(mktemp -d)"
+}
+
+teardown() {
+    [ -n "${TMP:-}" ] && rm -rf "$TMP"
+}
+
+# --- Syntax (1 & 2) ---
+
+@test "vault-maintenance-weekly.sh valid bash syntax" {
+    bash -n "$MAINT_SCRIPT"
+}
+
+@test "vault-maintenance-weekly.sh valid zsh syntax" {
+    if command -v zsh >/dev/null 2>&1; then
+        zsh -n "$MAINT_SCRIPT"
+    else
+        skip "zsh not available"
+    fi
+}
+
+# --- Structural guards (the script takes no args / has no usage seam) ---
+
+@test "vault-maintenance-weekly.sh uses set -euo pipefail" {
+    grep -q 'set -euo pipefail' "$MAINT_SCRIPT"
+}
+
+@test "vault-maintenance-weekly.sh derives SCRIPT_DIR with the zsh-safe BASH_SOURCE fallback" {
+    grep -qF '${BASH_SOURCE[0]:-$0}' "$MAINT_SCRIPT"
+}
+
+@test "vault-maintenance-weekly.sh invokes both maintenance siblings best-effort (|| true)" {
+    grep -qE 'knowledge-crystallize.sh" --all .*\|\| true' "$MAINT_SCRIPT"
+    grep -qE 'vault-health.sh" .*\|\| true' "$MAINT_SCRIPT"
+}
+
+@test "vault-maintenance-weekly.sh guards notify-send behind command -v (headless-safe)" {
+    grep -qF 'command -v notify-send >/dev/null 2>&1' "$MAINT_SCRIPT"
+}
+
+@test "vault-maintenance-weekly.sh counts issues with grep -ciE and a 0 fallback" {
+    grep -qE 'grep -ciE .*\|\| printf' "$MAINT_SCRIPT"
+}
+
+# --- Behavior: drive the real log/count logic against stub siblings ---
+
+# Build a sandbox: a copy of the script next to stub siblings, HOME redirected,
+# and a no-op notify-send shim first on PATH so the notification branch never
+# touches the real desktop bus.
+_prep_sandbox() {
+    # $1 = body printed by the knowledge-crystallize stub (controls issue count)
+    cp "$MAINT_SCRIPT" "$TMP/vault-maintenance-weekly.sh"
+    cat > "$TMP/knowledge-crystallize.sh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "$1"
+EOF
+    cat > "$TMP/vault-health.sh" <<'EOF'
+#!/usr/bin/env bash
+printf 'vault-health stub: ok\n'
+EOF
+    cat > "$TMP/notify-send" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$TMP"/*.sh "$TMP/notify-send"
+    export FAKE_HOME="$TMP/home"
+    mkdir -p "$FAKE_HOME"
+}
+
+@test "vault-maintenance-weekly.sh writes a log and reports its path (zsh run)" {
+    if ! command -v zsh >/dev/null 2>&1; then
+        skip "zsh not available"
+    fi
+    _prep_sandbox "all clean"
+    run env HOME="$FAKE_HOME" PATH="$TMP:$PATH" zsh "$TMP/vault-maintenance-weekly.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Log written to"* ]]
+    [ -f "$FAKE_HOME/.local/share/vault-maintenance/latest.log" ]
+}
+
+@test "vault-maintenance-weekly.sh log captures both maintenance sections (zsh run)" {
+    if ! command -v zsh >/dev/null 2>&1; then
+        skip "zsh not available"
+    fi
+    _prep_sandbox "all clean"
+    run env HOME="$FAKE_HOME" PATH="$TMP:$PATH" zsh "$TMP/vault-maintenance-weekly.sh"
+    [ "$status" -eq 0 ]
+    log="$FAKE_HOME/.local/share/vault-maintenance/latest.log"
+    grep -qF 'knowledge-crystallize --all' "$log"
+    grep -qF 'vault-health' "$log"
+    grep -qF '=== Done:' "$log"
+}
+
+@test "vault-maintenance-weekly.sh tolerates a sibling that prints issue keywords (still exit 0, zsh run)" {
+    if ! command -v zsh >/dev/null 2>&1; then
+        skip "zsh not available"
+    fi
+    # 'warning'/'stale'/'action' in the crystallize output bumps the issue
+    # counter; the script must still complete cleanly (the count only drives
+    # the notification urgency, never the exit code).
+    _prep_sandbox "WARNING: 3 stale memory files need action"
+    run env HOME="$FAKE_HOME" PATH="$TMP:$PATH" zsh "$TMP/vault-maintenance-weekly.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Log written to"* ]]
+}


### PR DESCRIPTION
## Summary

TEST-001 (#128): adds bats coverage for three previously-untested scripts, and fixes a real production bug the coverage surfaced.

**35 new tests** (full suite 998, 0 failures):
| File | Tests | Covers |
|---|---|---|
| `tests/claude-mem-heal.bats` | 17 | bash/zsh syntax, clean-install exit-0, `heal_mcp_json` (v12/v13 rewrites + convergence), `heal_zod` npm guards, marketplace symlink idempotence, `heal_hooks_json` |
| `tests/vault-maintenance-weekly.bats` | 11 | syntax, 5 structural guards, zsh+bash behavioral runs against stub siblings |
| `tests/backup-secrets-to-usb.bats` | 8 | syntax, usage, the 3 pre-copy validation gates |

## Bug found + fixed (incident→guard)

Writing the coverage surfaced a real defect: `scripts/vault-maintenance-weekly.sh` used `printf '--- ... ---'` for its section headers. The `--` prefix makes **bash** `printf` fail (`printf: --: invalid option`); with `set -e` the whole log block aborted, so the script **only worked under zsh** — but cron invokes it via bash, so it was effectively broken in production (and it violated the repo's mandatory bash+zsh rule).

Fixed to `printf '%s\n' '...'`, and added a **bash behavioral regression guard** that fails on the old script and passes on the fix — in the same PR, per the incident→guard discipline.

## Intentional coverage gaps (documented)
Side-effectful paths needing real npm / secrets / destructive writes are not exercised; coverage targets every guard up to the side effect (see each test file's header comment).

Closes #128