### PR TITLE
fix: mirror harness inputs into deploy dir so offline drift check passes

### DIFF
--- a/ai/opencode/opencode.jsonc
+++ b/ai/opencode/opencode.jsonc
@@ -47,8 +47,11 @@
       },
       "models": {
         "deepseek-v4-flash": {
-          "name": "DeepSeek V4 Flash (NaN - 1M)",
-          "contextWindow": 1000000,
+          "name": "DeepSeek V4 Flash (DeepSeek - 1M)",
+          "limit": {
+            "context": 1000000,
+            "output": 8192
+          },
           // Note: NaN returns reasoning chain in non-OpenAI fields
           // (`reasoning_content`, `provider_specific_fields.reasoning`).
           // Opencode (1.15.10) renders neither — the chain is invisible in TUI.
@@ -57,30 +60,107 @@
           "modalities": {
             "input": ["text"],
             "output": ["text"]
+          },
+          "options": {
+            "chat_template_kwargs": {
+              "enable_thinking": true
+            }
+          },
+          "variants": {
+            "fast": {
+              "chat_template_kwargs": {
+                "enable_thinking": false
+              }
+            },
+            "thinking": {
+              "chat_template_kwargs": {
+                "enable_thinking": true
+              }
+            }
           }
         },
         "qwen3.6": {
           "name": "Qwen 3.6 (Alibaba - 256K)",
-          "contextWindow": 262144,
+          "limit": {
+            "context": 256000,
+            "output": 8192
+          },
           "modalities": {
             "input": ["text", "image"],
             "output": ["text"]
+          },
+          "options": {
+            "chat_template_kwargs": {
+              "enable_thinking": true
+            }
+          },
+          "variants": {
+            "fast": {
+              "chat_template_kwargs": {
+                "enable_thinking": false
+              }
+            },
+            "thinking": {
+              "chat_template_kwargs": {
+                "enable_thinking": true
+              }
+            }
           }
         },
         "gemma4": {
           "name": "Gemma 4 (Google - 256K)",
-          "contextWindow": 262144,
+          "limit": {
+            "context": 256000,
+            "output": 8192
+          },
           "modalities": {
             "input": ["text", "image"],
             "output": ["text"]
+          },
+                    "options": {
+            "chat_template_kwargs": {
+              "enable_thinking": true
+            }
+          },
+          "variants": {
+            "fast": {
+              "chat_template_kwargs": {
+                "enable_thinking": false
+              }
+            },
+            "thinking": {
+              "chat_template_kwargs": {
+                "enable_thinking": true
+              }
+            }
           }
         },
         "mimo-v2.5": {
           "name": "MiMo V2.5 (Xiaomi - 1M)",
-          "contextWindow": 1000000,
+          "limit": {
+            "context": 1000000,
+            "output": 8192
+          },
           "modalities": {
             "input": ["text", "image", "audio"],
             "output": ["text"]
+          },
+                  "options": {
+            "chat_template_kwargs": {
+              "enable_thinking": true
+            }
+          },
+          "variants": {
+            "fast": {
+              "chat_template_kwargs": {
+                "enable_thinking": false
+              }
+            },
+            "thinking": {
+              "chat_template_kwargs": {
+                "enable_thinking": true
+              }
+            }
           }
         }
         // Non-chat NaN models (qwen3-embedding, kokoro TTS, whisper STT) are

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -475,6 +475,22 @@ else
     log_info "Vault absent; deploying committed harness override blocks"
 fi
 
+# Mirror the harness inputs into the deploy dir so `compile-harness.sh --check`
+# (healthcheck section 12) can verify drift offline from ~/.dotfiles. The engine
+# resolves its root from its own location, and the rootresolve regression test
+# models exactly this complete non-git copy: scripts/ (compile-harness.sh) +
+# AGENTS.md + ai/claude/CLAUDE.md + harness/. setup copied none of the latter
+# three, so --check exited 2 (manifest not found) and section 12 reported a false
+# drift FAIL. This runs AFTER --refresh so the snapshot matches the refreshed
+# repo state (else the repo<->deploy drift sub-check would then see drift).
+if [ "$CURRENT_DIR" != "$DOTFILES_DIR" ]; then
+    ensure_directory "$DOTFILES_DIR/harness"
+    cp -rf "$CURRENT_DIR/harness/." "$DOTFILES_DIR/harness/" 2>/dev/null || true
+    safe_copy "$CURRENT_DIR/AGENTS.md" "$DOTFILES_DIR/" 2>/dev/null || true
+    ensure_directory "$DOTFILES_DIR/ai/claude"
+    safe_copy "$CURRENT_DIR/ai/claude/CLAUDE.md" "$DOTFILES_DIR/ai/claude/" 2>/dev/null || true
+fi
+
 # Claude Code
 ensure_directory "$HOME/.claude"
 ensure_directory "$HOME/.claude/skills"

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -568,3 +568,33 @@ setup() {
     grep -q '\$env:DOTFILES_DIR' "$DOTFILES_DIR/powershell/profile.ps1"
     grep -q '\$env:CLAUDE_CONFIG_DIR' "$DOTFILES_DIR/powershell/profile.ps1"
 }
+
+# --- Harness deploy-dir mirror (drift false-FAIL fix) ---
+# healthcheck section 12 runs `compile-harness.sh --check` from the deploy copy
+# (~/.dotfiles), and the engine resolves its root from its own location. That
+# offline check needs the harness inputs mirrored into the deploy dir -- exactly
+# the complete non-git copy the rootresolve regression test models: scripts/
+# (compile-harness.sh, already copied) + AGENTS.md + ai/claude/CLAUDE.md +
+# harness/. setup copied none of the latter three, so --check exited 2 (manifest
+# not found) and section 12 reported a false drift FAIL. These guards lock the
+# mirror in, AND assert it runs AFTER --refresh so the snapshot matches the
+# refreshed repo state (else the repo<->deploy drift sub-check would see drift).
+
+@test "setup-linux.sh mirrors harness/ into the deploy dir (drift fix)" {
+    grep -qF 'cp -rf "$CURRENT_DIR/harness/." "$DOTFILES_DIR/harness/"' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh mirrors AGENTS.md into the deploy dir (drift fix)" {
+    grep -qF 'safe_copy "$CURRENT_DIR/AGENTS.md" "$DOTFILES_DIR/"' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh mirrors ai/claude/CLAUDE.md into the deploy dir (drift fix)" {
+    grep -qF 'safe_copy "$CURRENT_DIR/ai/claude/CLAUDE.md" "$DOTFILES_DIR/ai/claude/"' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh harness mirror runs AFTER compile-harness --refresh (ordering guard)" {
+    refresh_line=$(grep -n 'compile-harness.sh" --refresh' "$DOTFILES_DIR/setup-linux.sh" | head -1 | cut -d: -f1)
+    mirror_line=$(grep -n 'cp -rf "\$CURRENT_DIR/harness/\.' "$DOTFILES_DIR/setup-linux.sh" | head -1 | cut -d: -f1)
+    [ -n "$refresh_line" ] && [ -n "$mirror_line" ]
+    [ "$mirror_line" -gt "$refresh_line" ]
+}


### PR DESCRIPTION
## What

Fixes the false `harness/skill drift` FAIL in `healthcheck.sh` section 12
(Repo <-> Deploy-Dir Drift), reproduced on a real `setup-linux.sh` deploy.
Also folds in a manual restructure of `ai/opencode/opencode.jsonc`.

## Why (the drift FAIL)

Section 12 runs `compile-harness.sh --check` from `$SCRIPT_DIR` — the deploy
copy `~/.dotfiles/scripts`. The engine resolves its repo root from its own
location (by design, per `compile-harness-rootresolve.bats`), so it looks for
`~/.dotfiles/harness/manifest.json`. But `setup-linux.sh` mirrored only
`scripts/` into the deploy dir — never `AGENTS.md`, `ai/claude/CLAUDE.md`, or
`harness/`. So `--check` exited 2 (manifest not found) and section 12 reported
a false drift FAIL. (Sub-check 1, `diff-check.sh`, passed because it resolves
the repo via `DOTFILES_REPO_DIR` and skips deploy-absent files.)

## Fix

`setup-linux.sh`: mirror the three harness inputs into the deploy dir, **after**
`--refresh`, so the snapshot matches the just-refreshed repo state (else the
repo<->deploy sub-check would then see drift). This produces exactly the
complete non-git copy that the rootresolve regression test models.

Incident -> guard: 4 new `tests/setup-linux.bats` assertions, including an
ordering guard that the mirror runs after `--refresh`.

Verified: shellcheck (no new findings), `bash -n` + `zsh -n`, 161 bats across 5
suites green, and an end-to-end proof (`--check` from a mirrored non-git copy of
the real repo content -> exit 0, "no harness drift").

Note: `healthcheck.ps1` has no equivalent `compile-harness --check` sub-check, so
this incident is Linux-only; no Windows parity edit is required.

## Also included

`ai/opencode/opencode.jsonc`: manual restructure of the NaN chat-model
definitions (`contextWindow` -> `limit{context,output}`, plus per-model
`options` and fast/thinking `variants`). JSONC validated; `opencode.bats` green.

## SDD skip rationale

Bug fix with an obvious cause (~18-line setup mirror block) plus its regression
guards, bundled with a user-authored opencode config tweak. No public contract
change, new dependency, or multi-PR sequence — none of the SDD triggers apply.
Per AGENTS.md Discipline Gate, bug fixes with an obvious cause are explicitly
skip-eligible.
