### PR TITLE
refactor(spec): init-spec work-gate is an open GitHub issue (ADR-018)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,7 +389,7 @@ Before creating ANY branch for code changes in this repo, evaluate against `patt
 **If trigger met, follow this order — no shortcuts:**
 
 1. Open a GitHub issue (or reuse an existing one) and add it to the **bitácora** Project — this is the "work gate" replacing the former vault `11-tasks.md` entry
-2. Run `init-spec.{sh,ps1} <feature-id>` to scaffold `specs/<feature-id>/` (the script enforces the work-gate check; bypass only with `-ForceNoVault` + explicit user-facing justification)
+2. Run `init-spec.{sh,ps1} <feature-id> --issue <N>` to scaffold `specs/<feature-id>/` (the script verifies via `gh` that issue N exists and is OPEN; bypass only with `--force-no-gate` / `-ForceNoGate` + explicit user-facing justification)
 3. Fill `proposal.md` (why + what + acceptance criteria) **before** writing implementation code
 4. Fill `tasks.md` in TDD order
 5. Implement; tick boxes as you go

--- a/harness/skills/spec/SKILL.md
+++ b/harness/skills/spec/SKILL.md
@@ -4,14 +4,14 @@ type: skill
 status: active
 created: "2026-05-13"
 name: spec
-description: Manage Spec-Driven Development per-feature artifacts. Triggers on /spec, "create a spec for", "scaffold spec X", "bootstrap substrate for X", "fill proposal for X", "archive spec X". Four subcommands: init (scaffold, vault-rooted), bootstrap (optional 4-section substrate contract), fill (Socratic 5-question proposal), archive (move + selective vault promotion). Cross-OS Linux/Windows, cross-agent Claude/Copilot via AGENTS.md indirection.
+description: Manage Spec-Driven Development per-feature artifacts. Triggers on /spec, "create a spec for", "scaffold spec X", "bootstrap substrate for X", "fill proposal for X", "archive spec X". Four subcommands: init (scaffold, gated on an open GitHub issue per ADR-018), bootstrap (optional 4-section substrate contract), fill (Socratic 5-question proposal), archive (move + selective vault promotion). Cross-OS Linux/Windows, cross-agent Claude/Copilot via AGENTS.md indirection.
 allowed-tools: [Bash, Read, Edit, Write, mcp__hive__vault_query, mcp__hive__vault_search, mcp__hive__vault_write, mcp__hive__vault_patch]
 ---
 
 # Spec Workflow
 
 > Implements `pattern-spec-driven-development`. Four subcommands: `init`, `bootstrap` (optional), `fill`, `archive`.
-> **Core principle:** every spec is downstream of a vault entry (`11-tasks.md`, ADR, or roadmap). Vault is SSOT.
+> **Core principle:** every spec is downstream of an OPEN GitHub issue on the bitácora Project — the work-gate per ADR-018. The vault keeps templates and patterns; task state lives in GitHub.
 
 ## When to use
 
@@ -25,7 +25,7 @@ allowed-tools: [Bash, Read, Edit, Write, mcp__hive__vault_query, mcp__hive__vaul
 
 - Trivial change (typo, comment-only, mechanical rename) — per pattern's "Skip SDD" rules.
 - Strategic planning across milestones -> use `/writing-plans`.
-- If you cannot point to ANY vault entry justifying this spec (backlog, ADR, roadmap) — don't run the skill yet; first crystallize the work in the vault.
+- If you cannot point to ANY work-gate justifying this spec (open GitHub issue, ADR, roadmap) — don't run the skill yet; open the bitácora issue first.
 
 ---
 
@@ -49,11 +49,11 @@ If ANY trigger fires AND none of the "When NOT to propose" conditions hold → p
 
 Surface a short, skippable proposal that states the evidence — don't just assert. Template:
 
-> This looks like a Discipline-Gate trigger: **<which trigger(s) fired>** (e.g. "~120 LOC + touches a deployed config schema"). I ran the Skip-SDD checks — it does **not** qualify for skip. Propose `/spec init <feature-id>` before writing code? (id from the vault backlog, or a new `11-tasks.md` entry.)
+> This looks like a Discipline-Gate trigger: **<which trigger(s) fired>** (e.g. "~120 LOC + touches a deployed config schema"). I ran the Skip-SDD checks — it does **not** qualify for skip. Propose `/spec init <feature-id>` before writing code? (work-gate = an open GitHub issue — reuse one or open it now.)
 
 - **List the checks you ran**, not just the verdict — the evidence is the value (mirrors the Model-Tier "the proposal IS the value" rule in `AGENTS.md`).
 - **Offer, don't impose.** The human decides. If they decline, proceed without the spec and do not re-propose for the same change.
-- **Suggest the id.** Derive `<feature-id>` from an existing vault entry if one matches; otherwise propose creating the 1-line `11-tasks.md` entry first (the vault gate).
+- **Suggest the id.** Derive `<feature-id>` from the gating GitHub issue if one matches; otherwise propose opening the issue first (the work-gate).
 
 ### When NOT to propose
 
@@ -80,25 +80,22 @@ When unsure whether a change crosses the threshold, ASK rather than assume (`AGE
 
 ## Subcommand: init
 
-**Purpose:** Scaffold `$REPO_ROOT/specs/<feature-id>/` from vault templates. Vault-rooted: requires (or offers to create) a vault entry before scaffolding.
+**Purpose:** Scaffold `$REPO_ROOT/specs/<feature-id>/` from vault templates. Work-gated per ADR-018: requires an OPEN GitHub issue (bitácora) before scaffolding.
 
-**Signature:** `/spec init <feature-id> [--task <task-id>] [--force-no-vault]`
+**Signature:** `/spec init <feature-id> [--issue <number>] [--force-no-gate]` (`--force-no-vault` is a deprecated alias of `--force-no-gate`)
 
 **Steps:**
 
-1. **Validate id** matches `^[A-Z]+-\d+(-[a-z0-9-]+)?$` OR `^\d{4}-\d{2}-\d{2}-[a-z0-9-]+$`. Reject otherwise.
+1. **Validate id** matches `^[A-Z]+-\d+[a-z]?(-[a-z0-9-]+)?$` OR `^\d{4}-\d{2}-\d{2}-[a-z0-9-]+$`. Reject otherwise.
 2. **No clobber:** fail if `$REPO_ROOT/specs/<feature-id>/` exists. Warn if `specs/archive/<feature-id>/` exists.
-3. **Vault context pre-flight (mandatory):**
-   - Via Hive `vault_search`, look for `<feature-id>` (or `--task <id>` if provided) in:
-     - `$VAULT_PATH/10_projects/$REPO_NAME/11-tasks.md`
-     - the repo's `docs/adr/` (any ADR)
-     - `$VAULT_PATH/10_projects/$REPO_NAME/10-roadmap.md`
-   - If found in any -> note source for step 7.
-   - If NOT found -> present three options to user:
-     - **(a)** Create a 1-line backlog entry in `11-tasks.md` now. Ask for description. Append via Hive `vault_patch` (under appropriate stream/section).
-     - **(b)** Cancel. User creates vault entry manually, then re-runs `/spec init`.
-     - **(c)** Force-proceed via `--force-no-vault` flag (NOT RECOMMENDED — violates SSOT discipline; emit warning).
-   - Wait for choice. If (a) executed, treat the new entry as the source.
+3. **Work-gate pre-flight (mandatory):**
+   - The gate is an OPEN GitHub issue on the repo (tracked in the bitácora Project). Verify via `gh issue view <number> --json state,title`: the issue must exist and be `OPEN`.
+   - If `--issue` was not given, ask the user which issue gates this work (suggest candidates via `gh issue list --state open` if helpful).
+   - If the issue is missing or closed -> present three options to user:
+     - **(a)** Open (or reopen) the gating issue now, add it to the bitácora Project, then proceed with its number.
+     - **(b)** Cancel. User sorts out the issue manually, then re-runs `/spec init`.
+     - **(c)** Force-proceed via `--force-no-gate` flag (NOT RECOMMENDED — violates the work-gate discipline; emit warning).
+   - Wait for choice. Note the gating issue for step 7.
 4. `mkdir -p $REPO_ROOT/specs/<feature-id>/`.
 5. Read 3 templates from `$VAULT_PATH/00_meta/templates/spec-{proposal,tasks,verification}.md`.
 6. Substitute placeholders in memory:
@@ -106,17 +103,18 @@ When unsure whether a change crosses the threshold, ASK rather than assume (`AGE
    - `{TITLE}` -> derived from id (drop ticket prefix, title-case the slug). E.g. `AI-001-ollama-public` -> `AI-001: Ollama public`.
    - `{{date:YYYY-MM-DD}}` -> today (UTC).
    - `template_version: "1.0"` -> hardcoded v1.
-7. **Inject vault context** in proposal `## Why` as HTML comment: `<!-- from <source-path>: <one-line-extract> -->`. Always injected when vault source exists.
+7. **Inject issue context** in proposal `## Why` as HTML comment: `<!-- from issue #<number>: <issue-title> -->`, and set the `issue:` frontmatter field to `<repo>#<number>`. Always injected when the gate was verified.
 8. Write the 3 substituted files.
 9. **Output:**
    - Paths created.
-   - Vault source used (or `none — force-proceeded`).
+   - Gating issue used (or `none — force-proceeded`).
    - Next step: `/spec fill <feature-id>`.
 
 **Edge cases:**
-- Vault unreachable: cannot do step 3 -> emit error and instructions to set `$VAULT_PATH` or vendored-template fallback (v2).
+- `gh` unavailable or unauthenticated: gate cannot be verified -> fail with instructions (install/auth `gh`) or `--force-no-gate`.
 - Templates missing in vault -> fail with path hint.
 - Id collides with archived spec -> warn but allow (user may be reviving).
+- Mechanical fallback: `init-spec.sh <id> --issue <N>` / `init-spec.ps1 <id> -Issue <N>` implement this same gate for non-interactive use.
 
 ---
 
@@ -267,7 +265,7 @@ When unsure whether a change crosses the threshold, ASK rather than assume (`AGE
 
 | Subcommand | Reads | Writes |
 |---|---|---|
-| `init` (pre-flight) | `11-tasks.md`, the repo's `docs/adr/` (search for context) | `11-tasks.md` (if user chose option a — new entry) |
+| `init` (pre-flight) | GitHub issue via `gh` (work-gate, not a vault read) | nothing |
 | `init` (substitution) | `00_meta/templates/spec-*.md` | (filesystem only — repo specs/) |
 | `bootstrap` (template) | `00_meta/templates/bootstrap-contract.md`, sister contracts in `specs/archive/` | (filesystem only — repo specs/<id>/bootstrap-contract.md) |
 | `fill` (grounding) | `11-tasks.md`, `10-roadmap.md`, referenced ADRs, sister specs | nothing |

--- a/scripts/init-spec.ps1
+++ b/scripts/init-spec.ps1
@@ -1,9 +1,9 @@
 # init-spec.ps1
 # Purpose: Mechanical scaffold of a per-feature spec folder per pattern-spec-driven-development.
-#          Vault-rooted: requires vault entry before scaffolding (SSOT discipline).
+#          Work-gated: requires an OPEN GitHub issue (bitacora) before scaffolding (ADR-018).
 #
 # Usage:
-#   .\init-spec.ps1 <feature-id> [-Task <task-id>] [-ForceNoVault]
+#   .\init-spec.ps1 <feature-id> -Issue <number> [-ForceNoGate]
 #
 # Mechanical only. For Socratic proposal filling (Q1-Q6), use /spec fill in an agent.
 # See: $env:VAULT_PATH\00_meta\skills\spec\SKILL.md for the full workflow.
@@ -13,8 +13,11 @@ param(
     [Parameter(Mandatory = $true, Position = 0)]
     [string]$FeatureId,
 
-    [string]$Task,
+    [int]$Issue,
 
+    [switch]$ForceNoGate,
+
+    # Deprecated alias of -ForceNoGate (pre-ADR-018 name).
     [switch]$ForceNoVault,
 
     [switch]$Help
@@ -24,19 +27,27 @@ $ErrorActionPreference = 'Stop'
 
 if ($Help) {
     @"
-Usage: init-spec.ps1 <feature-id> [-Task <task-id>] [-ForceNoVault]
+Usage: init-spec.ps1 <feature-id> -Issue <number> [-ForceNoGate]
 
   <feature-id>      e.g. AI-001-ollama-public or 2026-05-13-foo
-  -Task <task-id>   override which task ID to look up in vault 11-tasks.md
-  -ForceNoVault     skip vault context check (NOT RECOMMENDED — violates SSOT)
+  -Issue <number>   GitHub issue that gates this work (must exist and be OPEN)
+  -ForceNoGate      skip the work-gate check (NOT RECOMMENDED -- gate is the SSOT)
+  -ForceNoVault     deprecated alias of -ForceNoGate
 "@ | Write-Host
     exit 0
 }
 
+if ($ForceNoVault) {
+    Write-Warning '-ForceNoVault is deprecated; use -ForceNoGate (ADR-018).'
+    $ForceNoGate = $true
+}
+
 # --- Validate id ---
-$Pattern = '^([A-Z]+-[0-9]+(-[a-z0-9-]+)?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+)$'
+# The optional single letter after the number admits the sub-id convention
+# (SDD-012b, WIN-002a) that check-backlog-integrity treats as a distinct ticket.
+$Pattern = '^([A-Z]+-[0-9]+[a-z]?(-[a-z0-9-]+)?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+)$'
 if ($FeatureId -notmatch $Pattern) {
-    Write-Error "Invalid feature-id: $FeatureId. Expected: TICKET-NNN[-slug] or YYYY-MM-DD-slug."
+    Write-Error "Invalid feature-id: $FeatureId. Expected: TICKET-NNN[letter][-slug] or YYYY-MM-DD-slug."
     exit 1
 }
 
@@ -58,7 +69,6 @@ if (-not $RepoRoot) {
     exit 1
 }
 
-$RepoName = Split-Path $RepoRoot -Leaf
 $SpecDir = Join-Path $RepoRoot "specs\$FeatureId"
 
 # --- No clobber ---
@@ -71,30 +81,44 @@ if (Test-Path $ArchivedPath) {
     Write-Warning "$FeatureId exists in specs\archive\. Possibly reviving."
 }
 
-# --- Vault context check ---
-$VaultLine = $null
-$TasksFile = Join-Path $VaultPath "10_projects\$RepoName\11-tasks.md"
+# --- Work-gate check (ADR-018: an OPEN GitHub issue, not a vault entry) ---
+$IssueTitle = $null
 
-if (-not $ForceNoVault) {
-    $SearchId = if ($Task) { $Task } else { $FeatureId }
-    if (Test-Path $TasksFile) {
-        $Escaped = [regex]::Escape($SearchId)
-        $VaultLine = Select-String -Path $TasksFile -Pattern "^- \[[ x-]\] \*\*$Escaped\*\*" |
-            Select-Object -First 1
-    }
-    if (-not $VaultLine) {
+if (-not $ForceNoGate) {
+    if (-not $Issue) {
         @"
-[ERROR] No vault entry found for "$SearchId" in $TasksFile.
+[ERROR] No work-gate given. Pass -Issue <number>.
 
-Spec must be downstream of a vault entry (backlog/ADR/roadmap) per SSOT discipline.
+Per ADR-018 every spec is downstream of an OPEN GitHub issue on the bitacora
+Project -- that issue is the work-gate (the vault no longer holds task state).
 
 Options:
-  (a) Cancel. Add an entry to 11-tasks.md, then re-run.
-  (b) Re-run with -ForceNoVault (NOT RECOMMENDED).
+  (a) Open (or find) the issue, then re-run with -Issue <number>.
+  (b) Re-run with -ForceNoGate (NOT RECOMMENDED).
 "@ | Write-Error
         exit 3
     }
-    Write-Host "[INFO] Vault context found in $TasksFile"
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        Write-Error "gh CLI not found -- cannot verify the work-gate issue #$Issue. Install gh, or re-run with -ForceNoGate (NOT RECOMMENDED)."
+        exit 3
+    }
+    $GateInfo = $null
+    try {
+        $GateInfo = gh issue view "$Issue" --json state,title --jq '.state + "\t" + .title' 2>&1
+        if ($LASTEXITCODE -ne 0) { $GateInfo = $null }
+    } catch { $GateInfo = $null }
+    if (-not $GateInfo) {
+        Write-Error "Work-gate issue #$Issue not found (or gh failed)."
+        exit 3
+    }
+    $Parts = ($GateInfo | Out-String).Trim() -split "`t", 2
+    $IssueState = $Parts[0]
+    $IssueTitle = if ($Parts.Count -gt 1) { $Parts[1] } else { '' }
+    if ($IssueState -ne 'OPEN') {
+        Write-Error "Work-gate issue #$Issue is not open (state: $IssueState). The work-gate is an OPEN issue."
+        exit 3
+    }
+    Write-Host "[INFO] Work-gate OK: issue #$Issue is open -- $IssueTitle"
 }
 
 # --- Scaffold ---
@@ -116,11 +140,10 @@ foreach ($tpl in @('proposal', 'tasks', 'verification')) {
     Set-Content -Path $dst -Value $content -NoNewline
 }
 
-# --- Inject vault context comment in proposal Why ---
-if ($VaultLine) {
+# --- Inject issue context comment in proposal Why ---
+if ($IssueTitle) {
     $proposal = Join-Path $SpecDir 'proposal.md'
-    $contextText = $VaultLine.Line -replace '^- \[[^]]+\] \*\*[^*]+\*\*:? *', ''
-    $contextLine = "<!-- from 11-tasks.md: $contextText -->"
+    $contextLine = "<!-- from issue #${Issue}: $IssueTitle -->"
     $content = Get-Content $proposal -Raw
     $content = $content -replace '(?m)^(## Why)\s*$', "`$1`n`n$contextLine"
     Set-Content -Path $proposal -Value $content -NoNewline
@@ -130,8 +153,8 @@ if ($VaultLine) {
 Write-Host ''
 Write-Host "[OK] Created: $SpecDir"
 Write-Host '     proposal.md, tasks.md, verification.md'
-if ($VaultLine) {
-    Write-Host "     Vault context linked from $TasksFile"
+if ($IssueTitle) {
+    Write-Host "     Work-gate linked: issue #$Issue"
 }
 Write-Host ''
 Write-Host "Next: fill proposal.md interactively (`"/spec fill $FeatureId`" in an agent)"

--- a/scripts/init-spec.sh
+++ b/scripts/init-spec.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # init-spec.sh
 # Purpose: Mechanical scaffold of a per-feature spec folder per pattern-spec-driven-development.
-#          Vault-rooted: requires vault entry before scaffolding (SSOT discipline).
+#          Work-gated: requires an OPEN GitHub issue (bitacora) before scaffolding (ADR-018).
 #
 # Usage:
-#   ./init-spec.sh <feature-id> [--task <task-id>] [--force-no-vault]
+#   ./init-spec.sh <feature-id> --issue <number> [--force-no-gate]
 #
 # Mechanical only. For Socratic proposal filling (Q1-Q6), use /spec fill in an agent.
 # See: $VAULT_PATH/00_meta/skills/spec/SKILL.md for the full workflow.
@@ -13,24 +13,28 @@ set -euo pipefail
 
 usage() {
     cat <<EOF
-Usage: init-spec.sh <feature-id> [--task <task-id>] [--force-no-vault]
+Usage: init-spec.sh <feature-id> --issue <number> [--force-no-gate]
 
   <feature-id>           e.g. AI-001-ollama-public or 2026-05-13-foo
-  --task <task-id>       override which task ID to look up in vault 11-tasks.md
-  --force-no-vault       skip vault context check (NOT RECOMMENDED — violates SSOT)
+  --issue <number>       GitHub issue that gates this work (must exist and be OPEN)
+  --force-no-gate        skip the work-gate check (NOT RECOMMENDED — gate is the SSOT)
+  --force-no-vault       deprecated alias of --force-no-gate
   -h, --help             show this help
 EOF
 }
 
 # --- Parse args ---
 FEATURE_ID=""
-TASK_ID=""
-FORCE_NO_VAULT=0
+ISSUE_NUM=""
+FORCE_NO_GATE=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --task) TASK_ID="$2"; shift 2 ;;
-        --force-no-vault) FORCE_NO_VAULT=1; shift ;;
+        --issue) ISSUE_NUM="$2"; shift 2 ;;
+        --force-no-gate) FORCE_NO_GATE=1; shift ;;
+        --force-no-vault)
+            printf '[WARN] --force-no-vault is deprecated; use --force-no-gate (ADR-018).\n' >&2
+            FORCE_NO_GATE=1; shift ;;
         -h|--help) usage; exit 0 ;;
         -*) printf '[ERROR] Unknown option: %s\n' "$1" >&2; usage >&2; exit 1 ;;
         *)
@@ -51,10 +55,15 @@ fi
 # The optional single letter after the number ([a-z]?) admits the sub-id
 # convention (SDD-012b, WIN-002a) that check-backlog-integrity.sh already treats
 # as a distinct ticket. Without it, init-spec rejected ids the rest of the system
-# accepts — sibling defect to BUG-024 in the same vault-gate.
+# accepts — sibling defect to BUG-024 in the same gate.
 if [[ ! "$FEATURE_ID" =~ ^([A-Z]+-[0-9]+[a-z]?(-[a-z0-9-]+)?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+)$ ]]; then
     printf '[ERROR] Invalid feature-id: %s\n' "$FEATURE_ID" >&2
     printf '        Expected: TICKET-NNN[letter][-slug] (e.g. AI-001-ollama-public, SDD-012b-guard) or YYYY-MM-DD-slug\n' >&2
+    exit 1
+fi
+
+if [[ -n "$ISSUE_NUM" && ! "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
+    printf '[ERROR] --issue expects a number, got: %s\n' "$ISSUE_NUM" >&2
     exit 1
 fi
 
@@ -73,12 +82,6 @@ if ! REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
     printf '[ERROR] Not in a git repo. cd into a repo first.\n' >&2
     exit 1
 fi
-# Canonical repo name = basename of the MAIN worktree. In a linked git worktree,
-# --show-toplevel points at the worktree dir (e.g. "dotfiles-harness"), not the
-# repo, which would break the vault project lookup below (10_projects/<repo>/).
-# --git-common-dir always resolves to the main repo's .git, so its parent dir is
-# the canonical repo root. (BUG-024)
-REPO_NAME="$(basename "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")")"
 SPEC_DIR="$REPO_ROOT/specs/$FEATURE_ID"
 
 # --- No clobber ---
@@ -90,28 +93,42 @@ if [[ -d "$REPO_ROOT/specs/archive/$FEATURE_ID" ]]; then
     printf '[WARN] %s exists in specs/archive/. Possibly reviving.\n' "$FEATURE_ID" >&2
 fi
 
-# --- Vault context check ---
-VAULT_LINE=""
-TASKS_FILE="$VAULT_PATH/10_projects/$REPO_NAME/11-tasks.md"
+# --- Work-gate check (ADR-018: an OPEN GitHub issue, not a vault entry) ---
+ISSUE_TITLE=""
 
-if [[ "$FORCE_NO_VAULT" -eq 0 ]]; then
-    SEARCH_ID="${TASK_ID:-$FEATURE_ID}"
-    if [[ -f "$TASKS_FILE" ]]; then
-        VAULT_LINE="$(grep -E "^- \[[ x-]\] \*\*${SEARCH_ID}\*\*" "$TASKS_FILE" 2>/dev/null || true)"
-    fi
-    if [[ -z "$VAULT_LINE" ]]; then
+if [[ "$FORCE_NO_GATE" -eq 0 ]]; then
+    if [[ -z "$ISSUE_NUM" ]]; then
         cat >&2 <<EOF
-[ERROR] No vault entry found for "$SEARCH_ID" in $TASKS_FILE.
+[ERROR] No work-gate given. Pass --issue <number>.
 
-Spec must be downstream of a vault entry (backlog/ADR/roadmap) per SSOT discipline.
+Per ADR-018 every spec is downstream of an OPEN GitHub issue on the bitacora
+Project — that issue is the work-gate (the vault no longer holds task state).
 
 Options:
-  (a) Cancel. Add an entry to 11-tasks.md, then re-run.
-  (b) Re-run with --force-no-vault (NOT RECOMMENDED).
+  (a) Open (or find) the issue, then re-run with --issue <number>.
+  (b) Re-run with --force-no-gate (NOT RECOMMENDED).
 EOF
         exit 3
     fi
-    printf '[INFO] Vault context found in %s\n' "$TASKS_FILE"
+    if ! command -v gh >/dev/null 2>&1; then
+        printf '[ERROR] gh CLI not found — cannot verify the work-gate issue #%s.\n' "$ISSUE_NUM" >&2
+        printf '        Install gh, or re-run with --force-no-gate (NOT RECOMMENDED).\n' >&2
+        exit 3
+    fi
+    GATE_INFO=""
+    if ! GATE_INFO="$(gh issue view "$ISSUE_NUM" --json state,title --jq '.state + "\t" + .title' 2>&1)"; then
+        printf '[ERROR] Work-gate issue #%s not found (or gh failed):\n' "$ISSUE_NUM" >&2
+        printf '        %s\n' "$GATE_INFO" >&2
+        exit 3
+    fi
+    ISSUE_STATE="${GATE_INFO%%$'\t'*}"
+    ISSUE_TITLE="${GATE_INFO#*$'\t'}"
+    if [[ "$ISSUE_STATE" != "OPEN" ]]; then
+        printf '[ERROR] Work-gate issue #%s is not open (state: %s).\n' "$ISSUE_NUM" "$ISSUE_STATE" >&2
+        printf '        The work-gate is an OPEN issue. Reopen it or pick the right one.\n' >&2
+        exit 3
+    fi
+    printf '[INFO] Work-gate OK: issue #%s is open — %s\n' "$ISSUE_NUM" "$ISSUE_TITLE"
 fi
 
 # --- Scaffold ---
@@ -132,11 +149,10 @@ for tpl in proposal tasks verification; do
         "$src" > "$dst"
 done
 
-# --- Inject vault context comment in proposal Why ---
-if [[ -n "$VAULT_LINE" ]]; then
+# --- Inject issue context comment in proposal Why ---
+if [[ -n "$ISSUE_TITLE" ]]; then
     proposal="$SPEC_DIR/proposal.md"
-    CONTEXT_TEXT="$(echo "$VAULT_LINE" | sed -E 's/^- \[[^]]+\] \*\*[^*]+\*\*:? *//')"
-    awk -v line="<!-- from 11-tasks.md: $CONTEXT_TEXT -->" '
+    awk -v line="<!-- from issue #$ISSUE_NUM: $ISSUE_TITLE -->" '
         /^## Why$/ {print; print ""; print line; next}
         {print}
     ' "$proposal" > "${proposal}.tmp" && mv "${proposal}.tmp" "$proposal"
@@ -145,8 +161,8 @@ fi
 # --- Output ---
 printf '\n[OK] Created: %s\n' "$SPEC_DIR"
 printf '     proposal.md, tasks.md, verification.md\n'
-if [[ -n "$VAULT_LINE" ]]; then
-    printf '     Vault context linked from %s\n' "$TASKS_FILE"
+if [[ -n "$ISSUE_TITLE" ]]; then
+    printf '     Work-gate linked: issue #%s\n' "$ISSUE_NUM"
 fi
 printf '\nNext: fill proposal.md interactively ("/spec fill %s" in an agent)\n' "$FEATURE_ID"
 printf '      or edit by hand. Do not skip the Why.\n'

--- a/specs/REFACTOR-012-init-spec-issue-gate/features.json
+++ b/specs/REFACTOR-012-init-spec-issue-gate/features.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "REFACTOR-012-f1",
+    "behavior": "init-spec.sh ID --issue N with an open issue scaffolds the spec and injects the issue context into ## Why (exit 0)",
+    "verification": "bats tests/init-spec.bats -f 'injects issue context'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "REFACTOR-012-f2",
+    "behavior": "Missing --issue, nonexistent issue, or closed issue exits 3 and creates no spec dir",
+    "verification": "bats tests/init-spec.bats -f 'gate fails'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "REFACTOR-012-f3",
+    "behavior": "--force-no-gate and legacy --force-no-vault bypass the gate without invoking gh",
+    "verification": "bats tests/init-spec.bats -f 'bypass'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "REFACTOR-012-f4",
+    "behavior": "No 11-tasks.md reference remains in init-spec.{sh,ps1}",
+    "verification": "bats tests/init-spec.bats -f 'ADR-018'",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/REFACTOR-012-init-spec-issue-gate/proposal.md
+++ b/specs/REFACTOR-012-init-spec-issue-gate/proposal.md
@@ -1,0 +1,56 @@
+---
+id: "REFACTOR-012-init-spec-issue-gate"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-06-09"
+issue: "dotfiles#304"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# REFACTOR-012: Init spec issue gate
+
+> **Naming**: file lives at `<repo>/specs/<feature-id>/proposal.md`. `<feature-id>` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #304: init-spec.{sh,ps1} still enforces the retired vault 11-tasks.md gate (ADR-018 drift) -->
+
+ADR-018 moved task/work state out of the vault into the bitácora GitHub Project — the vault no longer holds `11-tasks.md`. But `init-spec.{sh,ps1}` still hard-requires a matching `**ID**` entry in `$VAULT_PATH/10_projects/<repo>/11-tasks.md`, exiting 3 otherwise. The *default* path is now wrong by design: every scaffold has to be forced through `--force-no-vault` (hit during OPS-001 #295), which trains users to bypass the gate — the gate stops gating anything.
+
+## What
+
+The work-gate becomes an **open GitHub issue**, matching ADR-018:
+
+- `init-spec.sh <id> --issue <N>` / `init-spec.ps1 <id> -Issue <N>` verifies via `gh issue view <N>` that the issue exists and is OPEN, then scaffolds and injects `<!-- from issue #N: <title> -->` into the proposal's `## Why`.
+- Running without `--issue` (and without bypass) fails with exit 3 and guidance — the gate is now the issue, not a vault line.
+- The bypass is renamed `--force-no-gate` / `-ForceNoGate`; the old `--force-no-vault` / `-ForceNoVault` remains a working deprecated alias.
+- The vault `11-tasks.md` lookup and the `--task` / `-Task` flag are removed. Templates still come from `$VAULT_PATH/00_meta/templates` — only the task gate changes.
+- `AGENTS.md` SDD-workflow wording and the vault `/spec` skill SSOT (+ compiled `harness/skills/spec/SKILL.md` record) updated to describe the issue gate.
+
+## Out of scope
+
+- `archive-spec.{sh,ps1}` and the `/spec archive` backlog-tick step (vault `11-tasks.md` tick) — separate drift, separate ticket if confirmed.
+- Auto-discovery of the issue number from the feature-id (issue titles don't contain spec ids; explicit `--issue` is the contract).
+- Any change to the spec-gate CI workflow (`check-spec-gate.sh`) — it gates PRs on spec folders, not on the vault.
+
+## Risks / open questions
+
+- `gh` availability/auth (offline, CI, fresh machines): gate fails closed with a clear message; `--force-no-gate` is the documented escape hatch. Tests stub `gh` on PATH — no network in bats.
+- Closed issues: treated as gate failure (work-gate is an *open* issue per AGENTS.md); message says so explicitly.
+- Backward compatibility: `--force-no-vault` kept as alias so existing muscle memory / docs don't hard-break; emits a deprecation note.
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [ ] `init-spec.sh ID --issue N` with an open issue scaffolds the spec and injects `<!-- from issue #N: <title> -->` into `## Why` (exit 0).
+- [ ] Missing `--issue`, nonexistent issue, or closed issue → exit 3, no spec dir created, message names the issue gate.
+- [ ] `--force-no-gate` and legacy `--force-no-vault` both bypass the gate without invoking `gh`.
+- [ ] No `11-tasks.md` reference remains in `init-spec.{sh,ps1}`; full bats suite passes with `gh` stubbed.
+
+## References
+
+- GitHub issue: `dotfiles#304` (work-gate per ADR-018)
+- Related ADR: `docs/adr/adr-018-de-vault-task-placement.md`
+- Related patterns: `00_meta/patterns/pattern-spec-driven-development.md`

--- a/specs/REFACTOR-012-init-spec-issue-gate/tasks.md
+++ b/specs/REFACTOR-012-init-spec-issue-gate/tasks.md
@@ -1,0 +1,32 @@
+---
+tags: [spec, tasks]
+created: "2026-06-09"
+---
+
+# Tasks - REFACTOR-012-init-spec-issue-gate
+
+> TDD order. One task = one focused commit. Tick as you go.
+
+## Setup
+
+- [x] Branch created from main: `refactor/init-spec-issue-gate` (worktree)
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+- [x] Rewrite `tests/init-spec.bats` for the issue gate (stubbed `gh`): open-issue pass, missing/closed fail, bypass flags, no-11-tasks regression
+- [x] Implement issue gate in `scripts/init-spec.sh` (`--issue`, `--force-no-gate`, `--force-no-vault` alias, remove `--task` + vault lookup)
+- [x] Port to `scripts/init-spec.ps1` (`-Issue`, `-ForceNoGate`, `-ForceNoVault` alias; ASCII-only)
+- [x] Update `AGENTS.md` SDD-workflow wording (work-gate = open issue; new flag names)
+- [x] Update vault `/spec` skill SSOT + run `compile-harness --refresh` → refreshed `harness/skills/spec/SKILL.md` in this PR
+
+## Closing
+
+- [x] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [x] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [x] shellcheck passes
+- [x] Full bats suite passes (no regressions)
+- [x] No unrelated changes in the diff (no scope creep)
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder and closing #304

--- a/specs/REFACTOR-012-init-spec-issue-gate/verification.md
+++ b/specs/REFACTOR-012-init-spec-issue-gate/verification.md
@@ -1,0 +1,41 @@
+---
+tags: [spec, verification]
+created: "2026-06-09"
+---
+
+# Verification - REFACTOR-012-init-spec-issue-gate
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [x] Open issue scaffolds + injects context -> bats "scaffolds with an open issue gate" + "injects issue context into proposal ## Why"
+- [x] Missing/closed issue fails exit 3, no dir -> bats "gate fails (exit 3) without --issue / when the issue does not exist / when the issue is CLOSED"
+- [x] Both bypass flags work without gh -> bats "--force-no-gate bypasses the gate without calling gh" (poisoned stub) + "legacy --force-no-vault still works"
+- [x] No 11-tasks.md reference; suite green -> bats "ADR-018: no 11-tasks.md reference remains in init-spec.{sh,ps1}"
+
+## Test status
+
+- Test suite: `bats tests/init-spec.bats` -> 12/12 ok (gh stubbed on PATH, no network)
+- Full suite: `bats tests/*.bats` -> only pre-existing failures (6 pwsh-skips + 3 shell-profile env failures, reproduced identically on main)
+- shellcheck `scripts/init-spec.sh` -> clean; init-spec.ps1 ASCII-only verified (PSSA runs in CI)
+- No regressions in existing test suite: yes
+
+## Decisions made during implementation
+
+- Gate failure is always exit 3 (same code the vault gate used) -- callers only need "gate failed", the message differentiates missing flag / unknown issue / closed issue / no gh.
+- `--task` removed outright instead of deprecated: it only parameterized the vault lookup, which no longer exists.
+- `--force-no-vault` kept as a warning-emitting alias rather than removed, since AGENTS.md and muscle memory still reference it.
+
+## Promotion candidates
+
+- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no>
+- [ ] New pattern candidate for `00_meta/patterns/`? <yes / no>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/REFACTOR-012-init-spec-issue-gate/` -> `specs/archive/...`
+- [ ] Issue #304 closed by the PR
+- [ ] Promotions above executed (if any)

--- a/tests/init-spec.bats
+++ b/tests/init-spec.bats
@@ -1,19 +1,39 @@
 #!/usr/bin/env bats
-# Tests for scripts/init-spec.sh — spec scaffolder + vault-gate.
-# Regression guard for BUG-024: the vault-gate must resolve the CANONICAL repo
-# name (not the worktree dir basename), so init-spec works from a git worktree.
+# Tests for scripts/init-spec.sh — spec scaffolder + work-gate.
+#
+# REFACTOR-012 (ADR-018): the work-gate is an OPEN GitHub issue (--issue <N>),
+# not a vault 11-tasks.md entry. `gh` is stubbed on PATH — no network here.
+# Keeps the BUG-024 worktree regression coverage (scaffold from a linked
+# worktree must land files in the worktree).
 
 setup() {
     SCRIPTS_DIR="$BATS_TEST_DIRNAME/../scripts"
     TMP="/tmp/bats_initspec_$$_${BATS_TEST_NUMBER:-0}"
     mkdir -p "$TMP"
 
-    # --- fake vault with the three spec templates ---
+    # --- fake vault with the three spec templates (templates stay vault-sourced) ---
     VAULT="$TMP/vault"
     mkdir -p "$VAULT/00_meta/templates"
     printf '# proposal\n\n## Why\n' > "$VAULT/00_meta/templates/spec-proposal.md"
     printf '# tasks\n' > "$VAULT/00_meta/templates/spec-tasks.md"
     printf '# verification\n' > "$VAULT/00_meta/templates/spec-verification.md"
+
+    # --- stub gh: issue 42 is OPEN, issue 43 is CLOSED, anything else is unknown ---
+    # The script calls: gh issue view <N> --json state,title --jq <expr>
+    STUBBIN="$TMP/bin"
+    mkdir -p "$STUBBIN"
+    cat > "$STUBBIN/gh" <<'EOF'
+#!/bin/bash
+num="$2"
+[ "$1" = "issue" ] && num="$3"
+case "$num" in
+    42) printf 'OPEN\tDemo open issue for the gate\n'; exit 0 ;;
+    43) printf 'CLOSED\tAlready done\n'; exit 0 ;;
+    *)  echo "GraphQL: Could not resolve to an issue" >&2; exit 1 ;;
+esac
+EOF
+    chmod +x "$STUBBIN/gh"
+    export PATH="$STUBBIN:$PATH"
 
     # --- main repo; canonical name = "canonrepo" ---
     MAINREPO="$TMP/canonrepo"
@@ -26,11 +46,6 @@ setup() {
     echo seed > seed.txt
     git add -A
     git commit -q -m seed
-
-    # --- vault backlog for the CANONICAL project name ---
-    mkdir -p "$VAULT/10_projects/canonrepo"
-    printf -- '- [ ] **TEST-001-foo** demo backlog entry\n' \
-        > "$VAULT/10_projects/canonrepo/11-tasks.md"
 }
 
 teardown() {
@@ -38,60 +53,98 @@ teardown() {
     rm -rf "$TMP"
 }
 
-@test "scaffolds in a plain clone (backward compatible)" {
+@test "scaffolds with an open issue gate (--issue 42)" {
     cd "$MAINREPO"
-    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-001-foo
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-001-foo --issue 42
     [ "$status" -eq 0 ]
     [ -f "$MAINREPO/specs/TEST-001-foo/proposal.md" ]
+    [[ "$output" == *"Work-gate"* ]]
+}
+
+@test "injects issue context into proposal ## Why" {
+    cd "$MAINREPO"
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-001-foo --issue 42
+    [ "$status" -eq 0 ]
+    grep -q '<!-- from issue #42: Demo open issue for the gate -->' \
+        "$MAINREPO/specs/TEST-001-foo/proposal.md"
 }
 
 @test "accepts a sub-id feature-id (SDD-012b / WIN-002a convention)" {
-    # Sibling of BUG-024: the regex rejected sub-ids that check-backlog-integrity.sh
-    # treats as distinct tickets. A trailing single letter on the number is valid.
-    printf -- '- [ ] **TEST-002a-subid** sub-id backlog entry\n' \
-        >> "$VAULT/10_projects/canonrepo/11-tasks.md"
     cd "$MAINREPO"
-    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-002a-subid
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-002a-subid --issue 42
     [ "$status" -eq 0 ]
     [ -f "$MAINREPO/specs/TEST-002a-subid/proposal.md" ]
 }
 
 @test "still rejects a malformed feature-id (no ticket number)" {
     cd "$MAINREPO"
-    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" notaticket
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" notaticket --issue 42
     [ "$status" -eq 1 ]
     [[ "$output" == *"Invalid feature-id"* ]]
 }
 
-@test "BUG-024: scaffolds from a linked worktree (vault-gate resolves canonical name)" {
+@test "rejects a non-numeric --issue value" {
+    cd "$MAINREPO"
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-001-foo --issue abc
+    [ "$status" -eq 1 ]
+}
+
+@test "gate fails (exit 3) without --issue and without bypass" {
+    cd "$MAINREPO"
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-001-foo
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"--issue"* ]]
+    [ ! -e "$MAINREPO/specs/TEST-001-foo" ]
+}
+
+@test "gate fails (exit 3) when the issue does not exist" {
+    cd "$MAINREPO"
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-001-foo --issue 999
+    [ "$status" -eq 3 ]
+    [ ! -e "$MAINREPO/specs/TEST-001-foo" ]
+}
+
+@test "gate fails (exit 3) when the issue is CLOSED" {
+    cd "$MAINREPO"
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-001-foo --issue 43
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"not open"* ]]
+    [ ! -e "$MAINREPO/specs/TEST-001-foo" ]
+}
+
+@test "--force-no-gate bypasses the gate without calling gh" {
+    cd "$MAINREPO"
+    # poison the stub: any gh call now explodes — bypass must never invoke it
+    cat > "$STUBBIN/gh" <<'EOF'
+#!/bin/bash
+echo "gh must not be called on bypass" >&2
+exit 99
+EOF
+    chmod +x "$STUBBIN/gh"
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-777-bypass --force-no-gate
+    [ "$status" -eq 0 ]
+    [ -f "$MAINREPO/specs/TEST-777-bypass/proposal.md" ]
+}
+
+@test "legacy --force-no-vault still works as a deprecated alias" {
+    cd "$MAINREPO"
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-778-legacy --force-no-vault
+    [ "$status" -eq 0 ]
+    [ -f "$MAINREPO/specs/TEST-778-legacy/proposal.md" ]
+    [[ "$output" == *"deprecated"* ]]
+}
+
+@test "BUG-024 regression: scaffolds from a linked worktree into the worktree" {
     git -C "$MAINREPO" worktree add -q "$TMP/canonrepo-feature" -b feature
     cd "$TMP/canonrepo-feature"
-    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-001-foo
+    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-001-foo --issue 42
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Vault context found"* ]]
     # spec files land in the WORKTREE, not the main repo
     [ -f "$TMP/canonrepo-feature/specs/TEST-001-foo/proposal.md" ]
     [ ! -e "$MAINREPO/specs/TEST-001-foo" ]
 }
 
-@test "vault-gate still fails (exit 3) when the entry is genuinely missing" {
-    cd "$MAINREPO"
-    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-999-missing
-    [ "$status" -eq 3 ]
-    [[ "$output" == *"No vault entry"* ]]
-}
-
-@test "vault-gate missing-entry from a worktree also fails (no false-positive from the fix)" {
-    git -C "$MAINREPO" worktree add -q "$TMP/canonrepo-feature" -b feature
-    cd "$TMP/canonrepo-feature"
-    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-999-missing
-    [ "$status" -eq 3 ]
-}
-
-@test "--force-no-vault bypasses the gate from a worktree" {
-    git -C "$MAINREPO" worktree add -q "$TMP/canonrepo-feature" -b feature
-    cd "$TMP/canonrepo-feature"
-    run env VAULT_PATH="$VAULT" "$SCRIPTS_DIR/init-spec.sh" TEST-777-bypass --force-no-vault
-    [ "$status" -eq 0 ]
-    [ -f "$TMP/canonrepo-feature/specs/TEST-777-bypass/proposal.md" ]
+@test "ADR-018: no 11-tasks.md reference remains in init-spec.{sh,ps1}" {
+    ! grep -q '11-tasks' "$SCRIPTS_DIR/init-spec.sh"
+    ! grep -q '11-tasks' "$SCRIPTS_DIR/init-spec.ps1"
 }


### PR DESCRIPTION
## Why

ADR-018 moved task/work state out of the vault into the bitacora GitHub Project — the vault no longer holds `11-tasks.md`. But `init-spec.{sh,ps1}` still hard-required a matching vault entry (exit 3), so every scaffold had to bypass the gate with `--force-no-vault` (hit during OPS-001 #295). A gate everyone bypasses gates nothing.

## What

- **Work-gate = open GitHub issue**: `init-spec.sh <id> --issue <N>` / `init-spec.ps1 <id> -Issue <N>` verifies via `gh issue view` that the issue exists and is OPEN, then injects `<!-- from issue #N: <title> -->` into the proposal's `## Why`.
- Gate failures (no flag, unknown issue, closed issue, no `gh`) keep **exit 3**; messages differentiate.
- `--force-no-gate` / `-ForceNoGate` is the new bypass; `--force-no-vault` / `-ForceNoVault` stays as a deprecated warning-emitting alias. `--task` removed with the vault lookup.
- Templates still come from the vault (`00_meta/templates`) — only the task gate changes.
- `AGENTS.md` workflow wording updated; `harness/skills/spec/SKILL.md` refreshed from the vault SSOT (vault commit `afeee71`).

## Tests

- `tests/init-spec.bats` rewritten: 12 tests with `gh` stubbed on PATH (no network) — open-issue pass + context injection, missing/closed/no-flag exit 3, bypass via poisoned stub (proves `gh` is never called), legacy alias, BUG-024 worktree regression, and a grep asserting no `11-tasks` reference remains in either script.
- shellcheck clean on `init-spec.sh`; `init-spec.ps1` ASCII-only.
- Full bats suite: only pre-existing failures (pwsh skips + shell-profile env failures, identical on `main`).

Spec: `specs/REFACTOR-012-init-spec-issue-gate/`

Closes #304