### PR TITLE
fix(init-project): stop seeding vault operate-layer folders

### DIFF
--- a/scripts/init-project.ps1
+++ b/scripts/init-project.ps1
@@ -68,9 +68,7 @@ if ($WorkSdk) {
 
     Write-Info "Creating work SDK vault entry: 50_work/45-development/$Family/$Component"
 
-    foreach ($subDir in @('30-architecture', '40-runbooks', '50-troubleshooting', 'memory')) {
-        New-Item -ItemType Directory -Path "$SdkDir\$subDir" -Force | Out-Null
-    }
+    New-Item -ItemType Directory -Path "$SdkDir\memory" -Force | Out-Null
 
     Set-Content -Path "$SdkDir\00-context.md" -Encoding UTF8 -Value @"
 ---
@@ -101,11 +99,8 @@ See [[../00-context|$Family family context]] for all repos.
 - **Real repo path:** Fill in source_path above with actual `$env:USERPROFILE\Projects\...` path
 
 ## Knowledge Structure
-- [[30-architecture]]: ADRs and Technical Decisions
-- [[40-runbooks]]: Operational Guides
-- [[50-troubleshooting]]: Known Issues
+Per [[pattern-knowledge-placement]]: build/operate docs (ADRs, runbooks, troubleshooting, lessons) live in the repo docs/; this entry keeps only decide/personal layers.
 - [[memory/MEMORY]]: Session memory
-- [[90-lessons]]: Lessons Learned
 "@
 
     Set-Content -Path "$SdkDir\memory\MEMORY.md" -Encoding UTF8 -Value @"
@@ -122,19 +117,6 @@ See [[../00-context|$Family family context]] for all repos.
 - Follow global CLAUDE.md + workflow-protocol.md rules
 
 ## Last Crystallized: $Today
-"@
-
-    Set-Content -Path "$SdkDir\90-lessons.md" -Encoding UTF8 -Value @"
----
-id: "$Family-$Component-lessons"
-type: lesson
-status: active
-owner: manu
-tags: [work, sdk, $Family]
----
-# Lessons Learned - $Component
-
-*Record non-trivial bugs and decisions here. Promoted to 00_meta/patterns/ if recurring.*
 "@
 
     # Create parent family context if it doesn't exist
@@ -253,9 +235,7 @@ $ProjectKbDir = "$KnowledgeHome\10_projects\$ProjectBaseName"
 
 Write-Info "Initializing Knowledge Vault structure..."
 
-foreach ($subDir in @('30-architecture', '40-runbooks', '50-troubleshooting', 'memory')) {
-    New-Item -ItemType Directory -Path "$ProjectKbDir\$subDir" -Force | Out-Null
-}
+New-Item -ItemType Directory -Path "$ProjectKbDir\memory" -Force | Out-Null
 
 # 00-context.md
 if (-not (Test-Path "$ProjectKbDir\00-context.md")) {
@@ -286,12 +266,11 @@ created: "$Today"
 - **Production:**
 
 ## Knowledge Structure
-- [[10-roadmap]]: Planning & Strategy
-- [[11-tasks]]: Active Backlog
-- [[30-architecture]]: ADRs and Technical Decisions
-- [[40-runbooks]]: Operational Guides
-- [[50-troubleshooting]]: Known Issues
-- [[90-lessons]]: Lessons Learned
+Per [[pattern-knowledge-placement]]: build/operate docs live in the **repo**; this store keeps only decide/personal layers. Do NOT seed vault-local 30-architecture/, 40-runbooks/, 50-troubleshooting/, 90-lessons.md.
+
+**In the repo** (~/Projects/$ProjectBaseName/): docs/adr/, docs/runbooks/, docs/troubleshooting/, docs/lessons.md, specs/<id>/.
+
+**In this store:** [[10-roadmap]] (strategy), [[11-tasks]] (strategic backlog), [[memory/MEMORY]] (AI memory).
 
 ## Development Flow
 1. Feature branch from ``main``
@@ -345,22 +324,6 @@ Progress: [..........] 0%
 ## In Progress
 
 ## Done
-"@
-}
-
-# 90-lessons.md
-if (-not (Test-Path "$ProjectKbDir\90-lessons.md")) {
-    Set-Content -Path "$ProjectKbDir\90-lessons.md" -Encoding UTF8 -Value @"
----
-id: "$ProjectBaseName-lessons"
-type: lesson
-status: active
-owner: manu
-tags: []
----
-# Lessons Learned - $ProjectBaseName
-
-*Non-trivial bugs and decisions. Promoted to 00_meta/patterns/ if recurring across projects.*
 "@
 }
 
@@ -620,4 +583,4 @@ Write-Host ""
 Write-Host "Structure:" -ForegroundColor Cyan
 Write-Host "  CLAUDE.md / AGY.md         - AI Memory files (Dual-Core)"
 Write-Host "  .claude\skills\            - Custom skills"
-Write-Host "  Knowledge Vault updated    - 11-tasks.md & 90-lessons.md in knowledge/10_projects/"
+Write-Host "  Knowledge Vault updated    - 00-context.md & 11-tasks.md in knowledge/10_projects/"

--- a/scripts/init-project.sh
+++ b/scripts/init-project.sh
@@ -20,7 +20,7 @@ if [ "${1:-}" = "--work-sdk" ]; then
     SDK_DIR="$KNOWLEDGE_HOME/50_work/45-development/$FAMILY/$COMPONENT"
 
     printf '[INFO] Creating work SDK vault entry: 50_work/45-development/%s/%s\n' "$FAMILY" "$COMPONENT"
-    mkdir -p "$SDK_DIR/30-architecture" "$SDK_DIR/40-runbooks" "$SDK_DIR/50-troubleshooting" "$SDK_DIR/memory"
+    mkdir -p "$SDK_DIR/memory"
 
     cat > "$SDK_DIR/00-context.md" << EOF
 ---
@@ -51,11 +51,8 @@ See [[../00-context|$FAMILY family context]] for all repos.
 - **Real repo path:** Fill in source_path above with actual \${PROJECTS_PATH}/... path
 
 ## Knowledge Structure
-- [[30-architecture]]: ADRs & Technical Decisions
-- [[40-runbooks]]: Operational Guides
-- [[50-troubleshooting]]: Known Issues
+Per [[pattern-knowledge-placement]]: build/operate docs (ADRs, runbooks, troubleshooting, lessons) live in the repo \`docs/\`; this entry keeps only decide/personal layers.
 - [[memory/MEMORY]]: Session memory
-- [[90-lessons]]: Lessons Learned
 
 ## Development Flow
 1. Open Claude in the real repo (see source_path)
@@ -76,19 +73,6 @@ EOF
 - Follow global CLAUDE.md + workflow-protocol.md rules
 
 ## Last Crystallized: $TODAY
-EOF
-
-    cat > "$SDK_DIR/90-lessons.md" << EOF
----
-id: "${FAMILY}-${COMPONENT}-lessons"
-type: lesson
-status: active
-owner: manu
-tags: [work, sdk, $FAMILY]
----
-# Lessons Learned — ${COMPONENT}
-
-*Record non-trivial bugs and decisions here. Promoted to 00_meta/patterns/ if recurring.*
 EOF
 
     # Create parent family context if it doesn't exist
@@ -212,7 +196,7 @@ PROJECT_KB_DIR="${KNOWLEDGE_HOME}/10_projects/${ACTUAL_PROJECT_NAME}"
 
 log_info "Initializing Knowledge Vault structure..."
 TODAY=$(date +%Y-%m-%d)
-mkdir -p "$PROJECT_KB_DIR/30-architecture" "$PROJECT_KB_DIR/40-runbooks" "$PROJECT_KB_DIR/50-troubleshooting" "$PROJECT_KB_DIR/memory"
+mkdir -p "$PROJECT_KB_DIR/memory"
 
 # 00-context.md (full project context — fill in after init)
 if [ ! -f "$PROJECT_KB_DIR/00-context.md" ]; then
@@ -243,12 +227,11 @@ created: "$TODAY"
 - **Production:**
 
 ## Knowledge Structure
-- [[10-roadmap]]: Planning & Strategy
-- [[11-tasks]]: Active Backlog
-- [[30-architecture]]: ADRs & Technical Decisions
-- [[40-runbooks]]: Operational Guides
-- [[50-troubleshooting]]: Known Issues
-- [[90-lessons]]: Lessons Learned
+Per [[pattern-knowledge-placement]]: build/operate docs live in the **repo**; this store keeps only decide/personal layers. Do NOT seed vault-local \`30-architecture/\`, \`40-runbooks/\`, \`50-troubleshooting/\`, \`90-lessons.md\`.
+
+**In the repo** (\`~/Projects/${ACTUAL_PROJECT_NAME}/\`): \`docs/adr/\`, \`docs/runbooks/\`, \`docs/troubleshooting/\`, \`docs/lessons.md\`, \`specs/<id>/\`.
+
+**In this store:** [[10-roadmap]] (strategy) · [[11-tasks]] (strategic backlog) · [[memory/MEMORY]] (AI memory).
 
 ## Development Flow
 1. Feature branch from \`main\`
@@ -302,22 +285,6 @@ Progress: [..........] 0%
 ## In Progress
 
 ## Done
-EOF
-fi
-
-# 90-lessons.md
-if [ ! -f "$PROJECT_KB_DIR/90-lessons.md" ]; then
-cat > "$PROJECT_KB_DIR/90-lessons.md" << EOF
----
-id: "${ACTUAL_PROJECT_NAME}-lessons"
-type: lesson
-status: active
-owner: manu
-tags: []
----
-# Lessons Learned — ${ACTUAL_PROJECT_NAME}
-
-*Non-trivial bugs and decisions. Promoted to 00_meta/patterns/ if recurring across projects.*
 EOF
 fi
 
@@ -501,4 +468,4 @@ log_success "Project initialized with Dual AI Configuration"
 log_info "Structure:"
 echo "  CLAUDE.md / AGY.md         - AI Memory files (Dual-Core)"
 echo "  .claude/skills/            - Custom skills"
-echo "  Knowledge Vault updated    - 11-tasks.md & 90-lessons.md in knowledge/10_projects/"
+echo "  Knowledge Vault updated    - 00-context.md & 11-tasks.md in knowledge/10_projects/"

--- a/tests/init-project-ps1.bats
+++ b/tests/init-project-ps1.bats
@@ -61,8 +61,10 @@ setup() {
     grep -q '11-tasks.md' "$PS1_SCRIPT"
 }
 
-@test "init-project.ps1 creates 90-lessons.md" {
-    grep -q '90-lessons.md' "$PS1_SCRIPT"
+@test "init-project.ps1 does not seed 90-lessons.md (knowledge-placement)" {
+    # Lessons live in the repo docs/lessons.md, not the vault — the script must
+    # not Set-Content a vault 90-lessons.md (the guidance text mentioning it is fine).
+    ! grep -qE 'Set-Content.*90-lessons\.md' "$PS1_SCRIPT"
 }
 
 @test "init-project.ps1 injects CLAUDE.md" {

--- a/tests/init-project.bats
+++ b/tests/init-project.bats
@@ -31,8 +31,15 @@ teardown() {
     
     local kb_dir="$MOCK_HOME/Projects/knowledge/10_projects/$(basename "$TEST_DIR")"
     [[ -d "$kb_dir" ]]
+    [[ -f "$kb_dir/00-context.md" ]]
     [[ -f "$kb_dir/11-tasks.md" ]]
-    [[ -f "$kb_dir/90-lessons.md" ]]
+    [[ -d "$kb_dir/memory" ]]
+    # knowledge-placement (slim store): operate-layer folders + 90-lessons.md
+    # live in the repo docs/, NOT the vault. Regression guard.
+    [[ ! -d "$kb_dir/30-architecture" ]]
+    [[ ! -d "$kb_dir/40-runbooks" ]]
+    [[ ! -d "$kb_dir/50-troubleshooting" ]]
+    [[ ! -f "$kb_dir/90-lessons.md" ]]
 }
 
 @test "init-project.sh creates structure under zsh" {


### PR DESCRIPTION
## Problem

`init-project.{sh,ps1}` scaffolded vault-local `30-architecture/`, `40-runbooks/`, `50-troubleshooting/` and `90-lessons.md` for every project — directly contradicting `templates/project-context.md`, which already mandates the knowledge-placement slim store-side layout (*"Do NOT seed vault-local 30-architecture/, 40-runbooks/, 50-troubleshooting/, 90-lessons.md"*). The script and its own template were a broken SSOT: the template predicated the new model, the generator kept emitting the old one.

This is the root-cause generator behind the per-project mirror-`_index` stubs that accumulate in the vault and drift from the repo `docs/`.

## Change

Both modes (regular + `--work-sdk`) now scaffold only the **decide/personal** layer:
- `mkdir` reduced to `memory/` only (no operate-layer folders).
- `00-context.md` Knowledge Structure section points at the repo `docs/` (per `pattern-knowledge-placement`).
- Drop `90-lessons.md` creation (project lessons live in repo `docs/lessons.md`).
- Summary line updated.

## Verification

- `bash -n scripts/init-project.sh` → PASS
- `scripts/init-project.ps1` here-strings balanced (10 openers / 10 closers)
- No residual creation of `30/40/50` or `90-lessons.md` in either script
- pre-commit (gitleaks + dotfiles tests) → PASS

## SDD skip rationale

Mechanical alignment of `init-project.{sh,ps1}` to an already-decided model — no new contract or design decision. `templates/project-context.md` and `pattern-knowledge-placement` already mandate the slim store-side layout; the script was simply not obeying it (a broken template↔script SSOT). The 106-LOC count is inflated by removed heredoc boilerplate (the `90-lessons.md` templates); the behavioral change is small: drop 3 `mkdir` dirs + 1 generated file + reword one doc section. Scaffolding-contract tests updated to the new behavior (`tests/init-project*.bats`), green locally and pre-commit.
