### PR TITLE
fix: force-reset rollout branch to base; document the PR dashboard view

### DIFF
--- a/docs/runbooks/guide-bitacora-setup.md
+++ b/docs/runbooks/guide-bitacora-setup.md
@@ -103,7 +103,13 @@ gh project item-edit --id "$ITEM" --project-id PVT_kwHOAM7xJs4BZ6GY \
 
 - **Board** grouped by Status (Backlog / In Progress / Blocked / Done).
 - **By repo** — group by Repository (tasks span all repos).
-- **PRs pending review** (OPS-003) — filter `is:pr is:open`, group by repo.
+- **PRs pending review** (OPS-003, created 2026-06-09) — the cross-repo PR dashboard:
+  - Type: **Table** (scannable columns beat a one-field Board for PR triage).
+  - Filter: `is:pr is:open`. Group by: **Repository**.
+  - Columns: Title, Assignees, Status, Repository (hide Priority/Type/ID — issue fields, noise on PRs).
+  - PRs land on the board automatically (`add-to-project.yml` `pull_request` trigger, deployed to every repo by `scripts/bitacora-rollout.sh`, which also backfills open ones).
+  - Views are UI-only (no API) — pressing **Save** on the tab is what persists the filter.
+  - Optional second view for review-blocked PRs: `is:pr is:open review:required`.
 
 ## 7. Workflows (deploy BOTH to every linked repo)
 

--- a/scripts/bitacora-rollout.sh
+++ b/scripts/bitacora-rollout.sh
@@ -93,8 +93,17 @@ deploy_via_pr() {  # $1 = repo; deploys ${PR_FILES[@]} on a branch + opens an au
     local repo="$1" branch="ci/bitacora-workflows" base base_sha wf path src sha
     base="$(gh api "repos/$OWNER/$repo" -q '.default_branch')"
     base_sha="$(gh api "repos/$OWNER/$repo/git/ref/heads/$base" -q '.object.sha')"
-    gh api -X POST "repos/$OWNER/$repo/git/refs" \
-        -f ref="refs/heads/$branch" -f sha="$base_sha" >/dev/null 2>&1 || true   # exists → reuse
+    # Create the branch at base HEAD; if it already exists, FORCE-reset it to base.
+    # Blind reuse caused merge conflicts: after the previous PR was squash-merged the
+    # leftover branch held stale commits that textually conflicted with the new base
+    # (observed on pollex/yt-metrics-cli/pdf-modifier-mcp, 2026-06-10). Re-PUTting the
+    # canonical files on a base-fresh branch is the convergent form.
+    if ! gh api -X POST "repos/$OWNER/$repo/git/refs" \
+        -f ref="refs/heads/$branch" -f sha="$base_sha" >/dev/null 2>&1; then
+        gh api -X PATCH "repos/$OWNER/$repo/git/refs/heads/$branch" \
+            -f sha="$base_sha" -F force=true >/dev/null \
+            || { err "$repo: cannot reset $branch to $base HEAD"; return; }
+    fi
     for wf in "${PR_FILES[@]}"; do
         path=".github/workflows/$wf"
         src="$REPO_ROOT/.github/workflows/$wf"


### PR DESCRIPTION
Second live-run finding for the OPS-002 rollout (spec still active):

**Bug:** `deploy_via_pr` reused an existing `ci/bitacora-workflows` branch as-is. After the previous propagation PR was squash-merged (and the branch survived), the stale commits textually conflicted with the new base → DIRTY/conflicting PRs on pollex, yt-metrics-cli and pdf-modifier-mcp (the stale PRs are closed and their branches deleted).

**Fix:** create-or-force-reset the branch to base HEAD before PUTting the canonical files — the convergent form: the PR diff is always exactly canonical-vs-base.

Also documents in runbook §6 the **PRs pending review** view just created (OPS-003 #266): Table, `is:pr is:open`, grouped by Repository, recommended columns, and the note that Project views are UI-only (no API).