### PR TITLE
docs(AI-020): Antigravity migration decision (branch #1) + AI-023 scaffold

### DIFF
--- a/specs/AI-020-gemini-empirical-validation/proposal.md
+++ b/specs/AI-020-gemini-empirical-validation/proposal.md
@@ -1,7 +1,7 @@
 ---
 id: "AI-020-gemini-empirical-validation"
 type: spec
-status: draft # draft | implementing | verifying | archived
+status: verifying # draft | implementing | verifying | archived
 created: "2026-05-27"
 tags: [spec, proposal]
 template_version: "1.0"

--- a/specs/AI-020-gemini-empirical-validation/verification.md
+++ b/specs/AI-020-gemini-empirical-validation/verification.md
@@ -1,42 +1,81 @@
 ---
-tags: [spec, verification, templates]
+tags: [spec, verification, decision]
 created: "2026-05-13"
+decided: "2026-06-03"
 ---
 
 # Verification - AI-020-gemini-empirical-validation
 
+## Decision (matrix resolved 2026-06-03)
+
+**Chosen branch: #1 — Antigravity (`agy`) OAuth preserves the Google AI Plus
+subscription path. No tier upgrade.**
+
+Inputs that resolved the matrix:
+
+- **User tier: Google AI Plus.** AI Plus does not support Plan Linking with AI
+  Studio API keys — but `agy` does not use API keys. It authenticates via
+  browser OAuth against `cloudcode-pa.googleapis.com` (`loadCodeAssist`), the
+  same Code Assist backend that recognized consumer subscriptions under
+  gemini-cli. So the subscription path is preserved without an API key.
+- **Gemini reliance: nice-to-have, low.** This fixes the user-owned cost
+  decision (proposal R2): if AI Plus quota is *not* honored post-cutover, the
+  resolution is to fall back to the free Antigravity allotment or drop Gemini
+  (Claude Code + OpenCode remain) — **never a paid tier upgrade**.
+
+Two findings that reshaped scope versus the proposal:
+
+1. **The sunset is broader than the proposal assumed.** Google's canonical post
+   states gemini-cli stops serving **AI Pro and Ultra, plus free** individual
+   tiers on 2026-06-18 — not just free/Google One. Migration is mandatory for
+   any consumer tier, which only strengthens branch #1.
+2. **The migration infrastructure already shipped (SDD-007).** `setup-{linux,
+   windows}` install `agy` (not gemini-cli), run a one-time `gemini-cli → agy`
+   migration, and consolidate MCP to `~/.gemini/config/mcp_config.json`;
+   healthcheck §13 already guards it. So the downstream follow-up shrinks from
+   "port the install" to "verify the OAuth/quota path" → scaffolded as
+   **AI-023** (the proposal's "AI-022" id was already taken by #161/#211).
+
 ## Evidence
 
-Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
-
-- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+- [x] AC1 Phase-1 research summary (install / config / auth / models / MCP) →
+      recorded in this file + PR body; sources: Google Developers Blog
+      (goo.gle/gemini-cli-migration), The Register, opencode-antigravity-auth.
+- [x] AC2 Decision matrix completed, explicit branch chosen → **branch #1**
+      (this file).
+- [x] AC3 User tier identified → **Google AI Plus** (low Gemini reliance).
+- [x] AC4 Follow-up spec scaffolded → `specs/AI-023-antigravity-oauth-verification/`
+      (id corrected from AI-022, which is consumed by #161/#211).
+- [ ] AC5 Vault `11-tasks.md` AI-020 entry ticked with decision link → vault
+      master commit (this session).
+- [ ] AC6 Runbook `40-runbooks/guide-antigravity-cli-migration.md` written →
+      vault master commit (this session).
 
 ## Test status
 
-- Test suite: `<command> -> <output / coverage %>`
-- Manual smoke test: what was exercised, what was observed
-- No regressions in existing test suite: yes / no (if no, document)
+- No code change in this ticket (decision + docs + scaffold). No test impact.
+- Manual verification (user-run, optional de-risk): `agy -p "reply pong"` under
+  AI Plus OAuth, `$ANTIGRAVITY_ENDPOINT == https://cloudcode-pa.googleapis.com`,
+  no API-key prompt. Result folded into the runbook when available.
 
 ## Decisions made during implementation
 
-Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
-
--
--
+- Rejected the proposal's "evaluate AI Pro upgrade" path: low Gemini reliance
+  makes any paid upgrade non-justified; drop-or-free-allotment is the fallback.
+- Renamed the follow-up AI-022 → AI-023 after verifying AI-022 is already in use
+  (verify-before-act).
 
 ## Promotion candidates
 
-Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
-
-- [ ] Lesson for `<area>/90-lessons.md`? <yes / no - one line of what>
-- [ ] ADR-worthy decision for `<area>/30-architecture/adr-XXX.md`? <yes / no - one line of what>
-- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+- [x] Lesson for `90-lessons.md`? yes — "verify a spec's named follow-up id is
+      free before scaffolding (AI-022 was consumed); decision specs can resolve
+      on documentary evidence when the infra already shipped".
+- [ ] ADR-worthy decision? no — operational migration, captured in the runbook.
+- [ ] New pattern candidate? no — single-project migration.
 
 ## Archive checklist
 
-- [ ] `proposal.md` frontmatter set to `status: archived`
-- [ ] Folder moved: `specs/AI-020-gemini-empirical-validation/` -> `specs/archive/AI-020-gemini-empirical-validation/`
+- [ ] `proposal.md` frontmatter set to `status: archived` (after AC5/AC6 land)
+- [ ] Folder moved: `specs/AI-020-gemini-empirical-validation/` → `specs/archive/`
 - [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
-- [ ] Promotions above executed (if any)
+- [ ] Promotions above executed (lesson)

--- a/specs/AI-023-antigravity-oauth-verification/proposal.md
+++ b/specs/AI-023-antigravity-oauth-verification/proposal.md
@@ -1,0 +1,71 @@
+---
+id: "AI-023-antigravity-oauth-verification"
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-04"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# AI-023-antigravity-oauth-verification
+
+> Follow-up to AI-020 (Gemini CLI → Antigravity migration decision). AI-020
+> chose **branch #1** (`agy` OAuth via the Code Assist backend preserves the
+> Google AI Plus subscription path). This ticket verifies that decision holds
+> empirically and guards it.
+
+## Why
+
+AI-020 resolved the migration *decision* on documentary evidence: `agy` is
+already installed + configured cross-OS (SDD-007), and it authenticates via
+OAuth against `cloudcode-pa.googleapis.com` (`loadCodeAssist`) — the same
+subscription-recognizing backend gemini-cli used. But two things are unproven:
+(a) that `agy`'s OAuth actually serves requests under a **Google AI Plus** tier
+*after* the 2026-06-18 gemini-cli sunset, and (b) that this stays true on
+Windows. The migration infrastructure shipped; what remains is a verification +
+a regression guard so a silent post-cutover quota break is caught, not
+discovered mid-task.
+
+## What
+
+- A documented, reproducible check that `agy -p "..."` returns a served
+  response under the user's AI Plus OAuth session (no API key, endpoint is the
+  Code Assist production URL).
+- A healthcheck assertion (section 13, Antigravity CLI Health) that surfaces
+  `agy` auth state / reachability so a deauthenticated or quota-broken `agy` is
+  reported, not silent.
+
+## Out of scope
+
+- Re-doing the AI-020 decision matrix (settled: branch #1, no tier upgrade).
+- Any paid Google tier upgrade — AI-020 fixed the cost decision: Gemini is
+  low-reliance, so a broken quota means fall back to free allotment / drop
+  Gemini, never upgrade.
+- Replacing the `agy` install/config in setup scripts — already shipped
+  (SDD-007). This ticket only verifies + guards it.
+
+## Risks / open questions
+
+- R1: Google may move consumer (AI Plus) tiers to a different post-cutover quota
+  model than the Code Assist OAuth path currently honors. The healthcheck probe
+  must not assume "auth file present" == "quota served".
+- R2: A live quota probe costs a token round-trip; the healthcheck assertion
+  must stay offline/cheap (check auth-state presence + endpoint), with the
+  paid live probe left to the documented manual step.
+- R3: Windows empirical re-check is batched into the dedicated Windows session
+  (see [[feedback-batch-windows-work]]); this ticket's Linux part can land first.
+
+## Acceptance criteria
+
+- [ ] Manual verification recorded: `agy -p` serves a response under AI Plus
+      OAuth, no API key, endpoint = `https://cloudcode-pa.googleapis.com`.
+- [ ] healthcheck.sh section 13 reports `agy` auth-state presence + endpoint
+      (offline, cheap) and FAILs loudly if auth state is missing.
+- [ ] Cross-OS parity: matching probe in healthcheck.ps1 (Windows-empirical,
+      may land in the batched Windows session).
+
+## References
+
+- Predecessor: `specs/AI-020-gemini-empirical-validation/` (decision + matrix).
+- Vault: `10_projects/dotfiles/11-tasks.md` → AI-020 / AI-023.
+- Runbook: `40-runbooks/guide-antigravity-cli-migration.md`.
+- Upstream: <https://goo.gle/gemini-cli-migration>.

--- a/specs/AI-023-antigravity-oauth-verification/tasks.md
+++ b/specs/AI-023-antigravity-oauth-verification/tasks.md
@@ -1,0 +1,55 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-05-13"
+---
+
+# Tasks - AI-023-antigravity-oauth-verification
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+
+## Setup
+
+- [ ] Branch created from main: `feat/AI-023-antigravity-oauth-verification`
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+> Replace these with the actual steps for this feature. Keep them small (one commit each) and in TDD order.
+
+- [ ] Write failing test for <behavior 1>
+- [ ] Implement <module/function> to make it pass
+- [ ] Refactor for clarity (extract, rename, dedupe)
+- [ ] Write failing test for <behavior 2>
+- [ ] Implement to make it pass
+- [ ] ...
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
+- [ ] Type checks pass
+- [ ] Lint passes
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
+
+Minimal `features.json` skeleton (drop into `<repo>/specs/AI-023-antigravity-oauth-verification/features.json`):
+
+```json
+[
+  {
+    "id": "AI-023-antigravity-oauth-verification-f1",
+    "behavior": "<one-line copy of an acceptance criterion>",
+    "verification": "<single shell command; exit 0 means pass>",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/AI-023-antigravity-oauth-verification/verification.md
+++ b/specs/AI-023-antigravity-oauth-verification/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-05-13"
+---
+
+# Verification - AI-023-antigravity-oauth-verification
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for `<area>/90-lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for `<area>/30-architecture/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/AI-023-antigravity-oauth-verification/` -> `specs/archive/AI-023-antigravity-oauth-verification/`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
Closes the decision half of #142 (AI-020). Decision + scaffold only — no code
changes (per the ticket's anti-scope). The downstream verification lands as
AI-023; the vault runbook + backlog tick land on vault master.

## Decision: branch #1 — preserve AI Plus via `agy` OAuth, no upgrade

Inputs: **tier = Google AI Plus**, **Gemini reliance = nice-to-have, low**.

`agy` authenticates via browser OAuth against `cloudcode-pa.googleapis.com`
(`loadCodeAssist`) — the same Code-Assist backend that recognized consumer
subscriptions under gemini-cli. AI Plus lacks API-key Plan Linking, but `agy`
uses no API key, so the subscription path is preserved. **R2 (cost) resolved:**
low reliance ⇒ if quota ever breaks, fall back to free allotment or drop Gemini
— never a paid tier upgrade.

## Two scope corrections (vs the original spec)

1. **Broader sunset than assumed.** Google's own post: gemini-cli stops serving
   **AI Pro and Ultra, plus free** individual tiers on 2026-06-18 — not just
   free/Google One. Migration is mandatory for any consumer tier.
2. **Migration infra already shipped (SDD-007).** `setup-{linux,windows}` already
   install `agy` (not gemini-cli), run a one-time `gemini-cli → agy` migration,
   and consolidate MCP; healthcheck §13 guards it. So the follow-up is *verify
   the OAuth/quota path*, not *port the install* — scaffolded as **AI-023**
   (`AI-022` was already taken by #161/#211; verified before scaffolding).

## Changes

- `specs/AI-020-…/verification.md` — full decision record + AC evidence map.
- `specs/AI-020-…/proposal.md` — status → `verifying`.
- `specs/AI-023-antigravity-oauth-verification/` — scaffolded follow-up spec.

## AC status

①research ②matrix/branch ③tier — done here. ④AI-023 scaffold — done. ⑤vault
tick + ⑥runbook — vault master (this session). Optional empirical de-risk
(`agy -p` under AI Plus OAuth) folds into the runbook when run.

## References

- Source: <https://goo.gle/gemini-cli-migration>
- Predecessor infra: SDD-007 (agy install/config, PR #121-era)
