### PR TITLE
feat(harness): register pi as a skills deploy target (AI-022)

### DIFF
--- a/harness/manifest.json
+++ b/harness/manifest.json
@@ -28,7 +28,8 @@
       { "agent": "claude",   "render": "skill",   "dir": ".claude/skills" },
       { "agent": "opencode", "render": "command", "dir": ".config/opencode/commands" },
       { "agent": "agy",      "render": "skill",   "dir": ".gemini/skills" },
-      { "agent": "agy",      "render": "prompt",  "dir": ".gemini/prompts" }
+      { "agent": "agy",      "render": "prompt",  "dir": ".gemini/prompts" },
+      { "agent": "pi",       "render": "skill",   "dir": ".pi/agent/skills" }
     ],
     "catalog": { "agent": "copilot", "file": ".copilot/copilot-instructions.md" }
   }

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -472,6 +472,10 @@ fi
 # ADR-012). The invariant is intentionally strict — ANY symlink here is fragile
 # (a dangling/foreign link breaks discovery), so we surface all of them. Report
 # every offending path (not just the first) so cleanup is one pass.
+# ~/.pi/agent/skills is deliberately NOT swept (AI-022): pi's own installer
+# manages sibling skills as symlinks into ~/.agents/skills, so links there are
+# expected agent-owned state, not deploy fragility. Harness-deployed pi skills
+# are still regular copies (asserted in tests/skills-pipeline.bats).
 _skill_dirs=""
 for _d in "$HOME/.claude/skills" "$HOME/.config/opencode/commands" "$HOME/.gemini/skills" "$HOME/.gemini/prompts"; do
     [ -d "$_d" ] && _skill_dirs="$_skill_dirs $_d"

--- a/specs/AI-022-pi-harness-slot/features.json
+++ b/specs/AI-022-pi-harness-slot/features.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "AI-022-f1",
+    "behavior": "harness/manifest.json lists pi under skills.deploy[] with render skill and dir .pi/agent/skills",
+    "verification": "jq -e '.skills.deploy[] | select(.agent==\"pi\" and .render==\"skill\" and .dir==\".pi/agent/skills\")' harness/manifest.json",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-022-f2",
+    "behavior": "compile-harness --deploy renders /spec to .pi/agent/skills/spec/SKILL.md as a regular file",
+    "verification": "bats tests/skills-pipeline.bats -f 'pi gets /spec'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-022-f3",
+    "behavior": "A targets:-restricted skill that excludes pi is not deployed to pi",
+    "verification": "bats tests/skills-pipeline.bats -f 'NOT exposed to pi'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-022-f4",
+    "behavior": "Deploy leaves pi-installed sibling symlinks untouched",
+    "verification": "bats tests/skills-pipeline.bats -f 'sibling symlinks'",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/AI-022-pi-harness-slot/proposal.md
+++ b/specs/AI-022-pi-harness-slot/proposal.md
@@ -1,0 +1,53 @@
+---
+id: "AI-022-pi-harness-slot"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-06-10"
+issue: "dotfiles#161"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# AI-022: Pi harness slot
+
+> **Naming**: file lives at `<repo>/specs/AI-022-pi-harness-slot/proposal.md`. `AI-022-pi-harness-slot` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #161: AI-022: Install Pi coding agent (native AGENTS.md reader; registry slot) -->
+
+AI-025 made pi a managed agent (pinned npm install, `~/.pi/agent/` config deploy, healthcheck, NaN key substitution), but the **registry slot** half of #161 is still open: pi is not in `harness/manifest.json`, so the unified engine deploys vault skills to claude, opencode, and agy — and pi gets none. The skills pi has today are ad-hoc symlinks created by its own installer, invisible to the harness lifecycle (refresh/deploy/check/prune).
+
+## What
+
+- `harness/manifest.json` gains a `skills.deploy[]` entry: `{agent: "pi", render: "skill", dir: ".pi/agent/skills"}`. Both engines (`compile-harness.sh --deploy` on Linux, the `Deploy-SkillRecord` port in `setup-windows.ps1`) are manifest-driven, so vault skills land in `~/.pi/agent/skills/<name>/SKILL.md` as regular copies on both OSes, honoring per-skill `targets:` frontmatter and pruning stale outputs.
+- `tests/skills-pipeline.bats` covers pi end-to-end (deploy renders /spec for pi; copies, not symlinks; `targets:`-restricted skills excluded).
+- `scripts/healthcheck.sh` documents why `~/.pi/agent/skills` is deliberately NOT in the strict symlink sweep: pi's own installer manages sibling skills as symlinks into `~/.agents/skills` — flagging those would fight the agent's filesystem expectations (docs/lessons.md lesson 13; ADR-012 rationale).
+
+This completes the residual scope of #161 (install + AGENTS.md deploy + healthcheck shipped in AI-025).
+
+## Out of scope
+
+- Managing or versioning pi-installed skills (`~/.pi/agent/skills/*` symlinks into `~/.agents/skills`) — user-installed runtime state.
+- A `command`/`prompt` render variant for pi — pi consumes SKILL.md dirs natively; `skill` render is correct.
+- Windows empirical validation — stays on #297 (batch-Windows session).
+
+## Risks / open questions
+
+- Name collision between a vault skill and a pi-installed symlink of the same name: the engine de-symlinks the destination before copying (existing BUG-100 behavior), so ours wins deterministically. Current names don't collide.
+- pi skill discovery path: confirmed empirically on this box (`~/.pi/agent/skills/` holding SKILL.md dirs/symlinks).
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [ ] `harness/manifest.json` lists pi under `skills.deploy[]` with `render: skill`, `dir: .pi/agent/skills`.
+- [ ] `compile-harness.sh --deploy` with a fake `$HOME` renders /spec to `.pi/agent/skills/spec/SKILL.md` as a regular file (not a symlink).
+- [ ] A `targets:`-restricted skill that excludes pi is NOT deployed to pi.
+- [ ] Full bats suite green; shellcheck clean on changed scripts.
+
+## References
+
+- GitHub issue: `dotfiles#161` (work-gate)
+- Related ADR: `docs/adr/adr-012-deploy-strategy-copy-with-drift-assertion.md`
+- Related spec: `specs/archive/AI-025-pi-coding-agent/` (install + config deploy)

--- a/specs/AI-022-pi-harness-slot/tasks.md
+++ b/specs/AI-022-pi-harness-slot/tasks.md
@@ -1,0 +1,30 @@
+---
+tags: [spec, tasks]
+created: "2026-06-10"
+---
+
+# Tasks - AI-022-pi-harness-slot
+
+> TDD order. One task = one focused commit. Tick as you go.
+
+## Setup
+
+- [x] Branch created from main: `feat/pi-harness-slot` (worktree)
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+- [x] Extend `tests/skills-pipeline.bats`: pi gets /spec as a native skill (regular copy); Claude-only skill NOT exposed to pi; symlink sweep covers pi dir
+- [x] Add pi entry to `harness/manifest.json` `skills.deploy[]`
+- [x] Comment in `scripts/healthcheck.sh` documenting the deliberate pi exclusion from the strict symlink sweep
+
+## Closing
+
+- [x] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [x] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [x] shellcheck passes
+- [x] Full bats suite passes (no regressions)
+- [x] No unrelated changes in the diff (no scope creep)
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder and closing #161

--- a/specs/AI-022-pi-harness-slot/verification.md
+++ b/specs/AI-022-pi-harness-slot/verification.md
@@ -1,0 +1,39 @@
+---
+tags: [spec, verification]
+created: "2026-06-10"
+---
+
+# Verification - AI-022-pi-harness-slot
+
+## Evidence
+
+- [x] pi in `skills.deploy[]` -> `jq` check in features.json (AI-022-f1)
+- [x] /spec renders to `.pi/agent/skills/spec/SKILL.md` as a regular copy -> bats "AI-022: pi gets /spec as a native skill"
+- [x] `targets:`-restricted skill excluded from pi -> bats "AI-022: a Claude-only skill is NOT exposed to pi"
+- [x] pi-installed sibling symlinks untouched by deploy -> bats "AI-022: deploy leaves pi-installed sibling symlinks alone"
+
+## Test status
+
+- `bats tests/skills-pipeline.bats` -> 10/10 ok (3 new pi tests)
+- `bats tests/skills-pipeline.bats tests/compile-harness.bats tests/healthcheck.bats` -> 59/59 ok
+- Full suite: only pre-existing/environmental failures (3 shell-profile, identical on main; session-start byte-equivalence flaky under full suite, passes standalone, untouched by this diff)
+- shellcheck clean on `healthcheck.sh` + `compile-harness.sh`; manifest valid JSON
+
+## Decisions made during implementation
+
+- Single manifest entry instead of engine changes: both `compile-harness.sh --deploy` and the `setup-windows.ps1` port iterate `skills.deploy[]` generically, so pi inherits render/targets/prune behavior with zero engine code.
+- `~/.pi/agent/skills` deliberately excluded from healthcheck's strict symlink sweep: pi's own installer manages sibling skills as symlinks into `~/.agents/skills` (agent-owned state). Guarded instead by a bats test asserting harness deploys land as regular copies and foreign links survive.
+- Manifest edited textually (not via JSON round-trip) to keep the diff to 2 lines.
+
+## Promotion candidates
+
+- [ ] Lesson for the repo's `docs/lessons.md`? no — pattern already captured (lesson 13, stop fighting agent filesystem expectations)
+- [ ] ADR-worthy decision? no — ADR-010/ADR-012 already cover the parity + copy-deploy model
+- [ ] New pattern candidate for `00_meta/patterns/`? no
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/AI-022-pi-harness-slot/` -> `specs/archive/...`
+- [ ] Issue #161 closed by the PR
+- [ ] Promotions above executed (none)

--- a/tests/skills-pipeline.bats
+++ b/tests/skills-pipeline.bats
@@ -70,6 +70,34 @@ teardown() { cd / || true; rm -rf "$FAKEHOME"; }
     [ ! -d "$FAKEHOME/.gemini/skills/creating-skills" ]
 }
 
+@test "AI-022: pi gets /spec as a native skill (regular copy, not a symlink)" {
+    run env HOME="$FAKEHOME" "$SCRIPT" --deploy
+    [ "$status" -eq 0 ]
+    [ -f "$FAKEHOME/.pi/agent/skills/spec/SKILL.md" ]
+    grep -q '^name: spec' "$FAKEHOME/.pi/agent/skills/spec/SKILL.md"
+    [ ! -L "$FAKEHOME/.pi/agent/skills/spec" ]
+}
+
+@test "AI-022: a Claude-only skill is NOT exposed to pi" {
+    run env HOME="$FAKEHOME" "$SCRIPT" --deploy
+    [ "$status" -eq 0 ]
+    # creating-skills is targets:[claude]
+    [ ! -d "$FAKEHOME/.pi/agent/skills/creating-skills" ]
+}
+
+@test "AI-022: deploy leaves pi-installed sibling symlinks alone" {
+    # pi's own installer manages skills as symlinks into ~/.agents/skills; our
+    # deploy must only de-symlink destinations it owns, never prune foreign links.
+    mkdir -p "$FAKEHOME/.agents/skills/userskill" "$FAKEHOME/.pi/agent/skills"
+    printf -- '---\nname: userskill\n---\nuser-installed\n' \
+        > "$FAKEHOME/.agents/skills/userskill/SKILL.md"
+    ln -s "$FAKEHOME/.agents/skills/userskill" "$FAKEHOME/.pi/agent/skills/userskill"
+    run env HOME="$FAKEHOME" "$SCRIPT" --deploy
+    [ "$status" -eq 0 ]
+    [ -L "$FAKEHOME/.pi/agent/skills/userskill" ]
+    [ -f "$FAKEHOME/.pi/agent/skills/userskill/SKILL.md" ]
+}
+
 @test "AC1 smoke: no deployed skill path is a symlink" {
     run env HOME="$FAKEHOME" "$SCRIPT" --deploy
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Why

AI-025 made pi a managed agent (pinned install, `~/.pi/agent/` config, healthcheck, NaN key substitution), but the **registry slot** half of #161 stayed open: pi was not in `harness/manifest.json`, so the unified engine deployed vault skills to claude, opencode and agy — and pi got none (its only skills were ad-hoc symlinks created by its own installer, invisible to the harness lifecycle).

## What

- `harness/manifest.json`: one `skills.deploy[]` entry — `{agent: "pi", render: "skill", dir: ".pi/agent/skills"}`. Both engines (`compile-harness.sh --deploy` on Linux and the `Deploy-SkillRecord` port in `setup-windows.ps1`) iterate the manifest generically, so pi inherits rendering, per-skill `targets:` filtering and pruning on both OSes with zero engine code.
- `tests/skills-pipeline.bats` (+3): /spec lands at `.pi/agent/skills/spec/SKILL.md` as a regular copy; Claude-only skills are NOT exposed to pi; pi-installed sibling symlinks (`~/.agents/skills` convention) survive deploy untouched.
- `scripts/healthcheck.sh`: comment documenting why `~/.pi/agent/skills` is deliberately excluded from the strict symlink sweep — pi's own installer manages sibling skills as symlinks, which is agent-owned state, not the BUG-100 fragility class.

## Tests

- `bats tests/skills-pipeline.bats` -> 10/10; harness-related files 59/59.
- Full suite: only pre-existing/environmental failures (identical on `main`).
- shellcheck clean; manifest valid JSON (edited textually — 2-line diff).

Spec: `specs/AI-022-pi-harness-slot/`
Windows empirical validation stays on #297 (batch-Windows session).

Closes #161