### PR TITLE
chore: renumber antigravity follow-up AI-023 -> AI-024 (id collision)

### DIFF
--- a/docs/runbooks/guide-antigravity-cli-migration.md
+++ b/docs/runbooks/guide-antigravity-cli-migration.md
@@ -10,7 +10,7 @@ owner: manu
 # Antigravity CLI Migration
 
 Decision record + operating procedure for the `gemini-cli` → Antigravity CLI
-(`agy`) migration. Resolves AI-020 (decision) and feeds AI-023 (verification).
+(`agy`) migration. Resolves AI-020 (decision) and feeds AI-024 (verification).
 
 ## Why this exists
 
@@ -97,7 +97,7 @@ echo "$ANTIGRAVITY_ENDPOINT"   # expect https://cloudcode-pa.googleapis.com
 
 ## References
 
-- Decision spec: `specs/AI-020-gemini-empirical-validation/` (matrix + evidence).
-- Follow-up: `specs/AI-023-antigravity-oauth-verification/` (OAuth/quota guard).
+- Decision spec: `specs/archive/AI-020-gemini-empirical-validation/` (matrix + evidence).
+- Follow-up: `specs/AI-024-antigravity-oauth-verification/` (OAuth/quota guard).
 - Upstream: <https://goo.gle/gemini-cli-migration>.
 - Related: [AI Tools Setup](ai-tools-setup.md), [Gemini CLI Recovery](guide-gemini-cli-recovery.md).

--- a/specs/AI-024-antigravity-oauth-verification/proposal.md
+++ b/specs/AI-024-antigravity-oauth-verification/proposal.md
@@ -1,12 +1,12 @@
 ---
-id: "AI-023-antigravity-oauth-verification"
+id: "AI-024-antigravity-oauth-verification"
 status: draft # draft | implementing | verifying | archived
 created: "2026-06-04"
 tags: [spec, proposal]
 template_version: "1.0"
 ---
 
-# AI-023-antigravity-oauth-verification
+# AI-024-antigravity-oauth-verification
 
 > Follow-up to AI-020 (Gemini CLI → Antigravity migration decision). AI-020
 > chose **branch #1** (`agy` OAuth via the Code Assist backend preserves the
@@ -65,7 +65,7 @@ discovered mid-task.
 
 ## References
 
-- Predecessor: `specs/AI-020-gemini-empirical-validation/` (decision + matrix).
-- Vault: `10_projects/dotfiles/11-tasks.md` → AI-020 / AI-023.
-- Runbook: `40-runbooks/guide-antigravity-cli-migration.md`.
+- Predecessor: `specs/archive/AI-020-gemini-empirical-validation/` (decision + matrix).
+- Vault: `10_projects/dotfiles/11-tasks.md` → AI-020 / AI-024.
+- Runbook: `docs/runbooks/guide-antigravity-cli-migration.md`.
 - Upstream: <https://goo.gle/gemini-cli-migration>.

--- a/specs/AI-024-antigravity-oauth-verification/tasks.md
+++ b/specs/AI-024-antigravity-oauth-verification/tasks.md
@@ -3,13 +3,13 @@ tags: [spec, tasks, templates]
 created: "2026-05-13"
 ---
 
-# Tasks - AI-023-antigravity-oauth-verification
+# Tasks - AI-024-antigravity-oauth-verification
 
 > TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
 
 ## Setup
 
-- [ ] Branch created from main: `feat/AI-023-antigravity-oauth-verification`
+- [ ] Branch created from main: `feat/AI-024-antigravity-oauth-verification`
 - [ ] `proposal.md` is complete and acceptance criteria are testable
 - [ ] No open questions left in `proposal.md` "Risks / open questions"
 
@@ -40,12 +40,12 @@ This spec emits a sibling `features.json` (alongside this file) following [[patt
 
 **Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
 
-Minimal `features.json` skeleton (drop into `<repo>/specs/AI-023-antigravity-oauth-verification/features.json`):
+Minimal `features.json` skeleton (drop into `<repo>/specs/AI-024-antigravity-oauth-verification/features.json`):
 
 ```json
 [
   {
-    "id": "AI-023-antigravity-oauth-verification-f1",
+    "id": "AI-024-antigravity-oauth-verification-f1",
     "behavior": "<one-line copy of an acceptance criterion>",
     "verification": "<single shell command; exit 0 means pass>",
     "state": "pending",

--- a/specs/AI-024-antigravity-oauth-verification/verification.md
+++ b/specs/AI-024-antigravity-oauth-verification/verification.md
@@ -3,7 +3,7 @@ tags: [spec, verification, templates]
 created: "2026-05-13"
 ---
 
-# Verification - AI-023-antigravity-oauth-verification
+# Verification - AI-024-antigravity-oauth-verification
 
 ## Evidence
 
@@ -37,6 +37,6 @@ Before archiving, flag what (if anything) should be promoted to the vault. If al
 ## Archive checklist
 
 - [ ] `proposal.md` frontmatter set to `status: archived`
-- [ ] Folder moved: `specs/AI-023-antigravity-oauth-verification/` -> `specs/archive/AI-023-antigravity-oauth-verification/`
+- [ ] Folder moved: `specs/AI-024-antigravity-oauth-verification/` -> `specs/archive/AI-024-antigravity-oauth-verification/`
 - [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
 - [ ] Promotions above executed (if any)

--- a/specs/archive/AI-020-gemini-empirical-validation/verification.md
+++ b/specs/archive/AI-020-gemini-empirical-validation/verification.md
@@ -34,7 +34,8 @@ Two findings that reshaped scope versus the proposal:
    migration, and consolidate MCP to `~/.gemini/config/mcp_config.json`;
    healthcheck §13 already guards it. So the downstream follow-up shrinks from
    "port the install" to "verify the OAuth/quota path" → scaffolded as
-   **AI-023** (the proposal's "AI-022" id was already taken by #161/#211).
+   **AI-024** (the proposal's "AI-022" id was already taken by #161/#211, and
+   AI-023 was claimed concurrently by the parallel hive-timer session).
 
 ## Evidence
 
@@ -44,7 +45,7 @@ Two findings that reshaped scope versus the proposal:
 - [x] AC2 Decision matrix completed, explicit branch chosen → **branch #1**
       (this file).
 - [x] AC3 User tier identified → **Google AI Plus** (low Gemini reliance).
-- [x] AC4 Follow-up spec scaffolded → `specs/AI-023-antigravity-oauth-verification/`
+- [x] AC4 Follow-up spec scaffolded → `specs/AI-024-antigravity-oauth-verification/`
       (id corrected from AI-022, which is consumed by #161/#211).
 - [x] AC5 Vault `11-tasks.md` AI-020 entry ticked with decision link → vault
       master commit `6000362`.
@@ -64,8 +65,9 @@ Two findings that reshaped scope versus the proposal:
 
 - Rejected the proposal's "evaluate AI Pro upgrade" path: low Gemini reliance
   makes any paid upgrade non-justified; drop-or-free-allotment is the fallback.
-- Renamed the follow-up AI-022 → AI-023 after verifying AI-022 is already in use
-  (verify-before-act).
+- Renamed the follow-up AI-022 → AI-024: AI-022 was already in use (#161/#211),
+  and AI-023 was claimed concurrently by the parallel hive-timer session
+  (verify-before-act, twice over).
 
 ## Promotion candidates
 


### PR DESCRIPTION
Renumbers the antigravity OAuth-verification follow-up `AI-023` → `AI-024`.

The parallel hive-timer session claimed `AI-023` concurrently
(`specs/AI-023-hive-auto-upgrade-timer`, merged via #217, archived via #219),
colliding with the antigravity follow-up scaffolded in #216. The hive timer owns
the `AI-023` vault backlog entry, so the antigravity follow-up renumbers.

Branched off the latest `main` — **no "Update branch" needed** (please merge as-is
to avoid the squash race that dropped this rename from #218).

## Changes
- `specs/AI-023-antigravity-oauth-verification/` → `specs/AI-024-antigravity-oauth-verification/`
  (frontmatter id, headings, internal refs).
- Pointer updates in the AI-020 runbook + archived AI-020 `verification.md`.
