### PR TITLE
feat(bitacora): auto-move assigned issues to In Progress + codify status lifecycle (HARNESS-010)

### DIFF
--- a/.github/workflows/bitacora-status.yml
+++ b/.github/workflows/bitacora-status.yml
@@ -1,0 +1,50 @@
+name: Bitácora status — In Progress on assign
+
+# Flip the bitácora (GitHub Project #1) Status to "In Progress" when an issue is
+# assigned. The self-assign-on-pickup habit (AGENTS.md "Neural Hive" Phase 1) now
+# moves the board automatically — closing the manual-transition gap (HARNESS-010,
+# observed 2026-06-06 when #261 was worked while still in Backlog).
+#
+# The other transitions are already covered: built-in Project workflows set
+# "Backlog" on add and "Done" on close; "Blocked" stays a deliberate manual
+# transition (no reliable machine signal) — see runbook §5.
+#
+# Canonical IDs (re-list: gh project field-list 1 --owner mlorentedev --format json):
+#   Project  PVT_kwHOAM7xJs4BZ6GY
+#   Status   PVTSSF_lAHOAM7xJs4BZ6GYzhU1dtI   (option "In Progress" = 6c133cc8)
+# Full reference: docs/runbooks/guide-bitacora-setup.md §2 / §5 / §7.
+
+on:
+  issues:
+    types: [assigned]
+
+permissions: {}   # the job authenticates with BITACORA_PAT, not the default GITHUB_TOKEN
+
+jobs:
+  in-progress:
+    # Never resurrect a closed issue's status when it is (re)assigned.
+    if: github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set bitácora Status = In Progress
+        env:
+          GH_TOKEN: ${{ secrets.BITACORA_PAT }}   # needs project + repo scope
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          set -euo pipefail
+          PROJECT_ID=PVT_kwHOAM7xJs4BZ6GY
+          STATUS_FIELD=PVTSSF_lAHOAM7xJs4BZ6GYzhU1dtI
+          IN_PROGRESS=6c133cc8
+
+          # item-add is idempotent: if the issue is already on the board it
+          # returns the existing item id (verified — no duplicate is created),
+          # so add-then-edit is safe even if the auto-add workflow has not run.
+          ITEM_ID=$(gh project item-add 1 --owner mlorentedev --url "$ISSUE_URL" --format json --jq '.id')
+
+          gh project item-edit \
+            --project-id "$PROJECT_ID" \
+            --id "$ITEM_ID" \
+            --field-id "$STATUS_FIELD" \
+            --single-select-option-id "$IN_PROGRESS"
+
+          echo "Moved $ISSUE_URL → In Progress (item $ITEM_ID)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Senior Principal Software Architect & Technical Mentor. 20+ years production exp
 5. **Consult patterns before architectural decisions.** 37 universal patterns in `00_meta/patterns/`. Query via Hive MCP (when available) or read from `~/Projects/knowledge/00_meta/patterns/<name>.md` (Linux/macOS) / `%USERPROFILE%\Projects\knowledge\00_meta\patterns\<name>.md` (Windows).
 6. **Enterprise-grade or nothing.** Before proposing any code, evaluate: Is this a proven enterprise pattern? Is it scalable? Would a senior engineer approve this in code review? No hacks, no quick-and-dirty, no "it works for now" shortcuts. If the straightforward approach is sloppy, find the elegant one.
 7. **Noted = recorded, never verbal-only.** When you say something is "noted"/"apuntado", or the user tells you to note or track something, persist it to its canonical home **in the same session** — never leave it as conversation-only prose. Placement follows #2 + #3 (decide-vs-operate): build/operate artifacts → the repo (`specs/`, `docs/` — project lessons in `docs/lessons.md`, ADRs in `docs/adr/`, a GitHub issue / Project item); **only** cross-project / methodology knowledge → the vault (`00_meta/` patterns); a decision affecting how agents work → an ADR or this file. Project lessons are NOT a vault `90-lessons.md` (that path is a migration artifact — see `RFD-001`). If it genuinely cannot be filed now, create an explicit tracked task for the debt. "I'll note it" with no durable artifact is a broken promise. See `pattern-decision-persistence`.
+8. **Bitácora status reflects reality.** The board ([GitHub Project #1](https://github.com/users/mlorentedev/projects/1)) is only worth keeping if `Status` tracks what is actually happening. Cross-agent status-lifecycle discipline: **pick up an issue → self-assign it** (`gh issue edit <n> --add-assignee @me`) — the `bitacora-status` Action flips its `Status` to **In Progress**; **hit a hard blocker → set `Status` = Blocked** and name the blocker in an issue comment; **close the issue → the built-in workflow sets Done**. Never leave an issue you are actively working in `Backlog`. Mechanics, IDs, and the manual fallback live in `docs/runbooks/guide-bitacora-setup.md` §5.
 
 ### Pattern Catalog (00_meta/patterns/)
 
@@ -248,12 +249,14 @@ Defaults = personal solo project (this repo). Build/operate docs always live in 
 3. **Project Context:** Read `10_projects/<repo>/00-context.md`.
 4. **Global Rules:** Read relevant `00_meta/patterns/*.md`.
 5. **Tactical Plan:** Check the **bitácora** GitHub Project (user-level, cross-repo) for active backlog items. Filter by `Repo` field to see this repo's items. If offline, fall back to open GitHub issues.
+6. **Claim it:** When you pick an item to work, **self-assign it** (`gh issue edit <n> --add-assignee @me`) — the `bitacora-status` Action moves it to `In Progress` (Standing Order #8). Don't start editing while it still sits in `Backlog`.
 
 ### Phase 2: Execution (The Work)
 
 * **Plan:** Create a sub-task checklist in memory (or scratchpad).
 * **Act:** Implement code/tests in the repo.
 * **Verify:** Run tests.
+* **Blocked?** If a hard blocker stops progress, set the issue's bitácora `Status` = `Blocked` and name the blocker in an issue comment (Standing Order #8) — don't leave it silently stalled in `In Progress`.
 * **Document Dynamic** (decide-vs-operate — build/operate → repo, cross-project → vault):
   * New architectural decision → repo `docs/adr/adr-XXX.md`.
   * New operational procedure → repo `docs/runbooks/guide-XXX.md`.
@@ -263,7 +266,7 @@ Defaults = personal solo project (this repo). Build/operate docs always live in 
 
 ### Phase 3: Knowledge Crystallization (Write Back)
 
-* **Backlog (bitácora):** Close the GitHub issue — the built-in workflow moves it to Done automatically. No manual vault update needed.
+* **Backlog (bitácora):** Close the GitHub issue — the built-in workflow moves it to `Done` automatically (the close end of the Standing Order #8 lifecycle). No manual vault update needed.
   * Ticket IDs in the GitHub Project custom field `ID` use `AREA-NNN-slug` format (e.g. `SSOT-027-id-scheme`). Existing pure-numeric IDs remain valid — no backfill required.
 * **Strategy (`10-roadmap.md`):** ONLY if a major milestone is completed.
 * **Lessons:** project-specific → repo `docs/lessons.md`; cross-project / methodology → vault `90-lessons.md` (Lesson Template).

--- a/docs/runbooks/guide-bitacora-setup.md
+++ b/docs/runbooks/guide-bitacora-setup.md
@@ -55,8 +55,8 @@ The single source for field/option IDs — copy from here, do not re-discover.
 # 1. Link the repo to the project
 gh project link 1 --owner mlorentedev --repo mlorentedev/<repo>
 
-# 2. Deploy the workflow (§7) + upload the secret it needs
-#    copy .github/workflows/add-to-project.yml into the repo, then:
+# 2. Deploy BOTH workflows (§7) + upload the secret they need
+#    copy .github/workflows/add-to-project.yml AND bitacora-status.yml into the repo, then:
 age --decrypt -i ~/.config/age/key.txt sensitive/github.bitacora.secret.age \
   | gh secret set BITACORA_PAT --repo mlorentedev/<repo>
 
@@ -73,28 +73,30 @@ gh issue list --repo mlorentedev/<repo> --state open --limit 200 --json number \
 
 ## 5. Operating discipline — the status lifecycle (HARNESS-010)
 
-The board is only worth anything if Status reflects reality. On every issue you act on:
+The board is only worth anything if `Status` reflects reality. The cross-agent rule is canonical in
+`AGENTS.md` Standing Order #8; this section is the mechanical reference. On every issue you act on:
 
-| When | Action |
-|------|--------|
-| New issue opened | the *Item added* workflow sets **Backlog** automatically |
-| **You start working it** | set Status → **In Progress** (do this BEFORE the first edit) |
-| You hit a blocker | set Status → **Blocked** + name the blocker in a comment |
-| You finish / close it | close the issue → the *issue closed* workflow sets **Done** |
+| When | Status | How |
+|------|--------|-----|
+| New issue opened | **Backlog** | automatic — *Item added* built-in workflow |
+| **You start working it** | **In Progress** | automatic — **self-assign** (`gh issue edit <n> --add-assignee @me`); the `bitacora-status.yml` workflow (§7) flips the field |
+| You hit a blocker | **Blocked** | manual — set the field (helper below) + name the blocker in a comment |
+| You finish / close it | **Done** | automatic — *issue closed* built-in workflow |
 
-**Automated today** (built-in workflows): **Backlog** (item added) and **Done** (issue closed).
-**Manual today:** **In Progress** and **Blocked** — there is no clean built-in for "work started".
-Automating *In Progress* (trigger on a linked PR opening, or on issue-assignment) is tracked in
-**HARNESS-010**; until then it is a manual step, with the discipline above as the contract.
+**Automated (HARNESS-010):** *Backlog* (item added), *In Progress* (issue assigned → `bitacora-status.yml`),
+and *Done* (issue closed). In normal flow you therefore touch the field **only for `Blocked`** —
+self-assign starts it, closing finishes it. `Blocked` stays manual on purpose: there is no reliable
+machine signal for "stuck", and naming the blocker is a human judgement.
 
-Set **Priority** (default P2) and **Type** manually; set the **ID** field forward-only. Helper to move issue `#N`:
+Set **Priority** (default P2) and **Type** manually; set the **ID** field forward-only. Manual helper
+to move issue `#N` (Status options: In Progress `6c133cc8` · Blocked `7705a647` · Done `bb482da4`):
 
 ```bash
 ITEM=$(gh project item-list 1 --owner mlorentedev --format json --limit 300 \
   | python3 -c "import json,sys;[print(i['id']) for i in json.load(sys.stdin)['items'] \
        if i.get('content',{}).get('number')==N]")
 gh project item-edit --id "$ITEM" --project-id PVT_kwHOAM7xJs4BZ6GY \
-  --field-id PVTSSF_lAHOAM7xJs4BZ6GYzhU1dtI --single-select-option-id 6c133cc8   # -> In Progress
+  --field-id PVTSSF_lAHOAM7xJs4BZ6GYzhU1dtI --single-select-option-id 7705a647   # -> Blocked
 ```
 
 ## 6. Views
@@ -103,9 +105,12 @@ gh project item-edit --id "$ITEM" --project-id PVT_kwHOAM7xJs4BZ6GY \
 - **By repo** — group by Repository (tasks span all repos).
 - **PRs pending review** (OPS-003) — filter `is:pr is:open`, group by repo.
 
-## 7. `add-to-project.yml` (workflow template)
+## 7. Workflows (deploy BOTH to every linked repo)
 
-Deploy verbatim to every linked repo. Adds opened **issues and PRs** to the bitácora.
+Each linked repo carries two workflows. **OPS-002 (#258) rolls both out** to every repo in one pass;
+the canonical copies live in `mlorentedev/dotfiles/.github/workflows/`.
+
+### 7a. `add-to-project.yml` — puts opened **issues and PRs** on the board
 
 ```yaml
 name: Add to bitácora
@@ -127,15 +132,45 @@ jobs:
 > **Gotcha (2026-06-06):** `actions/add-to-project@v1` is unresolvable — there is no floating
 > `v1` tag. Pin `@v1.0.2` (latest v1) or `@v2.0.0`. `BITACORA_PAT` needs `project` + `repo` scope.
 
+### 7b. `bitacora-status.yml` — moves an **assigned** issue to *In Progress* (HARNESS-010)
+
+Fires on `issues: [assigned]`, so self-assigning at pickup flips `Status` automatically (§5). It is
+idempotent (`item-add` returns the existing item) and guarded to skip closed issues. The IDs are the
+canonical ones from §2 — re-list with `gh project field-list 1 --owner mlorentedev --format json`.
+
+```yaml
+name: Bitácora status — In Progress on assign
+on:
+  issues:
+    types: [assigned]
+permissions: {}   # authenticates with BITACORA_PAT, not the default GITHUB_TOKEN
+jobs:
+  in-progress:
+    if: github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set bitácora Status = In Progress
+        env:
+          GH_TOKEN: ${{ secrets.BITACORA_PAT }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          set -euo pipefail
+          ITEM_ID=$(gh project item-add 1 --owner mlorentedev --url "$ISSUE_URL" --format json --jq '.id')
+          gh project item-edit --project-id PVT_kwHOAM7xJs4BZ6GY --id "$ITEM_ID" \
+            --field-id PVTSSF_lAHOAM7xJs4BZ6GYzhU1dtI --single-select-option-id 6c133cc8
+```
+
 ## 8. Troubleshooting
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| "Add to bitácora" fails in ~4s, `unable to resolve action … v1` | invalid version pin | §7 — pin `@v1.0.2` |
+| "Add to bitácora" fails in ~4s, `unable to resolve action … v1` | invalid version pin | §7a — pin `@v1.0.2` |
 | Issue/PR never lands on the board | workflow missing, secret absent, or PAT expired | redo §4 step 2 |
+| Assigning an issue does **not** move it to *In Progress* | `bitacora-status.yml` missing in that repo, or PAT lacks `project` scope | §7b — deploy it (OPS-002 rollout) / check `BITACORA_PAT` |
 | `item-edit`: *could not resolve to ProjectV2 node* | wrong project-id / field-id | §2 reference |
 | `gh pr edit` errors with `projectCards` deprecation | classic-projects GraphQL path | use `gh api` instead |
 
 ## References
 
-- ADR-018 (de-vault task placement), epic #244 (Flow v2), OPS-002/003, CUR-008 (ID scheme), HARNESS-010 (status lifecycle).
+- ADR-018 (de-vault task placement), epic #244 (Flow v2), OPS-002/003, CUR-008 (ID scheme).
+- HARNESS-010 (status lifecycle): `AGENTS.md` Standing Order #8 (doctrine) + `bitacora-status.yml` (§7b automation).

--- a/specs/HARNESS-010-bitacora-status-lifecycle/features.json
+++ b/specs/HARNESS-010-bitacora-status-lifecycle/features.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "HARNESS-010-bitacora-status-lifecycle-f1",
+    "behavior": "AC1 — AGENTS.md codifies the status-lifecycle rule (In Progress / Blocked / Done) as a Standing Order and Neural Hive Loop touchpoints",
+    "verification": "grep -qi 'status.*lifecycle' AGENTS.md && grep -q 'In Progress' AGENTS.md && grep -q 'Blocked' AGENTS.md",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-010-bitacora-status-lifecycle-f2",
+    "behavior": "AC2 — bitacora-status.yml triggers on issues:[assigned], guards open state, sets Status=In Progress via the canonical In Progress option id",
+    "verification": "grep -q 'assigned' .github/workflows/bitacora-status.yml && grep -q \"state == 'open'\" .github/workflows/bitacora-status.yml && grep -q '6c133cc8' .github/workflows/bitacora-status.yml",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-010-bitacora-status-lifecycle-f3",
+    "behavior": "AC3 — the workflow file is valid YAML",
+    "verification": "python3 -c \"import yaml,sys; yaml.safe_load(open('.github/workflows/bitacora-status.yml'))\"",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-010-bitacora-status-lifecycle-f4",
+    "behavior": "AC4 — the bitácora runbook registers bitacora-status.yml in the per-repo deployment bundle",
+    "verification": "grep -q 'bitacora-status.yml' docs/runbooks/guide-bitacora-setup.md",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-010-bitacora-status-lifecycle-f5",
+    "behavior": "AC5 — /handoff SKILL.md (vault) has a board-status reconciliation step. Verified by observation; vault is a separate repo, not in dotfiles CI.",
+    "verification": "test -f \"$HOME/Projects/knowledge/00_meta/skills/handoff/SKILL.md\" && grep -qi 'reconcil' \"$HOME/Projects/knowledge/00_meta/skills/handoff/SKILL.md\"",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/HARNESS-010-bitacora-status-lifecycle/proposal.md
+++ b/specs/HARNESS-010-bitacora-status-lifecycle/proposal.md
@@ -1,0 +1,52 @@
+---
+id: "HARNESS-010-bitacora-status-lifecycle"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-06-07"
+issue: "mlorentedev/dotfiles#270"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# HARNESS-010-bitacora-status-lifecycle
+
+## Why
+
+The bitácora (GitHub Project #1) has a `Status` field but **no rule tells the agent when to transition it**, and **nothing flips it automatically**. Observed 2026-06-06: HARNESS-006 (#261) was actively implemented while still in `Backlog` — its status had to be moved by hand. The mechanical board exists (built-in workflows set `Backlog` on add and `Done` on close); the *start-of-work* and *blocked* transitions are pure manual discipline that, in practice, gets skipped. A board whose `Status` lags reality is worthless as a real-time picture across repos.
+
+## What
+
+After this PR:
+
+1. **Doctrine** — `AGENTS.md` codifies the status-lifecycle as a cross-agent rule: a Standing Order plus operational touchpoints in the Neural Hive Loop (pickup → self-assign; blocker → `Blocked`; close → `Done`). This is the canonical, agent-readable contract.
+2. **Automation** — a new per-repo GitHub Action (`.github/workflows/bitacora-status.yml`) listens on `issues: [assigned]` and sets the issue's bitácora `Status = In Progress`. Self-assigning when you pick up an issue (the new Phase-1 habit) now flips the board automatically — the previously-manual step is gone.
+3. **Rollout contract** — the bitácora runbook registers the new workflow in the per-repo deployment bundle (§4/§7) so OPS-002 (#258) rolls out *both* workflows (add-to-project + bitacora-status) to every linked repo in one pass.
+4. **Skill wiring** — `/handoff` reconciles board status at session end: any issue worked this session must be `In Progress`/`Blocked`/`Done`, never left in `Backlog`.
+
+## Out of scope
+
+- Deploying the workflow to all repos — that is **OPS-002 (#258)**; this PR ships + validates it on `dotfiles` and registers it as the template.
+- Auto-detecting `Blocked` — there is no reliable machine signal; it stays a doctrine-driven manual transition (one documented `gh` command).
+- A "PR-linked" trigger — a PR opens *after* work starts, so it is a late signal; `assigned` fires at the true start.
+- A cross-platform helper script (`.sh`/`.ps1`) — the `gh project item-edit` one-liner already in the runbook §5 is sufficient; a new script would add Windows-parity + test surface for no gain.
+
+## Risks / open questions
+
+- **Self-assign dependency.** The `assigned` trigger only fires if someone self-assigns. Mitigation: codify the habit in `AGENTS.md` Phase 1; `/handoff` reconciliation catches misses. (Resolved.)
+- **PAT scope.** `BITACORA_PAT` must carry `project` + `repo` scope per repo. Verified present in `dotfiles` and `knowledge`. (Resolved.)
+- **Add/edit race.** If `assigned` fires before the project auto-add, the item may not exist. Mitigation: the Action does `item-add` (idempotent — verified: re-adding #270 returned the existing item id, no duplicate) then `item-edit`; add-then-edit is self-sufficient. (Resolved.)
+- **Closed issues.** Assigning a closed issue should not resurrect it to `In Progress`. Mitigation: `if: github.event.issue.state == 'open'` guard. (Resolved.)
+
+## Acceptance criteria
+
+- [ ] AC1 — `AGENTS.md` contains a status-lifecycle rule covering start→`In Progress`, blocker→`Blocked`, close→`Done`, as a Standing Order and as Neural Hive Loop touchpoints.
+- [ ] AC2 — `.github/workflows/bitacora-status.yml` exists, triggers on `issues: [assigned]`, guards `state == 'open'`, and sets `Status = In Progress` via `gh` + `BITACORA_PAT` using the canonical project/field/option IDs.
+- [ ] AC3 — the workflow file is valid YAML.
+- [ ] AC4 — runbook §4/§7 registers `bitacora-status.yml` in the per-repo bundle; §5 marks `In Progress` as automated-on-assign while keeping `Blocked` manual.
+- [ ] AC5 — `/handoff` SKILL.md has a board-status reconciliation step.
+
+## References
+
+- Issue: `mlorentedev/dotfiles#270` (HARNESS-010); related #265 (HARNESS-009), epic #244 (Flow v2), #258 (OPS-002 rollout).
+- Runbook: `docs/runbooks/guide-bitacora-setup.md` (§5 status lifecycle, §7 workflow template) — OPS-004.
+- ADR: `docs/adr/adr-018-de-vault-task-placement.md` (task state lives in the bitácora).

--- a/specs/HARNESS-010-bitacora-status-lifecycle/tasks.md
+++ b/specs/HARNESS-010-bitacora-status-lifecycle/tasks.md
@@ -1,0 +1,32 @@
+---
+tags: [spec, tasks]
+created: "2026-06-07"
+---
+
+# Tasks - HARNESS-010-bitacora-status-lifecycle
+
+> One task = one focused change. Tick as you go.
+
+## Setup
+
+- [x] Branch created from `origin/main`: `harness-010-bitacora-status-lifecycle` (worktree)
+- [x] `proposal.md` complete; acceptance criteria testable; no open questions left
+
+## Implementation
+
+- [ ] AC2 — add `.github/workflows/bitacora-status.yml` (`issues:[assigned]` → `Status=In Progress`, `state==open` guard, idempotent `item-add` + `item-edit`)
+- [ ] AC1 — codify the status-lifecycle rule in `AGENTS.md` (Standing Order + Neural Hive Loop Phase 1/2/3 touchpoints)
+- [ ] AC4 — update runbook `guide-bitacora-setup.md` §4/§5/§7 (register workflow in per-repo bundle; mark In Progress automated-on-assign)
+- [ ] AC5 — wire board-status reconciliation into vault `00_meta/skills/handoff/SKILL.md`
+- [ ] AC3 — confirm workflow YAML parses
+
+## Closing
+
+- [ ] Every acceptance criterion covered by a `features.json` entry with a non-vacuous verification command
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder (`Closes #270`)
+
+## Machine-readable features
+
+See sibling `features.json`. **Pass-state gating:** only the harness may set `"state": "passing"`, after running `verification` with exit 0 and capturing `evidence`. The vault `/handoff` step (AC5) and the live `assigned → In Progress` behaviour are verified by observation (recorded in `verification.md`), since they cannot run in this repo's CI.

--- a/specs/HARNESS-010-bitacora-status-lifecycle/verification.md
+++ b/specs/HARNESS-010-bitacora-status-lifecycle/verification.md
@@ -1,0 +1,44 @@
+---
+tags: [spec, verification]
+created: "2026-06-07"
+---
+
+# Verification - HARNESS-010-bitacora-status-lifecycle
+
+## Evidence
+
+- [x] AC1 (doctrine in AGENTS.md) → Standing Order #8 + Neural Hive Loop Phase 1 step 6 (claim/self-assign), Phase 2 "Blocked?", Phase 3 Done cross-ref. `features.json` f1 grep passes.
+- [x] AC2 (`bitacora-status.yml`) → `.github/workflows/bitacora-status.yml`: `issues:[assigned]`, `if: github.event.issue.state == 'open'`, idempotent `item-add` + `item-edit` to option `6c133cc8`. f2 grep passes.
+- [x] AC3 (valid YAML) → `python3 -c "import yaml; yaml.safe_load(...)"` exit 0 **and** `actionlint` exit 0.
+- [x] AC4 (runbook) → §4 step 2 deploys both workflows; §5 marks In Progress automated-on-assign (Blocked stays manual); §7 split into 7a/7b with the new template; §8 troubleshooting row added. f4 grep passes.
+- [x] AC5 (`/handoff`) → vault `00_meta/skills/handoff/SKILL.md` step 2b "Bitácora status reconciliation" + description updated. f5 grep passes.
+
+## Test status
+
+- Static: `actionlint .github/workflows/bitacora-status.yml` → exit 0. YAML `safe_load` → OK.
+- features.json verifications f1–f5 → all exit 0 locally (run from repo root; f5 targets the vault path).
+- **Manual smoke (mechanism, pre-deploy):** the Action's exact command pair was exercised live against the real board —
+  - `gh project item-edit ... --single-select-option-id 6c133cc8` moved #270 → In Progress (confirmed on the board).
+  - `gh project item-add` idempotency confirmed: re-adding #270 returned the existing item id `PVTI_lAHOAM7xJs4BZ6GYzgu7wCI`, no duplicate, status preserved.
+- **Live end-to-end** (`assign → In Progress` via the deployed workflow) is verifiable only after this lands on `main` (workflows run from the default branch). Post-merge check: assign a throwaway/open issue and confirm the run is green and the field flips. Recorded as a closing step, not claimed done here.
+- No regressions: dotfiles CI (`lint`, `test`, `integration`, `spec-gate`) expected green — spec folder present satisfies the Discipline Gate regardless of LOC.
+
+## Decisions made during implementation
+
+- **Trigger = `issues:[assigned]`, not PR-linked.** The observed gap (work starts while Backlog) happens *before* any PR exists, so a PR-open trigger is a late signal; self-assign at pickup is the true start. No GitHub Projects built-in covers "assigned → status", hence a custom Action.
+- **`Blocked` left manual.** No reliable machine signal for "stuck"; naming the blocker is human judgement. Automating it would add label-management surface for little gain.
+- **Rollout deferred to OPS-002 (#258).** This PR ships + validates the workflow on `dotfiles` and registers it in the runbook's per-repo bundle (§4/§7); copying it to all repos + secret is OPS-002's job — keeps HARNESS-010 acotado and avoids a half-deployed automation.
+- **No helper script.** A `.sh`/`.ps1` wrapper would incur Windows-parity + test surface; the `gh project item-edit` one-liner in runbook §5 is enough for the only remaining manual transition (Blocked).
+
+## Promotion candidates
+
+- [ ] Lesson for `docs/lessons.md`? **yes (separate, not this PR)** — "re-running a failed GitHub Actions run replays the *original commit's* workflow file, so a workflow-file fix must be verified by firing a *fresh* event, not a re-run." Surfaced while fixing the `add-to-project@v1` failures this session. File in dotfiles `docs/lessons.md` next session.
+- [ ] ADR-worthy? **no** — doctrine fits AGENTS.md Standing Order #8; no architectural fork.
+- [ ] New `00_meta/patterns/` candidate? **not yet** — revisit if a second project needs the same assign→status automation (OPS-002 may surface it).
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/HARNESS-010-bitacora-status-lifecycle/` -> `specs/archive/HARNESS-010-bitacora-status-lifecycle/`
+- [ ] Issue #270 closed (built-in workflow → Done); PR linked
+- [ ] Promotions above executed (the `docs/lessons.md` lesson)


### PR DESCRIPTION
## Why

The bitácora (Project #1) has a `Status` field but nothing flipped it when work *started* — observed 2026-06-06 when #261 was actively implemented while still in `Backlog`. Built-ins cover `Backlog` (on add) and `Done` (on close); the start-of-work transition was pure manual discipline that, in practice, got skipped. A board whose `Status` lags reality is worthless as a real-time cross-repo picture.

## What

- **Automation** — `.github/workflows/bitacora-status.yml`: on `issues: [assigned]`, set `Status = In Progress`. Self-assigning at pickup now flips the board automatically. Idempotent (`item-add` returns the existing item), guarded to skip closed issues, authenticates with `BITACORA_PAT` (no default-token perms).
- **Doctrine** — `AGENTS.md` Standing Order #8 + Neural Hive Loop touchpoints (Phase 1 self-assign on pickup, Phase 2 `Blocked` on a hard blocker, Phase 3 `Done` on close). The canonical cross-agent rule.
- **Runbook** — `docs/runbooks/guide-bitacora-setup.md` §4/§5/§7: registers the workflow in the per-repo deployment bundle and marks `In Progress` automated-on-assign; `Blocked` stays a deliberate manual transition.
- **Spec** — `specs/HARNESS-010-bitacora-status-lifecycle/` (proposal/tasks/verification/features).

The `/handoff` board-status reconciliation step (AC5) lands in the vault (`00_meta/skills/handoff/SKILL.md`) separately — it is not a dotfiles file.

## Scope

- **In:** ship + validate the workflow on `dotfiles`; register it as the template.
- **Out:** rolling both workflows out to every repo — that is **OPS-002 (#258)**. `Blocked` auto-detection (no reliable signal). A PR-linked trigger (a PR opens after work starts — late signal).

## Verification

- `actionlint` → exit 0; YAML `safe_load` → OK; `spec-gate` → OK (spec folder present).
- Mechanism exercised live against the real board: `item-edit` moved #270 → In Progress; `item-add` idempotency confirmed (no duplicate). Live `assign → In Progress` via the deployed workflow is verifiable once this is on `main` (workflows run from the default branch).

Closes #270