### PR TITLE
fix(setup-windows): register hive-upgrade task windowless via S4U principal

### DIFF
--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -138,6 +138,29 @@ function Backup-AndRestoreClaudeJson {
     }
 }
 
+# ADR-015 / dotfiles#230: single registration point for hive Scheduled Tasks so
+# they ALWAYS run windowless. A task registered without an explicit principal
+# defaults to the Interactive logon type, which runs in the user's desktop
+# session and pops a console window every tick for a powershell.exe action. An
+# S4U principal ("run whether the user is logged on or not", no stored password,
+# no admin) runs the task in session 0 -- the non-interactive session with no
+# desktop -- so no window can appear. This matches the daemon task, which hive's
+# own render_windows_task_xml already registers as S4U. Route every hive task
+# through here so the windowless guarantee cannot be forgotten on a future task.
+function Register-HiveScheduledTask {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$TaskName,
+        [Parameter(Mandatory)]$Action,
+        [Parameter(Mandatory)]$Trigger,
+        [Parameter(Mandatory)]$Settings,
+        [Parameter(Mandatory)][string]$Description
+    )
+    $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType S4U -RunLevel Limited
+    Register-ScheduledTask -TaskName $TaskName -Action $Action -Trigger $Trigger `
+        -Settings $Settings -Principal $principal -Description $Description -Force | Out-Null
+}
+
 # Merge `ai/claude/settings.json` template into the deployed `~/.claude/settings.json`
 # per the per-key policy in specs/SDD-002-settings-portability/proposal.md. Bootstrap
 # when target missing. Preserves user customizations (Read paths,
@@ -441,12 +464,15 @@ if ((Get-Command hive -ErrorAction SilentlyContinue) -and $hiveVer -and ([versio
     # does NOT call `uv tool upgrade` directly -- it runs the orchestration script
     # (only-if-newer -> defer-if-locked -> stop daemon -> upgrade -> start),
     # deployed from the dotfiles SSOT. Cadence matches Linux: every 15 min.
-    # Self-healing: re-register when the action Execute/Arguments drift.
+    # Self-healing: re-register when the action OR the S4U principal drift, so a
+    # box that still has the old Interactive (windowed) task gets repaired.
     $hiveUvExe = Join-Path $env:USERPROFILE ".local\bin\uv.exe"
     $hiveUpgradeTask = "DotfilesHiveUpgrade"
     $hiveUpgradeSrc = Join-Path $DotfilesDir "windows\hive-upgrade.ps1"
     $hiveUpgradeDst = Join-Path $ClaudeHome "scripts\hive-upgrade.ps1"
-    $hiveUpgradeArg = "-NoProfile -ExecutionPolicy Bypass -File `"$hiveUpgradeDst`""
+    # -WindowStyle Hidden is belt-and-suspenders; the S4U principal applied by
+    # Register-HiveScheduledTask (session 0) is what actually guarantees no window.
+    $hiveUpgradeArg = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$hiveUpgradeDst`""
     if (Test-Path $hiveUpgradeSrc) {
         Ensure-Directory (Split-Path $hiveUpgradeDst -Parent)
         Copy-Item $hiveUpgradeSrc $hiveUpgradeDst -Force
@@ -456,11 +482,13 @@ if ((Get-Command hive -ErrorAction SilentlyContinue) -and $hiveVer -and ([versio
     $existingHiveTask = Get-ScheduledTask -TaskName $hiveUpgradeTask -ErrorAction SilentlyContinue
     $existingHiveArg = $null
     $existingHiveExe = $null
+    $existingHiveLogon = $null
     if ($existingHiveTask -and $existingHiveTask.Actions -and $existingHiveTask.Actions[0]) {
         $existingHiveArg = $existingHiveTask.Actions[0].Arguments
         $existingHiveExe = $existingHiveTask.Actions[0].Execute
+        if ($existingHiveTask.Principal) { $existingHiveLogon = "$($existingHiveTask.Principal.LogonType)" }
     }
-    if ($existingHiveTask -and ($existingHiveExe -eq "powershell.exe") -and ($existingHiveArg -eq $hiveUpgradeArg)) {
+    if ($existingHiveTask -and ($existingHiveExe -eq "powershell.exe") -and ($existingHiveArg -eq $hiveUpgradeArg) -and ($existingHiveLogon -eq "S4U")) {
         Write-Info "hive-upgrade task already correctly configured, skipping"
     } else {
         try {
@@ -468,10 +496,10 @@ if ((Get-Command hive -ErrorAction SilentlyContinue) -and $hiveVer -and ([versio
             $hiveTrigger = New-ScheduledTaskTrigger -Once -At (Get-Date) `
                 -RepetitionInterval (New-TimeSpan -Minutes 15)
             $hiveSettings = New-ScheduledTaskSettingsSet -StartWhenAvailable
-            Register-ScheduledTask -TaskName $hiveUpgradeTask -Action $hiveAction -Trigger $hiveTrigger `
+            Register-HiveScheduledTask -TaskName $hiveUpgradeTask -Action $hiveAction -Trigger $hiveTrigger `
                 -Settings $hiveSettings `
-                -Description "hive-vault auto-upgrade every 15 min (ADR-015 orchestrated stop-before-upgrade; feeds hive serve restart-on-upgrade)" -Force | Out-Null
-            Write-Success "Installed hive-upgrade task (15-min, v$hiveVer)"
+                -Description "hive-vault auto-upgrade every 15 min (ADR-015 orchestrated stop-before-upgrade; feeds hive serve restart-on-upgrade)"
+            Write-Success "Installed hive-upgrade task (15-min, windowless S4U, v$hiveVer)"
             if (-not (Test-Path $hiveUvExe)) {
                 Write-Warn "hive-upgrade task registered but uv not found at $hiveUvExe"
             }

--- a/tests/hive-upgrade-timer.bats
+++ b/tests/hive-upgrade-timer.bats
@@ -94,7 +94,7 @@ setup() {
 # `[version]$hiveVer -ge [version]'1.32.0'` branch (after that check).
 @test "setup-windows.ps1 hive-upgrade task is inside the version gate" {
     gate_line=$(grep -n "ge \[version\]'1.32.0'" "$DOTFILES_DIR/setup-windows.ps1" | head -1 | cut -d: -f1)
-    task_line=$(grep -n 'Register-ScheduledTask -TaskName $hiveUpgradeTask' "$DOTFILES_DIR/setup-windows.ps1" | head -1 | cut -d: -f1)
+    task_line=$(grep -n 'Register-HiveScheduledTask -TaskName $hiveUpgradeTask' "$DOTFILES_DIR/setup-windows.ps1" | head -1 | cut -d: -f1)
     [ -n "$gate_line" ] && [ -n "$task_line" ]
     [ "$task_line" -gt "$gate_line" ]
 }
@@ -105,6 +105,33 @@ setup() {
     [ -n "$block" ]
     printf '%s' "$block" | LC_ALL=C grep -nP '[^\x00-\x7F]' && return 1
     return 0
+}
+
+# dotfiles#230: hive Scheduled Tasks must run windowless. A task registered with
+# no explicit principal defaults to the Interactive logon type, runs in the
+# desktop session, and pops a console window every 15-min tick. An S4U principal
+# runs the task in session 0 (no desktop -> no window), with no admin rights.
+@test "setup-windows.ps1 registers hive tasks windowless via an S4U helper" {
+    grep -qF 'function Register-HiveScheduledTask' "$DOTFILES_DIR/setup-windows.ps1"
+    grep -qF -- '-LogonType S4U' "$DOTFILES_DIR/setup-windows.ps1"
+}
+
+# The upgrade task must go through the helper (S4U guaranteed), never the bare
+# Register-ScheduledTask (which would default to the windowed Interactive logon).
+@test "setup-windows.ps1 routes the hive-upgrade task through the S4U helper" {
+    grep -qF 'Register-HiveScheduledTask -TaskName $hiveUpgradeTask' "$DOTFILES_DIR/setup-windows.ps1"
+    ! grep -qF 'Register-ScheduledTask -TaskName $hiveUpgradeTask' "$DOTFILES_DIR/setup-windows.ps1"
+}
+
+@test "setup-windows.ps1 hive-upgrade action is windowless (-WindowStyle Hidden)" {
+    grep -qF -- '-WindowStyle Hidden' "$DOTFILES_DIR/setup-windows.ps1"
+}
+
+# Re-running setup on a box that still has the old Interactive task must repair
+# the principal -- the idempotence check has to inspect the logon type, not just
+# the action's Execute/Arguments.
+@test "setup-windows.ps1 self-heals a drifted (non-S4U) hive-upgrade principal" {
+    grep -qF '$existingHiveLogon -eq "S4U"' "$DOTFILES_DIR/setup-windows.ps1"
 }
 
 # --- Windows daemon upgrade orchestration (ADR-015 / hive#176) ---


### PR DESCRIPTION
## Why

`DotfilesHiveUpgrade` was registered with no explicit principal, so Task Scheduler defaulted it to the **Interactive** logon type. It ran in the desktop session and popped a PowerShell console window on every 15-minute tick. The daemon task (`HiveVaultDaemon`) already runs windowless under an **S4U** principal (session 0, no desktop); the upgrade task never got the same treatment. This is the ADR-015 Regla-del-3 gap: the windowless *contract* generalized across OSes, but the Windows *mechanism* (S4U) reached only one of the two tasks.

## What

- New `Register-HiveScheduledTask` helper: a single registration point that **always** attaches an S4U principal (`LogonType S4U`, `RunLevel Limited`, no admin, no stored password). A future hive task cannot forget the windowless guarantee.
- Route the upgrade task through the helper.
- `-WindowStyle Hidden` on the action as belt-and-suspenders (S4U is the real guarantee; Hidden just covers any pre-S4U edge).
- Extend the idempotence check to also verify `LogonType -eq 'S4U'`, so re-running setup **repairs** a drifted Interactive task instead of skipping it.
- 4 new bats assertions + fix the version-gate test grep to match the helper call.

## Verification

- `pwsh` AST parse: OK
- PSScriptAnalyzer (CI settings): clean
- bats: 28/28 pass (4 new)
- Live task on the maintainer box already re-registered to S4U + hidden for immediate relief.

Closes #230
