### PR TITLE
refactor(opencode): curate model picker to the shared free+NaN set (#300)

### DIFF
--- a/ai/opencode/opencode.jsonc
+++ b/ai/opencode/opencode.jsonc
@@ -189,9 +189,21 @@
       }
     },
 
-    // OpenRouter — frontier on-demand fallback (PAYG, existing $5 credit).
-    // No models override → uses OpenRouter's preloaded catalog; interactive picker.
-    "openrouter": {},
+    // OpenRouter — curated to the shared free+NaN set (#300; matches pi's
+    // ai/pi/settings.json enabledModels) so opencode and pi are interchangeable.
+    // An explicit models map restricts the /models picker to exactly these,
+    // whereas an empty {} loads OpenRouter's entire catalog. 3 most-powerful
+    // free + 3 paid non-OpenAI/Google/Anthropic.
+    "openrouter": {
+      "models": {
+        "qwen/qwen3-coder:free": { "name": "Qwen3 Coder (free)" },
+        "moonshotai/kimi-k2.6:free": { "name": "Kimi K2.6 (free)" },
+        "nvidia/nemotron-3-ultra-550b-a55b:free": { "name": "Nemotron 3 Ultra (free)" },
+        "deepseek/deepseek-v4-pro": { "name": "DeepSeek V4 Pro" },
+        "qwen/qwen3-coder-plus": { "name": "Qwen3 Coder Plus" },
+        "minimax/minimax-m3": { "name": "MiniMax M3" }
+      }
+    },
 
     // (compaction block sits at top level — see below the provider block)
 

--- a/tests/opencode.bats
+++ b/tests/opencode.bats
@@ -113,6 +113,16 @@ setup() {
     grep -q '"openrouter":' "$OPENCODE_CFG"
 }
 
+@test "opencode.jsonc openrouter picker is curated to the shared free+NaN set (#300, no big-3)" {
+    # An explicit models map (not an empty {}) restricts the /models picker, and
+    # must match pi's ai/pi/settings.json so the two agents are interchangeable.
+    grep -q '"qwen/qwen3-coder:free":' "$OPENCODE_CFG"
+    grep -q '"deepseek/deepseek-v4-pro":' "$OPENCODE_CFG"
+    grep -q '"minimax/minimax-m3":' "$OPENCODE_CFG"
+    # No OpenAI/Google/Anthropic OpenRouter model entries.
+    ! grep -qE '"(openai|google|anthropic)/[^"]+":[[:space:]]*\{[[:space:]]*"name"' "$OPENCODE_CFG"
+}
+
 @test "opencode.jsonc has ollama provider (homelab via VPN)" {
     grep -q '"ollama":' "$OPENCODE_CFG"
     grep -q 'ollama.kubelab.live' "$OPENCODE_CFG"


### PR DESCRIPTION
## What

opencode's `"openrouter": {}` (no models override) loaded OpenRouter's **entire catalog** into the `/models` picker. This curates it to an explicit `models` map of the **same 6 models pi exposes** (`ai/pi/settings.json`, AI-025/#298), so opencode and pi present the **same model environment** and are interchangeable.

Curated OpenRouter set (the NaN provider already lists its 4 explicitly):
- Free (most powerful): `qwen/qwen3-coder:free`, `moonshotai/kimi-k2.6:free`, `nvidia/nemotron-3-ultra-550b-a55b:free`
- Paid (non OpenAI/Google/Anthropic): `deepseek/deepseek-v4-pro`, `qwen/qwen3-coder-plus`, `minimax/minimax-m3`

## Verification

- JSONC parses (comment-aware strip + `JSON.parse`); `provider.openrouter.models` has the 6 expected keys.
- `bats tests/opencode.bats` -> green, incl. a new guard asserting the curated set + **no OpenAI/Google/Anthropic** OpenRouter entries.

## Notes

- Small config curation (<50 LOC, no schema change) -> SDD-skippable.
- `disabled_providers` already excludes ambient openai/anthropic/google.

Closes #300
