### PR TITLE
docs(spec): scaffold REFACTOR-011 single version manifest

### DIFF
--- a/specs/REFACTOR-011-version-manifest/proposal.md
+++ b/specs/REFACTOR-011-version-manifest/proposal.md
@@ -1,0 +1,68 @@
+---
+id: "REFACTOR-011-version-manifest"
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-07"
+issue: "mlorentedev/dotfiles#282"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, versions, ssot]
+template_version: "1.0"
+---
+
+# REFACTOR-011-version-manifest
+
+## Why
+
+`versions.conf` is the central version manifest and **is** sourced by `.zshrc`/`.bashrc`
+(`. "$DOTFILES_DIR/versions.conf"` one line above the tool-home exports). But a version
+bump is **not** "one line": every tool version is *also* hard-coded as a `${VAR:-X.Y.Z}`
+fallback in **both** RC files, so a bump must be repeated in three places or the fallback
+silently drifts from the manifest (a stale fallback only surfaces if `versions.conf` ever
+goes missing — i.e. it masks failure rather than catching it). Separately, **opencode is
+not pinned at all** (installed via `curl https://opencode.ai/install | bash` = always
+latest), so the daily-driver agent can differ across machines. REFACTOR-011 makes
+`versions.conf` the **sole** version source (true one-line bumps), pins opencode, and adds
+a guard so no version literal can re-appear outside the manifest.
+
+## What
+
+- `OPENCODE_VERSION` is added to `versions.conf`; opencode install (Linux + Windows) pins
+  to it (`curl … | bash -s -- --version "$OPENCODE_VERSION"` — the official installer
+  honors `--version`/`VERSION`, verified).
+- The hard-coded `${VAR:-X.Y.Z}` fallback literals in `.zshrc`/`.bashrc` are removed;
+  `versions.conf` (sourced immediately above) becomes the only source of each version.
+- A bats cross-check fails CI if any RC file re-introduces a hard-coded version literal, or
+  if a `*_HOME` references a version var that `versions.conf` does not define (incident→guard).
+- `healthcheck.{sh,ps1}` report/assert the installed opencode version against `OPENCODE_VERSION`.
+
+## Out of scope
+
+- Auto-bump / Dependabot-style version-update automation.
+- Migrating tools that are not currently path-pinned (node, gh, etc.) into the manifest — only `opencode` is added now.
+- Changing the versioned-install directory scheme (`~/Applications/tool-X.Y.Z`).
+- Fixing `init-spec.sh`'s legacy vault `11-tasks.md` rooting (ADR-018 moved tasks to the bitácora) — noted, separate ticket.
+
+## Risks / open questions
+
+- **Removing RC fallbacks**: if `versions.conf` is ever absent (broken checkout), `*_HOME`
+  paths resolve empty and those tools drop off PATH. Accepted as non-fatal; the source line
+  `[[ -f versions.conf ]] && . versions.conf` stays, and the new guard + healthcheck surface it.
+- **opencode pin contract**: the pin relies on the upstream installer's `--version` flag; if
+  upstream drops it the install silently falls back to latest. Mitigation: healthcheck asserts
+  installed == pinned (turns a silent drift into a visible warning).
+- **Windows parity**: `setup-windows.ps1` opencode install must accept the same pin — verify the Windows installer path honors a version argument.
+- **CI Docker build-arg**: `BATS_VERSION` is passed as a Docker build arg in `ci.yml`; adding `OPENCODE_VERSION` must not perturb that path.
+
+## Acceptance criteria
+
+- [ ] `versions.conf` contains `OPENCODE_VERSION` (semver); `versions-conf.bats` asserts it is set + semver.
+- [ ] `setup-linux.sh` and `setup-windows.ps1` install opencode pinned to `$OPENCODE_VERSION`.
+- [ ] `.zshrc` and `.bashrc` contain no hard-coded version fallback literal; every tool home resolves solely from `versions.conf`.
+- [ ] A bats test fails if a hard-coded version literal is re-introduced into either RC file (incident→guard, both shells).
+- [ ] `healthcheck.{sh,ps1}` report/assert opencode version against `OPENCODE_VERSION`.
+- [ ] Full `bats tests/*.bats` green; `shellcheck` clean on changed scripts.
+
+## References
+
+- GitHub: `mlorentedev/dotfiles#282`
+- Vault backlog: REFACTOR-011
+- Related: `docs/adr/dotfiles-architecture-map.md` ("where does X live" → `versions.conf`)
+- Patterns: `00_meta/patterns/pattern-spec-driven-development.md`; incident→guard (`90-lessons`)

--- a/specs/REFACTOR-011-version-manifest/tasks.md
+++ b/specs/REFACTOR-011-version-manifest/tasks.md
@@ -1,0 +1,45 @@
+---
+tags: [spec, tasks]
+created: "2026-06-07"
+---
+
+# Tasks - REFACTOR-011-version-manifest
+
+> Implementation **deferred** (spec-only session 2026-06-06). Concrete plan below with
+> exact file:line from the investigation, so the next session executes without re-scoping.
+> Decision approved: **remove RC fallbacks + add a guard** (single-source manifest).
+
+## Setup
+
+- [x] Branch created: `refactor-011-version-manifest` (from `origin/main`)
+- [x] `proposal.md` complete; acceptance criteria testable
+- [x] Open question resolved: the opencode installer honors `--version`/`VERSION` (verified against `https://opencode.ai/install`)
+
+## Implementation (TDD order — one commit each)
+
+1. **Add the pin to the manifest** — `versions.conf`: add `OPENCODE_VERSION=1.16.2` (currently-installed version; bump later as desired).
+2. **Assert it** — `tests/versions-conf.bats`: add `@test "versions.conf sets OPENCODE_VERSION"` mirroring the per-var tests (lines 30-52); the semver-all-values test (55-62) already covers format.
+3. **Make setup read the manifest** — `setup-linux.sh` does **not** currently source `versions.conf` (only `safe_copy` at :38). Add `[ -f "$CURRENT_DIR/versions.conf" ] && . "$CURRENT_DIR/versions.conf"` early (after `CURRENT_DIR`/`DOTFILES_DIR` are set, ~line 30) so `$OPENCODE_VERSION`/`$GHOSTTY_VERSION` are reliable regardless of the parent shell.
+4. **Pin opencode (Linux)** — `setup-linux.sh:596`: `curl -fsSL https://opencode.ai/install | bash -s -- --version "$OPENCODE_VERSION"`. Consider re-install-on-drift in the idempotence block (:593-602).
+5. **Drop the ghostty fallback** — `setup-linux.sh:688`: `${GHOSTTY_VERSION:-1.3.0}` → `${GHOSTTY_VERSION}` (now that the manifest is sourced).
+6. **Remove RC fallbacks** — `.zshrc:48-52` and `.bashrc:71-75`: `${JAVA_VERSION:-21.0.4}` → `${JAVA_VERSION}` for JAVA/MAVEN/PYTHON/MINIKUBE/GO (10 lines total). The `. versions.conf` source line stays (`.zshrc:45`, `.bashrc:68`).
+7. **Guard test (incident→guard)** — new `tests/versions-no-hardcode.bats`:
+   - fail if `.zshrc`/`.bashrc` match `\$\{[A-Z_]+_VERSION:-[0-9]` (a re-introduced hardcoded fallback);
+   - assert every `${*_VERSION}` referenced in the RC tool-home exports is a key defined in `versions.conf`.
+8. **healthcheck opencode assert (Linux)** — `scripts/healthcheck.sh` opencode block (~353-357): add a version-match mirroring the ghostty pattern (379-388): `OPENCODE_PINNED="$(grep -E '^OPENCODE_VERSION=' "$DOTFILES_DIR/versions.conf" | cut -d= -f2)"`, compare to `opencode --version`.
+9. **Windows (⚠️ Windows-empirical — defer to a Windows session per the batch-windows rule):**
+   - `setup-windows.ps1` installs opencode via **winget** (`SST.opencode`, generic loop :310-322). Pinning needs `winget install --version $OPENCODE_VERSION SST.opencode` (special-case out of the loop) **and** the script must parse `OPENCODE_VERSION` from `versions.conf`. Verify winget honors `--version` for this package + that the version is available.
+   - `scripts/healthcheck.ps1` (~472): mirror the opencode version assert.
+
+## Closing
+
+- [ ] Every AC covered by a test; add sibling `features.json` (harness contract) at implementation time.
+- [ ] `bats tests/*.bats` green; `shellcheck` clean on changed scripts.
+- [ ] `verification.md` filled with evidence (commit hashes / test names).
+- [ ] Windows items either landed (if at a Windows box) or split into a follow-up ticket.
+- [ ] PR opened referencing this spec folder.
+
+## Notes / discovered debt (capture, don't fix here)
+
+- `init-spec.sh` is still vault-`11-tasks.md`-rooted; ADR-018 moved task tracking to the bitácora. Used `--force-no-vault` to scaffold. Separate ticket candidate.
+- `setup-linux.sh` not sourcing `versions.conf` means `${GHOSTTY_VERSION:-1.3.0}` (:688) only worked via the invoking shell's env — same masked-failure class this refactor removes.

--- a/specs/REFACTOR-011-version-manifest/verification.md
+++ b/specs/REFACTOR-011-version-manifest/verification.md
@@ -1,0 +1,43 @@
+---
+tags: [spec, verification]
+created: "2026-06-07"
+---
+
+# Verification - REFACTOR-011-version-manifest
+
+> Implementation deferred — this records the **planned** verification command per acceptance
+> criterion so the next session has an executable target. Fill `Evidence` with commit hashes /
+> test names once implemented.
+
+## Planned verification per acceptance criterion
+
+- [ ] **OPENCODE_VERSION in manifest** → `grep -qE '^OPENCODE_VERSION=[0-9]+\.[0-9]+\.[0-9]+$' versions.conf` + new bats `versions.conf sets OPENCODE_VERSION`.
+- [ ] **opencode install pinned (Linux)** → `grep -qF 'bash -s -- --version "$OPENCODE_VERSION"' setup-linux.sh`; setup sources the manifest (`grep -qE '\. .*versions\.conf' setup-linux.sh`).
+- [ ] **opencode install pinned (Windows)** → `setup-windows.ps1` passes `--version` for `SST.opencode` (Windows-empirical: confirm on a Windows box).
+- [ ] **No hardcoded fallbacks in RC** → `! grep -qE '\$\{[A-Z_]+_VERSION:-[0-9]' .zshrc .bashrc`.
+- [ ] **Guard test exists + fails on re-introduction** → `bats tests/versions-no-hardcode.bats` green; manually add a `:-1.2.3` to a temp RC fixture → test goes red.
+- [ ] **healthcheck asserts opencode version** → `bats tests/healthcheck.bats` (+ `.ps1` mirror); `grep -q OPENCODE_VERSION scripts/healthcheck.sh`.
+- [ ] **No regressions** → `bats tests/*.bats` green (baseline this session: 1063 pass; 3 pre-existing `shell-profile.bats` failures are sandbox-environmental, unrelated).
+
+## Evidence
+
+- [ ] (pending implementation)
+
+## Decisions made
+
+- **Remove RC fallbacks rather than keep-and-cross-check** (user decision 2026-06-06): the explicit goal is a one-line bump; the lost "missing versions.conf" safety net is non-fatal (tools drop off PATH) and is replaced by the guard test + healthcheck.
+- **opencode pin is feasible** — official installer honors `--version`/`VERSION` (verified).
+- **Windows pin deferred** — winget path is Windows-empirical (batch-windows rule).
+
+## Promotion candidates
+
+- [ ] Lesson for `docs/lessons.md`? Maybe — "a sourced manifest + a hardcoded fallback is two sources of truth; the fallback masks failure instead of catching it." Decide at archive.
+- [ ] ADR-worthy? No.
+- [ ] New pattern for `00_meta/patterns/`? No (single-repo concern).
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter `status: archived`
+- [ ] Folder moved to `specs/archive/REFACTOR-011-version-manifest/`
+- [ ] Backlog entry ticked with PR link
+- [ ] Promotions executed (if any)


### PR DESCRIPTION
## Summary

Scaffolds the SDD spec for **REFACTOR-011** (single version manifest). **Spec only — implementation deferred** per session scope.

## What the spec covers

- Add `OPENCODE_VERSION` to `versions.conf` + pin the opencode install (installer honors `--version`, verified).
- Remove the duplicate `${VAR:-X.Y.Z}` fallbacks in `.zshrc`/`.bashrc` → `versions.conf` (already sourced one line above) becomes the **sole** source ⇒ one-line bumps.
- incident→guard bats test preventing re-introduction of hardcoded version literals.
- `healthcheck.{sh,ps1}` assert installed opencode == `OPENCODE_VERSION`.

## Notes

- Design decision recorded in the spec: **remove fallbacks** (not keep + cross-check) — aligns with the one-line-bump goal; lost safety net is non-fatal + replaced by the guard.
- `tasks.md` carries the concrete file:line implementation plan so the next session executes without re-scoping.
- Windows winget pin flagged **Windows-empirical** (deferred per the batch-windows rule).

Refs #282