### PR TITLE
ci(bitacora): auto-add opened issues and PRs to the board (OPS-002)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,21 @@
+name: Add to bitácora
+
+# Puts every opened/reopened issue and PR onto the cross-repo bitácora board
+# (GitHub Project #1). Pairs with bitacora-status.yml (which flips an assigned
+# issue to In Progress). Canonical copy for the OPS-002 (#258) multi-repo rollout.
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      # Pin a real release: actions/add-to-project@v1 does NOT resolve (no floating v1 tag).
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/mlorentedev/projects/1
+          github-token: ${{ secrets.BITACORA_PAT }}


### PR DESCRIPTION
## What

Adds `.github/workflows/add-to-project.yml` so newly **opened/reopened issues and PRs** auto-land on the bitácora board (Project #1), instead of needing a manual `gh project item-add`.

## Why

This repo only had `bitacora-status.yml` (assign → In Progress), not the auto-add half. AGENTS.md and `docs/runbooks/guide-bitacora-setup.md` §7a both claim the canonical copy lives in `dotfiles/.github/workflows/` — but the file was missing. Surfaced during OPS-001 (#295): #302 and #304 did not auto-add and had to be placed by hand.

## Notes

- `BITACORA_PAT` (scope `project` + `repo`) is **already a repo secret** and proven — it powers `bitacora-status.yml`. No secret work needed.
- Pins `actions/add-to-project@v1.0.2` (the `@v1` tag is unresolvable — runbook gotcha, 2026-06-06).
- No `run:` step and no `github.event.*` interpolation → no workflow-injection surface.
- SDD skipped: single ~15-line workflow, obvious cause; work-gate is #258.

## Verify after merge

Open a throwaway issue → it should appear on Project #1 automatically.

Part of #258 (OPS-002 rolls this canonical copy out to the remaining repos).
