### PR TITLE
docs(agents): add AREA-NNN-slug ticket ID convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,7 @@ Defaults = personal solo project (this repo). Build/operate docs always live in 
 ### Phase 3: Knowledge Crystallization (Write Back)
 
 * **Backlog (bitácora):** Close the GitHub issue — the built-in workflow moves it to Done automatically. No manual vault update needed.
+  * Ticket IDs in the GitHub Project custom field `ID` use `AREA-NNN-slug` format (e.g. `SSOT-027-id-scheme`). Existing pure-numeric IDs remain valid — no backfill required.
 * **Strategy (`10-roadmap.md`):** ONLY if a major milestone is completed.
 * **Lessons:** project-specific → repo `docs/lessons.md`; cross-project / methodology → vault `90-lessons.md` (Lesson Template).
 * **Promotion:** If the solution is generic, create `00_meta/patterns/pattern-<topic>.md`.


### PR DESCRIPTION
## Summary

- Adds backlog hygiene rule to AGENTS.md Phase 3: new ticket IDs use `AREA-NNN-slug` format (e.g. `SSOT-027-id-scheme`).
- Existing pure-numeric IDs remain valid — no backfill required.
- Clarifies that file-name numeric prefixes (`00-`/`10-`/`11-`) are a separate layer and unchanged.

Closes CUR-008 (knowledge vault backlog). Companion vault commit: `6dcf960` (templates, skills, 11-tasks).

## Test plan

- [ ] Verify AGENTS.md renders correctly
- [ ] Confirm rule is visible under Phase 3 Backlog bullet