### PR TITLE
feat(opencode): DX config — privacy, provider pruning, output trim, read-only plan agent

### DIFF
--- a/ai/opencode/opencode.jsonc
+++ b/ai/opencode/opencode.jsonc
@@ -205,6 +205,37 @@
     "reserved": 50000
   },
 
+  // Behaviour / DX (keys verified against https://opencode.ai/config.json, 2026-06).
+  // Privacy: never upload a session to a share URL. Default "manual" still
+  // exposes the /share command; "disabled" turns it off entirely — correct for
+  // a secrets-heavy dotfiles workflow.
+  "share": "disabled",
+  // Surface new releases instead of silently self-updating the binary mid-
+  // session (opencode moves fast; install is unpinned via opencode.ai/install).
+  "autoupdate": "notify",
+  // Keep the /models picker clean: don't auto-load providers detected from
+  // ambient env vars (OPENAI_API_KEY etc.). Only nan/openrouter/ollama remain.
+  "disabled_providers": ["openai", "anthropic", "google"],
+  // Trim noisy tool output before it burns context (defaults are 2000/51200).
+  // Pairs with the token-thrift compaction block above.
+  "tool_output": {
+    "max_lines": 500,
+    "max_bytes": 20480
+  },
+  // Agent overrides. `plan` is the built-in read-only planning mode (toggle in
+  // the TUI) — pin it to the fast model and hard-deny writes so planning never
+  // edits files or runs commands. deepseek-v4-flash stays the depth option via
+  // /models.
+  "agent": {
+    "plan": {
+      "model": "nan/qwen3.6",
+      "permission": {
+        "edit": "deny",
+        "bash": "deny"
+      }
+    }
+  },
+
   // MCP servers — mirror of mcp-servers.json (Claude Code SSOT).
   // 2026-05-25 cleanup: removed `drawio` (rarely used, spawned subprocess
   // even with --pure) and `socket` (mcp.socket.dev hung 30s+ on tool

--- a/tests/opencode.bats
+++ b/tests/opencode.bats
@@ -145,6 +145,17 @@ setup() {
     ! grep -qE '^\s*"drawio":|^\s*"socket":' "$OPENCODE_CFG"
 }
 
+@test "opencode.jsonc DX keys present (share disabled, autoupdate notify, providers pruned, tool_output, read-only plan agent)" {
+    grep -qE '"share":\s*"disabled"' "$OPENCODE_CFG"
+    grep -qE '"autoupdate":\s*"notify"' "$OPENCODE_CFG"
+    grep -qE '"disabled_providers":\s*\[' "$OPENCODE_CFG"
+    grep -qE '"tool_output":\s*\{' "$OPENCODE_CFG"
+    grep -qE '"max_lines":' "$OPENCODE_CFG"
+    # plan agent must exist, pin the fast model, and hard-deny writes
+    grep -qE '"agent":\s*\{' "$OPENCODE_CFG"
+    grep -qE '"plan":\s*\{' "$OPENCODE_CFG"
+}
+
 # --- Alias ---
 
 @test ".zsh/aliases.zsh has oc alias for opencode (--pure: skip MCPs/plugins)" {


### PR DESCRIPTION
## What

Additive opencode DX config — independent of #223 (which fixes the SSE
timeouts); the two PRs touch non-overlapping regions of `opencode.jsonc`.

All keys verified against the live schema at https://opencode.ai/config.json
(2026-06):

| Key | Value | Why |
|---|---|---|
| `share` | `"disabled"` | Never upload a session to a share URL. Default `"manual"` still exposes `/share`. Fits a secrets-heavy workflow. |
| `autoupdate` | `"notify"` | Surface releases instead of self-updating the unpinned binary mid-session. |
| `disabled_providers` | `[openai, anthropic, google]` | Keep `/models` to nan/openrouter/ollama; ignore providers from ambient env vars. |
| `tool_output` | `max_lines 500 / max_bytes 20480` | Trim noisy output before it burns context (pairs with `compaction`). |
| `agent.plan` | qwen3.6 + deny edit/bash | Read-only plan mode pinned to the fast model; planning never mutates the workspace. |

## Verification

- `bats tests/opencode.bats` green (new guard test asserts all five additions;
  also enforced by the pre-commit hook).
- JSONC validated; keys checked against the schema `$defs`.

## SDD

Skip-SDD: additive config, ~30-line production diff, low risk (under the 50-LOC
spec-gate threshold). The separately-selected `tui.json` deploy target will get
its own spec — it adds a cross-platform deploy path (new SSOT + both setups +
tests).
