### PR TITLE
docs(skills): finish 3-layer placement alignment for 4 skill records

### DIFF
--- a/harness/skills/architecture-session/SKILL.md
+++ b/harness/skills/architecture-session/SKILL.md
@@ -50,7 +50,7 @@ allowed-tools: [Bash, Read, Edit, Write, Grep, Glob, mcp__hive__vault_query, mcp
    - `$PROJECT_AREA/00-context.md` (technical stack, repo map, hotspots)
    - `$PROJECT_AREA/10-roadmap.md` (active phase, what is done vs pending)
    - `$PROJECT_AREA/11-tasks.md` (progress bar + last "Updated" frontmatter date)
-   - `$PROJECT_AREA/30-architecture/adr-index.md` (latest ADR number, accepted/deferred status)
+   - the repo's `docs/adr/` directory (latest ADR number, accepted/deferred status — GitHub self-indexes; legacy vault-only projects still use `$PROJECT_AREA/30-architecture/`)
    - `$PROJECT_AREA/30-architecture/plan-*.md` -- newest mtime first
    - `$PROJECT_AREA/memory/MEMORY.md` -- Session Handoff section
 2. If a `$PROJECT_AREA/30-architecture/session-protocol.md` exists, read it -- it is the project-specific overlay (constraints, rejection list, pending ADRs).
@@ -152,15 +152,16 @@ allowed-tools: [Bash, Read, Edit, Write, Grep, Glob, mcp__hive__vault_query, mcp
 - Write the ADR to the **repo** `docs/adr/adr-NNN-<slug>.md` (cross-cutting in the platform repo; repo-specific in the owning repo) via a PR — **NOT** the vault `30-architecture/`.
 - Track tasks/roadmap in the **GitHub Project + Issues** — NOT the vault `11-tasks`.
 - The vault keeps only personal/methodology lessons + AI memory + drafts.
-For **personal** projects, use the vault paths below.
+For **personal** projects on the placement model, ADRs ALSO go to the repo `docs/adr/` (per [[pattern-knowledge-placement]]); only the `11-tasks.md` / `memory/` steps below stay in the vault. The work-vs-personal split is now only about *tracking* (GitHub Project vs issues), not ADR placement.
 
 **Steps:**
 
-1. **Author the ADR draft.** Use `$VAULT_PATH/00_meta/templates/adr.md`. Path: `$PROJECT_AREA/30-architecture/adr-NNN-<slug>.md` where NNN = (highest existing ADR + 1).
+1. **Author the ADR draft.** Use `$VAULT_PATH/00_meta/templates/adr.md`. Path: the repo's `docs/adr/adr-NNN-<slug>.md` where NNN = (highest existing ADR + 1). (Legacy pre-migration project still vault-only: `$PROJECT_AREA/30-architecture/`.)
    - Required sections: Status, Date, Context, Options Considered, Decision, Rationale, Consequences (positive/negative/neutral), References.
    - If decision is deferred: status `deferred`, plus explicit "Triggers to Reopen Decision" section (per ADR-016 model).
+   - **GitHub issue link:** if a GitHub Project issue or task tracks this architectural decision, populate `issue: <repo>#NNN` in the ADR frontmatter before writing.
 2. **Update the plan** of record. If a `plan-*.md` motivated this session, patch it: append a "Decision recorded" line linking the new ADR, and update the "Next steps" section if the decision changes it.
-3. **Patch `adr-index.md`** to include the new ADR row.
+3. **Index:** the repo `docs/adr/` self-indexes (GitHub renders the directory) — no separate index file to patch. (Legacy vault-only project: patch the project `_index.md`.)
 4. **Update `11-tasks.md`** if the decision creates, closes, or reshapes tasks. Apply backlog ticks `- [x]` and add new tasks with the ADR-NNN reference inline.
 5. **Capture a lesson** (optional) via `mcp__hive__capture_lesson` if the discussion surfaced a non-obvious insight that future sessions should not re-derive.
 
@@ -168,7 +169,7 @@ For **personal** projects, use the vault paths below.
 
 **Override.** If the user genuinely cannot author an ADR this turn (interruption, missing data), Phase E creates a tracked task in `11-tasks.md` named `**ADR-NNN-draft**: write ADR for <topic>` with `(spec: ADR-NNN-...)` placeholder. Verbal deferral never counts.
 
-**Output of Phase E:** new ADR file + patched plan + patched adr-index + patched 11-tasks.
+**Output of Phase E:** new ADR file (repo `docs/adr/`, self-indexing) + patched plan + patched 11-tasks.
 
 ---
 
@@ -211,11 +212,11 @@ For **personal** projects, use the vault paths below.
 
 | Phase | Reads | Writes |
 |---|---|---|
-| A | `00-context.md`, `10-roadmap.md`, `11-tasks.md`, `adr-index.md`, `plan-*.md`, `memory/MEMORY.md`, `session-protocol.md` | nothing (read-only verification) |
+| A | `00-context.md`, `10-roadmap.md`, `11-tasks.md`, repo `docs/adr/`, `plan-*.md`, `memory/MEMORY.md`, `session-protocol.md` | nothing (read-only verification) |
 | B | `sensor-reference-audit-matrix.md` (or analog) | patches matrix + divergence-log |
 | C | `session-protocol.md` (constraints section) | patches constraint table |
 | D | `session-protocol.md` (rejection list), `00_meta/patterns/_index.md` | nothing (or patches rejection list if new alternatives discarded) |
-| E | `templates/adr.md` | new `adr-NNN-*.md`, patches `adr-index.md`, patches `plan-*.md`, patches `11-tasks.md` |
+| E | `templates/adr.md` | new repo `docs/adr/adr-NNN-*.md` (self-indexing), patches `plan-*.md`, patches `11-tasks.md` |
 | F | (nothing) | patches `memory/MEMORY.md` handoff; OPTIONAL delta proposal for `CURRENT-STATE.md` |
 
 ## Anti-patterns this skill blocks

--- a/harness/skills/handoff/SKILL.md
+++ b/harness/skills/handoff/SKILL.md
@@ -52,6 +52,18 @@ Rules: OVERWRITE entirely (never append); dense but bounded (~8 lines — handof
 - Worktrees for MERGED PRs removed; their branches deleted; `git fetch --prune` gone refs.
 - Every PR opened this session linked (number + merged/open state) in the handoff.
 
+### 3b. Housekeeping (active cleanup — run for every repo touched this session)
+
+Remove transient clutter before closing:
+
+- **Merged branches (local):** `git branch --merged main | grep -vE '^\*|main|master' | xargs -r git branch -d`. Inspect output — do not force-delete (`-D`) without reading why a branch is unmerged.
+- **Remote gone refs:** `git fetch --prune` on every repo touched. Removes stale remote-tracking refs for branches deleted upstream.
+- **Done worktrees:** any worktree whose PR is merged must be removed (`git worktree remove <path>`). If not yet merged, name it in **Open threads** with PR number.
+- **Temp / scratch files:** inspect `git status` for untracked `.bak`, `*.tmp`, scratch notes. Delete only files with no commit intent — never blindly `git clean -f`.
+- **Empty vault stubs:** if any vault file (e.g. `90-lessons.md`) is frontmatter-only with no real content, delete it and remove its inbound links. Scope: only paths touched this session.
+
+Scope: only repos and vault paths actually touched in this session — not a global cleanup pass.
+
 ### 4. Artifact summary
 
 List what the session produced: PRs (number + state), key commit hashes, files created/changed, vault entries added/ticked.

--- a/harness/skills/place-knowledge/SKILL.md
+++ b/harness/skills/place-knowledge/SKILL.md
@@ -48,4 +48,4 @@ Tool-agnostic: store = vault/Confluence/Notion/private-docs-repo; forge = GitHub
 - [[onboard-project-to-placement-model]] — the full runbook
 - [[pattern-three-layer-proposal-lifecycle]] — process view
 - [[feedback_pr_no_attribution]], [[feedback_agent_git_hygiene]] — hard rules learned during KPM-001
-- Epic: `10_projects/knowledge/specs/KPM-001-knowledge-placement-migration/`
+- Epic: `specs/archive/KPM-001-knowledge-placement-migration/` (archived)

--- a/harness/skills/spec/SKILL.md
+++ b/harness/skills/spec/SKILL.md
@@ -91,7 +91,7 @@ When unsure whether a change crosses the threshold, ASK rather than assume (`AGE
 3. **Vault context pre-flight (mandatory):**
    - Via Hive `vault_search`, look for `<feature-id>` (or `--task <id>` if provided) in:
      - `$VAULT_PATH/10_projects/$REPO_NAME/11-tasks.md`
-     - `$VAULT_PATH/10_projects/$REPO_NAME/30-architecture/` (any ADR)
+     - the repo's `docs/adr/` (any ADR)
      - `$VAULT_PATH/10_projects/$REPO_NAME/10-roadmap.md`
    - If found in any -> note source for step 7.
    - If NOT found -> present three options to user:
@@ -174,6 +174,7 @@ When unsure whether a change crosses the threshold, ASK rather than assume (`AGE
    - `$VAULT_PATH/10_projects/$REPO_NAME/10-roadmap.md` (strategic frame).
    - Referenced ADRs (frontmatter only via Hive).
    - Up to 3 sister specs in `$REPO_ROOT/specs/archive/` (for tone consistency).
+4. **GitHub issue link:** if the `issue:` frontmatter field is empty and a GitHub Project issue exists for this spec, ask: "What is the GitHub issue for this spec? (e.g. `kubelab#123` or `skip`)" and populate the field before proceeding.
 
 **The 5 questions (one at a time, wait for each answer):**
 


### PR DESCRIPTION
## What

Second pass of the post-ADR-018 skill-record sweep. #260 aligned the first batch (crystallize, insights, project-maturation, vault-doctor, and the simple `90-lessons.md` -> `docs/lessons.md` edits). This finishes the four records it left only partially aligned with the 3-layer knowledge model:

- **architecture-session** — ADRs authored in the repo `docs/adr/` (self-indexing, no `adr-index.md` to patch), not the vault `30-architecture/`; work-vs-personal is now only a *tracking* distinction; adds the GitHub issue-link step.
- **handoff** — new section **3b. Housekeeping** (merged-branch / gone-ref / done-worktree / temp-file / empty-stub cleanup, scoped to repos touched this session).
- **place-knowledge** — KPM-001 epic reference now points at `specs/archive/`.
- **spec** — pre-flight and archive-promotion read/write ADRs from the repo `docs/adr/`; adds the GitHub issue-link prompt in `fill`.

## How

Records regenerated from the vault SSOT (`00_meta/skills/`) via `compile-harness.sh --refresh`; the committed records under `harness/skills/` are the offline-verifiable artifact (ADR-013). `compile-harness.sh --check` is clean — no harness drift.

## Scope

Doc-only, 32 LOC, below the spec-gate threshold. Part of #250 (skills portion; vault patterns are swept separately on the vault's own master).