### PR TITLE
fix(opencode): relax SSE timeouts and default to qwen3.6

### DIFF
--- a/ai/opencode/opencode.jsonc
+++ b/ai/opencode/opencode.jsonc
@@ -28,7 +28,10 @@
   "instructions": ["{env:HOME}/.config/opencode/AGENTS.md"],
   // Explicit fast model for title generation — avoids fallback delay.
   "small_model": "nan/qwen3.6",
-  "model": "nan/deepseek-v4-flash",
+  // Default = fast model (matches the tier comment above). deepseek-v4-flash
+  // is reasoning-heavy (~3s + mandatory reasoning chain) — reach for it
+  // on-demand via the `qf` wrapper, not as the always-on default.
+  "model": "nan/qwen3.6",
 
   "provider": {
     // NaN community — primary daily provider.
@@ -40,10 +43,15 @@
         "baseURL": "https://api.nan.builders/v1",
         "apiKey": "{env:NAN_API_KEY}",
         "model": "qwen3.6",
-        // Reduced from 300s default — NaN is fast, fail fast on network issues.
-        "timeout": 60000,
-        // Reduced from 30s default — qwen3.6 streams quickly.
-        "chunkTimeout": 10000
+        // Overall request timeout (opencode default = 300000). Generous on
+        // purpose: reasoning models (deepseek-v4-flash via `qf`) and thinking-
+        // enabled chats produce long generations; 60s here cut them off with
+        // "operation timed out".
+        "timeout": 300000,
+        // Max ms between streamed SSE chunks before opencode aborts. NaN's
+        // reasoning models go silent for several seconds mid-chain; 10s was too
+        // tight and surfaced as "SSE timeout". 60s tolerates the pause.
+        "chunkTimeout": 60000
       },
       "models": {
         "deepseek-v4-flash": {

--- a/tests/opencode.bats
+++ b/tests/opencode.bats
@@ -118,11 +118,13 @@ setup() {
     grep -q 'ollama.kubelab.live' "$OPENCODE_CFG"
 }
 
-@test "opencode.jsonc default model is nan/deepseek-v4-flash (NaN, 1M context default)" {
-    # deepseek-v4-flash is the default (1M context, reasoning ON server-side);
-    # small_model stays nan/qwen3.6 for fast title generation. Switch the active
-    # model via /models per task.
-    grep -qE '"model":\s*"nan/deepseek-v4-flash"' "$OPENCODE_CFG"
+@test "opencode.jsonc default model is nan/qwen3.6 (fast default; deepseek-v4-flash on-demand)" {
+    # qwen3.6 is the default (256K, ~0.8s, fast) — matches the model-tier header
+    # comment. deepseek-v4-flash (1M context, reasoning-heavy ~3s) is reached
+    # on-demand via the `qf` wrapper, not as the always-on default; the tight
+    # SSE chunkTimeout made it abort with "SSE timeout" as the default. Switch
+    # the active model via /models per task.
+    grep -qE '"model":\s*"nan/qwen3.6"' "$OPENCODE_CFG"
 }
 
 @test "opencode.jsonc exposes 4 chat NaN models (non-chat models intentionally excluded — opencode schema rejects 'embedding' modality)" {


### PR DESCRIPTION
## Problem

opencode sessions failed repeatedly with `SSE timeout` and `operation timed out`.

Root cause is a model<->timeout mismatch. The default model was
`nan/deepseek-v4-flash` — reasoning-heavy (~3s wall + a mandatory reasoning
chain, ~4x slower than qwen3.6 per `scripts/nan-bench.sh`) — while
`provider.nan.options` timeouts were tuned for the *fast* qwen3.6:

- `chunkTimeout: 10000` aborts if >10s pass between streamed SSE chunks. The
  reasoning model goes silent mid-chain, surfacing as `SSE timeout`.
- `timeout: 60000` capped overall requests at 60s, cutting long generations
  with `operation timed out`.

This also contradicted the config's own model-tier header, which documents
`nan/qwen3.6` as the intended default and `deepseek-v4-flash` as on-demand.

## Fix

- default model -> `nan/qwen3.6` (fast; matches the documented tier).
  `deepseek-v4-flash` stays on-demand via the `qf` wrapper.
- `provider.nan.timeout` 60000 -> 300000 (opencode default).
- `provider.nan.chunkTimeout` 10000 -> 60000.
- `tests/opencode.bats`: default-model assertion updated to `nan/qwen3.6`
  (the contract changed, so its guard does too).

qwen3.6 also runs with thinking enabled, so the generous timeouts remain a
safety net regardless of the active model.

## Verification

- `bats tests/opencode.bats` green (also enforced by the pre-commit hook).
- JSONC validated.

## SDD

Skip-SDD: bug fix with an obvious cause, ~10-line production diff (well under
the 50-LOC spec-gate threshold; tests + comments excluded).
