### PR TITLE
feat(ops): opt-in self-deploy timer over fast-forward-only pull (OPS-001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ PRs ≥50 LOC of production diff must include an active `specs/<feature-id>/` fo
 Project-bound knowledge lives in [`docs/`](docs/) (docs-as-code):
 
 - [`docs/adr/`](docs/adr/) — Architecture Decision Records (age encryption, dual-shell, BATS testing, two-directory sync, symlinks vs copies, multi-agent runtime, model-tier policy, …) plus the repo audits and architecture map
-- [`docs/runbooks/`](docs/runbooks/) — operational procedures (secrets management, AI tools setup, tool installation, tmux, Ghostty, OpenCode)
+- [`docs/runbooks/`](docs/runbooks/) — operational procedures (secrets management, AI tools setup, tool installation, tmux, Ghostty, OpenCode, self-deploy timer)
 - [`docs/troubleshooting/`](docs/troubleshooting/) — known issues and their fixes (secrets, AI tools, Hive MCP, claude-mem)
 - [`docs/lessons.md`](docs/lessons.md) — accumulated gotchas and post-mortems
 

--- a/docs/adr/adr-019-self-deploy-fast-forward-only.md
+++ b/docs/adr/adr-019-self-deploy-fast-forward-only.md
@@ -1,0 +1,65 @@
+---
+id: "ADR-019-self-deploy-fast-forward-only"
+type: adr
+status: accepted
+owner: manu
+date: "2026-06-09"
+extends: [adr-012-deploy-strategy-copy-with-drift-assertion]
+tags: [architecture, decision, self-deploy, systemd, scheduled-task, opt-in, ops]
+created: "2026-06-09"
+---
+
+# ADR-019: Self-deploy is fast-forward-only, opt-in, and idempotent-setup-gated
+
+> An opt-in timer (systemd `--user` on Linux, Scheduled Task on Windows) keeps a machine
+> converged to `origin/main` by pulling and re-running the idempotent setup — but only via a
+> clean fast-forward, and only when `HEAD` actually moved. Closes [#295](https://github.com/mlorentedev/dotfiles/issues/295) (OPS-001).
+
+## Status
+
+Accepted.
+
+## Context
+
+Dotfiles changes merge to `main` but reach a machine only when someone manually `git pull`s and
+re-runs `setup`. On a multi-machine setup that drift is silent and unbounded. Standing Order #1
+("automate, don't instruct") calls for closing the loop. The hazard: an unattended `git pull` on a
+repo where the user does real work can clobber uncommitted changes or local commits, and re-running
+a full `setup` blindly is wasteful.
+
+`dotfiles-sync.sh` was *assumed* to be the base, but it pushes (`local → remote`) and rsyncs
+(`repo → ~/.dotfiles`) — the opposite direction. Self-deploy needs `remote → local repo` + setup.
+
+## Decision
+
+1. **Dedicated entrypoint** `scripts/dotfiles-selfupdate.sh` (+ `.ps1` parity), separate from
+   `dotfiles-sync.sh` (SRP: opposite data-flow directions stay in different scripts).
+2. **Fast-forward only.** `git fetch` then a `--ff-only` merge. Anything that is not a clean
+   fast-forward — dirty worktree, diverged history, no upstream, unreachable remote — is **logged
+   and skipped with exit 0**. The script never merges, rebases, stashes, or resets. An unattended
+   history rewrite is how you lose work silently; it is explicitly rejected.
+3. **Setup runs only when `HEAD` moved.** An already-current repo is a no-op (no setup churn).
+4. **Real failures surface.** Only a setup command that *runs and fails* exits non-zero, so
+   `systemctl --user status dotfiles-selfupdate` (and the journal) distinguish a genuine failure
+   from a benign skip.
+5. **Opt-in, default OFF.** Gated on `DOTFILES_AUTODEPLOY`: `1` installs + enables, `0` disables +
+   removes, unset is a no-op. A normal `setup` run never installs the timer.
+6. **Cadence: daily**, `Persistent=true` (a suspended/off machine runs the missed slot on next
+   boot), `RandomizedDelaySec` to spread multiple machines.
+
+## Consequences
+
+- **Safe by construction:** the common "I have local edits" case can never be clobbered — it is the
+  first guard, and it is the core regression test (incident → guard).
+- A machine with local commits ahead of `origin` simply stops auto-deploying until the user
+  reconciles — surfaced via the journal, not papered over.
+- Breaking config changes are gated by PR review on `main`, not by the timer (out of scope here).
+- Mirrors ADR-012's philosophy: deploy is mechanical and idempotent; correctness comes from refusing
+  to act on an ambiguous state rather than from clever recovery.
+
+## Alternatives rejected
+
+- **Stash → pull → pop:** leaves unattended stash-pop conflicts; defeats the safety goal.
+- **`--ff-only` + auto-rebase:** rewrites local history in a timer; silent and dangerous.
+- **Hard reset to remote:** clobbers local work outright.
+- **Extend `dotfiles-sync.sh` with a `--self-update` mode:** mixes opposite directions in one script.

--- a/docs/runbooks/guide-self-deploy-timer.md
+++ b/docs/runbooks/guide-self-deploy-timer.md
@@ -1,0 +1,85 @@
+---
+id: "guide-self-deploy-timer"
+type: runbook
+status: active
+tags: [runbook, self-deploy, systemd, scheduled-task, ops, opt-in]
+created: "2026-06-09"
+---
+
+# Runbook: dotfiles self-deploy timer (OPS-001)
+
+> Opt-in automation that keeps a machine converged to `origin/main` by pulling the dotfiles repo
+> (fast-forward only) and re-running the idempotent setup. Design: [ADR-019](../adr/adr-019-self-deploy-fast-forward-only.md).
+> Issue: [#295](https://github.com/mlorentedev/dotfiles/issues/295).
+
+## What it does
+
+Once a day the timer runs `scripts/dotfiles-selfupdate.sh`, which:
+
+1. Skips if the repo worktree is **dirty** (uncommitted changes).
+2. `git fetch`es; skips on a network failure.
+3. Fast-forwards `main` **only** if it can; skips on diverged/non-ff history.
+4. Re-runs `setup` **only if `HEAD` actually moved**.
+
+Every skip exits 0 (benign). Only a setup command that runs and fails exits non-zero.
+
+## Enable / disable
+
+The mechanism is opt-in and default OFF — a normal `setup` run never installs it.
+
+### Linux (systemd `--user`)
+
+```bash
+# Enable: deploy the units + enable the daily timer
+DOTFILES_AUTODEPLOY=1 ./setup-linux.sh
+
+# Disable: stop, disable, and remove the units
+DOTFILES_AUTODEPLOY=0 ./setup-linux.sh
+```
+
+### Windows (Scheduled Task)
+
+```powershell
+# Enable
+$env:DOTFILES_AUTODEPLOY = "1"; .\setup-windows.ps1
+# Disable
+$env:DOTFILES_AUTODEPLOY = "0"; .\setup-windows.ps1
+```
+
+## Verify it is active
+
+```bash
+# Linux: timer listed and next run scheduled
+systemctl --user list-timers dotfiles-selfupdate.timer
+systemctl --user status dotfiles-selfupdate.service   # last run result
+
+# Run it once by hand (safe; no-ops on a clean, current repo)
+./scripts/dotfiles-selfupdate.sh
+```
+
+```powershell
+# Windows
+Get-ScheduledTask -TaskName DotfilesSelfUpdate
+Get-ScheduledTaskInfo -TaskName DotfilesSelfUpdate   # LastRunTime / LastTaskResult
+```
+
+## Diagnose
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| `[skip] Dirty worktree` in the journal | uncommitted changes in the repo | commit or stash; the timer resumes next slot |
+| `[skip] ... diverged ... (non fast-forward)` | local commits not on `origin/main` | push or reconcile your branch; non-ff is never auto-resolved |
+| `[skip] git fetch failed (network?)` | offline / remote unreachable | transient; next slot retries |
+| `[skip] No upstream configured` | current branch has no `@{u}` | `git branch --set-upstream-to=origin/main` |
+| service shows **failed** | `setup` itself errored (not a skip) | read `journalctl --user -u dotfiles-selfupdate.service` |
+
+```bash
+# Linux logs
+journalctl --user -u dotfiles-selfupdate.service --since today
+```
+
+## Override the target repo
+
+The script defaults to `$HOME/Projects/dotfiles`. Override with `DOTFILES_REPO_DIR`. The setup
+command it re-runs can be overridden with `DOTFILES_SELFUPDATE_SETUP_CMD` (used by the test suite to
+inject a stub).

--- a/scripts/dotfiles-selfupdate.ps1
+++ b/scripts/dotfiles-selfupdate.ps1
@@ -1,0 +1,57 @@
+# dotfiles-selfupdate.ps1 -- OPS-001 (Windows parity of scripts/dotfiles-selfupdate.sh)
+#
+# Opt-in self-deploy, run by the DotfilesSelfUpdate Scheduled Task. Pulls the
+# dotfiles repo from its git remote and re-runs the idempotent setup -- but ONLY
+# via a clean fast-forward, and ONLY when HEAD actually moved. Anything else
+# (dirty worktree, diverged history, unreachable remote, no upstream) is logged
+# and skipped with exit 0. A real setup failure is the only non-zero exit.
+#
+# ASCII-only (PSScriptAnalyzer CI fails on non-ASCII without a BOM).
+#
+# Env:
+#   DOTFILES_REPO_DIR              repo to update  (default: $HOME\Projects\dotfiles)
+#   DOTFILES_SELFUPDATE_SETUP_CMD  setup .ps1 path (default: <repo>\setup-windows.ps1)
+
+$ErrorActionPreference = 'Stop'
+
+$repo = if ($env:DOTFILES_REPO_DIR) { $env:DOTFILES_REPO_DIR } else { Join-Path $env:USERPROFILE 'Projects\dotfiles' }
+$setupCmd = if ($env:DOTFILES_SELFUPDATE_SETUP_CMD) { $env:DOTFILES_SELFUPDATE_SETUP_CMD } else { Join-Path $repo 'setup-windows.ps1' }
+
+function Write-Skip([string]$m) { Write-Host "[skip] $m" }
+function Write-Step([string]$m) { Write-Host "-> $m" }
+
+# guard: must be a git repo
+& git -C $repo rev-parse --git-dir *> $null
+if ($LASTEXITCODE -ne 0) { Write-Skip "Not a git repo: $repo -- nothing to self-update"; exit 0 }
+
+# guard: never touch a dirty worktree
+$dirty = & git -C $repo status --porcelain
+if ($dirty) { Write-Skip "Dirty worktree in $repo -- skipping (commit or stash first)"; exit 0 }
+
+# fetch; a network failure is transient -> skip and retry next slot
+& git -C $repo fetch --quiet *> $null
+if ($LASTEXITCODE -ne 0) { Write-Skip "git fetch failed (network?) -- skipping this run"; exit 0 }
+
+# guard: an upstream must be configured for the current branch
+$upstream = & git -C $repo rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>$null
+if ($LASTEXITCODE -ne 0 -or -not $upstream) { Write-Skip "No upstream configured -- skipping"; exit 0 }
+
+$localRev  = & git -C $repo rev-parse HEAD
+$remoteRev = & git -C $repo rev-parse '@{u}'
+$baseRev   = & git -C $repo merge-base HEAD '@{u}'
+
+# already current: no deploy needed
+if ($localRev -eq $remoteRev) { Write-Step "Already current ($upstream) -- no deploy needed"; exit 0 }
+
+# diverged / non-fast-forward: never merge, rebase, or reset unattended
+if ($baseRev -ne $localRev) { Write-Skip "Local branch has diverged from $upstream (non fast-forward) -- skipping"; exit 0 }
+
+# clean fast-forward, then re-run the idempotent setup
+Write-Step "Fast-forwarding to $upstream ..."
+& git -C $repo merge --ff-only '@{u}' *> $null
+if ($LASTEXITCODE -ne 0) { Write-Skip "Fast-forward failed unexpectedly -- skipping (worktree untouched)"; exit 0 }
+
+Write-Step "Re-running setup: $setupCmd"
+& powershell.exe -NoProfile -ExecutionPolicy Bypass -File $setupCmd
+if ($LASTEXITCODE -ne 0) { Write-Host "[err] Setup failed (exit $LASTEXITCODE) -- see output above"; exit $LASTEXITCODE }
+Write-Host "[ok] Self-update complete"

--- a/scripts/dotfiles-selfupdate.sh
+++ b/scripts/dotfiles-selfupdate.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# dotfiles-selfupdate.sh -- OPS-001
+#
+# Opt-in self-deploy entrypoint, run by the systemd --user timer (Linux) /
+# Scheduled Task (Windows). Pulls the dotfiles repo from its git remote and
+# re-runs the idempotent setup -- but ONLY via a clean fast-forward, and ONLY
+# when HEAD actually moved. Anything else (dirty worktree, diverged history,
+# unreachable remote, no upstream) is logged and skipped with exit 0. A real
+# setup failure is the only non-zero exit, so `systemctl --user status
+# dotfiles-selfupdate` (and the journal) surface it.
+#
+# This is the OPPOSITE direction to dotfiles-sync.sh (which pushes the repo and
+# rsyncs repo -> ~/.dotfiles). Kept as a separate script on purpose (SRP).
+#
+# Usage: dotfiles-selfupdate.sh
+# Env:
+#   DOTFILES_REPO_DIR              repo to update   (default: $HOME/Projects/dotfiles)
+#   DOTFILES_SELFUPDATE_SETUP_CMD  setup to re-run  (default: <repo>/setup-linux.sh)
+
+set -euo pipefail
+
+REPO="${DOTFILES_REPO_DIR:-$HOME/Projects/dotfiles}"
+SETUP_CMD="${DOTFILES_SELFUPDATE_SETUP_CMD:-$REPO/setup-linux.sh}"
+
+# Colors only on a real terminal (a timer run has none).
+if [ -t 1 ]; then
+    BLUE='\033[0;34m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; RED='\033[0;31m'; NC='\033[0m'
+else
+    BLUE='' GREEN='' YELLOW='' RED='' NC=''
+fi
+log_info()    { printf '%b->%b %s\n'    "$BLUE"   "$NC" "$1"; }
+log_success() { printf '%b[ok]%b %s\n'  "$GREEN"  "$NC" "$1"; }
+log_skip()    { printf '%b[skip]%b %s\n' "$YELLOW" "$NC" "$1"; }
+log_error()   { printf '%b[err]%b %s\n' "$RED"    "$NC" "$1" >&2; }
+
+# --- guard: must be a git repo ---
+if ! git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
+    log_skip "Not a git repo: $REPO -- nothing to self-update"
+    exit 0
+fi
+
+# --- guard: never touch a dirty worktree (the primary failure mode) ---
+if [ -n "$(git -C "$REPO" status --porcelain 2>/dev/null)" ]; then
+    log_skip "Dirty worktree in $REPO -- skipping (commit or stash your changes first)"
+    exit 0
+fi
+
+# --- fetch; a network failure is transient -> skip and retry next slot ---
+if ! git -C "$REPO" fetch --quiet 2>/dev/null; then
+    log_skip "git fetch failed (network?) -- skipping self-update this run"
+    exit 0
+fi
+
+# --- guard: an upstream must be configured for the current branch ---
+if ! upstream="$(git -C "$REPO" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)"; then
+    log_skip "No upstream configured for the current branch -- skipping"
+    exit 0
+fi
+
+local_rev="$(git -C "$REPO" rev-parse HEAD)"
+remote_rev="$(git -C "$REPO" rev-parse '@{u}')"
+base_rev="$(git -C "$REPO" merge-base HEAD '@{u}')"
+
+# --- already current: no deploy needed ---
+if [ "$local_rev" = "$remote_rev" ]; then
+    log_info "Already current ($upstream) -- no deploy needed"
+    exit 0
+fi
+
+# --- diverged / non-fast-forward: never merge, rebase, or reset unattended ---
+if [ "$base_rev" != "$local_rev" ]; then
+    log_skip "Local branch has diverged from $upstream (non fast-forward) -- skipping"
+    exit 0
+fi
+
+# --- clean fast-forward, then re-run the idempotent setup ---
+log_info "Fast-forwarding to $upstream ..."
+if ! git -C "$REPO" merge --ff-only '@{u}' >/dev/null 2>&1; then
+    log_skip "Fast-forward failed unexpectedly -- skipping (worktree left untouched)"
+    exit 0
+fi
+log_success "Updated $(git -C "$REPO" rev-parse --short "$local_rev") -> $(git -C "$REPO" rev-parse --short HEAD)"
+
+log_info "Re-running setup: $SETUP_CMD"
+if "$SETUP_CMD"; then
+    log_success "Self-update complete"
+else
+    rc=$?
+    log_error "Setup failed (exit $rc) -- see output above"
+    exit "$rc"
+fi

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -979,6 +979,42 @@ elif command -v hive >/dev/null 2>&1; then
     log_warning "hive ${hive_ver:-<unknown>} predates 'hive service' (need >= 1.32.0); skipping daemon supervision"
 fi
 
+# OPS-001: opt-in self-deploy timer (git pull --ff-only + idempotent setup).
+# Tri-state, gated on DOTFILES_AUTODEPLOY so a normal setup never touches it:
+#   1     -> deploy units + enable --now the daily --user timer
+#   0     -> disable + remove the timer (clean opt-out / teardown)
+#   unset -> no-op (opt-in, default OFF)
+# Non-fatal: any failure leaves setup succeeding; the timer is a convenience, and
+# `dotfiles-selfupdate.sh` itself no-ops on a dirty/diverged repo (OPS-001).
+if command -v systemctl >/dev/null 2>&1; then
+    SYSTEMD_USER_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+    case "${DOTFILES_AUTODEPLOY:-}" in
+        1)
+            ensure_directory "$SYSTEMD_USER_DIR"
+            if cp -f "$CURRENT_DIR/systemd/dotfiles-selfupdate.service" "$SYSTEMD_USER_DIR/" \
+                && cp -f "$CURRENT_DIR/systemd/dotfiles-selfupdate.timer" "$SYSTEMD_USER_DIR/"; then
+                systemctl --user daemon-reload >/dev/null 2>&1 || true
+                if systemctl --user enable --now dotfiles-selfupdate.timer >/dev/null 2>&1; then
+                    log_success "Enabled dotfiles-selfupdate.timer (daily self-deploy, systemd --user)"
+                else
+                    log_warning "dotfiles-selfupdate.timer enable failed (non-fatal; re-run setup manually to update)"
+                fi
+            else
+                log_warning "Could not deploy dotfiles-selfupdate units to $SYSTEMD_USER_DIR (non-fatal)"
+            fi
+            ;;
+        0)
+            systemctl --user disable --now dotfiles-selfupdate.timer >/dev/null 2>&1 || true
+            rm -f "$SYSTEMD_USER_DIR/dotfiles-selfupdate.timer" "$SYSTEMD_USER_DIR/dotfiles-selfupdate.service"
+            systemctl --user daemon-reload >/dev/null 2>&1 || true
+            log_info "Disabled + removed dotfiles-selfupdate.timer (DOTFILES_AUTODEPLOY=0)"
+            ;;
+        *)
+            : # unset -> no-op (opt-in, default OFF)
+            ;;
+    esac
+fi
+
 # Claude Code plugins (requires claude CLI).
 # Idempotent: cache the installed-plugins list ONCE before the loop and skip
 # entries already present. The wrapper above (BUG-004/011) catches the

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1724,6 +1724,44 @@ if (Test-Path $healthcheckScript) {
 # 9. SUMMARY
 # ============================================================================
 
+# OPS-001: opt-in self-deploy Scheduled Task (Windows parity of the systemd timer).
+# Tri-state, gated on DOTFILES_AUTODEPLOY so a normal setup never touches it:
+#   1     -> deploy the selfupdate script + register a daily windowless S4U task
+#   0     -> unregister the task (clean opt-out)
+#   unset -> no-op (opt-in, default OFF)
+# Routes through Register-HiveScheduledTask (the generic S4U/windowless registrar)
+# so the task runs in session 0 with no console window, same as the hive tasks.
+$selfUpdateTask = "DotfilesSelfUpdate"
+switch ("$env:DOTFILES_AUTODEPLOY") {
+    "1" {
+        $selfUpdateSrc = Join-Path $DotfilesDir "scripts\dotfiles-selfupdate.ps1"
+        $selfUpdateDst = Join-Path $ClaudeHome "scripts\dotfiles-selfupdate.ps1"
+        if (Test-Path $selfUpdateSrc) {
+            Ensure-Directory (Split-Path $selfUpdateDst -Parent)
+            Copy-Item $selfUpdateSrc $selfUpdateDst -Force
+            $selfUpdateArg = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$selfUpdateDst`""
+            try {
+                $suAction = New-ScheduledTaskAction -Execute "powershell.exe" -Argument $selfUpdateArg
+                $suTrigger = New-ScheduledTaskTrigger -Daily -At 3am
+                $suSettings = New-ScheduledTaskSettingsSet -StartWhenAvailable
+                Register-HiveScheduledTask -TaskName $selfUpdateTask -Action $suAction -Trigger $suTrigger `
+                    -Settings $suSettings `
+                    -Description "dotfiles self-deploy: daily git pull --ff-only + idempotent setup (OPS-001)"
+                Write-Success "Enabled DotfilesSelfUpdate task (daily, windowless S4U)"
+            } catch {
+                Write-Warn "Could not register DotfilesSelfUpdate task (non-fatal): $_"
+            }
+        } else {
+            Write-Warn "self-update script not found at $selfUpdateSrc"
+        }
+    }
+    "0" {
+        Unregister-ScheduledTask -TaskName $selfUpdateTask -Confirm:$false -ErrorAction SilentlyContinue
+        Write-Info "Disabled DotfilesSelfUpdate task (DOTFILES_AUTODEPLOY=0)"
+    }
+    default { }
+}
+
 Write-Host ""
 Write-Host "============================================" -ForegroundColor Green
 Write-Host "  Setup Complete!                          " -ForegroundColor Green

--- a/specs/OPS-001-self-deploy-timer/features.json
+++ b/specs/OPS-001-self-deploy-timer/features.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "OPS-001-self-deploy-timer-f1",
+    "behavior": "AC1 dirty worktree: skip + exit 0, no fetch, no setup",
+    "verification": "bats tests/dotfiles-selfupdate.bats -f 'dirty'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "OPS-001-self-deploy-timer-f2",
+    "behavior": "AC2 diverged/non-ff: skip + exit 0, no setup",
+    "verification": "bats tests/dotfiles-selfupdate.bats -f 'diverged'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "OPS-001-self-deploy-timer-f3",
+    "behavior": "AC3 already current: exit 0, no setup",
+    "verification": "bats tests/dotfiles-selfupdate.bats -f 'current'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "OPS-001-self-deploy-timer-f4",
+    "behavior": "AC4 clean fast-forward: ff + run setup once",
+    "verification": "bats tests/dotfiles-selfupdate.bats -f 'fast-forward'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "OPS-001-self-deploy-timer-f5",
+    "behavior": "AC5 setup failure propagates non-zero exit",
+    "verification": "bats tests/dotfiles-selfupdate.bats -f 'setup failure'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "OPS-001-self-deploy-timer-f6",
+    "behavior": "AC6/AC7 opt-in gate + units structure",
+    "verification": "bats tests/dotfiles-selfupdate-install.bats",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/OPS-001-self-deploy-timer/proposal.md
+++ b/specs/OPS-001-self-deploy-timer/proposal.md
@@ -1,0 +1,64 @@
+---
+id: "OPS-001-self-deploy-timer"
+type: spec
+status: verifying # draft | implementing | verifying | archived
+created: "2026-06-09"
+issue: "dotfiles#295"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# OPS-001-self-deploy-timer
+
+> **Naming**: file lives at `<repo>/specs/OPS-001-self-deploy-timer/proposal.md`. `OPS-001-self-deploy-timer` is `AREA-NNN-slug`.
+
+## Why
+
+Dotfiles changes (new tools, version bumps, config edits) merge to `main` but only reach a machine when someone remembers to `git pull` and re-run `setup`. On a multi-machine setup that drift is silent and unbounded — a fix can sit undeployed for weeks. An opt-in timer that periodically pulls the repo and re-runs the *idempotent* setup closes the loop with zero manual steps (Standing Order #1: automate, don't instruct), while staying safe enough to never touch local work-in-progress.
+
+## What
+
+A new opt-in **self-deploy** mechanism:
+
+- A dedicated entrypoint `scripts/dotfiles-selfupdate.sh` that: guards against a dirty worktree, `git fetch`es, fast-forwards `main` **only** when it can, and re-runs the platform `setup` **only when `HEAD` actually moved**. It never merges, rebases, or resets — anything that is not a clean fast-forward is logged and skipped.
+- A systemd `--user` timer + oneshot service (`systemd/dotfiles-selfupdate.{timer,service}`) firing **daily** with `Persistent=true` (a suspended/off laptop runs the missed slot on next boot).
+- Opt-in wiring in `setup-linux.sh` gated on `DOTFILES_AUTODEPLOY`: `1` installs + enables the timer, `0` disables + removes it, **unset leaves the machine untouched** (default OFF).
+- Windows parity authored: `scripts/dotfiles-selfupdate.ps1` + a daily Scheduled Task registered by `setup-windows.ps1` under the same env gate (runtime verification deferred to a Windows-box session).
+
+Observable change: after `DOTFILES_AUTODEPLOY=1 ./setup-linux.sh`, the machine converges to `origin/main` within ~24h on its own, and **never** does so when the worktree is dirty or history has diverged.
+
+## Out of scope
+
+- Auto-applying breaking config changes without review — the timer redeploys whatever is on `main`; gating *what* lands on `main` is the PR review's job, not the timer's.
+- Touching `dotfiles-sync.sh` — it stays the push/deploy tool (`local repo → remote`, `repo → ~/.dotfiles`); self-update is the opposite direction and gets its own script.
+- Merge/rebase/stash/reset recovery strategies — explicitly rejected (see Risks). Non-fast-forward is a skip, not a fix.
+- Pulling from the vault — self-update pulls from the **git remote** only.
+
+## Risks / open questions
+
+- **Clobbering local work** → guarded: dirty worktree (`git status --porcelain` non-empty) → log + skip, exit 0. This is the primary failure mode and the core guard test.
+- **Diverged history / local commits** → `--ff-only`; non-ff → log + skip, exit 0. No unattended merge/rebase/reset (rejected: rewriting history or auto-merging in a timer is how you lose work silently).
+- **Network failure** → `git fetch` failure → log + skip, exit 0 (transient; next slot retries).
+- **Redundant setup churn** → setup runs **only if `HEAD` moved**; an already-current repo is a no-op (exit 0, no setup).
+- **Real setup failure surfacing** → if setup *runs and fails*, exit **non-zero** so `systemctl --user status dotfiles-selfupdate` and the journal show it (distinct from the benign skips above).
+- **Repo path assumption** → script defaults `DOTFILES_REPO_DIR=$HOME/Projects/dotfiles` (the documented repo location); overridable via env.
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [ ] AC1 — Dirty worktree: `dotfiles-selfupdate.sh` against a repo with uncommitted changes logs a skip and exits 0 **without** fetching or running setup.
+- [ ] AC2 — Diverged/non-ff: when local `main` cannot fast-forward to the remote, it logs a skip and exits 0 without running setup.
+- [ ] AC3 — Already current: when `HEAD == @{u}`, it exits 0 and does **not** run setup.
+- [ ] AC4 — Clean fast-forward: when the remote is ahead and ff is possible, it fast-forwards and runs setup exactly once.
+- [ ] AC5 — Setup failure: when the injected setup command exits non-zero, the script exits non-zero.
+- [ ] AC6 — Opt-in gate: `DOTFILES_AUTODEPLOY` unset → `setup-linux.sh` neither installs nor enables the timer; `=1` installs + enables; `=0` disables + removes. (Asserted by a guard test on the setup block / unit presence.)
+- [ ] AC7 — Units valid: `systemd/dotfiles-selfupdate.{service,timer}` exist, the timer is `OnCalendar=daily Persistent=true`, and `systemd-analyze verify` (or a structural grep guard) passes.
+- [ ] AC8 — Cross-shell: `dotfiles-selfupdate.sh` passes shellcheck and the bats suite under both bash and zsh; `.ps1` files are ASCII-only.
+
+## References
+
+- GitHub: `dotfiles#295` (work-gate, bitácora Project)
+- Reference pattern in-repo: `systemd/hive-upgrade.{service,timer}` + its install block in `setup-linux.sh` (AI-023 / hive#176)
+- ADR: `docs/adr/adr-005-*` (`~/.dotfiles` is a deployed copy, not a git repo — why self-update targets `~/Projects/dotfiles`)
+- Related patterns: `00_meta/patterns/pattern-config-defaults.md` (opt-in defaults), `pattern-shell-standards.md`

--- a/specs/OPS-001-self-deploy-timer/tasks.md
+++ b/specs/OPS-001-self-deploy-timer/tasks.md
@@ -1,0 +1,38 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-06-09"
+---
+
+# Tasks - OPS-001-self-deploy-timer
+
+> TDD order. One task = one focused commit. Tick as you go.
+
+## Setup
+
+- [x] Branch created from main: `feat/self-deploy-timer` (worktree `~/Projects/dotfiles-wt/self-deploy-timer`)
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions" (all resolved by the design pass)
+
+## Implementation
+
+- [x] Write failing bats `tests/dotfiles-selfupdate.bats` covering AC1–AC5 (fixture git repo + fake remote + injectable setup stub)
+- [x] Implement `scripts/dotfiles-selfupdate.sh` (guard → fetch → ff-only → conditional setup); make AC1–AC5 green
+- [x] `shellcheck` clean; bash+zsh pass
+- [x] Add `systemd/dotfiles-selfupdate.service` (oneshot, ExecStart = repo script) + `systemd/dotfiles-selfupdate.timer` (OnCalendar=daily, Persistent=true, RandomizedDelaySec) — AC7
+- [x] Wire opt-in block in `setup-linux.sh` gated on `DOTFILES_AUTODEPLOY` (1=install+enable, 0=disable+remove, unset=no-op), mirroring the hive-upgrade block — AC6
+- [x] Guard test for the opt-in gate + unit structure (AC6/AC7) — incident→guard
+- [x] Windows parity: `scripts/dotfiles-selfupdate.ps1` (ASCII-only) + Scheduled Task in `setup-windows.ps1` under `$env:DOTFILES_AUTODEPLOY` — AC8 (runtime verify deferred)
+- [x] Docs: `docs/adr/adr-019-*` + `docs/runbooks/guide-self-deploy-timer.md` (healthcheck line intentionally skipped — opt-in would false-positive; `.claude/CLAUDE.md` is gitignored, left untouched)
+
+## Closing
+
+- [x] Every acceptance criterion covered by ≥1 test
+- [x] `features.json` present (states stay `pending` — only the harness may mark `passing`)
+- [x] Lint passes (shellcheck + ASCII guard)
+- [x] No unrelated changes in the diff
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+See sibling `features.json`. Pass-state gating: only the harness may set `"state": "passing"` after capturing exit 0.

--- a/specs/OPS-001-self-deploy-timer/verification.md
+++ b/specs/OPS-001-self-deploy-timer/verification.md
@@ -1,0 +1,65 @@
+---
+tags: [spec, verification, templates]
+created: "2026-06-09"
+---
+
+# Verification - OPS-001-self-deploy-timer
+
+## Evidence
+
+All acceptance criteria are covered by the bats suites
+`tests/dotfiles-selfupdate.bats` (behavior) and `tests/dotfiles-selfupdate-install.bats`
+(units + wiring). Full run: **24/24 passing**.
+
+- [x] AC1 dirty worktree skip -> test `skips on a dirty worktree without running setup`
+- [x] AC2 diverged/non-ff skip -> test `skips when local has diverged (non fast-forward) without running setup`
+- [x] AC3 already current no-op -> test `is a no-op when already current (no setup run)`
+- [x] AC4 clean fast-forward runs setup once -> test `fast-forwards and runs setup exactly once when the remote is ahead`
+- [x] AC5 setup failure -> non-zero -> test `exits non-zero when the setup command fails`
+- [x] AC6 opt-in gate (1/0/unset) -> tests `setup-linux.sh gates the timer on DOTFILES_AUTODEPLOY`,
+      `enables the timer with --now when opted in`, `disables + removes the timer on opt-out (=0)`,
+      `self-deploy block is non-fatal`
+- [x] AC7 units valid -> tests `systemd unit files exist`, `fires daily with catch-up`,
+      `installs to timers.target`, `oneshot running the repo selfupdate script`, `ExecStart is absolute`
+- [x] AC8 cross-shell / ASCII -> tests `has valid bash syntax`, `has valid zsh syntax`,
+      `scripts/dotfiles-selfupdate.ps1 exists and is ASCII-only`; shellcheck clean
+
+## Test status
+
+- New suites: `bats tests/dotfiles-selfupdate.bats tests/dotfiles-selfupdate-install.bats` -> **24 tests, 0 failures**.
+- Lint: `shellcheck scripts/dotfiles-selfupdate.sh` -> clean; `shellcheck --severity=error setup-linux.sh`
+  (the CI invocation) -> clean. `.ps1` files ASCII-only (`grep -P '[^\x00-\x7F]'` finds nothing new).
+- Full suite regression gate: `bats tests/*.bats` -> the only non-passing entries are **pre-existing and
+  unrelated**: 6 PowerShell tests skipped (`# skip pwsh not available` on this Linux box) and 3
+  `shell-profile.bats` env-dependent failures that fail **identically on the untouched `main` checkout**
+  (verified by running `bats /home/manu/Projects/dotfiles/tests/shell-profile.bats`). Zero regressions from this change.
+- Live smoke (deferred to the user, by preference): enabling the real timer and observing a real
+  fast-forward + setup run. The `fast-forwards and runs setup exactly once` test exercises the real
+  `git fetch` + `--ff-only` path against a fixture remote, so the mechanism itself is proven.
+- Windows runtime: authored (ps1 + Scheduled Task), runtime verification deferred to a Windows-box
+  session (batch-windows-work).
+
+## Decisions made during implementation
+
+- The issue assumed `dotfiles-sync.sh` was the base; it actually pushes + rsyncs (opposite direction).
+  Pivoted to a dedicated `dotfiles-selfupdate.sh` (verify-before-act).
+- Made the setup command injectable via `DOTFILES_SELFUPDATE_SETUP_CMD` purely for testability
+  (the suite injects a stub that records runs) — default stays `<repo>/setup-linux.sh`.
+- No healthcheck assertion added: the timer is opt-in/default-OFF, so a healthcheck line would
+  false-positive on every machine that opted out.
+- `.claude/CLAUDE.md` left untouched: it is gitignored / local-only, not a tracked repo artifact.
+
+## Promotion candidates
+
+- [x] Lesson for the repo's `docs/lessons.md`? **no** — the "verify-before-act on a stale issue premise"
+      lesson already exists in the vault; nothing new generalizes beyond ADR-019.
+- [x] ADR-worthy decision? **yes — done in this PR**: `docs/adr/adr-019-self-deploy-fast-forward-only.md`.
+- [x] New pattern candidate for `00_meta/patterns/`? **no** — single-project ops automation; revisit only
+      if a second repo grows the same self-deploy need.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/OPS-001-self-deploy-timer/` -> `specs/archive/OPS-001-self-deploy-timer/`
+- [ ] Backlog entry (bitácora #295) closed with PR link
+- [ ] Promotions above executed (ADR-019 shipped in-PR)

--- a/systemd/dotfiles-selfupdate.service
+++ b/systemd/dotfiles-selfupdate.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Self-deploy dotfiles (git pull --ff-only + idempotent setup)
+Documentation=https://github.com/mlorentedev/dotfiles/issues/295
+
+[Service]
+Type=oneshot
+# %h resolves to the user home. Absolute path because a --user oneshot gets a
+# minimal PATH. The script fast-forwards the repo and re-runs setup only when
+# HEAD actually moved; a dirty/diverged/unreachable repo is a no-op (exit 0),
+# so this oneshot is safe to run unattended and is never marked failed for a skip.
+ExecStart=%h/Projects/dotfiles/scripts/dotfiles-selfupdate.sh

--- a/systemd/dotfiles-selfupdate.timer
+++ b/systemd/dotfiles-selfupdate.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Daily dotfiles self-deploy (git pull --ff-only + idempotent setup)
+Documentation=https://github.com/mlorentedev/dotfiles/issues/295
+
+[Timer]
+# Daily wall-clock. Persistent runs a missed slot once on the next boot/resume,
+# so a laptop that was off still converges to origin/main. RandomizedDelaySec
+# spreads multiple machines so they do not all hit the remote on the same second.
+OnCalendar=daily
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target

--- a/tests/dotfiles-selfupdate-install.bats
+++ b/tests/dotfiles-selfupdate-install.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# OPS-001: structure + wiring guards for the self-deploy timer.
+# Mirrors hive-upgrade-timer.bats: assert the units, the opt-in gate, and
+# cross-OS parity as permanent regression assertions (incident -> guard).
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+}
+
+# --- systemd units (SSOT) ---
+
+@test "systemd unit files exist (timer + oneshot service)" {
+    [ -f "$DOTFILES_DIR/systemd/dotfiles-selfupdate.timer" ]
+    [ -f "$DOTFILES_DIR/systemd/dotfiles-selfupdate.service" ]
+}
+
+@test "dotfiles-selfupdate.timer fires daily with catch-up" {
+    grep -qF 'OnCalendar=daily' "$DOTFILES_DIR/systemd/dotfiles-selfupdate.timer"
+    grep -qF 'Persistent=true' "$DOTFILES_DIR/systemd/dotfiles-selfupdate.timer"
+    grep -qF 'RandomizedDelaySec=' "$DOTFILES_DIR/systemd/dotfiles-selfupdate.timer"
+}
+
+@test "dotfiles-selfupdate.timer installs to timers.target" {
+    grep -qF 'WantedBy=timers.target' "$DOTFILES_DIR/systemd/dotfiles-selfupdate.timer"
+}
+
+@test "dotfiles-selfupdate.service is a oneshot running the repo selfupdate script" {
+    grep -qF 'Type=oneshot' "$DOTFILES_DIR/systemd/dotfiles-selfupdate.service"
+    grep -qF 'dotfiles-selfupdate.sh' "$DOTFILES_DIR/systemd/dotfiles-selfupdate.service"
+}
+
+# A --user oneshot gets a minimal PATH; ExecStart must be an absolute path
+# (resolved via %h), never a bare script name on PATH.
+@test "dotfiles-selfupdate.service ExecStart is absolute (%h-resolved)" {
+    grep -qE '^ExecStart=%h/' "$DOTFILES_DIR/systemd/dotfiles-selfupdate.service"
+}
+
+# --- setup-linux.sh opt-in wiring (tri-state gate) ---
+
+@test "setup-linux.sh gates the timer on DOTFILES_AUTODEPLOY" {
+    grep -qF 'DOTFILES_AUTODEPLOY' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh deploys both units into the systemd --user dir" {
+    grep -qF 'systemd/dotfiles-selfupdate.service' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF 'systemd/dotfiles-selfupdate.timer' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF 'systemd/user' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh enables the timer with --now when opted in" {
+    grep -qF 'enable --now dotfiles-selfupdate.timer' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh disables + removes the timer on opt-out (=0)" {
+    grep -qF 'disable --now dotfiles-selfupdate.timer' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh self-deploy block is non-fatal (warns, never hard-exits)" {
+    grep -qF 'dotfiles-selfupdate.timer enable failed (non-fatal' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh stays valid bash after the self-deploy block" {
+    bash -n "$DOTFILES_DIR/setup-linux.sh"
+}
+
+# --- setup-windows.ps1 parity ---
+
+@test "setup-windows.ps1 registers a daily DotfilesSelfUpdate task gated on the env var" {
+    grep -qF 'DotfilesSelfUpdate' "$DOTFILES_DIR/setup-windows.ps1"
+    grep -qF 'DOTFILES_AUTODEPLOY' "$DOTFILES_DIR/setup-windows.ps1"
+}
+
+@test "setup-windows.ps1 self-deploy task runs the selfupdate ps1 script" {
+    grep -qF 'dotfiles-selfupdate.ps1' "$DOTFILES_DIR/setup-windows.ps1"
+}
+
+# PSScriptAnalyzer fails CI on non-ASCII in .ps1 (em dash / arrows / smart quotes).
+@test "scripts/dotfiles-selfupdate.ps1 exists and is ASCII-only" {
+    [ -f "$DOTFILES_DIR/scripts/dotfiles-selfupdate.ps1" ]
+    LC_ALL=C grep -nP '[^\x00-\x7F]' "$DOTFILES_DIR/scripts/dotfiles-selfupdate.ps1" && return 1
+    return 0
+}
+
+# --- cross-OS parity ---
+
+@test "parity: both setup scripts install a self-deploy mechanism gated on DOTFILES_AUTODEPLOY" {
+    grep -qF 'enable --now dotfiles-selfupdate.timer' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF 'DotfilesSelfUpdate' "$DOTFILES_DIR/setup-windows.ps1"
+    grep -qF 'DOTFILES_AUTODEPLOY' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF 'DOTFILES_AUTODEPLOY' "$DOTFILES_DIR/setup-windows.ps1"
+}

--- a/tests/dotfiles-selfupdate.bats
+++ b/tests/dotfiles-selfupdate.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# OPS-001: behavior tests for scripts/dotfiles-selfupdate.sh
+#
+# The self-deploy entrypoint: guard a dirty worktree, fetch, fast-forward ONLY,
+# and re-run the (injected) setup only when HEAD actually moved. Anything that is
+# not a clean fast-forward is logged and skipped (exit 0). A real setup failure
+# is the ONLY non-zero exit.
+#
+# Fixture: a bare remote + a local clone + a stub setup command injected via
+# DOTFILES_SELFUPDATE_SETUP_CMD that records each run to $RAN.
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    SCRIPT="$DOTFILES_DIR/scripts/dotfiles-selfupdate.sh"
+
+    TMP="$(mktemp -d)"
+    REMOTE="$TMP/remote.git"
+    REPO="$TMP/repo"
+    RAN="$TMP/setup-ran"
+
+    git init -q --bare "$REMOTE"
+    git init -q "$REPO"
+    git -C "$REPO" config user.email t@t.t
+    git -C "$REPO" config user.name tester
+    git -C "$REPO" config commit.gpgsign false
+    printf 'v1\n' > "$REPO/file"
+    git -C "$REPO" add file
+    git -C "$REPO" commit -qm init
+    git -C "$REPO" remote add origin "$REMOTE"
+    git -C "$REPO" push -qu origin HEAD
+
+    STUB="$TMP/stub-setup.sh"
+    printf '#!/usr/bin/env bash\necho ran >> "%s"\n' "$RAN" > "$STUB"
+    chmod +x "$STUB"
+
+    export DOTFILES_REPO_DIR="$REPO"
+    export DOTFILES_SELFUPDATE_SETUP_CMD="$STUB"
+}
+
+teardown() {
+    [ -n "${TMP:-}" ] && rm -rf "$TMP"
+}
+
+# Advance the remote by one commit (a second clone commits + pushes).
+advance_remote() {
+    local work="$TMP/work_$RANDOM"
+    git clone -q "$REMOTE" "$work"
+    git -C "$work" config user.email t@t.t
+    git -C "$work" config user.name tester
+    git -C "$work" config commit.gpgsign false
+    printf 'remote change\n' >> "$work/file"
+    git -C "$work" commit -qam "remote advance"
+    git -C "$work" push -q origin HEAD
+    rm -rf "$work"
+}
+
+ran_count() {
+    [ -f "$RAN" ] && wc -l < "$RAN" | tr -d ' ' || echo 0
+}
+
+# --- syntax (cross-shell, per project standard) ---
+
+@test "dotfiles-selfupdate.sh has valid bash syntax" {
+    bash -n "$SCRIPT"
+}
+
+@test "dotfiles-selfupdate.sh has valid zsh syntax" {
+    zsh -n "$SCRIPT"
+}
+
+# --- AC1: dirty worktree -> skip, exit 0, no setup ---
+
+@test "skips on a dirty worktree without running setup" {
+    printf 'local edit\n' >> "$REPO/file"   # uncommitted change
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *[Dd]irty* ]]
+    [ "$(ran_count)" -eq 0 ]
+}
+
+# --- AC2: diverged / non-fast-forward -> skip, exit 0, no setup ---
+
+@test "skips when local has diverged (non fast-forward) without running setup" {
+    advance_remote                              # remote moves ahead
+    printf 'local only\n' >> "$REPO/file"       # and a divergent local commit
+    git -C "$REPO" commit -qam "local advance"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *diverg* ]] || [[ "$output" == *"fast-forward"* ]]
+    [ "$(ran_count)" -eq 0 ]
+}
+
+# --- AC3: already current -> exit 0, no setup ---
+
+@test "is a no-op when already current (no setup run)" {
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(ran_count)" -eq 0 ]
+}
+
+# --- AC4: clean fast-forward -> ff + run setup exactly once ---
+
+@test "fast-forwards and runs setup exactly once when the remote is ahead" {
+    advance_remote
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(ran_count)" -eq 1 ]
+    # HEAD now matches the upstream (fast-forward happened)
+    [ "$(git -C "$REPO" rev-parse HEAD)" = "$(git -C "$REPO" rev-parse '@{u}')" ]
+}
+
+# --- AC5: setup failure -> non-zero exit ---
+
+@test "exits non-zero when the setup command fails" {
+    advance_remote
+    printf '#!/usr/bin/env bash\nexit 7\n' > "$STUB"   # failing setup
+    chmod +x "$STUB"
+    run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+# --- network fetch failure -> skip, exit 0 (transient) ---
+
+@test "skips (exit 0) when the remote is unreachable" {
+    git -C "$REPO" remote set-url origin "$TMP/does-not-exist.git"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(ran_count)" -eq 0 ]
+}
+
+# --- missing repo dir -> skip, exit 0 (no spam) ---
+
+@test "skips (exit 0) when the repo dir is not a git repo" {
+    export DOTFILES_REPO_DIR="$TMP/nonrepo"
+    mkdir -p "$DOTFILES_REPO_DIR"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(ran_count)" -eq 0 ]
+}


### PR DESCRIPTION
## What

Opt-in self-deploy: a daily systemd `--user` timer (Linux) / Scheduled Task (Windows) that keeps a machine converged to `origin/main` by pulling the dotfiles repo and re-running the idempotent setup.

Safe by construction (ADR-019): **fast-forward only**. A dirty worktree, diverged history, missing upstream, or unreachable remote is logged and skipped (exit 0). Setup runs **only when `HEAD` actually moved**. Only a real setup failure exits non-zero.

## Design pass (locked with the user)

- **Cadence:** daily, `Persistent=true` (catches a missed slot after suspend/off), `RandomizedDelaySec`.
- **On conflict:** `--ff-only` or skip+log. No merge/rebase/stash/reset unattended.
- **Opt-in:** `DOTFILES_AUTODEPLOY` env gate, default OFF (`1` install+enable, `0` disable+remove, unset no-op).
- **Entrypoint:** dedicated `dotfiles-selfupdate.sh`, separate from `dotfiles-sync.sh` (opposite data-flow direction).

## Spec

`specs/OPS-001-self-deploy-timer/` (proposal / tasks / verification / features.json). ADR: `docs/adr/adr-019-self-deploy-fast-forward-only.md`. Runbook: `docs/runbooks/guide-self-deploy-timer.md`.

## Tests

`tests/dotfiles-selfupdate.bats` (behavior, AC1-AC5 + network/no-upstream/non-repo) + `tests/dotfiles-selfupdate-install.bats` (units + opt-in gate + cross-OS parity). **24/24 passing.** shellcheck clean; `.ps1` ASCII-only. No regressions in the existing suite.

## Deferred

Windows runtime verification (Scheduled Task) is authored but verified on a Windows box in a later session.

Closes #295
