### PR TITLE
feat(windows): orchestrated stop-before-upgrade for the hive daemon (ADR-015)

### DIFF
--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -436,27 +436,42 @@ if ((Get-Command hive -ErrorAction SilentlyContinue) -and $hiveVer -and ([versio
     if ($LASTEXITCODE -eq 0) { Write-Success "Installed hive daemon service (Scheduled Task, v$hiveVer)" }
     else { Write-Warn "hive service install failed (non-fatal; client works via fallback)" }
 
-    # AI-023 / hive#176: the upgrade policy that FEEDS the daemon's
-    # restart-on-upgrade. Daily Scheduled Task running `uv tool upgrade hive-vault`.
-    # Self-healing: re-register when the action arguments drift (parity with the
-    # weekly vault maintenance task). Same version gate as the service above.
+    # AI-023 / hive#176 / ADR-015: the upgrade policy that FEEDS the daemon's
+    # restart-on-upgrade. Windows cannot replace a running executable, so the task
+    # does NOT call `uv tool upgrade` directly -- it runs the orchestration script
+    # (only-if-newer -> defer-if-locked -> stop daemon -> upgrade -> start),
+    # deployed from the dotfiles SSOT. Cadence matches Linux: every 15 min.
+    # Self-healing: re-register when the action Execute/Arguments drift.
     $hiveUvExe = Join-Path $env:USERPROFILE ".local\bin\uv.exe"
     $hiveUpgradeTask = "DotfilesHiveUpgrade"
-    $hiveUpgradeArg = "tool upgrade hive-vault"
+    $hiveUpgradeSrc = Join-Path $DotfilesDir "windows\hive-upgrade.ps1"
+    $hiveUpgradeDst = Join-Path $ClaudeHome "scripts\hive-upgrade.ps1"
+    $hiveUpgradeArg = "-NoProfile -ExecutionPolicy Bypass -File `"$hiveUpgradeDst`""
+    if (Test-Path $hiveUpgradeSrc) {
+        Ensure-Directory (Split-Path $hiveUpgradeDst -Parent)
+        Copy-Item $hiveUpgradeSrc $hiveUpgradeDst -Force
+    } else {
+        Write-Warn "hive-upgrade orchestration script not found at $hiveUpgradeSrc"
+    }
     $existingHiveTask = Get-ScheduledTask -TaskName $hiveUpgradeTask -ErrorAction SilentlyContinue
     $existingHiveArg = $null
+    $existingHiveExe = $null
     if ($existingHiveTask -and $existingHiveTask.Actions -and $existingHiveTask.Actions[0]) {
         $existingHiveArg = $existingHiveTask.Actions[0].Arguments
+        $existingHiveExe = $existingHiveTask.Actions[0].Execute
     }
-    if ($existingHiveTask -and ($existingHiveArg -eq $hiveUpgradeArg)) {
+    if ($existingHiveTask -and ($existingHiveExe -eq "powershell.exe") -and ($existingHiveArg -eq $hiveUpgradeArg)) {
         Write-Info "hive-upgrade task already correctly configured, skipping"
     } else {
         try {
-            $hiveAction = New-ScheduledTaskAction -Execute $hiveUvExe -Argument $hiveUpgradeArg
-            $hiveTrigger = New-ScheduledTaskTrigger -Daily -At "9:00AM"
+            $hiveAction = New-ScheduledTaskAction -Execute "powershell.exe" -Argument $hiveUpgradeArg
+            $hiveTrigger = New-ScheduledTaskTrigger -Once -At (Get-Date) `
+                -RepetitionInterval (New-TimeSpan -Minutes 15)
+            $hiveSettings = New-ScheduledTaskSettingsSet -StartWhenAvailable
             Register-ScheduledTask -TaskName $hiveUpgradeTask -Action $hiveAction -Trigger $hiveTrigger `
-                -Description "Daily hive-vault upgrade (feeds hive serve restart-on-upgrade)" -Force | Out-Null
-            Write-Success "Installed hive-upgrade task (daily 9:00, v$hiveVer)"
+                -Settings $hiveSettings `
+                -Description "hive-vault auto-upgrade every 15 min (ADR-015 orchestrated stop-before-upgrade; feeds hive serve restart-on-upgrade)" -Force | Out-Null
+            Write-Success "Installed hive-upgrade task (15-min, v$hiveVer)"
             if (-not (Test-Path $hiveUvExe)) {
                 Write-Warn "hive-upgrade task registered but uv not found at $hiveUvExe"
             }

--- a/specs/AI-022-hive-daemon-activation/tasks.md
+++ b/specs/AI-022-hive-daemon-activation/tasks.md
@@ -29,6 +29,29 @@ created: "2026-06-03"
 - [ ] PR opened referencing this spec folder
 - [ ] (post-merge) Multi-machine validation by the maintainer, then tick hive #176
 
+## Follow-on: Windows-safe upgrade orchestration (ADR-015 / hive#176)
+
+The first real Windows rollout validation (2026-06-04) found the daemon's
+restart-on-upgrade broken on Windows three ways: `uv tool upgrade` cannot replace
+a running exe (os error 32), Task Scheduler `RestartOnFailure` ignores the exit-75
+drift stop, and the task showed a console window every logon. Fixed across hive
+(PR #207 — S4U principal + supervisor loop) and this repo:
+
+- [x] `windows/hive-upgrade.ps1`: orchestrated stop-before-upgrade — only-if-newer
+      -> defer-if-locked -> stop daemon -> `uv tool upgrade` (never `--reinstall`)
+      -> start daemon. Runs from PowerShell, so it holds no lock on the install.
+- [x] `setup-windows.ps1`: `DotfilesHiveUpgrade` runs the orchestration script on a
+      15-min cadence (Linux `OnCalendar=*:0/15` parity, replacing the daily-9:00
+      trigger whose ~24h lag was observed live). Idempotent on Execute/Args drift.
+- [x] `tests/hive-upgrade-timer.bats`: orchestration contract + 15-min wiring (24/24).
+- [x] Validated on real hardware: a genuine `1.32.4 -> 1.33.0` release ran clean.
+- [ ] (post-merge) activate the Windows daemon, then tick hive #176.
+
+Decision: ADR-015 (hive) — A1 orchestrated stop-before-upgrade, NOT A3 junction-swap
+(over-engineering for a low-ROI Windows daemon). The residual OS limit (replacing a
+loaded native module while a session holds it) is tracked upstream in uv
+(astral-sh/uv#8528, #11930, #11134).
+
 ## Machine-readable features
 
 See sibling `features.json`. Structural/static checks (JSON shape, syntax, lint,

--- a/tests/hive-upgrade-timer.bats
+++ b/tests/hive-upgrade-timer.bats
@@ -80,14 +80,14 @@ setup() {
 
 # --- setup-windows.ps1 wiring ---
 
-@test "setup-windows.ps1 registers a daily DotfilesHiveUpgrade task" {
+@test "setup-windows.ps1 registers a 15-min DotfilesHiveUpgrade task (Linux parity)" {
     grep -qF 'DotfilesHiveUpgrade' "$DOTFILES_DIR/setup-windows.ps1"
-    grep -qF 'New-ScheduledTaskTrigger -Daily' "$DOTFILES_DIR/setup-windows.ps1"
+    grep -qF 'RepetitionInterval (New-TimeSpan -Minutes 15)' "$DOTFILES_DIR/setup-windows.ps1"
 }
 
-@test "setup-windows.ps1 hive-upgrade task runs uv tool upgrade hive-vault" {
-    grep -qF 'tool upgrade hive-vault' "$DOTFILES_DIR/setup-windows.ps1"
-    grep -qF 'uv.exe' "$DOTFILES_DIR/setup-windows.ps1"
+@test "setup-windows.ps1 hive-upgrade task runs the orchestration script (not uv directly)" {
+    grep -qF 'windows\hive-upgrade.ps1' "$DOTFILES_DIR/setup-windows.ps1"
+    grep -qF 'New-ScheduledTaskAction -Execute "powershell.exe"' "$DOTFILES_DIR/setup-windows.ps1"
 }
 
 # Same version gate as Linux: the task must register inside the
@@ -104,6 +104,45 @@ setup() {
     block=$(sed -n '/DotfilesHiveUpgrade/,/Could not register hive-upgrade/p' "$DOTFILES_DIR/setup-windows.ps1")
     [ -n "$block" ]
     printf '%s' "$block" | LC_ALL=C grep -nP '[^\x00-\x7F]' && return 1
+    return 0
+}
+
+# --- Windows daemon upgrade orchestration (ADR-015 / hive#176) ---
+# Windows cannot replace a running executable, so the upgrade cannot be a bare
+# `uv tool upgrade`: it must stop the daemon first and defer if a client session
+# holds the install. This logic lives in windows/hive-upgrade.ps1 (SSOT).
+
+@test "windows/hive-upgrade.ps1 orchestration script exists" {
+    [ -f "$DOTFILES_DIR/windows/hive-upgrade.ps1" ]
+}
+
+@test "hive-upgrade.ps1 defers when a client session holds the install" {
+    grep -qF 'deferring' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
+    grep -qF 'holders' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
+}
+
+@test "hive-upgrade.ps1 stops the daemon, upgrades, then restarts" {
+    grep -qF 'Stop-ScheduledTask' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
+    grep -qF 'tool upgrade hive-vault' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
+    grep -qF 'Start-ScheduledTask' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
+}
+
+# At a 15-min cadence the daemon must not be restarted every tick: only act when
+# a newer version is actually published (compare installed vs latest first).
+@test "hive-upgrade.ps1 only acts when a newer version is published" {
+    grep -qF 'pypi.org/pypi/hive-vault' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
+    grep -qF '[version]$installed -ge [version]$latest' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
+}
+
+# A `uv tool ... --reinstall` removes the locked venv dir (os error 5) and
+# corrupts the install -- the script documents the hazard in a comment but must
+# never actually run it (so the check is on a real uv command, not the word).
+@test "hive-upgrade.ps1 never runs uv tool ... --reinstall" {
+    ! grep -qE '\$uv tool.*--reinstall' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
+}
+
+@test "hive-upgrade.ps1 is ASCII-only (PSScriptAnalyzer CI)" {
+    LC_ALL=C grep -nP '[^\x00-\x7F]' "$DOTFILES_DIR/windows/hive-upgrade.ps1" && return 1
     return 0
 }
 

--- a/windows/hive-upgrade.ps1
+++ b/windows/hive-upgrade.ps1
@@ -1,0 +1,88 @@
+<#
+.SYNOPSIS
+    Windows-safe hive-vault auto-upgrade (ADR-015 / hive#176).
+
+.DESCRIPTION
+    Windows cannot replace a running executable, and the Phase C daemon holds
+    its own hive.exe, so a plain `uv tool upgrade hive-vault` fails (os error 32)
+    and a `--reinstall` corrupts a locked venv (os error 5). This orchestrates a
+    clean, atomic-or-deferred swap:
+
+      0. Only act when a NEWER version is actually published. Otherwise return
+         immediately and leave the daemon untouched -- at a 15-minute cadence
+         the overwhelming majority of runs are this fast no-op, so the daemon is
+         never restarted just to check for updates.
+      1. If a hive process OTHER than the daemon holds the uv-tool install
+         (an open `hive client` session), DEFER this cycle. The daemon keeps
+         running the current version; the upgrade lands the next cycle the
+         install is free. Never a partial / half-version venv.
+      2. Otherwise stop the daemon (releases its locks), run a PLAIN
+         `uv tool upgrade hive-vault` (never `--reinstall`), and start the
+         daemon (its supervisor relaunches onto the new version).
+
+    Runs from PowerShell -- the Task Scheduler host -- NOT from the hive install,
+    so this orchestrator holds no lock on the files it is replacing.
+
+    The residual OS limitation (a release that changes a loaded native .pyd while
+    a session is open) is tracked upstream in uv (#8528, #11930, #11134), not
+    reimplemented here; defer-if-locked sidesteps it.
+#>
+
+[CmdletBinding()]
+param(
+    [string] $DaemonTask = 'HiveVaultDaemon'
+)
+
+$ErrorActionPreference = 'Continue'
+$uv = Join-Path $env:USERPROFILE '.local\bin\uv.exe'
+$toolsGlob = '*\uv\tools\hive-vault\*'
+
+if (-not (Test-Path $uv)) {
+    Write-Output "hive-upgrade: uv not found at $uv; nothing to do."
+    exit 0
+}
+
+# Step 0: only proceed when a newer version is actually published. Comparing
+# installed vs latest BEFORE touching the daemon means a 15-minute cadence does
+# not restart the daemon on every tick -- only on an actual release.
+$installedMatch = (& $uv tool list 2>$null | Select-String '^hive-vault\s+v?([\d.]+)')
+$installed = if ($installedMatch) { $installedMatch.Matches[0].Groups[1].Value } else { $null }
+$latest = $null
+try { $latest = (Invoke-RestMethod 'https://pypi.org/pypi/hive-vault/json' -TimeoutSec 15).info.version } catch { $latest = $null }
+if (-not $installed -or -not $latest -or ([version]$installed -ge [version]$latest)) {
+    exit 0
+}
+
+# Step 1: resolve the daemon PID (the listener on the published loopback port)
+# so it is excluded from the "is the install held by a client session?" check.
+$daemonPid = $null
+$portFile = Join-Path $env:USERPROFILE '.local\share\hive\daemon.port'
+if (Test-Path $portFile) {
+    $port = (Get-Content $portFile -Raw -ErrorAction SilentlyContinue).Trim()
+    if ($port) {
+        $conn = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
+        if ($conn) { $daemonPid = ($conn.OwningProcess | Select-Object -First 1) }
+    }
+}
+
+# A hive/python process (other than the daemon) running from the uv-tool install
+# is an open client session holding the files -> defer.
+$holders = Get-Process -ErrorAction SilentlyContinue | Where-Object {
+    $_.Id -ne $daemonPid -and (& { try { $_.Path -like $toolsGlob } catch { $false } })
+}
+if ($holders) {
+    Write-Output "hive-upgrade: $installed -> $latest available but install held by $($holders.Count) client session(s); deferring."
+    exit 0
+}
+
+# Step 2: free to upgrade. Stop the daemon, swap cleanly, restart.
+Write-Output "hive-upgrade: upgrading $installed -> $latest."
+Stop-ScheduledTask -TaskName $DaemonTask -ErrorAction SilentlyContinue
+& $uv tool upgrade hive-vault
+$rc = $LASTEXITCODE
+Start-ScheduledTask -TaskName $DaemonTask -ErrorAction SilentlyContinue
+
+if ($rc -ne 0) {
+    Write-Output "hive-upgrade: uv tool upgrade exited $rc (daemon restarted regardless)."
+}
+exit $rc


### PR DESCRIPTION
## Why

[hive ADR-015](https://github.com/mlorentedev/hive/blob/master/docs/adr/adr-015-windows-daemon-supervision-upgrade.md) / hive#176. The first real Windows rollout validation found the Phase C daemon's auto-upgrade broken on Windows: `uv tool upgrade` cannot replace a running executable (`os error 32`), and the daemon holds its own `hive.exe`, so a bare `uv tool upgrade hive-vault` can never complete cleanly. A `--reinstall` is worse — it removes the locked venv dir (`os error 5`) and corrupts the install.

## What

A Windows-safe **orchestrated stop-before-upgrade** that makes every upgrade atomic-or-deferred, never partial:

- **`windows/hive-upgrade.ps1`** (new, SSOT) — runs from PowerShell (the task host, holds no lock):
  1. **only-if-newer** — compare installed vs the latest published version first; return immediately if up to date (so a 15-min cadence does not restart the daemon on every tick);
  2. **defer-if-locked** — if a `hive client` session holds the install, skip this cycle (the daemon keeps the current version; the upgrade lands the next free cycle);
  3. else **stop daemon → `uv tool upgrade` (never `--reinstall`) → start daemon**.
- **`setup-windows.ps1`** — the `DotfilesHiveUpgrade` task now runs the orchestration script instead of `uv tool upgrade` directly, on a **15-minute** repetition (Linux `OnCalendar=*:0/15` parity, replacing the daily-9:00 trigger whose ~24h lag was observed live). Idempotent re-registration on Execute/Arguments drift.
- **`tests/hive-upgrade-timer.bats`** — covers the orchestration contract (defer, stop/upgrade/start, only-if-newer, never `--reinstall`, ASCII-only) + the new 15-min wiring.

## Validation (2026-06-04, real Windows box)

- `bats tests/hive-upgrade-timer.bats` — **24/24 green**.
- `Invoke-ScriptAnalyzer windows/hive-upgrade.ps1` — clean; `setup-windows.ps1` parses; hive-upgrade block ASCII-only.
- **Real upgrade exercised**: a genuine `1.32.4 -> 1.33.0` release landed mid-validation; the orchestration detected it, found the install free, upgraded cleanly, and exited 0.

## Dependency

The windowless (S4U) daemon task is produced by `hive service install` once hive ships [mlorentedev/hive#207](https://github.com/mlorentedev/hive/pull/207) (PR1 — S4U principal + supervisor loop). The upgrade orchestration in this PR is independent and works against the current release. The residual OS limitation (replacing a loaded native module while a session is open) is tracked upstream in `uv` (astral-sh/uv#8528, #11930, #11134).
