### PR TITLE
fix: skip fork PRs in add-to-project workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   add-to-project:
+    # Fork PRs run without repository secrets — BITACORA_PAT would be empty and the
+    # job would fail (Codex review on kubelab#237). Skip them; fork PRs reach the
+    # board via the rollout backfill or a manual item-add.
+    if: github.event_name == 'issues' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       # Pin a real release: actions/add-to-project@v1 does NOT resolve (no floating v1 tag).


### PR DESCRIPTION
Codex review finding (P2) on kubelab#237, valid for every public repo in the OPS-002 rollout: `pull_request` runs from forks get no repository secrets, so `actions/add-to-project` runs with an empty `BITACORA_PAT` and the job fails.

Fix in the canonical copy: job-level `if` that skips fork PRs (issues unaffected). Fork PRs still reach the board via `scripts/bitacora-rollout.sh` backfill or a manual `item-add`. Propagated to all repos by re-running the rollout after merge (spec `specs/OPS-002-bitacora-rollout/` active).