### PR TITLE
fix(claude-mem-heal): drain consumer pipe with sed -n 1p to kill hooks.json EPIPE

### DIFF
--- a/scripts/claude-mem-heal.ps1
+++ b/scripts/claude-mem-heal.ps1
@@ -191,13 +191,19 @@ function Repair-ZodDep {
     }
 }
 
-# BUG-017 (2026-05-21): patch hooks.json against the same EPIPE race that
-# BUG-016 closed for .mcp.json. The 6 upstream hooks (Setup, SessionStart x2,
-# UserPromptSubmit, PostToolUse, PreToolUse, Stop) all use the
-# `{ printf; ls; printf; } | while ... break` pipe cascade. When the consumer
-# breaks early, unconsumed producer writes EPIPE on Git Bash Windows.
-# Minimal substitution: `break; }; done` -> `}; done | head -n1` keeps the
-# loop running to completion, then head takes the first printed match.
+# BUG-017 (2026-05-21) + 2026-05-27-claude-mem-heal-consumer-epipe (2026-06-06):
+# rewrite the path-resolution pipe so the consumer never closes early while the
+# inner `while` is still writing. BUG-017 used `}; done | head -n1`, but
+# `head -n1` IS an early-closing consumer: with >=2 matching candidates the loop
+# writes a 2nd line after head has closed its stdin -> consumer-side EPIPE. Node
+# ignores SIGPIPE and Claude Code spawns hooks with that disposition, so the
+# failed write is REPORTED (`printf: write error`) instead of dying silently,
+# surfacing as a hook-error banner on every tool call. Fix: `sed -n 1p` prints
+# only line 1 but reads to EOF (no early `q`), draining the writer so it never
+# closes under it. Normalise BOTH the pristine upstream form (`break; }; done`)
+# and any already-deployed `}; done | head -n1` form, so existing installs
+# converge on the next session with no `/plugin update`. Mirrors
+# scripts/claude-mem-heal.sh::heal_hooks_json.
 function Repair-HooksJson {
     param([string]$Target)
 
@@ -208,31 +214,41 @@ function Repair-HooksJson {
     $content = Get-Content $Target -Raw -ErrorAction SilentlyContinue
     if (-not $content) { return }
 
-    $broken017 = 'break; }; done'
-    $fixed017  = '}; done | head -n1'
+    # EPIPE drain: converge both the pristine pipe and the BUG-017-era head -n1
+    # consumer onto `sed -n 1p` (prints line 1 but reads to EOF -> no early close).
+    $brokenBreak  = 'break; }; done'
+    $brokenHeadN1 = '}; done | head -n1'
+    $drainForm    = '}; done | sed -n 1p'
     # BUG-018: ALL hooks that terminate with `hook claude-code <X>"` lack
     # Claude Code's {"continue":true,"suppressOutput":true} directive. The
     # bun-runner empty-stdin diagnostic (upstream claude-mem#2188) goes to
-    # stdout and Claude Code blocks the operation. User empirically hit
-    # UserPromptSubmit first and Stop minutes later -- regex captures all
-    # 5 (session-init / context / observation / file-context / summarize).
-    # Setup hook's version-check.js terminator is left untouched -- not on
-    # the user hot path (fires only on plugin install/update).
+    # stdout and Claude Code blocks the operation. Regex captures all 5
+    # (session-init / context / observation / file-context / summarize). The
+    # Setup hook's version-check.js terminator is left untouched -- not on the
+    # user hot path (fires only on plugin install/update).
     $pattern018     = 'hook claude-code ([a-z][a-z-]*)"'
     $replacement018 = 'hook claude-code $1 2>/dev/null; echo ''{\"continue\":true,\"suppressOutput\":true}''"'
 
-    $has017 = $content.Contains($broken017)
-    $has018 = $content -match $pattern018
-    if (-not $has017 -and -not $has018) {
+    $hasBreak  = $content.Contains($brokenBreak)
+    $hasHeadN1 = $content.Contains($brokenHeadN1)
+    $has018    = $content -match $pattern018
+    if (-not $hasBreak -and -not $hasHeadN1 -and -not $has018) {
         Write-HealVerbose "hooks.json already healthy: $Target"
         return
     }
 
     $patched = $content
-    if ($has017) {
-        $count017 = ([regex]::Matches($patched, [regex]::Escape($broken017))).Count
-        $patched = $patched.Replace($broken017, $fixed017)
-        Write-HealLog "patched hooks.json (BUG-017, $count017 hook(s) -> head -n1 race-free form): $Target"
+    $epipeFixed = 0
+    if ($hasBreak) {
+        $epipeFixed += ([regex]::Matches($patched, [regex]::Escape($brokenBreak))).Count
+        $patched = $patched.Replace($brokenBreak, $drainForm)
+    }
+    if ($hasHeadN1) {
+        $epipeFixed += ([regex]::Matches($patched, [regex]::Escape($brokenHeadN1))).Count
+        $patched = $patched.Replace($brokenHeadN1, $drainForm)
+    }
+    if ($epipeFixed -gt 0) {
+        Write-HealLog "patched hooks.json (EPIPE drain, $epipeFixed hook(s) -> sed -n 1p): $Target"
     }
     if ($has018) {
         $count018 = ([regex]::Matches($patched, $pattern018)).Count

--- a/scripts/claude-mem-heal.sh
+++ b/scripts/claude-mem-heal.sh
@@ -141,50 +141,48 @@ heal_zod() {
     log "installed missing zod dep in $plugin_dir"
 }
 
-# BUG-017 (2026-05-21): patch hooks.json against the same EPIPE race that
-# BUG-016 closed for .mcp.json. The 6 upstream hooks (Setup, SessionStart x2,
-# UserPromptSubmit, PostToolUse, PreToolUse, Stop) all use the
-# `{ printf; ls; printf; } | while ... break` pipe cascade. When the consumer
-# breaks early, unconsumed producer writes EPIPE on Git Bash Windows.
-# Minimal substitution: `break; }; done` -> `}; done | head -n1` keeps the
-# loop running to completion, then head takes the first printed match.
+# BUG-017 (2026-05-21) + 2026-05-27-claude-mem-heal-consumer-epipe (2026-06-06):
+# rewrite the path-resolution pipe so the consumer never closes early while the
+# inner `while` is still writing. BUG-017 used `... }; done | head -n1`, but
+# `head -n1` IS an early-closing consumer: with >=2 matching candidates (a cache
+# version dir AND the marketplace junction) the loop writes a 2nd line after head
+# has closed its stdin -> consumer-side EPIPE. Node ignores SIGPIPE and Claude
+# Code spawns hooks with that disposition, so the failed write is REPORTED
+# (`printf: write error`) instead of dying silently, surfacing as a hook-error
+# banner on every tool call. Fix: `sed -n 1p` prints only line 1 but reads to
+# EOF (no early `q`), draining the writer so it never closes under it. We
+# normalise BOTH the pristine upstream form (`break; }; done`) and any
+# already-deployed `}; done | head -n1` form, so existing installs converge on
+# the next session with no `/plugin update`.
 #
-# BUG-018 (2026-05-21): after BUG-017 closed the EPIPE race, the
-# UserPromptSubmit hook STILL blocked because its command terminates with
-# `node ... hook claude-code session-init` and does NOT emit Claude Code's
-# `{"continue":true,"suppressOutput":true}` directive. bun-runner.js's
-# empty-stdin diagnostic (upstream claude-mem#2188) goes to stdout, Claude
-# Code reads it as non-continue, blocks the prompt. Heal appends the
-# directive in the same pass.
+# BUG-018 (2026-05-21): hooks terminating with `hook claude-code <X>"` lack
+# Claude Code's `{"continue":true,"suppressOutput":true}` directive; bun-runner's
+# empty-stdin diagnostic (upstream claude-mem#2188) then blocks the operation.
+# Append the directive in the same pass, generic across all 5 hot-path hooks
+# (session-init / context / observation / file-context / summarize). The Setup
+# hook (`version-check.js`) is left untouched -- not on the user hot path.
 heal_hooks_json() {
     target="$1"
     [ -f "$target" ] || { verbose "no hooks.json at $target"; return 0; }
-    # Detect either BUG-017 signature (break; }; done) or BUG-018 signature
-    # (UserPromptSubmit terminator without the continue directive).
-    has_017=$(grep -cF 'break; }; done' "$target" 2>/dev/null || echo 0)
-    has_018=$(grep -cE 'session-init"$|session-init"[^}]*$' "$target" 2>/dev/null | head -1)
-    has_018=${has_018:-0}
-    # Simpler: also check explicitly for the un-patched session-init terminator.
+    # Heal when any signature is present: the pristine EPIPE pipe
+    # (`break; }; done`), the BUG-017-era `head -n1` consumer, or a missing
+    # BUG-018 directive (un-patched `session-init"` terminator).
     if ! grep -qF 'break; }; done' "$target" && \
+       ! grep -qF 'head -n1' "$target" && \
        ! grep -qF 'session-init"' "$target"; then
         verbose "hooks.json already healthy: $target"
         return 0
     fi
-    # Use `#` as sed delimiter -- `|` appears literally in the replacement
-    # (`done | head -n1`) and would confuse `s|...|...|g`.
-    #
-    # BUG-018 substitution is GENERIC across all 5 `hook claude-code <X>"`
-    # terminators (UserPromptSubmit/session-init, SessionStart/context,
-    # PostToolUse/observation, PreToolUse/file-context, Stop/summarize).
-    # The user empirically hit UserPromptSubmit first (BUG-018 narrow scope)
-    # then Stop minutes later (originally deferred as BUG-018b -- now folded
-    # in via regex capture). Setup hook (`version-check.js`) is left untouched:
-    # it only fires on plugin install/update, not user hot path.
+    # `#` sed delimiter -- `|` appears literally in the replacements. `sed -n 1p`
+    # carries no quotes/backslashes/newlines, so it is safe both inside this
+    # single-quoted sed script and inside the hook's JSON string. The two EPIPE
+    # substitutions converge the pristine and head-n1 forms onto the same drain.
     tmp="$target.tmp.$$"
-    sed -e 's#break; }; done#}; done | head -n1#g' \
+    sed -e 's#break; }; done#}; done | sed -n 1p#g' \
+        -e 's#}; done | head -n1#}; done | sed -n 1p#g' \
         -e 's#hook claude-code \([a-z][a-z-]*\)"#hook claude-code \1 2>/dev/null; echo '\''{\\"continue\\":true,\\"suppressOutput\\":true}'\''"#g' \
         "$target" > "$tmp" && mv "$tmp" "$target"
-    log "patched hooks.json (BUG-017 head-n1 + BUG-018 continue-directive on all 5 hooks): $target"
+    log "patched hooks.json (EPIPE drain sed -n 1p + BUG-018 continue-directive): $target"
 }
 
 # BUG-019 (2026-06-05): the claude-mem SessionStart "context" hook injects a

--- a/specs/2026-05-27-claude-mem-heal-consumer-epipe/proposal.md
+++ b/specs/2026-05-27-claude-mem-heal-consumer-epipe/proposal.md
@@ -1,0 +1,118 @@
+---
+id: "2026-05-27-claude-mem-heal-consumer-epipe"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-06-06"
+tags: [spec, proposal, claude-mem, windows, epipe]
+template_version: "1.0"
+---
+
+# 2026-05-27-claude-mem-heal-consumer-epipe
+
+> Regression of BUG-017. Fixes a consumer-side EPIPE in the hooks.json the
+> `claude-mem-heal` scripts deploy. RESUMED 2026-06-06 with **Option A**
+> (minimal `head -n1` → `sed -n 1p` drain), which supersedes the original
+> 2026-05-27 canonical-template-emission plan — see "Decisions" below.
+
+## Why
+
+`claude-mem-heal.{sh,ps1}` patches the `thedotmack/claude-mem` plugin's
+`hooks.json` at every session start. BUG-017 rewrote the path-resolution pipe
+from `... }; done` (with an early `break`) to `... }; done | head -n1` to close
+a **producer**-side EPIPE. That introduced a **consumer**-side EPIPE: the inner
+`while` loop is the writer into `head -n1`; when ≥2 plugin candidates match
+(cache version dir **and** the marketplace junction both contain the hook
+scripts), the loop emits ≥2 lines. `head -n1` prints the first and closes its
+stdin; if the loop is still writing, its next `printf` hits a closed pipe →
+EPIPE. Because Claude Code is a Node process and **Node sets SIGPIPE to
+SIG_IGN**, that disposition is inherited by the spawned hook, so the write
+error is *reported* (`printf: write error: …`) instead of dying silently.
+Claude Code surfaces the non-empty hook stderr as a `PreToolUse/PostToolUse
+hook error` banner on tool calls. It is non-blocking (the `$(…)` capture
+completes before the failing write, so `_P` is set correctly) but pollutes
+every session on Windows.
+
+## What
+
+After this PR the `hooks.json` deployed by `claude-mem-heal.{sh,ps1}` resolves
+the plugin path with `... }; done | sed -n 1p` instead of `... }; done |
+head -n1`. `sed -n 1p` prints only the first line **but reads its input to
+EOF** (no early `q`), so it never closes the pipe while the writer is still
+running — the consumer-side EPIPE is eliminated for any number of matching
+candidates. Both heal scripts also detect and normalise the pre-existing
+`head -n1` form (already deployed on machines healed before this PR), so the
+next session converts them with no `/plugin update` required. Output of the
+discovery (the resolved path) is byte-identical to the `head -n1` form.
+
+## Out of scope
+
+- The `.mcp.json` heal (`heal_mcp_json` / `Repair-McpJson`), which also emits
+  `head -n1`. It is loaded once at MCP-server startup, not per tool call, so it
+  is not the per-call banner source. Its theoretical exposure to the same race
+  is logged under "Risks / open questions" as a follow-up, not fixed here
+  (atomic PR).
+- The original "emit our own canonical hooks.json template" rewrite (rejected —
+  see Decisions).
+- The `init-spec.{sh,ps1}` vault-gate regex gap that rejects `[~]` (paused)
+  entries — surfaced while resuming this task; tracked as a separate follow-up.
+- BUG-019's `neuter_context_hook` behaviour (unchanged; only its sibling
+  `heal_hooks_json` changes).
+
+## Risks / open questions
+
+- **sed availability/behaviour.** `sed -n 1p` (no quotes, no `q`) must read to
+  EOF on the runtime sed (GNU/BSD/busys/MSYS). Guarded by the functional test;
+  `sed` is already assumed present (the heal scripts and hooks use coreutils).
+- **Upstream shape drift.** Detection covers the two known forms
+  (`break; }; done` pristine, `}; done | head -n1` BUG-017-era). If upstream
+  ships a third pipe shape, heal no-ops on it and a new bug is filed — accepted
+  trade-off of keeping the sed-patch architecture (Option A) over a static
+  self-emitted template (Option B), which would instead be fragile to upstream
+  *semantic* drift.
+- **Follow-up:** `.mcp.json` uses the same `head -n1`; same race is possible
+  when ≥2 candidates carry `mcp-server.cjs`. Lower blast radius (one-shot at MCP
+  load, not per tool call). Decide separately whether to apply the same
+  `sed -n 1p` drain there.
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [x] **AC1 (root-cause guard, functional, cross-OS):** under `trap '' PIPE`
+  (Node's SIGPIPE-ignore) with a slow writer, the `head -n1` consumer reports a
+  write error and the `sed -n 1p` consumer does not. (`tests/claude-mem-heal.bats` #18)
+- [x] **AC2 (.sh heal):** `heal_hooks_json` on a `break; }; done` fixture and on
+  a `}; done | head -n1` fixture both yield a file containing `sed -n 1p`, with
+  no `head -n1` remaining, and the BUG-018 continue-directive preserved. (#19, #20)
+- [x] **AC3 (.ps1 parity):** `Repair-HooksJson` produces the equivalent
+  result on the same fixtures (Windows). (`tests/claude-mem-heal-ps1.bats` #22, #23)
+- [x] **AC4 (idempotency):** re-running each heal on its own output is a no-op
+  (file unchanged, "already healthy"/silent). (#21, #24)
+- [x] **AC5 (live):** healing a copy of the actual deployed
+  `~/.claude/.../13.3.0/hooks/hooks.json` converts all 7 `head -n1` to
+  `sed -n 1p`; second run silent; output still valid JSON; diff is surgical.
+
+## Decisions
+
+- **Option A over Option B.** Option B (the paused 2026-05-27 plan: stop
+  patching upstream's shape, emit our own canonical `hooks.json` template with a
+  `_candidates=$(…)` materialise + here-doc `break`) is immune to upstream
+  *shape* changes but **fragile to upstream *semantic* changes** (a new hook
+  stage or changed `node` invocation would make our static template ship a
+  broken/stale hooks.json). claude-mem is volatile (12.7.4 → 13.0.0 → 13.3.0,
+  hooks evolving), so a static self-emitted template is the larger long-term
+  risk. Option A keeps the resilient sed-patch (rewrites only the pipe shape,
+  preserves upstream's `node` invocation) and fixes the EPIPE with a 2-line
+  change: `head -n1` → `sed -n 1p`.
+- **`sed -n 1p` over a `{ read; printf; cat >/dev/null; }` drain.** Equivalent
+  first-line output, but `sed -n 1p` has no quotes/newlines/backslashes, so it
+  needs no JSON-string escaping inside the hook command nor single-quote
+  gymnastics inside the heal's own `sed` script.
+
+## References
+
+- Vault: `10_projects/dotfiles/11-tasks.md` (entry `2026-05-27-claude-mem-heal-consumer-epipe`)
+- Predecessors: `specs/archive/BUG-016-claude-mem-heal-v13-refresh/`,
+  `specs/archive/BUG-017-claude-mem-heal-hooks-json-race/`
+- Upstream: thedotmack/claude-mem#2607 (EPIPE race) — heal becomes a no-op if/when upstream fixes it
+- Related: TEST-001 (#128) wants bats coverage for `claude-mem-heal.{sh,ps1}`

--- a/specs/2026-05-27-claude-mem-heal-consumer-epipe/tasks.md
+++ b/specs/2026-05-27-claude-mem-heal-consumer-epipe/tasks.md
@@ -1,0 +1,37 @@
+---
+tags: [spec, tasks, claude-mem, epipe]
+created: "2026-06-06"
+---
+
+# Tasks - 2026-05-27-claude-mem-heal-consumer-epipe
+
+> TDD order. One task = one focused commit (squashed into one PR). Tick as you go.
+
+## Setup
+
+- [x] Branch created from main: `fix/claude-mem-heal-consumer-epipe`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] Vault entry flipped `[~]` → `[ ]` (resumed), Option-A decision recorded
+
+## Implementation (TDD)
+
+- [x] **RED** — extended `tests/claude-mem-heal.bats` with the functional EPIPE
+  guard (AC1) + structural tests (AC2) + idempotency (AC4). Structural tests
+  confirmed FAILING against the old `head -n1`-emitting code.
+- [x] **GREEN (.sh)** — `heal_hooks_json`: detect `break; }; done` OR `head -n1`;
+  sed-substitute both to `}; done | sed -n 1p`; kept BUG-018 directive sub;
+  refreshed comments + log; dropped 2 dead assignments. bats green.
+- [x] **GREEN (.ps1)** — `Repair-HooksJson`: drain form → `sed -n 1p`; detect +
+  convert existing `head -n1`; refreshed comments + log.
+- [x] **PARITY** — added `tests/claude-mem-heal-ps1.bats` (AC3): drives
+  `Repair-HooksJson` via `pwsh` (cygpath path bridge), same outcome + idempotency.
+- [x] **LIVE (AC5)** — healed a copy of the real deployed `13.3.0/hooks/hooks.json`:
+  7 × `head -n1` → `sed -n 1p`; second run silent; valid JSON; surgical diff.
+
+## Closing
+
+- [x] Every acceptance criterion (AC1–AC5) is covered by ≥1 test or recorded evidence
+- [x] `bats tests/claude-mem-heal.bats tests/claude-mem-heal-ps1.bats` green (25/26; the 1 failure is a pre-existing Windows-only symlink env issue)
+- [x] No unrelated changes in the diff (no `.mcp.json` / no `init-spec` changes)
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder

--- a/specs/2026-05-27-claude-mem-heal-consumer-epipe/tasks.md
+++ b/specs/2026-05-27-claude-mem-heal-consumer-epipe/tasks.md
@@ -34,4 +34,4 @@ created: "2026-06-06"
 - [x] `bats tests/claude-mem-heal.bats tests/claude-mem-heal-ps1.bats` green (25/26; the 1 failure is a pre-existing Windows-only symlink env issue)
 - [x] No unrelated changes in the diff (no `.mcp.json` / no `init-spec` changes)
 - [x] `verification.md` filled in
-- [ ] PR opened referencing this spec folder
+- [x] PR opened referencing this spec folder ([#242](https://github.com/mlorentedev/dotfiles/pull/242))

--- a/specs/2026-05-27-claude-mem-heal-consumer-epipe/verification.md
+++ b/specs/2026-05-27-claude-mem-heal-consumer-epipe/verification.md
@@ -1,0 +1,78 @@
+---
+tags: [spec, verification, claude-mem, epipe]
+created: "2026-06-06"
+---
+
+# Verification - 2026-05-27-claude-mem-heal-consumer-epipe
+
+## Evidence
+
+- [x] **AC1 (root-cause guard, functional, cross-OS)** → `tests/claude-mem-heal.bats`
+  test 18 "consumer pipe: head -n1 races but sed -n 1p drains under SIGPIPE-ignore".
+  Deterministic repro: `trap '' PIPE` (Node's disposition) + slow writer →
+  `head -n1` reports a write error, `sed -n 1p` is clean. Confirmed manually:
+  variant C (slow + trap) printed `printf: write error: Broken pipe` 5/5;
+  variant D (slow, default SIGPIPE) clean 3/3.
+- [x] **AC2 (.sh heal)** → tests 19 (`break; }; done` fixture) + 20 (`head -n1`
+  fixture): both yield `sed -n 1p`, no `head -n1`, BUG-018 directive preserved.
+  Were RED before the fix (produced `head -n1`), GREEN after.
+- [x] **AC3 (.ps1 parity)** → `tests/claude-mem-heal-ps1.bats` tests 22–23: same
+  structural outcome from `Repair-HooksJson` via pwsh.
+- [x] **AC4 (idempotency)** → tests 21 (.sh) + 24 (.ps1): re-heal of the fixed
+  form is a silent no-op, file byte-unchanged.
+- [x] **AC5 (live)** → healed a copy of the real deployed
+  `~/.claude/.../13.3.0/hooks/hooks.json`: `head -n1` 7 → 0, `sed -n 1p` 0 → 7;
+  second run silent; output still valid JSON (6 hook groups / 7 commands);
+  word-level diff shows ONLY `head -n1` → `sed -n 1p` (7×), nothing else touched.
+
+## Test status
+
+- `bats tests/claude-mem-heal.bats tests/claude-mem-heal-ps1.bats` → 25/26 ok.
+  The single failure (test 14, `ensure_marketplace_compat_symlink creates the
+  legacy symlink`) is **pre-existing and environment-only**: Git Bash/MSYS does
+  not create a real symlink without Developer Mode, so `[ -L ... ]` fails
+  locally; it passes on the Linux CI runner and is unrelated to this change
+  (it failed identically before any edit in this branch).
+- `bash -n scripts/claude-mem-heal.sh` → OK (bats test 1). ShellCheck not
+  installed locally; runs in CI.
+- `Invoke-ScriptAnalyzer scripts/claude-mem-heal.ps1 -Severity Error,Warning`
+  → CLEAN (0).
+- No regressions in `heal_mcp_json` / `heal_zod` / symlink tests (unchanged).
+
+## Decisions made during implementation
+
+- **`sed -n 1p` over `head -n1`** (not `1q`): prints line 1 but reads to EOF, so
+  it drains the writer and never closes the pipe under it. No quotes/backslashes
+  /newlines → no JSON-string or sed-script escaping, unlike a `{ read; printf;
+  cat >/dev/null; }` drain.
+- **Option A (sed-patch) over Option B (canonical template emission).** Kept the
+  resilient sed-patch: it only rewrites the pipe shape and preserves upstream's
+  `node` invocation, so it survives upstream *semantic* drift. A static
+  self-emitted hooks.json would be fragile to new hook stages / changed args.
+- **Removed two dead assignments** (`has_017` / `has_018`) in `heal_hooks_json`
+  while rewriting (were computed but never read).
+- **Live ~/.claude left untouched.** The deployed heal copy still carries the
+  old logic until the next `setup` re-deploys scripts; verification used a copy.
+  AC5 evidence is on the real file shape, no live mutation mid-session.
+
+## Promotion candidates
+
+- [ ] Lesson for vault `90-lessons.md`? **no** — project-specific; the
+  cross-OS-via-timing nuance is recorded here + in the proposal.
+- [ ] ADR-worthy? **no** — within the existing claude-mem-heal pattern (BUG-016/017).
+- [ ] New cross-project pattern? **no** — single-project healer.
+
+## Follow-ups surfaced (tracked, not done here — atomic PR)
+
+- `.mcp.json` heal still emits `head -n1`; same race is theoretically possible
+  when ≥2 candidates carry `mcp-server.cjs`. Lower blast radius (one-shot at MCP
+  load, not per tool call). Decide separately whether to apply the same drain.
+- `init-spec.{sh,ps1}` vault-gate regex `\[[ x-]\]` rejects `[~]` (paused)
+  entries, so a resumed paused task can't be scaffolded without `-ForceNoVault`.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/2026-05-27-claude-mem-heal-consumer-epipe/` → `specs/archive/...`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (none)

--- a/tests/claude-mem-heal-ps1.bats
+++ b/tests/claude-mem-heal-ps1.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# Tests for scripts/claude-mem-heal.ps1::Repair-HooksJson
+# (spec 2026-05-27-claude-mem-heal-consumer-epipe).
+#
+# Cross-OS parity for the consumer-EPIPE fix: the PowerShell heal must produce
+# the same structural outcome as claude-mem-heal.sh::heal_hooks_json -- converge
+# both the pristine `break; }; done` form and the BUG-017-era `}; done | head
+# -n1` form onto the EPIPE-safe `}; done | sed -n 1p` drain, while preserving
+# the BUG-018 continue directive. Driven via pwsh against fixtures; no real
+# ~/.claude mutation.
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    export HEAL_PS1="$DOTFILES_DIR/scripts/claude-mem-heal.ps1"
+    if ! command -v pwsh >/dev/null 2>&1; then
+        skip "pwsh not available"
+    fi
+    TMP="$(mktemp -d)"
+    # Point CLAUDE_CONFIG_DIR at the sandbox so dot-sourcing never touches the
+    # real profile and never reads $env:USERPROFILE (StrictMode-safe on Linux).
+    export CLAUDE_CONFIG_DIR="$TMP/claude"
+    mkdir -p "$CLAUDE_CONFIG_DIR"
+    # Function-only copy: truncate before the top-level heal loop, which ends in
+    # `exit 0` and would kill the test pwsh. Marker matches the .sh convention.
+    FUNCS="$TMP/heal-funcs.ps1"
+    awk '/^# Heal every cached version/ { exit } { print }' "$HEAL_PS1" > "$FUNCS"
+}
+
+teardown() {
+    [ -n "${TMP:-}" ] && rm -rf "$TMP"
+}
+
+# Convert an MSYS path to a Windows path for the native pwsh process. On Linux
+# (no cygpath) pwsh understands the path as-is.
+_winpath() {
+    if command -v cygpath >/dev/null 2>&1; then cygpath -w "$1"; else printf '%s' "$1"; fi
+}
+
+# Drive Repair-HooksJson against a fixture path via pwsh.
+_repair() {
+    pwsh -NoProfile -Command ". '$(_winpath "$FUNCS")'; Repair-HooksJson -Target '$(_winpath "$1")'" 2>&1
+}
+
+@test "Repair-HooksJson converts the pristine break;}done form to sed -n 1p (AC3)" {
+    f="$TMP/break.hooks.json"
+    printf '%s\n' '{ "command": "X | while IFS= read -r _R; do [ -f Z ] && { printf Y; break; }; done); node B hook claude-code session-init" }' > "$f"
+    _repair "$f"
+    grep -qF 'sed -n 1p' "$f"
+    ! grep -qF 'head -n1' "$f"
+    grep -qF 'session-init 2>/dev/null' "$f"
+}
+
+@test "Repair-HooksJson converts the already-head-n1 form to sed -n 1p (AC3)" {
+    f="$TMP/headn1.hooks.json"
+    printf '%s\n' '{ "command": "X | while IFS= read -r _R; do [ -f Z ] && { printf Y; }; done | head -n1); node B hook claude-code observation 2>/dev/null; echo Z" }' > "$f"
+    _repair "$f"
+    grep -qF 'sed -n 1p' "$f"
+    ! grep -qF 'head -n1' "$f"
+}
+
+@test "Repair-HooksJson is idempotent: re-healing the fixed form is a no-op (AC4)" {
+    f="$TMP/idem.hooks.json"
+    printf '%s\n' '{ "command": "X | while IFS= read -r _R; do [ -f Z ] && { printf Y; break; }; done); node B hook claude-code session-init" }' > "$f"
+    _repair "$f" >/dev/null
+    first="$(cat "$f")"
+    out="$(_repair "$f")"
+    [ "$(cat "$f")" = "$first" ]
+    [[ "$out" != *"patched"* ]]
+}
+
+@test "Repair-HooksJson leaves a healthy hooks.json untouched" {
+    f="$TMP/healthy.hooks.json"
+    printf '%s\n' '{ "hooks": { "Stop": [] } }' > "$f"
+    before="$(cat "$f")"
+    _repair "$f" >/dev/null
+    [ "$(cat "$f")" = "$before" ]
+}
+
+@test "Repair-HooksJson no-ops on a missing target" {
+    out="$(_repair "$TMP/does-not-exist.json")"
+    [ -z "$out" ]
+}

--- a/tests/claude-mem-heal.bats
+++ b/tests/claude-mem-heal.bats
@@ -203,3 +203,79 @@ _source_heal() {
     [ -z "$output" ]
     [ "$(cat "$healthy")" = "$before" ]
 }
+
+# --- Consumer-EPIPE fix (spec 2026-05-27-claude-mem-heal-consumer-epipe) ---
+#
+# Root cause: the path-resolution pipe `... }; done | head -n1` makes the inner
+# while loop the WRITER into head. head -n1 closes its stdin after line 1; if
+# the loop is still writing (>=2 matching candidates, slow FS), the next printf
+# hits a closed pipe -> EPIPE. Node ignores SIGPIPE and Claude Code spawns hooks
+# with that disposition, so the write error is REPORTED (printf: write error)
+# instead of dying silently, and surfaces as a hook-error banner on every tool
+# call. Fix: `head -n1` -> `sed -n 1p`. sed prints only line 1 but reads to EOF
+# (no early `q`), so it never closes the pipe while the writer runs.
+
+@test "consumer pipe: head -n1 races but sed -n 1p drains under SIGPIPE-ignore (AC1)" {
+    # Mimic the production parent: SIGPIPE ignored (as Node does) + a slow writer
+    # so the consumer closes stdin mid-write. This is the deterministic form of
+    # the otherwise-flaky timing race; it reproduces on Linux and Windows alike.
+    run bash -c 'trap "" PIPE; { { printf "a\n"; sleep 0.05; printf "b\n"; } | head -n1; } 2>&1 1>/dev/null'
+    # head -n1 closes early -> the second printf reports a write error.
+    [ -n "$output" ]
+
+    run bash -c 'trap "" PIPE; { { printf "a\n"; sleep 0.05; printf "b\n"; } | sed -n 1p; } 2>&1 1>/dev/null'
+    # sed -n 1p drains to EOF -> no closed pipe -> clean.
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# Fixture helpers: a hooks.json command in the pristine upstream form
+# (`break; }; done`) and in the BUG-017-healed form (`}; done | head -n1`).
+_write_break_form() {
+    # Terminator is a bare `"` after the verb -- the JSON string-closing quote,
+    # which is what the real (pre-BUG-018) hooks.json carries and what the
+    # directive substitution keys on.
+    printf '%s\n' \
+'{ "command": "_P=$({ ls -dt X 2>/dev/null; printf Y; } | while IFS= read -r _R; do [ -f Z ] && { printf '"'"'%s\n'"'"' \"$_R\"; break; }; done); node B hook claude-code session-init" }' \
+        > "$1"
+}
+_write_headn1_form() {
+    # Already BUG-017-healed AND BUG-018-directive applied (current deployed shape).
+    printf '%s\n' \
+'{ "command": "_P=$({ ls -dt X 2>/dev/null; printf Y; } | while IFS= read -r _R; do [ -f Z ] && { printf '"'"'%s\n'"'"' \"$_R\"; }; done | head -n1); node B hook claude-code observation 2>/dev/null; echo '"'"'{\"continue\":true}'"'"'" }' \
+        > "$1"
+}
+
+@test "heal_hooks_json converts the pristine break;}done form to sed -n 1p (AC2)" {
+    _source_heal
+    f="$TMP/break.hooks.json"
+    _write_break_form "$f"
+    run heal_hooks_json "$f"
+    [ "$status" -eq 0 ]
+    grep -qF 'sed -n 1p' "$f"
+    ! grep -qF 'head -n1' "$f"
+    # BUG-018 continue-directive applied to the session-init terminator.
+    grep -qF 'session-init 2>/dev/null' "$f"
+}
+
+@test "heal_hooks_json converts the already-head-n1 form to sed -n 1p (AC2)" {
+    _source_heal
+    f="$TMP/headn1.hooks.json"
+    _write_headn1_form "$f"
+    run heal_hooks_json "$f"
+    [ "$status" -eq 0 ]
+    grep -qF 'sed -n 1p' "$f"
+    ! grep -qF 'head -n1' "$f"
+}
+
+@test "heal_hooks_json is idempotent: re-healing the fixed form is a silent no-op (AC4)" {
+    _source_heal
+    f="$TMP/idem.hooks.json"
+    _write_break_form "$f"
+    heal_hooks_json "$f" >/dev/null
+    first="$(cat "$f")"
+    run heal_hooks_json "$f"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ "$(cat "$f")" = "$first" ]
+}


### PR DESCRIPTION
## Why

The `hooks.json` that `claude-mem-heal.{sh,ps1}` deploys resolves the plugin path with `... }; done | head -n1`. `head -n1` closes its stdin after the first line; when **≥2 plugin candidates match** (a cache version dir **and** the marketplace junction) the inner `while` loop writes a second line to the now-closed pipe → **EPIPE**. Node ignores SIGPIPE and Claude Code spawns hooks with that disposition, so the failed write is **reported** (`printf: write error`) instead of dying silently, and surfaces as a `PreToolUse/PostToolUse hook error` banner on every tool call. It is non-blocking but pollutes every session (predominantly on Windows, where the slower NTFS+MSYS `stat` loop opens the timing window far more often).

Regression of BUG-017, whose `break; }; done` → `}; done | head -n1` substitution introduced this consumer-side race.

## What

Replace `head -n1` with **`sed -n 1p`**: prints only line 1 but reads to EOF (no early `q`), so it drains the writer and never closes the pipe under it — the race is eliminated for any number of matching candidates. Output (the resolved path) is byte-identical. Both heal scripts normalise the pristine `break; }; done` form **and** the previously-deployed `}; done | head -n1` form, so existing installs converge on the next session with no `/plugin update`.

**Option A (sed-patch) over Option B (canonical-template emission):** kept the resilient sed-patch — it only rewrites the pipe shape and preserves upstream's `node` invocation, surviving upstream *semantic* drift; a static self-emitted hooks.json would be fragile to new hook stages / changed args.

## Test plan

- `bats tests/claude-mem-heal.bats tests/claude-mem-heal-ps1.bats` → 25/26 ok. The one failure (`ensure_marketplace_compat_symlink creates the legacy symlink`) is **pre-existing and Windows-environment-only** (MSYS `ln -s` needs Developer Mode); passes on the Linux CI runner.
- **AC1 functional guard** (`#18`): under `trap '' PIPE` + slow writer, `head -n1` reports a write error and `sed -n 1p` does not — reproduces the race deterministically, cross-OS.
- **AC2/AC3** structural (`.sh` + `.ps1` parity): both forms → `sed -n 1p`, no `head -n1`, BUG-018 directive preserved.
- **AC5 (live):** healed a copy of the real deployed `13.3.0/hooks/hooks.json` → 7×`head -n1` to 7×`sed -n 1p`, idempotent, still valid JSON, surgical diff.
- `Invoke-ScriptAnalyzer scripts/claude-mem-heal.ps1` → CLEAN.

## Scope

Anti-scope respected: no `.mcp.json` change, no `init-spec` change. Both logged as follow-ups in the spec's `verification.md`.

Spec: `specs/2026-05-27-claude-mem-heal-consumer-epipe/`