### PR TITLE
feat(AI-023): periodic hive-vault auto-upgrade timer (Linux) + daily task (Windows)

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -853,6 +853,34 @@ if command -v hive >/dev/null 2>&1 && [ -n "$hive_ver" ] \
     else
         log_warning "hive service install failed (non-fatal; client works via fallback)"
     fi
+    # AI-023 / hive#176: the upgrade policy that FEEDS the daemon's
+    # restart-on-upgrade. Deploy the --user timer + oneshot from the repo's
+    # systemd/ SSOT and enable the timer (every 15 min). Same version gate as the
+    # service above -- daemon + its feeder install together or not at all.
+    if command -v systemctl >/dev/null 2>&1; then
+        SYSTEMD_USER_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+        ensure_directory "$SYSTEMD_USER_DIR"
+        if cp -f "$CURRENT_DIR/systemd/hive-upgrade.service" "$SYSTEMD_USER_DIR/" \
+            && cp -f "$CURRENT_DIR/systemd/hive-upgrade.timer" "$SYSTEMD_USER_DIR/"; then
+            systemctl --user daemon-reload >/dev/null 2>&1 || true
+            if systemctl --user enable --now hive-upgrade.timer >/dev/null 2>&1; then
+                log_success "Enabled hive-upgrade.timer (every 15 min, systemd --user)"
+                # Single owner: retire the legacy manual cron now the timer owns
+                # the upgrade policy (only after a successful enable).
+                if crontab -l 2>/dev/null | grep -q 'uv tool upgrade hive-vault'; then
+                    if crontab -l 2>/dev/null | grep -v 'uv tool upgrade hive-vault' | crontab -; then
+                        log_info "Removed legacy 'uv tool upgrade hive-vault' cron (timer is now the single owner)"
+                    fi
+                fi
+            else
+                log_warning "hive-upgrade.timer enable failed (non-fatal; setup still upgrades hive each run)"
+            fi
+        else
+            log_warning "Could not deploy hive-upgrade units to $SYSTEMD_USER_DIR (non-fatal)"
+        fi
+    else
+        log_warning "systemctl not found; skipping hive-upgrade.timer (setup still upgrades hive each run)"
+    fi
 elif command -v hive >/dev/null 2>&1; then
     log_warning "hive ${hive_ver:-<unknown>} predates 'hive service' (need >= 1.32.0); skipping daemon supervision"
 fi

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -435,6 +435,35 @@ if ((Get-Command hive -ErrorAction SilentlyContinue) -and $hiveVer -and ([versio
     & hive service install *> $null
     if ($LASTEXITCODE -eq 0) { Write-Success "Installed hive daemon service (Scheduled Task, v$hiveVer)" }
     else { Write-Warn "hive service install failed (non-fatal; client works via fallback)" }
+
+    # AI-023 / hive#176: the upgrade policy that FEEDS the daemon's
+    # restart-on-upgrade. Daily Scheduled Task running `uv tool upgrade hive-vault`.
+    # Self-healing: re-register when the action arguments drift (parity with the
+    # weekly vault maintenance task). Same version gate as the service above.
+    $hiveUvExe = Join-Path $env:USERPROFILE ".local\bin\uv.exe"
+    $hiveUpgradeTask = "DotfilesHiveUpgrade"
+    $hiveUpgradeArg = "tool upgrade hive-vault"
+    $existingHiveTask = Get-ScheduledTask -TaskName $hiveUpgradeTask -ErrorAction SilentlyContinue
+    $existingHiveArg = $null
+    if ($existingHiveTask -and $existingHiveTask.Actions -and $existingHiveTask.Actions[0]) {
+        $existingHiveArg = $existingHiveTask.Actions[0].Arguments
+    }
+    if ($existingHiveTask -and ($existingHiveArg -eq $hiveUpgradeArg)) {
+        Write-Info "hive-upgrade task already correctly configured, skipping"
+    } else {
+        try {
+            $hiveAction = New-ScheduledTaskAction -Execute $hiveUvExe -Argument $hiveUpgradeArg
+            $hiveTrigger = New-ScheduledTaskTrigger -Daily -At "9:00AM"
+            Register-ScheduledTask -TaskName $hiveUpgradeTask -Action $hiveAction -Trigger $hiveTrigger `
+                -Description "Daily hive-vault upgrade (feeds hive serve restart-on-upgrade)" -Force | Out-Null
+            Write-Success "Installed hive-upgrade task (daily 9:00, v$hiveVer)"
+            if (-not (Test-Path $hiveUvExe)) {
+                Write-Warn "hive-upgrade task registered but uv not found at $hiveUvExe"
+            }
+        } catch {
+            Write-Warn "Could not register hive-upgrade task (non-fatal; setup still upgrades hive each run): $_"
+        }
+    }
 } elseif (Get-Command hive -ErrorAction SilentlyContinue) {
     $shownVer = if ($hiveVer) { $hiveVer } else { '<unknown>' }
     Write-Warn "hive $shownVer predates 'hive service' (need >= 1.32.0); skipping daemon supervision"

--- a/specs/AI-023-hive-auto-upgrade-timer/features.json
+++ b/specs/AI-023-hive-auto-upgrade-timer/features.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "AI-023-hive-auto-upgrade-timer-f1",
+    "behavior": "hive-upgrade.timer fires every 15 min wall-clock with catch-up and installs to timers.target",
+    "verification": "grep -q 'OnCalendar=\\*:0/15' systemd/hive-upgrade.timer && grep -q 'Persistent=true' systemd/hive-upgrade.timer && grep -q 'WantedBy=timers.target' systemd/hive-upgrade.timer",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-023-hive-auto-upgrade-timer-f2",
+    "behavior": "hive-upgrade.service is a oneshot that runs `uv tool upgrade hive-vault` via the absolute %h/.local/bin/uv",
+    "verification": "grep -q 'Type=oneshot' systemd/hive-upgrade.service && grep -q 'ExecStart=%h/.local/bin/uv tool upgrade hive-vault' systemd/hive-upgrade.service",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-023-hive-auto-upgrade-timer-f3",
+    "behavior": "setup-linux.sh deploys the units and enables the timer inside the hive >= 1.32.0 gate (non-fatal); enable line comes after the sort -V gate",
+    "verification": "grep -q 'enable --now hive-upgrade.timer' setup-linux.sh && [ \"$(grep -n 'sort -V' setup-linux.sh | head -1 | cut -d: -f1)\" -lt \"$(grep -n 'enable --now hive-upgrade.timer' setup-linux.sh | head -1 | cut -d: -f1)\" ]",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-023-hive-auto-upgrade-timer-f4",
+    "behavior": "setup-linux.sh removes the legacy `uv tool upgrade hive-vault` crontab line once the timer is enabled (single owner)",
+    "verification": "grep -q \"grep -v 'uv tool upgrade hive-vault' | crontab -\" setup-linux.sh",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-023-hive-auto-upgrade-timer-f5",
+    "behavior": "setup-windows.ps1 registers a daily DotfilesHiveUpgrade task running `uv tool upgrade hive-vault`, gated >= 1.32.0",
+    "verification": "grep -q 'DotfilesHiveUpgrade' setup-windows.ps1 && grep -q 'tool upgrade hive-vault' setup-windows.ps1 && grep -q 'New-ScheduledTaskTrigger -Daily' setup-windows.ps1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-023-hive-auto-upgrade-timer-f6",
+    "behavior": "setup-linux.sh stays valid + shellcheck-clean in the added block and the units are valid systemd",
+    "verification": "bash -n setup-linux.sh && bats tests/hive-upgrade-timer.bats",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/AI-023-hive-auto-upgrade-timer/proposal.md
+++ b/specs/AI-023-hive-auto-upgrade-timer/proposal.md
@@ -1,0 +1,97 @@
+---
+id: "AI-023-hive-auto-upgrade-timer"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-06-03"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# AI-023-hive-auto-upgrade-timer
+
+> The policy half of the Phase C daemon model. Sibling of
+> `specs/AI-022-hive-daemon-activation/` (which activated the daemon + migrated
+> the MCP entry). Tracking SSOT: `mlorentedev/hive` issue #176. This is the last
+> dotfiles piece before the multi-machine rollout.
+
+## Why
+
+hive shipped the *mechanism* for zero-downtime upgrades in v1.32.2:
+`hive serve` polls its installed version and exits 75 under
+`Restart=on-failure`, so the supervisor relaunches it into new code within
+`HIVE_UPGRADE_POLL_S`. AI-022 then flipped the fleet onto that daemon
+(`hive client` proxy + `hive service install`). But nothing *feeds* the
+mechanism: a machine only gets new hive code when someone manually runs
+`uv tool upgrade hive-vault`. Today that is a hand-rolled `0 9 * * *` crontab
+line on one machine — invisible, per-machine, and a second owner of a policy the
+daemon model should own centrally.
+
+This change adds the periodic upgrade so every machine always runs the latest
+hive-vault with zero added client-launch latency, and makes that schedule the
+**single owner** of the upgrade policy.
+
+## What
+
+After `setup-linux.sh` / `setup-windows.ps1` runs on a machine with
+hive-vault >= 1.32.0:
+
+- **Linux:** a systemd `--user` `hive-upgrade.timer` (every 15 min, wall-clock
+  slots with catch-up after suspend/boot) triggers a `hive-upgrade.service`
+  oneshot that runs `uv tool upgrade hive-vault`. Units ship as static files in
+  `systemd/` (SSOT), deployed to `~/.config/systemd/user/` and enabled inside the
+  same version gate as `hive service install`.
+- **Windows:** a daily `DotfilesHiveUpgrade` Scheduled Task running
+  `uv tool upgrade hive-vault`, self-healing on action drift, parity with the
+  existing `DotfilesVaultMaintenance` task.
+- **SSOT cleanup:** on Linux, once the timer is enabled, any legacy
+  `uv tool upgrade hive-vault` crontab line is removed so the timer is the single
+  owner of the upgrade policy.
+
+## Out of scope
+
+- macOS / launchd timer (hive's daemon model is non-zero stub there; follow-up).
+- Any change to hive itself (the daemon, CLI, restart-on-upgrade already shipped
+  on PyPI >= 1.32.2).
+- Changing the upgrade cadence per-machine / making it configurable (single fixed
+  policy for now; revisit only if a machine needs a different window).
+
+## Risks / open questions
+
+- **`uv` not on the systemd service PATH** — a `--user` oneshot gets a minimal
+  environment. Resolved: `ExecStart` uses the absolute `%h/.local/bin/uv`, exactly
+  where `setup-linux.sh` installs uv.
+- **No systemd `--user` / Task Scheduler** (headless/CI, or logged-out without
+  linger) — the timer/task cannot be enabled. Resolved: non-fatal (warning); the
+  setup `prerequisite_command` (`uv tool install --upgrade hive-vault`) still
+  upgrades hive on every run, so the machine never goes stale silently.
+- **Two owners of the upgrade policy** — the manual 9am cron and the timer would
+  both run `uv tool upgrade`. Resolved: the timer-install path strips the legacy
+  crontab line (only after a successful enable, so an old-hive machine that skips
+  the gate keeps its cron).
+- **Old hive (< 1.32.0)** — gate skips both service and timer. In practice the
+  `prerequisite_command` already bumped hive to latest earlier in the same setup
+  run, so the gate passes; the skip is only a safety net for the offline /
+  failed-upgrade case.
+
+## Acceptance criteria
+
+- [ ] `systemd/hive-upgrade.timer` fires every 15 min wall-clock (`OnCalendar=*:0/15`)
+  with `Persistent=true` (catch-up) and installs to `timers.target`.
+- [ ] `systemd/hive-upgrade.service` is a `Type=oneshot` running
+  `uv tool upgrade hive-vault` via the absolute `%h/.local/bin/uv`.
+- [ ] `setup-linux.sh` deploys the units to `~/.config/systemd/user/` and enables
+  the timer inside the existing hive-vault >= 1.32.0 version gate (never on an old
+  hive); non-fatal if systemd `--user` is unavailable.
+- [ ] `setup-linux.sh` removes a legacy `uv tool upgrade hive-vault` crontab line
+  once the timer is enabled (single owner).
+- [ ] `setup-windows.ps1` registers a daily `DotfilesHiveUpgrade` Scheduled Task
+  running `uv tool upgrade hive-vault`, gated the same way; self-heals on drift.
+- [ ] `setup-linux.sh` passes `bash -n` + shellcheck; `setup-windows.ps1` stays
+  ASCII-only (PSScriptAnalyzer); `make test` / bats stay green.
+
+## References
+
+- hive issue: [mlorentedev/hive#176](https://github.com/mlorentedev/hive/issues/176)
+- sibling spec: `specs/AI-022-hive-daemon-activation/` (daemon activation + MCP migration)
+- restart-on-upgrade mechanism: hive v1.32.2 (`hive serve` exits 75 under `Restart=on-failure`)
+- systemd timer reference: `man systemd.timer` (`OnCalendar`, `Persistent`, `RandomizedDelaySec`)

--- a/specs/AI-023-hive-auto-upgrade-timer/tasks.md
+++ b/specs/AI-023-hive-auto-upgrade-timer/tasks.md
@@ -1,0 +1,39 @@
+---
+tags: [spec, tasks]
+created: "2026-06-03"
+---
+
+# Tasks - AI-023-hive-auto-upgrade-timer
+
+> One task = one focused commit. Tick as you go.
+
+## Setup
+
+- [x] Branch (worktree) created from main: `feat/hive-auto-update-timer`
+- [x] `proposal.md` complete; acceptance criteria testable
+- [x] Timer scheduling semantics decided with the maintainer: wall-clock
+  (`OnCalendar=*:0/15`) + `Persistent=true` catch-up
+
+## Implementation
+
+- [x] `systemd/hive-upgrade.service`: `Type=oneshot`, absolute `%h/.local/bin/uv tool upgrade hive-vault`
+- [x] `systemd/hive-upgrade.timer`: `OnCalendar=*:0/15`, `Persistent=true`, `RandomizedDelaySec=60`, `WantedBy=timers.target`
+- [x] `setup-linux.sh`: inside the >=1.32.0 gate, deploy units to `~/.config/systemd/user/`, `daemon-reload`, `enable --now hive-upgrade.timer` (non-fatal), strip legacy `uv tool upgrade hive-vault` cron on success
+- [x] `setup-windows.ps1`: inside the >=1.32.0 gate, register/self-heal daily `DotfilesHiveUpgrade` Scheduled Task running `uv tool upgrade hive-vault`
+- [x] `bash -n` + shellcheck clean on the added block; `setup-windows.ps1` ASCII-only
+
+## Closing
+
+- [x] Each acceptance criterion covered by a `features.json` entry
+- [x] `tests/hive-upgrade-timer.bats` added (units + both setup scripts + parity)
+- [x] No unrelated changes
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+- [ ] (post-merge) Multi-machine rollout by the maintainer, then tick hive #176
+
+## Machine-readable features
+
+See sibling `features.json`. Static/structural checks (unit file shape, setup
+wiring, version gate, cron strip, ASCII). The dynamic timer firing + real upgrade
+is validated by the maintainer's rollout (the systemd journal + `uv tool list`).
+The agent must NOT set `state: passing` — only the harness may, after a clean run.

--- a/specs/AI-023-hive-auto-upgrade-timer/verification.md
+++ b/specs/AI-023-hive-auto-upgrade-timer/verification.md
@@ -1,0 +1,61 @@
+---
+tags: [spec, verification]
+created: "2026-06-03"
+---
+
+# Verification - AI-023-hive-auto-upgrade-timer
+
+## Evidence
+
+- [x] Timer cadence + catch-up -> `grep -qF 'OnCalendar=*:0/15' systemd/hive-upgrade.timer && grep -qF 'Persistent=true' systemd/hive-upgrade.timer`
+- [x] Oneshot runs the upgrade via absolute uv -> `grep -qF 'Type=oneshot' systemd/hive-upgrade.service && grep -qF 'ExecStart=%h/.local/bin/uv tool upgrade hive-vault' systemd/hive-upgrade.service`
+- [x] Linux deploys units + enables timer inside the version gate -> `enable --now hive-upgrade.timer` line number > `sort -V` line number
+- [x] Linux strips the legacy cron (single owner) -> `grep -qF "grep -v 'uv tool upgrade hive-vault' | crontab -" setup-linux.sh`
+- [x] Windows registers the daily DotfilesHiveUpgrade task, gated -> `Register-ScheduledTask -TaskName $hiveUpgradeTask` line number > `[version]'1.32.0'` line number
+- [x] `setup-linux.sh` syntax + lint -> `bash -n setup-linux.sh` clean; `shellcheck` adds no findings in the added block (842-895)
+- [x] Windows block ASCII-only -> bats test 16 (PSScriptAnalyzer non-ASCII guard)
+- [ ] (post-merge, maintainer) Real fleet rollout -> on each machine: `systemctl --user list-timers hive-upgrade.timer` active; `uv tool list` tracks latest; the legacy 9am cron is gone
+
+## Test status
+
+- `bash -n setup-linux.sh` -> OK
+- `shellcheck -f gcc setup-linux.sh` -> no findings in the added block (lines 842-895); pre-existing findings elsewhere untouched
+- `bats tests/hive-upgrade-timer.bats` -> 18/18 passing
+- `bats tests/setup-linux.bats` -> 82/82 passing (no regression)
+- `bats tests/setup-windows.bats` -> passing (PSScriptAnalyzer/parse skipped: pwsh unavailable on this host; covered by lint-powershell CI + the ASCII bats guard)
+- pwsh parse of `setup-windows.ps1` -> not run here (pwsh unavailable); the block mirrors the existing `Register-ScheduledTask` self-healing pattern already in the file (weekly vault maintenance task) and stays ASCII-only.
+- Manual smoke (Linux, this machine): deferred to the maintainer's rollout (running the setup mutates `~/.config/systemd/user/` + the crontab).
+
+## Decisions made during implementation
+
+- **Wall-clock + catch-up, not interval-since-last-run.** `OnCalendar=*:0/15` +
+  `Persistent=true` (maintainer's call) means a suspended laptop converges to the
+  latest hive-vault on resume instead of drifting. Matches the "always latest" goal.
+- **Static unit files in `systemd/`, not an inline heredoc.** SSOT + greppable by
+  bats + reviewable in the PR, consistent with `mcp-servers.json` / `env-contract.json`.
+  `ExecStart` uses the absolute `%h/.local/bin/uv` because a `--user` oneshot gets a
+  minimal PATH that may omit `~/.local/bin`.
+- **Co-located in the existing `hive >= 1.32.0` gate.** The upgrade timer is the
+  policy that feeds the daemon's restart-on-upgrade; installing them together (or
+  not at all) keeps "daemon + feeder" a single unit and honours "never route an
+  auto-upgrade onto an old hive".
+- **Cron strip only after a successful enable.** An old-hive machine that skips the
+  gate keeps its manual cron, so it is never left with zero upgrade owners.
+- **Non-fatal everywhere.** No systemd `--user` / Task Scheduler downgrades to a
+  warning; the setup `prerequisite_command` still upgrades hive on every run, so the
+  machine never goes stale silently.
+
+## Promotion candidates
+
+- [ ] Lesson for `docs/lessons.md`? maybe -- "co-locate the policy timer with the
+  mechanism it feeds, under one version gate" is a small reusable shape; capture only
+  if it recurs.
+- [ ] ADR-worthy? no -- ADR-011 in the hive repo owns the daemon-model decision; this
+  is its fleet-side policy arm.
+- [ ] New pattern? no -- single-project rollout mechanics.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved to `specs/archive/AI-023-hive-auto-upgrade-timer/`
+- [ ] hive #176 ticked / closed with the PR link after multi-machine rollout

--- a/systemd/hive-upgrade.service
+++ b/systemd/hive-upgrade.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Upgrade hive-vault to the latest PyPI release
+Documentation=https://github.com/mlorentedev/hive/issues/176
+
+[Service]
+Type=oneshot
+# uv is installed to ~/.local/bin by setup-linux.sh; %h resolves to the user home.
+# Absolute path because a --user oneshot gets a minimal PATH that may omit it.
+# uv tool upgrade exits 0 when already current, so the oneshot is not marked failed.
+ExecStart=%h/.local/bin/uv tool upgrade hive-vault

--- a/systemd/hive-upgrade.timer
+++ b/systemd/hive-upgrade.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Periodically upgrade hive-vault (feeds hive serve restart-on-upgrade)
+Documentation=https://github.com/mlorentedev/hive/issues/176
+
+[Timer]
+# Wall-clock slots at :00/:15/:30/:45. Persistent runs a missed slot once on the
+# next boot/resume, so a suspended laptop still converges to the latest hive-vault.
+# RandomizedDelaySec spreads the fleet so machines do not all hit PyPI on the minute.
+OnCalendar=*:0/15
+Persistent=true
+RandomizedDelaySec=60
+
+[Install]
+WantedBy=timers.target

--- a/tests/hive-upgrade-timer.bats
+++ b/tests/hive-upgrade-timer.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# Tests for AI-023: hive-vault auto-upgrade timer (Linux systemd --user) +
+# daily Scheduled Task (Windows). The upgrade policy that feeds the Phase C
+# daemon's restart-on-upgrade (hive#176).
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+}
+
+# --- systemd unit files (SSOT) ---
+
+@test "systemd unit files exist (timer + oneshot service)" {
+    [ -f "$DOTFILES_DIR/systemd/hive-upgrade.timer" ]
+    [ -f "$DOTFILES_DIR/systemd/hive-upgrade.service" ]
+}
+
+@test "hive-upgrade.timer fires every 15 min wall-clock with catch-up" {
+    grep -qF 'OnCalendar=*:0/15' "$DOTFILES_DIR/systemd/hive-upgrade.timer"
+    grep -qF 'Persistent=true' "$DOTFILES_DIR/systemd/hive-upgrade.timer"
+    grep -qF 'RandomizedDelaySec=' "$DOTFILES_DIR/systemd/hive-upgrade.timer"
+}
+
+@test "hive-upgrade.timer installs to timers.target" {
+    grep -qF 'WantedBy=timers.target' "$DOTFILES_DIR/systemd/hive-upgrade.timer"
+}
+
+@test "hive-upgrade.service is a oneshot running uv tool upgrade hive-vault" {
+    grep -qF 'Type=oneshot' "$DOTFILES_DIR/systemd/hive-upgrade.service"
+    grep -qF 'ExecStart=%h/.local/bin/uv tool upgrade hive-vault' "$DOTFILES_DIR/systemd/hive-upgrade.service"
+}
+
+# The ExecStart must be an ABSOLUTE path: a --user oneshot gets a minimal PATH
+# that may omit ~/.local/bin, so a bare `uv` would fail every slot.
+@test "hive-upgrade.service ExecStart is absolute, not a bare uv on PATH" {
+    ! grep -qE '^ExecStart=uv ' "$DOTFILES_DIR/systemd/hive-upgrade.service"
+    grep -qE '^ExecStart=%h/' "$DOTFILES_DIR/systemd/hive-upgrade.service"
+}
+
+# --- setup-linux.sh wiring ---
+
+@test "setup-linux.sh deploys both units into the systemd --user dir" {
+    grep -qF 'systemd/hive-upgrade.service' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF 'systemd/hive-upgrade.timer' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF 'systemd/user' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh enables the timer with --now" {
+    grep -qF 'enable --now hive-upgrade.timer' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+# The timer must install inside the SAME hive >= 1.32.0 gate as `hive service
+# install` -- never route an auto-upgrade onto an old hive. The version gate
+# uses `sort -V`; the timer enable line must come AFTER it.
+@test "setup-linux.sh timer install is inside the version gate (after sort -V)" {
+    gate_line=$(grep -n 'sort -V' "$DOTFILES_DIR/setup-linux.sh" | head -1 | cut -d: -f1)
+    enable_line=$(grep -n 'enable --now hive-upgrade.timer' "$DOTFILES_DIR/setup-linux.sh" | head -1 | cut -d: -f1)
+    [ -n "$gate_line" ] && [ -n "$enable_line" ]
+    [ "$enable_line" -gt "$gate_line" ]
+}
+
+# SSOT cleanup: once the timer is the owner, the legacy manual cron must go.
+@test "setup-linux.sh removes the legacy uv tool upgrade hive-vault cron" {
+    grep -qF "grep -v 'uv tool upgrade hive-vault' | crontab -" "$DOTFILES_DIR/setup-linux.sh"
+}
+
+# The cron strip must be guarded (only remove when a matching line exists) and
+# only run after a successful timer enable -- an old-hive machine that skips the
+# gate keeps its cron so it is never left with no upgrade owner.
+@test "setup-linux.sh cron strip is guarded on the line existing" {
+    grep -qF "crontab -l 2>/dev/null | grep -q 'uv tool upgrade hive-vault'" "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh timer install is non-fatal (warns, never hard-exits)" {
+    grep -qF 'hive-upgrade.timer enable failed (non-fatal' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh stays valid bash after the timer block" {
+    bash -n "$DOTFILES_DIR/setup-linux.sh"
+}
+
+# --- setup-windows.ps1 wiring ---
+
+@test "setup-windows.ps1 registers a daily DotfilesHiveUpgrade task" {
+    grep -qF 'DotfilesHiveUpgrade' "$DOTFILES_DIR/setup-windows.ps1"
+    grep -qF 'New-ScheduledTaskTrigger -Daily' "$DOTFILES_DIR/setup-windows.ps1"
+}
+
+@test "setup-windows.ps1 hive-upgrade task runs uv tool upgrade hive-vault" {
+    grep -qF 'tool upgrade hive-vault' "$DOTFILES_DIR/setup-windows.ps1"
+    grep -qF 'uv.exe' "$DOTFILES_DIR/setup-windows.ps1"
+}
+
+# Same version gate as Linux: the task must register inside the
+# `[version]$hiveVer -ge [version]'1.32.0'` branch (after that check).
+@test "setup-windows.ps1 hive-upgrade task is inside the version gate" {
+    gate_line=$(grep -n "ge \[version\]'1.32.0'" "$DOTFILES_DIR/setup-windows.ps1" | head -1 | cut -d: -f1)
+    task_line=$(grep -n 'Register-ScheduledTask -TaskName $hiveUpgradeTask' "$DOTFILES_DIR/setup-windows.ps1" | head -1 | cut -d: -f1)
+    [ -n "$gate_line" ] && [ -n "$task_line" ]
+    [ "$task_line" -gt "$gate_line" ]
+}
+
+# PSScriptAnalyzer fails CI on non-ASCII in .ps1 (em dash / arrows / smart quotes).
+@test "setup-windows.ps1 hive-upgrade block is ASCII-only" {
+    block=$(sed -n '/DotfilesHiveUpgrade/,/Could not register hive-upgrade/p' "$DOTFILES_DIR/setup-windows.ps1")
+    [ -n "$block" ]
+    printf '%s' "$block" | LC_ALL=C grep -nP '[^\x00-\x7F]' && return 1
+    return 0
+}
+
+# --- cross-OS parity ---
+
+@test "parity: both setup scripts install an auto-upgrade mechanism for hive-vault" {
+    grep -qF 'enable --now hive-upgrade.timer' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF 'DotfilesHiveUpgrade' "$DOTFILES_DIR/setup-windows.ps1"
+}
+
+@test "parity: both setup scripts gate the upgrade install on hive >= 1.32.0" {
+    grep -qF '1.32.0' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF '1.32.0' "$DOTFILES_DIR/setup-windows.ps1"
+}


### PR DESCRIPTION
## What

The policy half of the Phase C daemon model (hive#176): the periodic upgrade that feeds `hive serve`'s restart-on-upgrade. Sibling of AI-022 (which activated the daemon + migrated the MCP entry). hive ships on PyPI independently of dotfiles, so both OSes work with no further dotfiles change — installing it is just running the setup script (version-gated).

## Changes

- **Linux** (`setup-linux.sh`): inside the existing hive >= 1.32.0 gate, deploy `systemd/hive-upgrade.{timer,service}` to `~/.config/systemd/user/` and `enable --now hive-upgrade.timer` (every 15 min, wall-clock `OnCalendar=*:0/15` + `Persistent` catch-up after suspend/boot). The oneshot runs `uv tool upgrade hive-vault` via the absolute `%h/.local/bin/uv`. Non-fatal if systemd `--user` is unavailable.
- **SSOT cleanup**: once the timer is enabled, the legacy manual `uv tool upgrade hive-vault` crontab line is removed so the timer is the single owner of the upgrade policy.
- **Windows** (`setup-windows.ps1`): a daily `DotfilesHiveUpgrade` Scheduled Task running the same upgrade, self-healing on action drift, gated the same way.
- **Tests**: `tests/hive-upgrade-timer.bats` (18) cover the unit files, both setup wirings, the version gate, the cron strip, and ASCII-only PowerShell.

## Verification

- `bash -n setup-linux.sh` clean; shellcheck clean in the added block.
- `bats tests/hive-upgrade-timer.bats` 18/18; `bats tests/setup-linux.bats` 82/82 (no regression).
- Full bats suite green modulo 3 pre-existing environmental failures in `shell-profile.bats` (confirmed unrelated: they fail identically with this branch's changes stashed).

## Rollout

Live validation + multi-machine rollout (including the first real Windows `hive service install`) tracked on hive#176.

Spec: `specs/AI-023-hive-auto-upgrade-timer/`