### PR TITLE
fix: install-dotf.sh standalone run reads DOTF_VERSION from versions.conf

### DIFF
--- a/scripts/install-dotf.sh
+++ b/scripts/install-dotf.sh
@@ -12,9 +12,12 @@
 # the version/dest/base_url as args so bats can drive them against a file://
 # fixture with no network. Cross-shell: bash + zsh safe.
 
+# Resolve this script's directory once — used to find utils.sh and, when run
+# standalone, versions.conf (the DOTF_VERSION SSOT).
+_DOTF_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
 # Load logging + helpers if the caller (setup) has not already sourced utils.sh.
 if ! command -v log_info >/dev/null 2>&1; then
-    _DOTF_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
     # shellcheck source=/dev/null
     . "$_DOTF_SCRIPT_DIR/utils.sh"
 fi
@@ -117,5 +120,12 @@ install_dotf() {
 # `(return)` succeeds only in a sourced context, so this is robust where the
 # BASH_SOURCE-vs-$0 comparison is not (some shells/harnesses align them).
 if ! (return 0 2>/dev/null); then
+    # Standalone: with no version arg and none exported, load the pinned
+    # DOTF_VERSION from versions.conf (the SSOT). setup-linux.sh sources
+    # versions.conf before us, so this only fires on a direct ./install-dotf.sh run.
+    if [ -z "${1:-}" ] && [ -z "${DOTF_VERSION:-}" ] && [ -f "$_DOTF_SCRIPT_DIR/../versions.conf" ]; then
+        # shellcheck source=/dev/null
+        . "$_DOTF_SCRIPT_DIR/../versions.conf"
+    fi
     install_dotf "$@"
 fi

--- a/tests/install-dotf.bats
+++ b/tests/install-dotf.bats
@@ -85,3 +85,15 @@ EOF
     [[ "$output" == *"already installed"* ]]
     [ ! -e "$DEST/dotf" ]
 }
+
+@test "standalone (executed, no arg, no DOTF_VERSION env) resolves the pinned version from versions.conf" {
+    # Regression guard: the standalone run-guard called install_dotf with no version
+    # because the script read DOTF_VERSION only from the env and never sourced
+    # versions.conf. Execute it directly (NOT sourced) with DOTF_VERSION unset and no
+    # arg, pointed at a non-existent file:// base so it never touches the network. It
+    # must get PAST the "no version given" check and name the pinned versions.conf value.
+    pinned="$(grep -m1 '^DOTF_VERSION=' "$SCRIPTS_DIR/../versions.conf" | cut -d= -f2)"
+    run env -u DOTF_VERSION DOTF_RELEASE_BASE="file://$TMP/nope" "$SCRIPTS_DIR/install-dotf.sh"
+    [[ "$output" != *"no version given"* ]]
+    [[ "$output" == *"$pinned"* ]]
+}


### PR DESCRIPTION
## What

`./scripts/install-dotf.sh` run standalone with no version argument failed:
`[ERROR] install_dotf: no version given (set DOTF_VERSION in versions.conf)`.

## Root cause

`install_dotf` reads the version from `$1` or `$DOTF_VERSION` (env) **only** — the script never sources `versions.conf`, despite its own error message naming it as the SSOT. `setup-linux.sh` sources `versions.conf` before calling the function, so the gap only surfaces on a direct `./install-dotf.sh` run from a shell that does not already have `DOTF_VERSION` exported.

## Fix

- Resolve `_DOTF_SCRIPT_DIR` once at the top (reused for `utils.sh` + `versions.conf`).
- In the standalone run-guard, source `versions.conf` when there is no version arg and none is exported — making the documented no-arg invocation work.
- **Regression guard (incident→guard):** a bats test that executes the script with `DOTF_VERSION` unset and no arg against a `file://` base, asserting it gets past the "no version given" check and names the pinned version.

## Verification

- `shellcheck scripts/install-dotf.sh` clean.
- `bats tests/install-dotf.bats` → **6/6** (5 existing + new guard).
- Repro: `env -u DOTF_VERSION ./scripts/install-dotf.sh` now resolves the pinned `0.2.0` from `versions.conf` instead of erroring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standalone installer now automatically uses a default version when invoked without explicit version arguments.

* **Bug Fixes**
  * Improved script directory resolution for standalone execution.

* **Tests**
  * Added test coverage for standalone installer bootstrap behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->