### PR TITLE
chore(harness): refresh skill records — quote colon-bearing descriptions

### DIFF
--- a/harness/skills/architecture-session/SKILL.md
+++ b/harness/skills/architecture-session/SKILL.md
@@ -4,7 +4,7 @@ type: skill
 status: active
 created: "2026-05-28"
 name: architecture-session
-description: Run a pure-architecture / definition session on a project. Triggers on /architecture-session, /arch, "sesion de arquitectura", "arch session for X", "definir arquitectura de X", "revisar arquitectura de X", "evaluar opciones para X". Six phases A-F: state verification, multi-reference audit (Regla del 3 gate), constraint formalization, options + rejection list, decision (ADR + plan + vault patch in-session), recap. Refuses to advance past Phase B without N>=2 references audited for any decision affecting cross-instance reuse. Pairs with /spec init (downstream implementation) and /adversarial-review (post-implementation gate).
+description: "Run a pure-architecture / definition session on a project. Triggers on /architecture-session, /arch, \"sesion de arquitectura\", \"arch session for X\", \"definir arquitectura de X\", \"revisar arquitectura de X\", \"evaluar opciones para X\". Six phases A-F: state verification, multi-reference audit (Regla del 3 gate), constraint formalization, options + rejection list, decision (ADR + plan + vault patch in-session), recap. Refuses to advance past Phase B without N>=2 references audited for any decision affecting cross-instance reuse. Pairs with /spec init (downstream implementation) and /adversarial-review (post-implementation gate)."
 allowed-tools: [Bash, Read, Edit, Write, Grep, Glob, mcp__hive__vault_query, mcp__hive__vault_search, mcp__hive__vault_write, mcp__hive__vault_patch, mcp__hive__capture_lesson]
 ---
 

--- a/harness/skills/spec/SKILL.md
+++ b/harness/skills/spec/SKILL.md
@@ -4,7 +4,7 @@ type: skill
 status: active
 created: "2026-05-13"
 name: spec
-description: Manage Spec-Driven Development per-feature artifacts. Triggers on /spec, "create a spec for", "scaffold spec X", "bootstrap substrate for X", "fill proposal for X", "archive spec X". Four subcommands: init (scaffold, gated on an open GitHub issue per ADR-018), bootstrap (optional 4-section substrate contract), fill (Socratic 5-question proposal), archive (move + selective vault promotion). Cross-OS Linux/Windows, cross-agent Claude/Copilot via AGENTS.md indirection.
+description: "Manage Spec-Driven Development per-feature artifacts. Triggers on /spec, \"create a spec for\", \"scaffold spec X\", \"bootstrap substrate for X\", \"fill proposal for X\", \"archive spec X\". Four subcommands: init (scaffold, gated on an open GitHub issue per ADR-018), bootstrap (optional 4-section substrate contract), fill (Socratic 5-question proposal), archive (move + selective vault promotion). Cross-OS Linux/Windows, cross-agent Claude/Copilot via AGENTS.md indirection."
 allowed-tools: [Bash, Read, Edit, Write, mcp__hive__vault_query, mcp__hive__vault_search, mcp__hive__vault_write, mcp__hive__vault_patch]
 ---
 


### PR DESCRIPTION
## Why

pi v0.79.1 flagged two deployed skills as **Skill conflicts** on startup: `spec` and `architecture-session`. Their frontmatter `description:` values contain `': '` sequences (e.g. "Four subcommands: init (...)") without quoting — Claude's parser tolerates it, pi's strict YAML parser reads it as a nested mapping and rejects the file.

## What

Quoted both description values at the vault SSOT (vault commit `75fe67c`) and re-rendered the committed records with `compile-harness --refresh`. Mechanical mirror; a sweep over all 32 vault skills found no other unquoted colon-bearing descriptions.

## SDD skip rationale

Generated records re-rendered verbatim from the vault SSOT by `compile-harness.sh --refresh` — no hand-written production logic.