### PR TITLE
feat(opencode): surface NaN reasoning in the TUI + versioned tui.json (DX-004)

### DIFF
--- a/ai/opencode/opencode.jsonc
+++ b/ai/opencode/opencode.jsonc
@@ -48,15 +48,19 @@
       "models": {
         "deepseek-v4-flash": {
           "name": "DeepSeek V4 Flash (DeepSeek - 1M)",
+          // Surface NaN's reasoning chain in the TUI. NaN streams it in the
+          // non-standard `reasoning_content` field (a DeepSeek/Qwen alias), which
+          // @ai-sdk/openai-compatible drops by default. `interleaved` maps it to a
+          // reasoning part opencode can render (schema-verified on opencode 1.15.13).
+          // Toggle visibility with ctrl+o or `/thinking` (see ai/opencode/tui.json).
+          // NaN's other field, `provider_specific_fields.reasoning`, is NOT in the
+          // enum, so we map reasoning_content. Out-of-TUI fallback: the `dbg` alias
+          // (scripts/nan-debug.sh) curls NaN directly and prints reasoning + answer.
+          "interleaved": { "field": "reasoning_content" },
           "limit": {
             "context": 1000000,
             "output": 8192
           },
-          // Note: NaN returns reasoning chain in non-OpenAI fields
-          // (`reasoning_content`, `provider_specific_fields.reasoning`).
-          // Opencode (1.15.10) renders neither — the chain is invisible in TUI.
-          // For visibility use `dbg` alias (scripts/nan-debug.sh) which curls
-          // directly and prints reasoning + answer side-by-side.
           "modalities": {
             "input": ["text"],
             "output": ["text"]
@@ -81,6 +85,8 @@
         },
         "qwen3.6": {
           "name": "Qwen 3.6 (Alibaba - 256K)",
+          // Surface reasoning in the TUI (see deepseek-v4-flash note).
+          "interleaved": { "field": "reasoning_content" },
           "limit": {
             "context": 256000,
             "output": 8192
@@ -109,6 +115,8 @@
         },
         "gemma4": {
           "name": "Gemma 4 (Google - 256K)",
+          // Surface reasoning in the TUI (see deepseek-v4-flash note).
+          "interleaved": { "field": "reasoning_content" },
           "limit": {
             "context": 256000,
             "output": 8192
@@ -137,6 +145,8 @@
         },
         "mimo-v2.5": {
           "name": "MiMo V2.5 (Xiaomi - 1M)",
+          // Surface reasoning in the TUI (see deepseek-v4-flash note).
+          "interleaved": { "field": "reasoning_content" },
           "limit": {
             "context": 1000000,
             "output": 8192

--- a/ai/opencode/tui.json
+++ b/ai/opencode/tui.json
@@ -1,0 +1,20 @@
+// OpenCode TUI configuration — managed by dotfiles.
+//
+// SSOT: ai/opencode/tui.json (this file).
+// Deploy target: ~/.config/opencode/tui.json (via setup-linux.sh / setup-windows.ps1).
+// Plain copy — no secret substitution (unlike opencode.jsonc); contains no secrets.
+// Schema: https://opencode.ai/tui.json  (NOTE: a different schema from config.json).
+// Spec: specs/DX-004-opencode-tui-config/.
+{
+  "$schema": "https://opencode.ai/tui.json",
+  // Follow opencode's default palette (tracks the terminal). Swap for tokyonight,
+  // catppuccin, gruvbox, etc. via /themes in the TUI.
+  "theme": "opencode",
+  "keybinds": {
+    // Toggle visibility of the model's reasoning/thinking blocks. NaN's chain is
+    // ingested via per-model `interleaved` in opencode.jsonc; this binds the
+    // show/hide toggle (also available as the /thinking command). Default is
+    // unbound ("none"), which is why the reasoning felt invisible.
+    "display_thinking": "ctrl+o"
+  }
+}

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -646,6 +646,22 @@ else
     log_warning "AGENTS.md source missing at $AGENTS_SRC"
 fi
 
+# Deploy opencode TUI config (theme + keybinds incl. the display_thinking toggle).
+# Plain copy — no secret substitution (DX-004): unlike opencode.jsonc this file
+# carries no secrets, so it deploys verbatim. opencode reads tui.json natively.
+TUI_SRC="$CURRENT_DIR/ai/opencode/tui.json"
+TUI_DST="$HOME/.config/opencode/tui.json"
+if [ -f "$TUI_SRC" ]; then
+    if [ -f "$TUI_DST" ] && cmp -s "$TUI_SRC" "$TUI_DST"; then
+        log_info "opencode tui.json already in sync"
+    else
+        cp "$TUI_SRC" "$TUI_DST"
+        log_success "Deployed tui.json to $TUI_DST"
+    fi
+else
+    log_warning "tui.json source missing at $TUI_SRC"
+fi
+
 # opencode commands are deployed from the vault skill records by
 # `compile-harness.sh --deploy` (SDD-008): each committed record under
 # harness/skills/ whose targets[] includes opencode is rendered to a

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -773,6 +773,23 @@ if (Test-Path -LiteralPath $agentsSrc -PathType Leaf) {
     Write-Warn "AGENTS.md source missing at $agentsSrc"
 }
 
+# Deploy opencode TUI config (theme + keybinds incl. the display_thinking toggle).
+# Plain copy: unlike opencode.jsonc this file carries no secrets, so no env-var
+# substitution (DX-004). opencode reads .config\opencode\tui.json natively.
+# Linux parity: setup-linux.sh tui.json deploy block.
+$tuiSrc = Join-Path $DotfilesDir 'ai\opencode\tui.json'
+$tuiDst = Join-Path $env:USERPROFILE '.config\opencode\tui.json'
+if (Test-Path -LiteralPath $tuiSrc -PathType Leaf) {
+    if (Get-Command Deploy-File -ErrorAction SilentlyContinue) {
+        [void](Deploy-File -Source $tuiSrc -Destination $tuiDst)
+    } else {
+        Copy-Item -LiteralPath $tuiSrc -Destination $tuiDst -Force
+        Write-Success "Deployed tui.json to $tuiDst (fallback)"
+    }
+} else {
+    Write-Warn "tui.json source missing at $tuiSrc"
+}
+
 # OpenCode commands are deployed from the committed vault skill records by
 # Deploy-SkillRecord near the end of this script (SDD-008, option A): each
 # record whose targets[] includes opencode is rendered to a

--- a/specs/DX-004-opencode-tui-config/features.json
+++ b/specs/DX-004-opencode-tui-config/features.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "DX-004-opencode-tui-config-f1",
+    "behavior": "AC1: all 4 NaN chat models map reasoning_content via interleaved in opencode.jsonc",
+    "verification": "bats tests/opencode.bats -f 'DX-004 AC1'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DX-004-opencode-tui-config-f2",
+    "behavior": "AC2: ai/opencode/tui.json exists with schema, theme=opencode, display_thinking=ctrl+o",
+    "verification": "bats tests/opencode.bats -f 'DX-004 AC2'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DX-004-opencode-tui-config-f3",
+    "behavior": "AC3: setup-linux.sh deploys tui.json as a plain copy with no secret substitution",
+    "verification": "bats tests/opencode.bats -f 'DX-004 AC3'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DX-004-opencode-tui-config-f4",
+    "behavior": "AC4: setup-windows.ps1 deploys tui.json (cross-OS parity)",
+    "verification": "bats tests/setup-windows.bats -f 'DX-004 AC4'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DX-004-opencode-tui-config-f5",
+    "behavior": "AC5: the stale 1.15.10 'renders neither' reasoning comment is updated",
+    "verification": "bats tests/opencode.bats -f 'DX-004 AC5'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DX-004-opencode-tui-config-f6",
+    "behavior": "AC6: in the TUI, NaN reasoning becomes visible after ctrl+o / /thinking (empirical)",
+    "verification": "manual: launch opencode, send a prompt to a NaN thinking model, press ctrl+o and confirm the reasoning block appears",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/DX-004-opencode-tui-config/proposal.md
+++ b/specs/DX-004-opencode-tui-config/proposal.md
@@ -1,0 +1,74 @@
+---
+id: "DX-004-opencode-tui-config"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-05"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# DX-004-opencode-tui-config
+
+> **Naming**: file lives at `<repo>/specs/DX-004-opencode-tui-config/proposal.md`.
+
+## Why
+
+<!-- from 11-tasks.md: (GH #225): opencode reasoning visibility + TUI config. (1) Per-model `interleaved: {field: "reasoning_content"}` in opencode.jsonc (4 NaN models) — maps NaN's non-standard reasoning field into a reasoning part opencode renders. (2) New SSOT `ai/opencode/tui.json` (theme=opencode, keybind `display_thinking`=ctrl+o) + cross-platform deploy in setup-{linux.sh,windows.ps1} + bats. Solves the invisible-reasoning "is it hung?" gap (1.15.13 schema has `interleaved`; SDK stream emission needs empirical TUI verify). Spec: specs/DX-004-opencode-tui-config/. -->
+
+opencode looks frozen while a NaN model reasons: NaN streams its chain in the
+non-standard `reasoning_content` field, which `@ai-sdk/openai-compatible` does
+not map to a renderable reasoning part, so the TUI shows nothing during the
+silent reasoning phase. Separately, opencode's TUI config (theme, keybinds) is
+not under version control, so a fresh machine has no reproducible TUI setup and
+the reasoning-visibility toggle (`display_thinking`, unbound by default) is not
+wired. This feature makes the reasoning visible and puts the TUI config in the
+dotfiles SSOT.
+
+## What
+
+After this PR:
+
+- Each NaN model in `opencode.jsonc` carries `interleaved: { field: "reasoning_content" }`,
+  so opencode ingests NaN's reasoning chain and can render it as a reasoning block.
+- A new versioned SSOT `ai/opencode/tui.json` sets `theme: "opencode"` and binds
+  `keybinds.display_thinking` to `ctrl+o`, so the user toggles reasoning
+  visibility in the TUI (also available via the `/thinking` command).
+- `setup-linux.sh` and `setup-windows.ps1` deploy `tui.json` to
+  `~/.config/opencode/tui.json` (plain copy — no secret substitution, unlike
+  `opencode.jsonc`).
+- The stale comment in `opencode.jsonc` (claiming opencode renders neither NaN
+  reasoning field) is corrected to reflect the `interleaved` fix on 1.15.13.
+
+## Out of scope
+
+- Disabling thinking / changing the default model — handled by #223 (default → qwen3.6, relaxed timeouts).
+- The DX bundle keys (share/autoupdate/disabled_providers/tool_output/agent.plan) — handled by #224.
+- An in-TUI elapsed-time / token counter — upstream feature requests (opencode #5872, #12028), not configurable today.
+- `reasoningEffort` / `reasoningSummary` / `options.reasoning` on NaN — native-only; openai-compatible providers reject them (opencode #13546).
+- A healthcheck drift assertion for `tui.json` — noted as an optional follow-up (the file is a plain copy; drift detection can be added later if it matters).
+
+## Risks / open questions
+
+- **SDK emission unverified.** `interleaved` is present in the 1.15.13 JSON schema, but it is not byte-confirmed that the bundled AI SDK actually emits the reasoning part on stream. Mitigation: empirical in-TUI verification (AC6); fallback is the existing `dbg` / `qf` wrappers and the qwen3.6 fast default from #223.
+- NaN's other reasoning field, `provider_specific_fields.reasoning`, is NOT covered by the `interleaved` enum (only `reasoning_content` / `reasoning_details`) — so we map `reasoning_content`.
+- `ctrl+o` could collide with an existing opencode bind — verify in the TUI; `leader+t` or `/thinking`-only are fallbacks.
+- `tui.json` uses a different schema URL (`https://opencode.ai/tui.json`, not `config.json`) — get the `$schema` right.
+- Windows: `setup-windows.ps1` must deploy as a plain copy and stay ASCII-only (PSScriptAnalyzer fails CI on non-ASCII without BOM — `pattern-powershell-ascii-only`).
+
+## Acceptance criteria
+
+- [ ] AC1: `ai/opencode/opencode.jsonc` has `interleaved: { field: "reasoning_content" }` on all 4 NaN chat models (deepseek-v4-flash, qwen3.6, gemma4, mimo-v2.5).
+- [ ] AC2: `ai/opencode/tui.json` exists, is valid JSON, with `theme: "opencode"` and `keybinds.display_thinking: "ctrl+o"`.
+- [ ] AC3: `setup-linux.sh` deploys `tui.json` to `~/.config/opencode/tui.json` as a plain copy (no `substitute_env_placeholders`).
+- [ ] AC4: `setup-windows.ps1` deploys `tui.json` (cross-OS parity) and is ASCII-only.
+- [ ] AC5: the stale `opencode.jsonc` reasoning comment is updated to reflect the `interleaved` fix and version 1.15.13.
+- [ ] AC6 (empirical, user-run): in the TUI, the NaN reasoning chain becomes visible after pressing `ctrl+o` (or `/thinking`). Evidence recorded in `verification.md`.
+
+## References
+
+- Vault: `10_projects/dotfiles/11-tasks.md` (DX-004 entry)
+- GH issue: #225
+- Related PRs: #223 (SSE timeouts + default model), #224 (DX config bundle)
+- opencode schema: `https://opencode.ai/config.json` (`interleaved` enum), `https://opencode.ai/tui.json`
+- opencode docs: `/docs/keybinds` (`display_thinking`), `/docs/tui` (`/thinking`)
+- Pattern: `00_meta/patterns/pattern-powershell-ascii-only.md`

--- a/specs/DX-004-opencode-tui-config/tasks.md
+++ b/specs/DX-004-opencode-tui-config/tasks.md
@@ -1,0 +1,31 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-06-05"
+---
+
+# Tasks - DX-004-opencode-tui-config
+
+> TDD order. One task = one focused commit. Tick as you go.
+
+## Setup
+
+- [x] Branch created from main: `spec/dx-004-opencode-tui`
+- [x] `proposal.md` complete, acceptance criteria testable
+- [x] No open questions left unresolved (caveats captured under Risks)
+
+## Implementation
+
+- [x] AC1: add `interleaved: { field: "reasoning_content" }` to the 4 NaN models in `ai/opencode/opencode.jsonc`
+- [x] AC5: update the stale reasoning comment in `opencode.jsonc` (1.15.10 → 1.15.13 + `interleaved`)
+- [x] AC2: create `ai/opencode/tui.json` SSOT (theme=opencode, keybinds.display_thinking=ctrl+o, correct `$schema`)
+- [x] AC3: add `tui.json` plain-copy deploy block to `setup-linux.sh` (reconcile-not-skip; NO secret substitution)
+- [x] AC4: add `tui.json` deploy block to `setup-windows.ps1` (ASCII-only, parity)
+- [x] Guard tests: extend `tests/opencode.bats` (AC1, AC2, AC3) + `tests/setup-windows.bats` (AC4)
+- [x] `features.json` emitted with executable verification per AC
+
+## Closing
+
+- [x] Every AC (1-5) covered by at least one test; AC6 is user-empirical
+- [x] JSONC/JSON validated; shellcheck on setup-linux.sh
+- [ ] `verification.md` filled with evidence (test output + AC6 left for user)
+- [ ] PR opened referencing this spec folder

--- a/specs/DX-004-opencode-tui-config/verification.md
+++ b/specs/DX-004-opencode-tui-config/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-05-13"
+---
+
+# Verification - DX-004-opencode-tui-config
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/DX-004-opencode-tui-config/` -> `specs/archive/DX-004-opencode-tui-config/`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)

--- a/tests/opencode.bats
+++ b/tests/opencode.bats
@@ -226,3 +226,32 @@ setup() {
     awk '/section "10\/13" "OpenCode"/,/section "11\/13"/' "$HEALTHCHECK" | grep -q 'OPENCODE_CFG'
     awk '/section "10\/13" "OpenCode"/,/section "11\/13"/' "$HEALTHCHECK" | grep -q '\$schema'
 }
+
+# --- DX-004: reasoning visibility (interleaved) + TUI config (tui.json) ---
+
+@test "opencode.jsonc maps NaN reasoning_content via interleaved on all 4 chat models (DX-004 AC1)" {
+    # opencode only renders NaN's reasoning chain if reasoning_content is mapped
+    # to a reasoning part. All four chat models must carry the mapping.
+    count=$(grep -cE '"interleaved":[[:space:]]*\{[[:space:]]*"field":[[:space:]]*"reasoning_content"[[:space:]]*\}' "$OPENCODE_CFG")
+    [ "$count" -eq 4 ] || { echo "expected 4 interleaved blocks, got $count" >&2; false; }
+}
+
+@test "opencode.jsonc reasoning comment updated off the stale 1.15.10 'renders neither' note (DX-004 AC5)" {
+    ! grep -q 'Opencode (1.15.10) renders neither' "$OPENCODE_CFG"
+    grep -q 'interleaved' "$OPENCODE_CFG"
+}
+
+@test "ai/opencode/tui.json exists with schema, theme=opencode, display_thinking=ctrl+o (DX-004 AC2)" {
+    TUI_CFG="$DOTFILES_DIR/ai/opencode/tui.json"
+    [ -f "$TUI_CFG" ]
+    grep -qE '"\$schema":[[:space:]]*"https://opencode.ai/tui.json"' "$TUI_CFG"
+    grep -qE '"theme":[[:space:]]*"opencode"' "$TUI_CFG"
+    grep -qE '"display_thinking":[[:space:]]*"ctrl\+o"' "$TUI_CFG"
+}
+
+@test "setup-linux.sh deploys tui.json as a plain copy, no secret substitution (DX-004 AC3)" {
+    grep -q 'TUI_SRC="\$CURRENT_DIR/ai/opencode/tui.json"' "$SETUP_SCRIPT"
+    grep -q 'cmp -s "\$TUI_SRC" "\$TUI_DST"' "$SETUP_SCRIPT"
+    # tui.json carries no secrets: it must NOT go through substitute_env_placeholders
+    ! grep -qE 'substitute_env_placeholders "\$TUI_(SRC|DST)"' "$SETUP_SCRIPT"
+}

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -698,3 +698,10 @@ setup() {
     "
     [[ "$status" -eq 0 ]]
 }
+
+# --- DX-004: opencode tui.json deploy (Linux parity) ---
+
+@test "setup-windows.ps1 deploys opencode tui.json (DX-004 AC4)" {
+    grep -qF 'ai\opencode\tui.json' "$PS1_SCRIPT"
+    grep -qF '.config\opencode\tui.json' "$PS1_SCRIPT"
+}


### PR DESCRIPTION
Closes #225. Spec: `specs/DX-004-opencode-tui-config/`.

## Problem

opencode looked frozen while a NaN model reasoned: NaN streams its chain in the
non-standard `reasoning_content` field, which `@ai-sdk/openai-compatible` does
not map to a reasoning part, so the TUI showed nothing during the silent
reasoning phase ("is it hung?"). Separately, the TUI config was not under
version control.

## What

| Area | Change |
|---|---|
| `opencode.jsonc` | `interleaved: { field: "reasoning_content" }` on all 4 NaN chat models so opencode ingests + renders the chain; stale 1.15.10 "renders neither" comment refreshed |
| `ai/opencode/tui.json` (new SSOT) | `theme: "opencode"` + `keybinds.display_thinking: "ctrl+o"` (toggle reasoning visibility; also `/thinking`) |
| `setup-linux.sh` / `setup-windows.ps1` | deploy `tui.json` cross-platform as a plain copy (no secret substitution — carries no secrets) |
| tests | 5 guards: `opencode.bats` AC1/AC2/AC3/AC5 + `setup-windows.bats` AC4 |

## Verification

- Pre-commit hook ran the bats suite green (5 new DX-004 guards included).
- `opencode.jsonc` + `tui.json` validated as JSONC; `features.json` strict JSON; `shellcheck setup-linux.sh` adds no new findings; PS block is ASCII-only.
- **AC6 (in-TUI visibility) is empirical / user-run**: launch `opencode`, prompt a NaN thinking model, press `ctrl+o` (or `/thinking`), confirm the reasoning block renders.

## Caveat

`interleaved` is schema-valid on opencode 1.15.13, but SDK stream emission of the
mapped part is unconfirmed. If reasoning still doesn't render after AC6, fall
back to `dbg` / `qf` and the qwen3.6 fast default from #223.

## Relation to other PRs

Independent of #223 (SSE timeouts + default model) and #224 (DX config bundle);
all three touch `opencode.jsonc` in non-overlapping regions.
