### PR TITLE
Keep deeper sub-headings inside an enforced section when compiling

### DIFF
--- a/scripts/compile-harness.sh
+++ b/scripts/compile-harness.sh
@@ -72,14 +72,22 @@ require_tools() {
 
 # Extract a markdown section body by GitHub-style heading slug.
 # Args: <pattern_file> <slug>. Prints the section body (heading excluded).
+# The section ends at the next heading of the SAME-OR-HIGHER level, so deeper
+# sub-headings (e.g. a ### under a ## rule) stay inside the body instead of
+# silently truncating it (the #156 regression class — ENGINE-002).
 extract_section() {
     local file="$1" want="$2" out
     out="$(awk -v want="$want" '
         function slug(s){ s=tolower(s); gsub(/[^a-z0-9 -]/,"",s); gsub(/ +/,"-",s); gsub(/-+/,"-",s); return s }
         /^#{1,6} / {
-            if (cap) { exit }
-            hdr=$0; sub(/^#{1,6} +/,"",hdr)
-            if (slug(hdr)==want) { cap=1; next }
+            match($0, /^#+/); lvl=RLENGTH
+            if (cap) {
+                if (lvl <= caplvl) { exit }   # same/higher level == section boundary
+                # deeper sub-heading: fall through, it is part of the body
+            } else {
+                hdr=$0; sub(/^#{1,6} +/,"",hdr)
+                if (slug(hdr)==want) { cap=1; caplvl=lvl; next }
+            }
         }
         cap { print }
     ' "$file")"

--- a/tests/compile-harness.bats
+++ b/tests/compile-harness.bats
@@ -343,3 +343,63 @@ EOF
     [ "$status" -ne 0 ]
     [[ "$output" == *"frontmatter"* ]]
 }
+
+# --- ENGINE-002: follow-up hardening from the ENGINE-001 adversarial review ---
+
+@test "ENGINE-002: extract_section keeps deeper sub-headings inside an enforced section" {
+    # Regression guard for the #156 truncation class: a future deeper sub-heading
+    # (###) under an enforced section must NOT cut the rule short. The extractor
+    # stops only at a same-or-higher-level heading, so the next ## section is the
+    # real boundary; the nested ### and its content stay in the record.
+    cat > "$VAULT/00_meta/patterns/test-pattern.md" <<'EOF'
+# Test Pattern
+
+## 1. Demo Rule
+- rule line one
+### 1.1 Nested detail
+- nested rule line
+- rule line two
+
+## 2. Next Section
+- unrelated
+EOF
+    run_refresh
+    [ "$status" -eq 0 ]
+    grep -qF '### 1.1 Nested detail' "$REPO/harness/enforced/demo.md"
+    grep -qF 'nested rule line'      "$REPO/harness/enforced/demo.md"
+    grep -qF 'rule line two'         "$REPO/harness/enforced/demo.md"
+    # the next same-level section is the boundary and must not leak in
+    ! grep -qF 'unrelated'        "$REPO/harness/enforced/demo.md"
+    ! grep -qF 'Next Section'     "$REPO/harness/enforced/demo.md"
+}
+
+@test "ENGINE-002: --refresh aborts loudly when the manifest anchor is missing (FM D3)" {
+    # Anchor typo / renamed section: the extractor must abort with a clear error
+    # rather than silently writing an empty record.
+    cat > "$REPO/harness/manifest.json" <<'EOF'
+{ "version": 1, "vault_subpath": "00_meta/patterns",
+  "enforced": [ { "id": "demo", "source": "test-pattern.md#9-does-not-exist" } ],
+  "targets":  [ { "agent": "t", "kind": "native", "file": "TARGET.md", "inject": ["demo"] } ] }
+EOF
+    run_refresh
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"section"* ]]
+    [[ "$output" == *"not found"* ]]
+    # no broken record left behind
+    [ ! -f "$REPO/harness/enforced/demo.md" ]
+}
+
+@test "ENGINE-002: AC6 behavioral — the drift gate healthcheck wires passes clean, fails tampered" {
+    # healthcheck.sh gates on `if compile-harness.sh --check; then pass; else fail`.
+    # Running the full healthcheck here can't isolate that gate (unrelated tool/vault
+    # checks would dominate its exit code), so we exercise the exact command it wires
+    # and assert BOTH branches: clean tree -> exit 0 (pass), tampered block -> exit !=0
+    # (fail). Complements the structural test that healthcheck calls --check.
+    run_refresh; [ "$status" -eq 0 ]
+    run "$SCRIPT" --check
+    [ "$status" -eq 0 ]
+    sed -i 's/rule line one/TAMPERED/' "$REPO/TARGET.md"
+    run "$SCRIPT" --check
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"DRIFT"* ]]
+}


### PR DESCRIPTION
## Summary

ENGINE-001 follow-up hardening (the 3 non-blocking MINORs from its adversarial review, tracked in #177). All in `scripts/compile-harness.sh` + `tests/compile-harness.bats`.

## Changes

1. **`extract_section` sub-heading hardening (fix).** The awk extractor stopped at the next heading of *any* level, so a future `###` sub-heading under an enforced rule in `pattern-git-workflow.md` would silently truncate that rule when compiled into the overrides block — the exact #156 regression class the engine prevents. It now stops only at a **same-or-higher-level** heading (`match($0,/^#+/); RLENGTH`), so deeper sub-headings stay in the section body.
2. **anchor-missing regression test.** The missing-section-anchor abort (FM D3) was guarded but untested — now covered (asserts non-zero exit, clear error, no broken record left behind).
3. **AC6 behavioral test.** The existing AC6 test only greps that `healthcheck.sh` wires `--check`; this adds a behavioral test that exercises that exact gate on both branches — clean tree passes, tampered block fails.

## Verification

- `bats tests/compile-harness.bats` — 30/30 pass (item-1 test was red before the fix, green after).
- `bats tests/compile-harness-rootresolve.bats` — 2/2 pass.
- `compile-harness.sh --check` against the live tree — `OK: no harness drift`.
- `compile-harness.sh --refresh` against the live vault is a **no-op** (enforced sections §6–§9 have no sub-headings), so committed records / injected blocks are unchanged — confirming the fix is behavior-preserving.

Closes #177.

> Do not enable auto-merge — merge is human-reviewed and manual.