### PR TITLE
fix(claude-mem-heal): drain .mcp.json template via sed -n 1p

### DIFF
--- a/scripts/claude-mem-heal.ps1
+++ b/scripts/claude-mem-heal.ps1
@@ -97,10 +97,13 @@ function Repair-MarketplaceCompatJunction {
 # on Windows Git Bash).
 #
 # The healthy form mirrors the v13.x cascade structure (so it works whether
-# or not Claude Code sets CLAUDE_PLUGIN_ROOT) but pipes the consumer's
-# matches through `head -n1` instead of breaking the inner `while` loop --
-# this drains the entire producer pipe, eliminating the EPIPE writes that
-# trigger the upstream bug.
+# or not Claude Code sets CLAUDE_PLUGIN_ROOT) but drains the consumer pipe
+# with `sed -n 1p` instead of breaking the inner `while` loop or using
+# `head -n1`. `head -n1` closes stdin after line 1, so with >=2 matching
+# candidates the still-writing loop hits a closed pipe -> EPIPE (the same
+# consumer-EPIPE race fixed for hooks.json in Repair-HooksJson; mirrored here
+# under task 2026-06-06-mcp-json-consumer-epipe-drain). `sed -n 1p` prints
+# only line 1 but reads to EOF, so it never closes under the writer.
 #
 # Idempotent: skips when neither v12.7.4 nor v13.x signature present.
 function Repair-McpJson {
@@ -131,7 +134,7 @@ function Repair-McpJson {
       "command": "sh",
       "args": [
         "-c",
-        "_C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack-claude-mem/plugin\" \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/mcp-server.cjs\" ] && printf '%s\\n' \"$_Q\"; done | head -n1); [ -n \"$_P\" ] || { echo 'claude-mem: mcp server not found' >&2; exit 1; }; exec node \"$_P/scripts/mcp-server.cjs\""
+        "_C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack-claude-mem/plugin\" \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/mcp-server.cjs\" ] && printf '%s\\n' \"$_Q\"; done | sed -n 1p); [ -n \"$_P\" ] || { echo 'claude-mem: mcp server not found' >&2; exit 1; }; exec node \"$_P/scripts/mcp-server.cjs\""
       ]
     }
   }
@@ -139,9 +142,9 @@ function Repair-McpJson {
 '@
     Set-Content -Path $Target -Value $healthy -Encoding UTF8 -NoNewline
     if ($hasV13) {
-        Write-HealLog "patched .mcp.json (v13.x cascade -> head -n1 race-free form): $Target"
+        Write-HealLog "patched .mcp.json (v13.x cascade -> sed -n 1p race-free form): $Target"
     } else {
-        Write-HealLog "patched .mcp.json (v12.7.4 -> head -n1 race-free form): $Target"
+        Write-HealLog "patched .mcp.json (v12.7.4 -> sed -n 1p race-free form): $Target"
     }
 }
 

--- a/scripts/claude-mem-heal.sh
+++ b/scripts/claude-mem-heal.sh
@@ -67,10 +67,13 @@ ensure_marketplace_compat_symlink() {
 # thedotmack/claude-mem#2607 (causes `/mcp ... -32000` failures intermittently).
 #
 # The healthy form mirrors the v13.x cascade structure (so it works whether
-# or not Claude Code sets CLAUDE_PLUGIN_ROOT) but pipes the consumer's
-# matches through `head -n1` instead of breaking the inner `while` loop --
-# this drains the entire producer pipe, eliminating the EPIPE writes that
-# trigger the upstream bug.
+# or not Claude Code sets CLAUDE_PLUGIN_ROOT) but drains the consumer pipe
+# with `sed -n 1p` instead of breaking the inner `while` loop or using
+# `head -n1`. `head -n1` closes stdin after line 1, so with >=2 matching
+# candidates the still-writing loop hits a closed pipe -> EPIPE (the same
+# consumer-EPIPE race fixed for hooks.json in heal_hooks_json; mirrored here
+# under task 2026-06-06-mcp-json-consumer-epipe-drain). `sed -n 1p` prints
+# only line 1 but reads to EOF, so it never closes under the writer.
 #
 # Idempotent: skips when neither v12.7.4 nor v13.x signature present.
 heal_mcp_json() {
@@ -93,16 +96,16 @@ heal_mcp_json() {
       "command": "sh",
       "args": [
         "-c",
-        "_C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack-claude-mem/plugin\" \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/mcp-server.cjs\" ] && printf '%s\\n' \"$_Q\"; done | head -n1); [ -n \"$_P\" ] || { echo 'claude-mem: mcp server not found' >&2; exit 1; }; exec node \"$_P/scripts/mcp-server.cjs\""
+        "_C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack-claude-mem/plugin\" \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/mcp-server.cjs\" ] && printf '%s\\n' \"$_Q\"; done | sed -n 1p); [ -n \"$_P\" ] || { echo 'claude-mem: mcp server not found' >&2; exit 1; }; exec node \"$_P/scripts/mcp-server.cjs\""
       ]
     }
   }
 }
 EOF
     if [ "$has_v13" -gt 0 ]; then
-        log "patched .mcp.json (v13.x cascade -> head -n1 race-free form): $target"
+        log "patched .mcp.json (v13.x cascade -> sed -n 1p race-free form): $target"
     else
-        log "patched .mcp.json (v12.7.4 \${_R%/} -> head -n1 race-free form): $target"
+        log "patched .mcp.json (v12.7.4 \${_R%/} -> sed -n 1p race-free form): $target"
     fi
 }
 

--- a/tests/claude-mem-heal-ps1.bats
+++ b/tests/claude-mem-heal-ps1.bats
@@ -41,6 +41,11 @@ _repair() {
     pwsh -NoProfile -Command ". '$(_winpath "$FUNCS")'; Repair-HooksJson -Target '$(_winpath "$1")'" 2>&1
 }
 
+# Drive Repair-McpJson against a fixture path via pwsh.
+_repair_mcp() {
+    pwsh -NoProfile -Command ". '$(_winpath "$FUNCS")'; Repair-McpJson -Target '$(_winpath "$1")'" 2>&1
+}
+
 @test "Repair-HooksJson converts the pristine break;}done form to sed -n 1p (AC3)" {
     f="$TMP/break.hooks.json"
     printf '%s\n' '{ "command": "X | while IFS= read -r _R; do [ -f Z ] && { printf Y; break; }; done); node B hook claude-code session-init" }' > "$f"
@@ -79,4 +84,20 @@ _repair() {
 @test "Repair-HooksJson no-ops on a missing target" {
     out="$(_repair "$TMP/does-not-exist.json")"
     [ -z "$out" ]
+}
+
+# --- Repair-McpJson: .mcp.json consumer-EPIPE drain parity ---
+# (task 2026-06-06-mcp-json-consumer-epipe-drain). The emitted template's
+# path-resolution pipe must drain via `sed -n 1p` (reads to EOF), not the
+# early-closing `head -n1` that races under SIGPIPE-ignore -- the same root
+# cause Repair-HooksJson fixes for hooks.json, mirrored for .mcp.json.
+
+@test "Repair-McpJson emits the sed -n 1p drain, not head -n1 (mcp consumer-EPIPE)" {
+    f="$TMP/v13.mcp.json"
+    printf '%s\n' '{ "command": "sh", "args": ["-c", "X | while IFS= read -r _R; do printf Y; done | head -n1"] }' > "$f"
+    out="$(_repair_mcp "$f")"
+    [[ "$out" == *"patched .mcp.json"* ]]
+    grep -qF 'sed -n 1p' "$f"
+    ! grep -qF 'head -n1' "$f"
+    grep -qF '"mcpServers"' "$f"
 }

--- a/tests/claude-mem-heal.bats
+++ b/tests/claude-mem-heal.bats
@@ -92,7 +92,10 @@ _source_heal() {
     heal_mcp_json "$f"
     second="$(cat "$f")"
     [ "$first" = "$second" ]
-    grep -qF 'head -n1' "$f"
+    # The convergent template drains the path-resolution pipe via `sed -n 1p`
+    # (reads to EOF), not the early-closing `head -n1` (consumer-EPIPE race).
+    grep -qF 'sed -n 1p' "$f"
+    ! grep -qF 'head -n1' "$f"
 }
 
 @test "heal_mcp_json rewrites a v12.7.4 \${_R%/} broken file and logs the patch" {
@@ -106,9 +109,11 @@ _source_heal() {
     [[ "$output" == *"patched .mcp.json"* ]]
     [[ "$output" == *"v12.7.4"* ]]
     # The file was rewritten to the canonical race-free form: it changed, it
-    # carries the head -n1 discovery, and it is now a full mcpServers block.
+    # drains the path-resolution pipe via `sed -n 1p` (not the early-closing
+    # `head -n1`), and it is now a full mcpServers block.
     [ "$(cat "$broken")" != "$before" ]
-    grep -qF 'head -n1' "$broken"
+    grep -qF 'sed -n 1p' "$broken"
+    ! grep -qF 'head -n1' "$broken"
     grep -qF '"mcpServers"' "$broken"
 }
 
@@ -120,7 +125,8 @@ _source_heal() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"patched .mcp.json"* ]]
     [[ "$output" == *"v13.x"* ]]
-    grep -qF 'head -n1' "$broken"
+    grep -qF 'sed -n 1p' "$broken"
+    ! grep -qF 'head -n1' "$broken"
 }
 
 # --- heal_zod: guards before any npm side effect (4) ---

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -188,11 +188,17 @@ setup() {
     grep -q 'while IFS=' "$DOTFILES_DIR/scripts/claude-mem-heal.ps1"
 }
 
-@test "claude-mem-heal scripts write the race-free head -n1 form (BUG-016)" {
-    # The replacement .mcp.json template must contain `head -n1` to
-    # consume the entire producer pipe and avoid the EPIPE race.
-    grep -q 'head -n1' "$DOTFILES_DIR/scripts/claude-mem-heal.sh"
-    grep -q 'head -n1' "$DOTFILES_DIR/scripts/claude-mem-heal.ps1"
+@test "claude-mem-heal scripts write the race-free sed -n 1p .mcp.json template (BUG-016 + mcp consumer-EPIPE)" {
+    # The .mcp.json template's path-resolution pipe must drain via `sed -n 1p`
+    # (reads to EOF), NOT the early-closing `head -n1` (consumer-EPIPE race --
+    # task 2026-06-06-mcp-json-consumer-epipe-drain). Anchor on the template's
+    # unique `); [ -n` tail so this targets the .mcp.json emitter specifically,
+    # not heal_hooks_json's `head -n1` sed match pattern (which stays, to
+    # converge already-deployed installs).
+    grep -qF 'sed -n 1p); [ -n' "$DOTFILES_DIR/scripts/claude-mem-heal.sh"
+    ! grep -qF 'head -n1); [ -n' "$DOTFILES_DIR/scripts/claude-mem-heal.sh"
+    grep -qF 'sed -n 1p); [ -n' "$DOTFILES_DIR/scripts/claude-mem-heal.ps1"
+    ! grep -qF 'head -n1); [ -n' "$DOTFILES_DIR/scripts/claude-mem-heal.ps1"
 }
 
 @test "parity: both heal scripts reference BUG-016 + thedotmack/claude-mem#2607 (BUG-016)" {


### PR DESCRIPTION
## What

The `.mcp.json` remediation template emitted by `heal_mcp_json` / `Repair-McpJson` ended its path-resolution pipe with `done | head -n1`. `head -n1` closes stdin after the first line, so when ≥2 candidates carry `mcp-server.cjs` the still-writing `while` loop hits a closed pipe → **consumer-side EPIPE at MCP-server load**.

This is the sibling of the `hooks.json` race fixed in #242. The fix is identical: `sed -n 1p` prints only line 1 but reads to EOF, so it never closes the pipe under the writer.

## Changes

- `scripts/claude-mem-heal.sh` + `scripts/claude-mem-heal.ps1`: template pipe `head -n1` → `sed -n 1p`; corrected the (now-accurate) drain comment; updated the two patch log strings.
- `tests/claude-mem-heal.bats`: 3 `.mcp.json` functional assertions flipped to require `sed -n 1p` (+ negative `head -n1` guard).
- `tests/claude-mem-heal-ps1.bats`: new `Repair-McpJson` parity test.
- `tests/setup-linux.bats`: BUG-016 static guard re-anchored on the template's unique `); [ -n` tail (so it targets the `.mcp.json` emitter, not `heal_hooks_json`'s `head -n1` match pattern).

## Verification

- TDD red→green: the 4 target tests failed on the `sed -n 1p` assertion against the old template, then passed after the fix.
- `bats tests/claude-mem-heal.bats` 20/21, `tests/claude-mem-heal-ps1.bats` 6/6, `setup-linux.bats` heal-suite 21/21. The 1 non-pass is `ensure_marketplace_compat_symlink … [-L]`, a local MSYS `winsymlinks`-disabled limitation unrelated to this diff (passes on Linux CI).
- On a **copy** of the live deployed `.mcp.json`: a regressed v13 cascade form now drains via `sed -n 1p` (no `head -n1`), stays valid JSON, and is convergent. Live files untouched.

## Scope / follow-up

Atomic to the template drain. Verification surfaced a **separate, Linux/macOS-only** pre-existing bug: `heal_mcp_json`'s count guards use `grep -cF … || echo 0`, which yields `"0\n0"` on no-match (grep prints `0` *and* exits 1), so the "already healthy" guard errors (`[: integer expected`) and clobbers a healthy `.mcp.json` instead of returning early. Windows is unaffected (`Repair-McpJson` uses `-match` booleans). Filed as P2 `2026-06-06-heal-mcp-json-guard-clobber`; intentionally not folded in here.

## Blast radius

Lower than #242: the template is written only when upstream regresses to a v12/v13 cascade form, and the resulting EPIPE is one-shot at MCP load rather than per tool call.