### PR TITLE
fix: stamp generation date in scaffolded spec files (CodeRabbit follow-up to #359)

### DIFF
--- a/cli/internal/spec/spec_test.go
+++ b/cli/internal/spec/spec_test.go
@@ -73,6 +73,22 @@ func TestRenderSubstitutesAndFixesIssueFrontmatter(t *testing.T) {
 	}
 }
 
+// TestRenderStampsCreatedInAllFiles guards the CodeRabbit-found bug (dotfiles#359):
+// tasks.md and verification.md once hard-coded the template authoring date in
+// created:, so scaffolded specs inherited it. All three templates must now carry
+// the {{date}} placeholder and have it substituted with the generation date.
+func TestRenderStampsCreatedInAllFiles(t *testing.T) {
+	files, err := Render("BUG-007-x", "2026-06-13", 0, "")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	for _, name := range []string{"proposal.md", "tasks.md", "verification.md"} {
+		if !strings.Contains(files[name], `created: "2026-06-13"`) {
+			t.Errorf("%s did not stamp created: with the generation date:\n%s", name, files[name])
+		}
+	}
+}
+
 func TestRenderWithoutIssueLeavesFrontmatterEmpty(t *testing.T) {
 	files, err := Render("BUG-007", "2026-06-13", 0, "")
 	if err != nil {

--- a/cli/internal/spec/templates/tasks.md
+++ b/cli/internal/spec/templates/tasks.md
@@ -1,6 +1,6 @@
 ---
 tags: [spec, tasks, templates]
-created: "2026-05-13"
+created: "{{date:YYYY-MM-DD}}"
 ---
 
 # Tasks - <feature-id>

--- a/cli/internal/spec/templates/verification.md
+++ b/cli/internal/spec/templates/verification.md
@@ -1,6 +1,6 @@
 ---
 tags: [spec, verification, templates]
-created: "2026-05-13"
+created: "{{date:YYYY-MM-DD}}"
 ---
 
 # Verification - <feature-id>

--- a/specs/CLI-007-dot-spec-init/features.json
+++ b/specs/CLI-007-dot-spec-init/features.json
@@ -44,7 +44,7 @@
   {
     "id": "CLI-007-dot-spec-init-f7",
     "behavior": "Drift guard fails if an embedded template diverges from the vault SSOT, and skips (not fails) when the vault is absent",
-    "verification": "cd cli && go test ./internal/spec/ -run TestEmbeddedTemplatesMatchVault -v",
+    "verification": "cd cli && go test ./internal/spec/ -run TestEmbeddedTemplatesMatchVault -v && VAULT_PATH=/nonexistent go test ./internal/spec/ -run TestEmbeddedTemplatesMatchVault -v 2>&1 | grep -q SKIP",
     "state": "pending",
     "evidence": ""
   },


### PR DESCRIPTION
## What

Follow-up to #359 (CLI-007), addressing CodeRabbit's review.

`scripts/init-spec.sh` and the new `dot spec init` share the SDD templates. The `proposal` template stamps `created:` via the `{{date:YYYY-MM-DD}}` placeholder, but `tasks` and `verification` **hard-coded the authoring date `2026-05-13`** — so every scaffolded spec inherited the template's birthday instead of its own generation date.

## Fix

- Fixed at the **vault SSOT** (`00_meta/templates/spec-{tasks,verification}.md`, vault `685f7396`) — the drift guard forbids patching only the embedded copy — and **re-vendored** the embedded templates byte-identically. Drift guard stays green. `init-spec.sh` gets the fix for free (it `sed`s the same placeholder).
- `TestRenderStampsCreatedInAllFiles` guards the regression (all three files stamp the generation date).
- CLI-007 `features.json` f7 now exercises the drift-guard **skip** branch explicitly (`VAULT_PATH=/nonexistent … | grep -q SKIP`), not just the pass path — a sharper version of CodeRabbit's nitpick (`env -u VAULT_PATH` wouldn't trigger the skip where `~/Projects/knowledge` exists).

## CodeRabbit triage

| Finding | Verdict |
|---|---|
| `created:` hard-coded (tasks/verification) | ✅ Real → fixed at SSOT + re-vendor |
| f7 only covers the pass path | 🟡 Valid → added a forced-skip run |
| stray `50` line in proposal template | ❌ False positive — the template is 49 lines |

## Verification

`cd cli && gofmt -l . && go vet ./... && go test ./... && go build ./...` → green. Drift guard: `--- PASS` with vault present, `--- SKIP` with `VAULT_PATH=/nonexistent`.

Bugfix (<20 LOC, obvious cause) — SDD spec skipped per the Discipline Gate; touches the existing `specs/CLI-007-dot-spec-init/` folder so spec-gate passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Spec templates now generate with the current date instead of a hardcoded date, ensuring accurate creation timestamps across all generated spec files.

* **Tests**
  * Added verification to confirm generated specs include the correct creation date across all template files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->