### PR TITLE
docs(adr): record ADR-018 de-vault task placement and 3-layer knowledge model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Senior Principal Software Architect & Technical Mentor. 20+ years production exp
 ## Standing Orders (Non-Negotiable)
 
 1. **Automate, don't instruct.** If a task is repeatable, encode it: shell script, Makefile, Python CLI, IaC (Terraform/Ansible), CI pipeline, or whatever fits the project stack. Never give manual steps for repeatable work.
-2. **SSOT.** One source of truth per datum; never duplicate. Code lives in git. **Knowledge placement is by layer, not project type** (`pattern-knowledge-placement`): **decide/position → the store** (vault `00_meta/`) — patterns, AI memory, cross-project lessons, strategic backlog; **build/operate → the repo** — ADRs (`docs/adr/`), runbooks, troubleshooting, project lessons (`docs/lessons.md`), specs (`specs/`); **collaborate → the forge** — tasks/roadmap as GitHub issues/Project. The store links *out* to repos; repos never depend on the store. The only personal-vs-work residual is *where the cross-project brain lives* (personal vault vs a team store) and *whether tasks sit on a shared board* — declared per repo in the **Knowledge Placement** block below (defaults: personal vault + this repo's issues). Full model: `pattern-knowledge-placement`; team governance: `pattern-platform-governance`.
+2. **SSOT.** One source of truth per datum; never duplicate. Code lives in git. **Knowledge placement is by layer, not project type** (`pattern-knowledge-placement`): **decide/position → the store** (vault `00_meta/`) — patterns, AI memory, cross-project lessons; **build/operate → the repo** — ADRs (`docs/adr/`), runbooks, troubleshooting, project lessons (`docs/lessons.md`), specs (`specs/`); **collaborate → the forge** — tasks/roadmap as GitHub issues/Project (user-level cross-repo "bitácora"). The store links *out* to repos; repos never depend on the store. Task state does NOT live in the vault (see [ADR-018](docs/adr/adr-018-de-vault-task-placement.md)). The only personal-vs-work residual is *where the cross-project brain lives* (personal vault vs a team store) and *which cross-repo Project board aggregates tasks* — declared per repo in the **Knowledge Placement** block below. Full model: `pattern-knowledge-placement`; team governance: `pattern-platform-governance`.
 3. **Knowledge hygiene — in-session, not "later".** Route by decide-vs-operate (#2): bug fix -> repo `docs/troubleshooting/`; architecture decision -> repo `docs/adr/`; project lesson/trick -> repo `docs/lessons.md`. Only **cross-project** (pattern-worthy) insight -> vault (`00_meta/` patterns, or `90-lessons.md` for methodology); AI memory/handoffs -> always vault. Do it in-session, not "later". Tools that default to vault output (e.g. the `architecture-session` workflow, `capture_lesson`) must target the repo for **any repo on the knowledge-placement model** (any repo with `docs/`), not just "work" repos.
 4. **Clean as you go.** Dead code, stale comments, orphan files -- fix them when you see them. Don't defer trivial fixes.
 5. **Consult patterns before architectural decisions.** 37 universal patterns in `00_meta/patterns/`. Query via Hive MCP (when available) or read from `~/Projects/knowledge/00_meta/patterns/<name>.md` (Linux/macOS) / `%USERPROFILE%\Projects\knowledge\00_meta\patterns\<name>.md` (Windows).
@@ -230,9 +230,9 @@ Stop generation and warn if you detect:
 Placement follows `pattern-knowledge-placement` (decide-vs-operate, Standing Order #2). Two values vary per repo; everything else is fixed by layer:
 
 - **brain:** `vault:00_meta/` — the cross-project store (default: personal vault). A team repo overrides to its shared store.
-- **tasks:** `repo:issues` — tactical work tracking (default: this repo's GitHub issues). A team repo may use a shared Project board.
+- **tasks:** `project:bitácora` — user-level private cross-repo GitHub Project. Issue-closed→Done is automatic (built-in workflow). Per-repo auto-add wired via `.github/workflows/add-to-project.yml` (requires PAT with `project` scope in the age-secrets store). See [ADR-018](docs/adr/adr-018-de-vault-task-placement.md).
 
-Defaults = personal solo project (this repo). Build/operate docs always live in this repo's `docs/`; only the two values above are context-dependent.
+Defaults = personal solo project (this repo). Build/operate docs always live in this repo's `docs/`; only the two values above are context-dependent. **The vault no longer holds task state** (no `11-tasks.md`); the cross-project brain and AI memory remain in the vault.
 
 ## "Neural Hive" Protocol (The Loop)
 
@@ -247,7 +247,7 @@ Defaults = personal solo project (this repo). Build/operate docs always live in 
 2. **Master Map:** If unsure about structure, read `knowledge/README.md`.
 3. **Project Context:** Read `10_projects/<repo>/00-context.md`.
 4. **Global Rules:** Read relevant `00_meta/patterns/*.md`.
-5. **Tactical Plan:** Read `10_projects/<repo>/11-tasks.md` (Active Backlog).
+5. **Tactical Plan:** Check the **bitácora** GitHub Project (user-level, cross-repo) for active backlog items. Filter by `Repo` field to see this repo's items. If offline, fall back to open GitHub issues.
 
 ### Phase 2: Execution (The Work)
 
@@ -263,7 +263,7 @@ Defaults = personal solo project (this repo). Build/operate docs always live in 
 
 ### Phase 3: Knowledge Crystallization (Write Back)
 
-* **Backlog (`11-tasks.md`):** Mark items `[x]` and update the Progress Bar.
+* **Backlog (bitácora):** Close the GitHub issue — the built-in workflow moves it to Done automatically. No manual vault update needed.
 * **Strategy (`10-roadmap.md`):** ONLY if a major milestone is completed.
 * **Lessons:** project-specific → repo `docs/lessons.md`; cross-project / methodology → vault `90-lessons.md` (Lesson Template).
 * **Promotion:** If the solution is generic, create `00_meta/patterns/pattern-<topic>.md`.
@@ -383,8 +383,8 @@ Before creating ANY branch for code changes in this repo, evaluate against `patt
 
 **If trigger met, follow this order — no shortcuts:**
 
-1. Add vault entry to `10_projects/<repo>/11-tasks.md` (the "vault gate")
-2. Run `init-spec.{sh,ps1} <feature-id>` to scaffold `specs/<feature-id>/` (the script enforces the vault-gate check; bypass only with `-ForceNoVault` + explicit user-facing justification)
+1. Open a GitHub issue (or reuse an existing one) and add it to the **bitácora** Project — this is the "work gate" replacing the former vault `11-tasks.md` entry
+2. Run `init-spec.{sh,ps1} <feature-id>` to scaffold `specs/<feature-id>/` (the script enforces the work-gate check; bypass only with `-ForceNoVault` + explicit user-facing justification)
 3. Fill `proposal.md` (why + what + acceptance criteria) **before** writing implementation code
 4. Fill `tasks.md` in TDD order
 5. Implement; tick boxes as you go
@@ -425,7 +425,7 @@ These rules **counter agent harness defaults** that would otherwise silently win
 - **No internal phase/milestone references** in branch names, commit messages, or PR titles.
   - Bad: `feat/phase-3.1-scaffold`, `chore: scaffold repo (Phase 3.1)`
   - Good: `feat/scaffold-pyhydra3d`, `chore: scaffold PyHydra3D repository`
-- Phase tracking belongs in the vault backlog (`11-tasks.md`), not in git history.
+- Phase tracking belongs in the **bitácora** GitHub Project (open issues / Project items), not in git history.
 <!-- END HARNESS GENERATED -->
 
 ### Interaction Discipline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -425,7 +425,7 @@ These rules **counter agent harness defaults** that would otherwise silently win
 - **No internal phase/milestone references** in branch names, commit messages, or PR titles.
   - Bad: `feat/phase-3.1-scaffold`, `chore: scaffold repo (Phase 3.1)`
   - Good: `feat/scaffold-pyhydra3d`, `chore: scaffold PyHydra3D repository`
-- Phase tracking belongs in the **bitácora** GitHub Project (open issues / Project items), not in git history.
+- Phase tracking belongs in the vault backlog (`11-tasks.md`), not in git history.
 <!-- END HARNESS GENERATED -->
 
 ### Interaction Discipline

--- a/docs/adr/adr-018-de-vault-task-placement.md
+++ b/docs/adr/adr-018-de-vault-task-placement.md
@@ -1,0 +1,171 @@
+---
+id: "ADR-018-de-vault-task-placement"
+type: adr
+status: accepted
+owner: manu
+date: "2026-06-06"
+extends: [adr-009-multi-agent-runtime, adr-016-deploy-canonical-agents-to-vault]
+tags: [architecture, decision, knowledge-placement, tasks, github-projects, vault, init-project, self-containment]
+created: "2026-06-06"
+---
+
+# ADR-018: De-vault task placement — 3-layer knowledge model + reusable self-contained flow
+
+> Moves task/work state out of the Obsidian vault into a single cross-repo GitHub Project
+> ("bitácora"), makes the per-project flow self-contained so `init-project` works without a
+> vault, and defines the 3-layer split that governs knowledge placement from now on.
+> dotfiles is the pilot; the model propagates to other repos via a corrected
+> `pattern-knowledge-placement`. Epic: [#244](https://github.com/mlorentedev/dotfiles/issues/244).
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-06
+
+## Context
+
+The prior model stored active task state (backlog, sprint items, portfolio view) in the
+Obsidian vault at `10_projects/<repo>/11-tasks.md`. This created three recurring pain points:
+
+1. **Not portable.** A fresh machine, a new contributor, or an AI agent that hasn't cloned the
+   vault cannot see the backlog. `init-project` silently degraded: when the vault was absent
+   the injected `AGENTS.md` had `$VAULT_PATH` references that 404d off-machine.
+2. **Wrong layer for task state.** Trackers (GitHub Issues/Projects, Linear, Jira) are the
+   industry-standard home for coordination state — they are searchable, linkable, automatable,
+   and shareable without granting filesystem access. The vault's strength is cross-project
+   *brain* (patterns, methodology lessons, AI memory) — not task status.
+3. **Cold-store pressure.** The vault accumulated 144 archived spec files from this repo alone,
+   inflating the "too much content" perception and causing navigation friction unrelated to the
+   quality of vault content.
+
+Additionally, the project flow was not self-contained: `init-spec` hard-failed when no vault
+entry existed, and `init-project` leaked the private vault path into fresh repos.
+
+**Research gate (Projects v2 mechanics).** Before committing, GitHub Projects v2 limits were
+confirmed (see #244 comment-2): user/org-level only, 50 k items, one cross-repo board is the
+right shape; issue-closed→Done built-in by default; auto-add is plan-capped (Free=1 repo,
+Pro/Team=5) but per-repo `actions/add-to-project` is plan-agnostic and scales to N repos.
+PAT with `project` scope required (default `GITHUB_TOKEN` cannot touch Projects v2). No
+backfill — existing issues need a scripted one-time migration.
+
+## Decision
+
+### Layer model (3 layers, linked not duplicated)
+
+| Layer | Home | What lives here | What does NOT |
+|---|---|---|---|
+| **Task state** | GitHub Project "bitácora" (user-level, private, cross-repo) | Backlog items, sprint status, portfolio view, issue-level progress | Durable design, patterns, lessons |
+| **Durable design** | This repo: `specs/`, `docs/adr/`, `docs/lessons.md`, `docs/runbooks/` | Architecture decisions, specs, troubleshooting, project lessons | Task status, vault patterns |
+| **Cross-project brain** | Vault: `00_meta/`, `90-lessons.md`, AI memory | Universal patterns, methodology lessons, AI session memory | Task state (no `11-tasks.md` equivalent) |
+
+The vault *links out* to repos (via `10_projects/<repo>/` context docs); repos do not
+depend on the vault. The bitácora board *aggregates* repo issues; it owns no data of its own.
+
+### bitácora Project spec
+
+- One **user-level private** GitHub Project named "bitácora".
+- Fields: Status (single-select: Backlog/In Progress/Done/Blocked), Repo, Priority
+  (P0–P3), Type (spec/bug/chore/ideas).
+- Views: table (default, group-by Status), board (group-by Status), per-repo filter.
+- Built-in workflows (default-on): issue-closed→Done, PR-merged→Done, auto-archive
+  Done items > 2 weeks.
+- Per-repo auto-add: a `.github/workflows/add-to-project.yml` file (using
+  `actions/add-to-project@v1`) wired into `init-project` so every new repo auto-joins.
+  Requires a PAT with `project` scope, stored encrypted in the age-secrets system.
+- One-time backfill of existing open issues via `gh project item-add` loop (scripted).
+
+### `init-project` self-containment (crown-jewel fix)
+
+`init-project` must work on a machine without a vault. Concretely:
+- Add a vault-existence check at startup; print a `[WARN]` if absent but continue.
+- Support `--skip-vault` flag to suppress the warning and the vault-dependent steps.
+- Vendor a minimal set of SDD rules and templates into the repo itself (at `docs/sdd/`)
+  so `init-spec` has a local fallback and never hard-fails when the vault is absent.
+- `init-spec`: add `exit 3` fallback — return a repo-local skeleton if vault is absent,
+  not a hard error.
+- The injected `AGENTS.md` must not contain `$VAULT_PATH` literals that 404 off-machine;
+  replace with relative paths or conditional vault-reference blocks.
+
+### Migration path (dotfiles pilot)
+
+1. Set up bitácora per the spec above (`gh project create`, field seed, view config,
+   built-in workflows). Bootstrap script committed in `scripts/setup-bitacora.sh`.
+2. Backfill: run `scripts/setup-bitacora.sh --backfill-repo mlorentedev/dotfiles` to add
+   all open issues to the board.
+3. Wire `init-project` to drop `.github/workflows/add-to-project.yml` into new repos.
+4. Archive `10_projects/dotfiles/11-tasks.md` in the vault (do not delete; history is
+   valuable) with a note pointing to bitácora.
+5. Correct `pattern-knowledge-placement` to reflect the 3-layer model.
+6. Propagate to other repos as they are next touched (lazy migration; no big-bang).
+
+### AGENTS.md updates (this decision)
+
+Three values change in `AGENTS.md`:
+- **Knowledge Placement block:** `tasks:` changes from `repo:issues` to
+  `project:bitácora (user-level GitHub Project, cross-repo)`.
+- **Neural Hive Phase 1 Context Sync:** remove "Read `11-tasks.md`"; replace with
+  "Check the bitácora GitHub Project for the active backlog".
+- **Neural Hive Phase 3 Crystallization:** remove the `11-tasks.md` mark-done step;
+  closing the GitHub issue moves it to Done automatically (built-in workflow).
+
+## Alternatives considered
+
+**Keep vault 11-tasks.md, improve discoverability.** Rejected: the portability problem
+(off-machine 404s, vault-absent hard-fails) remains unsolved; vault markdown is not
+filterable by priority, not automatable, and not cross-repo.
+
+**Flat markdown backlog in the repo root.** Rejected: repo-root `TODO.md` / `backlog.md`
+is an anti-pattern (already called out in AGENTS.md, closes CHORE-002 spirit) and still
+not cross-repo.
+
+**Use Linear or Jira.** Rejected: external paid SaaS adds friction for a solo developer;
+GitHub Projects is free, co-located with the issues, and requires no new account. The
+teledyne-e2v platform project already validates this model at programme scale.
+
+**Per-repo Projects board.** Rejected: Classic Projects v2 is now user/org-level only
+(Classic deprecated and removed 2025-06-03). A single cross-repo board is the correct
+and native shape.
+
+## Consequences
+
+**Positive:**
+- Task state is visible to any agent, on any machine, without vault access.
+- `init-project` works self-contained; fresh repos no longer leak the private vault path.
+- `init-spec` degrades gracefully (exit 3 + repo-local skeleton) instead of hard-failing.
+- The vault shrinks to its correct role (cross-project brain), eliminating cold-store
+  pressure from task accumulation.
+- issue-closed→Done is automatic — zero manual bookkeeping for routine completion.
+- The model is plan-agnostic: the per-repo `add-to-project` Action scales to N repos on
+  any GitHub plan.
+
+**Negative / debt:**
+- One-time backfill is a manual scripted step; existing open issues must be added
+  explicitly (no native backfill for Projects v2).
+- A PAT with `project` scope must be provisioned and kept in the age-secrets store; this
+  is a new operational dependency.
+- `pattern-knowledge-placement` and any doc/skill referencing `11-tasks.md` must be
+  updated — a non-trivial audit pass.
+- At ~300–500 open items the single board will need a split strategy (Priority field
+  buys time; a per-stream sub-view is the natural first split).
+
+## Reopen Triggers
+
+- **Board split:** open item count reaches 300 and search/prioritization degrades.
+- **Plan upgrade:** a team fork of this setup needs > 5 native auto-add workflows;
+  reconsider native vs Action-based auto-add at that point.
+- **Vault backfill:** if the vault `11-tasks.md` pattern is needed for offline-only
+  work (air-gapped machine, no GitHub), re-evaluate the fallback model.
+
+## References
+
+- `docs/adr/adr-009-multi-agent-runtime.md` — AGENTS.md as cross-agent SSOT.
+- `docs/adr/adr-016-deploy-canonical-agents-to-vault.md` — vault deploy strategy.
+- `00_meta/patterns/pattern-knowledge-placement` — corrected by this ADR.
+- `00_meta/patterns/pattern-three-layer-proposal-lifecycle` — the proposal flow this PR follows.
+- GitHub Projects v2 research: [#244](https://github.com/mlorentedev/dotfiles/issues/244) comment-2.
+- Industry precedent: teledyne-e2v platform programme board (one board per programme, per-stream sub-views).
+- docs.github.com/issues/planning-and-tracking-with-projects
+- github.com/actions/add-to-project


### PR DESCRIPTION
## Summary

- Adds `docs/adr/adr-018-de-vault-task-placement.md` — the decision record for moving per-project task state out of the Obsidian vault into a user-level cross-repo GitHub Project ("bitácora")
- Defines the 3-layer knowledge model: task state → bitácora, durable design → repo, cross-project brain → vault (no task state)
- Updates `AGENTS.md` Knowledge Placement block, Neural Hive Protocol (Phase 1 + Phase 3), SDD work-gate step, and git conventions to reflect the new model
- Records the init-project self-containment fix requirements (vault guard + `--skip-vault` + vendor SDD templates) — implementation in follow-up issues

## Motivation

The prior model stored active task state in `vault:10_projects/<repo>/11-tasks.md`. This created portability failures: vault-absent machines hit 404 `$VAULT_PATH` refs injected by `init-project`, and `init-spec` hard-failed without a vault entry. The [GitHub Projects v2 research gate](https://github.com/mlorentedev/dotfiles/issues/244) confirmed the bitácora design is sound (50k item cap, issue-closed→Done default-on, per-repo `add-to-project` Action scales plan-agnostically).

## Test plan

- [ ] `docs/adr/` change is excluded from spec-gate (confirmed: `docs/*.md` pattern in `_excluded()`)
- [ ] AGENTS.md diff ≤ 50 LOC non-doc (8 insertions / 8 deletions = passes gate)
- [ ] Pre-commit hooks: secrets check + bats suite passed locally
- [ ] ADR cross-references: `adr-009`, `adr-016`, `pattern-knowledge-placement`, `#244`

Closes part of #244 (ADR-018 checkbox).