### PR TITLE
fix(spec): gate the work-issue against its real repo, not the current one (HARNESS-023)

### DIFF
--- a/cli/internal/cmd/spec.go
+++ b/cli/internal/cmd/spec.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/mlorentedev/dotfiles/cli/internal/initrepo"
 	"github.com/mlorentedev/dotfiles/cli/internal/spec"
 )
 
@@ -30,8 +31,9 @@ func newSpecCmd() *cobra.Command {
 
 func newSpecInitCmd() *cobra.Command {
 	var (
-		issueNum    int
-		forceNoGate bool
+		issueNum     int
+		forceNoGate  bool
+		bitacoraRepo string
 	)
 
 	cmd := &cobra.Command{
@@ -42,7 +44,9 @@ embedded SDD templates.
 
 Work-gate (ADR-018): the spec must be downstream of an OPEN GitHub issue.
 Pass --issue <N>; the issue is verified via 'gh issue view' and its title is
-recorded in the proposal's frontmatter (issue: dotfiles#N) and ## Why comment.
+recorded in the proposal's frontmatter (issue: owner/repo#N) and ## Why comment.
+The issue's repo defaults to the current repo's origin; override with
+--bitacora-repo owner/repo or $DOTF_BITACORA_REPO for a cross-repo work-gate.
 Use --force-no-gate to scaffold without an issue (NOT RECOMMENDED).
 
 Mechanical only: fill the proposal interactively afterwards ("/spec fill" in an
@@ -65,7 +69,7 @@ agent) or by hand. Do not skip the Why.`,
 				return err
 			}
 
-			var issueTitle string
+			var issueTitle, repoSlug string
 			if !forceNoGate {
 				if issueNum == 0 {
 					return fmt.Errorf("no work-gate given: pass --issue <number>.\n" +
@@ -73,15 +77,39 @@ agent) or by hand. Do not skip the Why.`,
 						"bitácora Project. Options: (a) open/find the issue, re-run with --issue;\n" +
 						"(b) re-run with --force-no-gate (NOT RECOMMENDED)")
 				}
-				issueTitle, err = spec.Gate(issueNum)
+				// Resolve the repo that hosts the work-gate issue (HARNESS-023):
+				// explicit --bitacora-repo, then DOTF_BITACORA_REPO, else the
+				// current repo's origin slug. Used for BOTH the gate check and the
+				// proposal's issue: frontmatter, so a cross-repo gate (e.g. a
+				// kubelab spec gated by a knowledge issue) resolves correctly
+				// instead of silently checking the current repo.
+				repoSlug = bitacoraRepo
+				if repoSlug == "" {
+					repoSlug = os.Getenv("DOTF_BITACORA_REPO")
+				}
+				if repoSlug == "" {
+					if s, e := initrepo.OriginRepo(repoRoot); e == nil {
+						repoSlug = s
+					}
+				}
+				if repoSlug == "" {
+					return fmt.Errorf("cannot determine the repo hosting issue #%d: no "+
+						"--bitacora-repo, no DOTF_BITACORA_REPO, and no origin remote in %s.\n"+
+						"Pass --bitacora-repo owner/repo (e.g. mlorentedev/knowledge) or set "+
+						"DOTF_BITACORA_REPO", issueNum, repoRoot)
+				}
+				if !initrepo.ValidRepoSlug(repoSlug) {
+					return fmt.Errorf("invalid bitácora repo %q: want owner/name", repoSlug)
+				}
+				issueTitle, err = spec.Gate(issueNum, repoSlug)
 				if err != nil {
 					return err
 				}
-				cmd.Printf("[INFO] Work-gate OK: issue #%d is open — %s\n", issueNum, issueTitle)
+				cmd.Printf("[INFO] Work-gate OK: %s#%d is open — %s\n", repoSlug, issueNum, issueTitle)
 			}
 
 			date := now().Format("2006-01-02")
-			warning, err := spec.Scaffold(repoRoot, id, date, issueNum, issueTitle)
+			warning, err := spec.Scaffold(repoRoot, id, date, repoSlug, issueNum, issueTitle)
 			if warning != "" {
 				cmd.PrintErrf("[WARN] %s\n", warning)
 			}
@@ -101,6 +129,7 @@ agent) or by hand. Do not skip the Why.`,
 	}
 
 	cmd.Flags().IntVar(&issueNum, "issue", 0, "GitHub issue number that gates this work (must exist and be OPEN)")
+	cmd.Flags().StringVar(&bitacoraRepo, "bitacora-repo", "", "owner/repo hosting the work-gate issue (default: current repo's origin, or $DOTF_BITACORA_REPO)")
 	cmd.Flags().BoolVar(&forceNoGate, "force-no-gate", false, "skip the open-issue work-gate (NOT RECOMMENDED — the gate is the SSOT)")
 	return cmd
 }

--- a/cli/internal/cmd/spec_test.go
+++ b/cli/internal/cmd/spec_test.go
@@ -78,16 +78,17 @@ func TestSpecInitWithOpenIssueSetsFrontmatter(t *testing.T) {
 	root := makeRepo(t)
 	pinClock(t)
 	stubGhCmd(t, "OPEN\tPort init-spec")
+	t.Setenv("DOTF_BITACORA_REPO", "mlorentedev/dotfiles")
 
 	stdout, _, err := execute(t, "spec", "init", "CLI-007-dot-spec-init", "--issue", "358")
 	if err != nil {
 		t.Fatalf("spec init --issue: %v", err)
 	}
-	if !strings.Contains(stdout, "Work-gate OK: issue #358 is open") {
+	if !strings.Contains(stdout, "Work-gate OK: mlorentedev/dotfiles#358 is open") {
 		t.Errorf("missing work-gate confirmation:\n%s", stdout)
 	}
 	proposal := readFile(t, filepath.Join(root, "specs", "CLI-007-dot-spec-init", "proposal.md"))
-	if !strings.Contains(proposal, `issue: "dotfiles#358"`) {
+	if !strings.Contains(proposal, `issue: "mlorentedev/dotfiles#358"`) {
 		t.Errorf("frontmatter issue not populated (the fix):\n%s", proposal)
 	}
 	if !strings.Contains(proposal, "<!-- from issue #358: Port init-spec -->") {
@@ -109,6 +110,7 @@ func TestSpecInitMissingGateFails(t *testing.T) {
 func TestSpecInitClosedIssueFails(t *testing.T) {
 	root := makeRepo(t)
 	stubGhCmd(t, "CLOSED\tAlready done")
+	t.Setenv("DOTF_BITACORA_REPO", "mlorentedev/dotfiles")
 	_, _, err := execute(t, "spec", "init", "CLI-007-dot-spec-init", "--issue", "358")
 	if err == nil {
 		t.Fatalf("expected error for a closed work-gate issue")
@@ -127,6 +129,43 @@ func TestSpecInitInvalidIDFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid feature-id") {
 		t.Errorf("error should name the invalid id, got: %v", err)
+	}
+}
+
+// TestSpecInitBitacoraRepoFlagOverrides guards HARNESS-023: --bitacora-repo
+// sets BOTH the gate repo and the frontmatter issue: prefix, so a cross-repo
+// work-gate (e.g. a kubelab spec gated by a knowledge issue) resolves to the
+// right repo instead of the current one.
+func TestSpecInitBitacoraRepoFlagOverrides(t *testing.T) {
+	root := makeRepo(t)
+	pinClock(t)
+	stubGhCmd(t, "OPEN\tCross-repo gate")
+
+	_, _, err := execute(t, "spec", "init", "CLI-007-dot-spec-init",
+		"--issue", "358", "--bitacora-repo", "mlorentedev/knowledge")
+	if err != nil {
+		t.Fatalf("spec init --bitacora-repo: %v", err)
+	}
+	proposal := readFile(t, filepath.Join(root, "specs", "CLI-007-dot-spec-init", "proposal.md"))
+	if !strings.Contains(proposal, `issue: "mlorentedev/knowledge#358"`) {
+		t.Errorf("frontmatter should record the overridden repo:\n%s", proposal)
+	}
+}
+
+// TestSpecInitUnresolvableRepoFails guards that a gated init refuses to fabricate
+// an issue prefix when the repo can't be resolved (no flag, no env, no origin) —
+// it errors pointing at --bitacora-repo rather than scaffolding a bogus "#N".
+// stubGhCmd points PATH at a dir with only `gh`, so the origin-slug fallback
+// (which shells out to `git`) finds no git and yields an empty slug.
+func TestSpecInitUnresolvableRepoFails(t *testing.T) {
+	makeRepo(t)
+	stubGhCmd(t, "OPEN\tWhatever")
+	_, _, err := execute(t, "spec", "init", "CLI-007-dot-spec-init", "--issue", "358")
+	if err == nil {
+		t.Fatalf("expected error when the bitácora repo is unresolvable")
+	}
+	if !strings.Contains(err.Error(), "bitacora-repo") {
+		t.Errorf("error should point at --bitacora-repo, got: %v", err)
 	}
 }
 

--- a/cli/internal/spec/spec.go
+++ b/cli/internal/spec/spec.go
@@ -17,12 +17,6 @@ import (
 	"strings"
 )
 
-// repoSlug is the GitHub repo the work-gate issue belongs to. It is written
-// into the proposal frontmatter `issue:` field as "<repoSlug>#<num>" — the fix
-// for init-spec.sh, which injected the Why provenance comment but left the
-// frontmatter field empty.
-const repoSlug = "dotfiles"
-
 // templateNames are the spec files rendered into specs/<id>/, in a stable
 // order. proposal.md is special-cased (it carries the issue: frontmatter and
 // the ## Why provenance comment); the others are pure placeholder substitution.
@@ -65,14 +59,20 @@ func RepoRoot(start string) (string, error) {
 // Gate verifies that issue #num exists and is OPEN, returning its title. It
 // shells out to `gh issue view` — a faithful twin of init-spec.sh, and the same
 // path the bitácora workflow uses — rather than reimplementing the GitHub API.
-// Callers skip Gate entirely under --force-no-gate.
-func Gate(num int) (title string, err error) {
+// When repo ("owner/name") is non-empty it is passed as --repo so the gate is
+// checked against the issue's actual home, not the current git repo's default
+// (HARNESS-023). Callers skip Gate entirely under --force-no-gate.
+func Gate(num int, repo string) (title string, err error) {
 	if _, err := exec.LookPath("gh"); err != nil {
 		return "", fmt.Errorf("gh CLI not found — cannot verify work-gate issue #%d "+
 			"(install gh, or use --force-no-gate)", num)
 	}
-	out, err := exec.Command("gh", "issue", "view", strconv.Itoa(num),
-		"--json", "state,title", "--jq", `.state + "\t" + .title`).Output()
+	args := []string{"issue", "view", strconv.Itoa(num),
+		"--json", "state,title", "--jq", `.state + "\t" + .title`}
+	if repo != "" {
+		args = append(args, "--repo", repo)
+	}
+	out, err := exec.Command("gh", args...).Output()
 	if err != nil {
 		return "", fmt.Errorf("work-gate issue #%d not found (or gh failed): %s",
 			num, strings.TrimSpace(stderrOf(err)))
@@ -100,9 +100,10 @@ func stderrOf(err error) string {
 
 // Render returns each spec file's content keyed by filename, with placeholders
 // substituted. When issueNum > 0 the proposal frontmatter `issue:` field is set
-// to "<repo>#<num>"; when a non-empty issueTitle is also given, the ## Why
-// provenance comment is injected. date is the value for created: (YYYY-MM-DD).
-func Render(id, date string, issueNum int, issueTitle string) (map[string]string, error) {
+// to "<repoSlug>#<num>" (repoSlug is the issue's "owner/name" home, not a
+// hardcoded repo — HARNESS-023); when a non-empty issueTitle is also given, the
+// ## Why provenance comment is injected. date is the value for created:.
+func Render(id, date, repoSlug string, issueNum int, issueTitle string) (map[string]string, error) {
 	files := make(map[string]string, len(templateNames))
 	for _, name := range templateNames {
 		raw, err := templatesFS.ReadFile("templates/" + name)
@@ -131,8 +132,8 @@ func Render(id, date string, issueNum int, issueTitle string) (map[string]string
 // Scaffold renders the spec for id and writes it under repoRoot/specs/<id>. It
 // refuses to overwrite an existing specs/<id> (returns an error). If <id>
 // already exists under specs/archive/, it returns a non-empty warning but still
-// scaffolds. issueNum/issueTitle are passed through to Render.
-func Scaffold(repoRoot, id, date string, issueNum int, issueTitle string) (warning string, err error) {
+// scaffolds. repoSlug/issueNum/issueTitle are passed through to Render.
+func Scaffold(repoRoot, id, date, repoSlug string, issueNum int, issueTitle string) (warning string, err error) {
 	specDir := filepath.Join(repoRoot, "specs", id)
 	if _, err := os.Stat(specDir); err == nil {
 		return "", fmt.Errorf("already exists: %s", specDir)
@@ -140,7 +141,7 @@ func Scaffold(repoRoot, id, date string, issueNum int, issueTitle string) (warni
 	if _, err := os.Stat(filepath.Join(repoRoot, "specs", "archive", id)); err == nil {
 		warning = fmt.Sprintf("%s exists in specs/archive/. Possibly reviving.", id)
 	}
-	files, err := Render(id, date, issueNum, issueTitle)
+	files, err := Render(id, date, repoSlug, issueNum, issueTitle)
 	if err != nil {
 		return warning, err
 	}

--- a/cli/internal/spec/spec_test.go
+++ b/cli/internal/spec/spec_test.go
@@ -38,7 +38,7 @@ func TestValidateID(t *testing.T) {
 }
 
 func TestRenderSubstitutesAndFixesIssueFrontmatter(t *testing.T) {
-	files, err := Render("CLI-007-dot-spec-init", "2026-06-13", 358, "Port init-spec")
+	files, err := Render("CLI-007-dot-spec-init", "2026-06-13", "mlorentedev/knowledge", 358, "Port init-spec")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -47,7 +47,9 @@ func TestRenderSubstitutesAndFixesIssueFrontmatter(t *testing.T) {
 	wantContains := []string{
 		`id: "CLI-007-dot-spec-init"`,
 		`created: "2026-06-13"`,
-		`issue: "dotfiles#358"`, // the fix: frontmatter populated, not left empty
+		// HARNESS-023: records the issue's real owner/repo, not a hardcoded
+		// "dotfiles" — and the full owner/name form, not the bare repo.
+		`issue: "mlorentedev/knowledge#358"`,
 		"# CLI-007-dot-spec-init",
 		"<!-- from issue #358: Port init-spec -->",
 	}
@@ -78,7 +80,7 @@ func TestRenderSubstitutesAndFixesIssueFrontmatter(t *testing.T) {
 // created:, so scaffolded specs inherited it. All three templates must now carry
 // the {{date}} placeholder and have it substituted with the generation date.
 func TestRenderStampsCreatedInAllFiles(t *testing.T) {
-	files, err := Render("BUG-007-x", "2026-06-13", 0, "")
+	files, err := Render("BUG-007-x", "2026-06-13", "", 0, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -90,7 +92,7 @@ func TestRenderStampsCreatedInAllFiles(t *testing.T) {
 }
 
 func TestRenderWithoutIssueLeavesFrontmatterEmpty(t *testing.T) {
-	files, err := Render("BUG-007", "2026-06-13", 0, "")
+	files, err := Render("BUG-007", "2026-06-13", "", 0, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -106,7 +108,7 @@ func TestRenderWithoutIssueLeavesFrontmatterEmpty(t *testing.T) {
 func TestScaffoldWritesFilesAndGuardsClobber(t *testing.T) {
 	root := t.TempDir()
 
-	warn, err := Scaffold(root, "CLI-007-dot-spec-init", "2026-06-13", 358, "Port init-spec")
+	warn, err := Scaffold(root, "CLI-007-dot-spec-init", "2026-06-13", "mlorentedev/dotfiles", 358, "Port init-spec")
 	if err != nil {
 		t.Fatalf("Scaffold: %v", err)
 	}
@@ -121,7 +123,7 @@ func TestScaffoldWritesFilesAndGuardsClobber(t *testing.T) {
 	}
 
 	// Re-scaffolding the same id must refuse to clobber.
-	if _, err := Scaffold(root, "CLI-007-dot-spec-init", "2026-06-13", 358, "Port init-spec"); err == nil {
+	if _, err := Scaffold(root, "CLI-007-dot-spec-init", "2026-06-13", "mlorentedev/dotfiles", 358, "Port init-spec"); err == nil {
 		t.Errorf("expected clobber guard error on second scaffold")
 	}
 }
@@ -131,7 +133,7 @@ func TestScaffoldWarnsOnArchivedID(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(root, "specs", "archive", "AI-001-x"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	warn, err := Scaffold(root, "AI-001-x", "2026-06-13", 0, "")
+	warn, err := Scaffold(root, "AI-001-x", "2026-06-13", "", 0, "")
 	if err != nil {
 		t.Fatalf("Scaffold: %v", err)
 	}
@@ -174,7 +176,7 @@ func shellQuote(s string) string {
 
 func TestGateOpenIssueReturnsTitle(t *testing.T) {
 	stubGh(t, "OPEN\tMy open issue", "", false)
-	title, err := Gate(42)
+	title, err := Gate(42, "")
 	if err != nil {
 		t.Fatalf("Gate: %v", err)
 	}
@@ -185,7 +187,7 @@ func TestGateOpenIssueReturnsTitle(t *testing.T) {
 
 func TestGateClosedIssueFails(t *testing.T) {
 	stubGh(t, "CLOSED\tDone already", "", false)
-	if _, err := Gate(42); err == nil {
+	if _, err := Gate(42, ""); err == nil {
 		t.Errorf("expected error for a closed work-gate issue")
 	} else if !strings.Contains(err.Error(), "not open") {
 		t.Errorf("error should mention not-open, got: %v", err)
@@ -194,7 +196,7 @@ func TestGateClosedIssueFails(t *testing.T) {
 
 func TestGateMissingIssueFails(t *testing.T) {
 	stubGh(t, "", "gh: could not resolve issue", true)
-	if _, err := Gate(99999); err == nil {
+	if _, err := Gate(99999, ""); err == nil {
 		t.Errorf("expected error when gh fails to find the issue")
 	}
 }

--- a/specs/HARNESS-023-spec-init-bitacora-repo/proposal.md
+++ b/specs/HARNESS-023-spec-init-bitacora-repo/proposal.md
@@ -1,0 +1,52 @@
+---
+id: "HARNESS-023-spec-init-bitacora-repo"
+type: spec
+status: verifying # draft | implementing | verifying | archived
+created: "2026-06-16"
+issue: "mlorentedev/dotfiles#392"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# HARNESS-023-spec-init-bitacora-repo
+
+> **Naming**: file lives at `<repo>/specs/HARNESS-023-spec-init-bitacora-repo/proposal.md`. `HARNESS-023-spec-init-bitacora-repo` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #392: HARNESS-023: dotf spec init assumes bitácora == dotfiles repo (wrong gate repo + hardcoded frontmatter prefix) -->
+
+`dotf spec init --issue N` assumed the work-gate issue always lives in the dotfiles repo. The bitácora spans many repos (kubelab, knowledge, …) on one GitHub Project, so a cross-repo gate broke twice: the gate ran `gh issue view N` against the *current* repo's default (checking the wrong, often-closed issue), and the scaffolded frontmatter hardcoded `issue: "dotfiles#N"`. Found scaffolding a kubelab spec gated by `knowledge#104`.
+
+## What
+
+- The gate check AND the proposal frontmatter both use the repo that actually hosts the issue.
+- Resolution precedence: `--bitacora-repo owner/repo` flag → `$DOTF_BITACORA_REPO` → the current repo's `git remote origin` slug.
+- Frontmatter records the full `owner/repo#N` (e.g. `mlorentedev/knowledge#392`), not the bare/hardcoded `dotfiles#N`.
+- A gated init whose repo cannot be resolved errors (pointing at `--bitacora-repo`) instead of fabricating a bogus `#N`.
+- The `[INFO] Work-gate OK` line names the repo (`owner/repo#N`), so a wrong-repo gate is visible, not silent.
+
+## Out of scope
+
+- Where the bitácora Project lives or its field schema.
+- Any `dotf` command other than `spec init`.
+- Auto-discovering which repo hosts an issue from the number alone (no cross-repo search).
+
+## Risks / open questions
+
+- **Default = current-repo origin** (resolved): correct for the common same-repo gate; cross-repo needs the explicit flag/env. Chosen over a fixed `mlorentedev/knowledge` default, which would have broken same-repo gating — swapping one hardcode for another.
+- `OriginRepo` shells out to `git`; environments without git or an origin remote must pass the flag/env — the error message names this path.
+
+## Acceptance criteria
+
+- [x] Gate checks the issue in its real repo via `gh issue view --repo <slug>`, not the current repo's default.
+- [x] Frontmatter records the full `owner/repo#N` resolved from flag/env/origin, never a hardcoded `dotfiles#`.
+- [x] `--bitacora-repo` flag + `DOTF_BITACORA_REPO` env override the default; precedence flag > env > origin.
+- [x] A gated init with an unresolvable repo errors pointing at `--bitacora-repo` (no fabricated issue prefix).
+- [x] `go test ./cli/...` green; regression guards added in `spec_test.go` + `cmd/spec_test.go`.
+
+## References
+
+- Issue: `mlorentedev/dotfiles#392`
+- Convention precedent: kubelab `specs/NOTIFY-001` (full `owner/repo#N` in frontmatter)
+- Touched: `cli/internal/spec/spec.go` (Gate/Render/Scaffold), `cli/internal/cmd/spec.go` (resolution + `--bitacora-repo`)

--- a/specs/HARNESS-023-spec-init-bitacora-repo/tasks.md
+++ b/specs/HARNESS-023-spec-init-bitacora-repo/tasks.md
@@ -1,0 +1,50 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-06-16"
+---
+
+# Tasks - HARNESS-023-spec-init-bitacora-repo
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+
+## Setup
+
+- [x] Branch created from main: `fix/spec-init-bitacora-repo`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+- [x] `spec.Gate(num, repo)` — append `--repo <slug>` when repo non-empty; update Gate tests to new signature.
+- [x] `spec.Render(id, date, repoSlug, …)` / `spec.Scaffold(…, repoSlug, …)` — drop the `const repoSlug = "dotfiles"`, thread the slug through; frontmatter writes full `owner/repo#N`.
+- [x] `cmd/spec.go` — resolve slug (flag `--bitacora-repo` > `$DOTF_BITACORA_REPO` > `initrepo.OriginRepo`); validate with `ValidRepoSlug`; error if unresolvable while gating; wire into Gate + Scaffold; `[INFO]` line names the repo.
+- [x] Regression guards: `TestRenderSubstitutesAndFixesIssueFrontmatter` (full slug), `TestSpecInitBitacoraRepoFlagOverrides` (flag/cross-repo), `TestSpecInitUnresolvableRepoFails` (error path), env path in `TestSpecInitWithOpenIssueSetsFrontmatter`.
+
+## Closing
+
+- [x] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [x] Type checks / build pass (`go build`, `go vet`)
+- [x] Lint passes (`gofmt -l` clean)
+- [x] No unrelated changes in the diff (no scope creep)
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
+
+Minimal `features.json` skeleton (drop into `<repo>/specs/HARNESS-023-spec-init-bitacora-repo/features.json`):
+
+```json
+[
+  {
+    "id": "HARNESS-023-spec-init-bitacora-repo-f1",
+    "behavior": "<one-line copy of an acceptance criterion>",
+    "verification": "<single shell command; exit 0 means pass>",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/HARNESS-023-spec-init-bitacora-repo/verification.md
+++ b/specs/HARNESS-023-spec-init-bitacora-repo/verification.md
@@ -1,0 +1,43 @@
+---
+tags: [spec, verification, templates]
+created: "2026-06-16"
+---
+
+# Verification - HARNESS-023-spec-init-bitacora-repo
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof.
+
+- [x] **AC1** gate uses the issue's repo -> `spec.Gate(num, repo)` appends `--repo <slug>`; covered by `cmd/spec_test.go:TestSpecInitBitacoraRepoFlagOverrides` + `TestSpecInitWithOpenIssueSetsFrontmatter`.
+- [x] **AC2** full `owner/repo#N` frontmatter -> `spec/spec_test.go:TestRenderSubstitutesAndFixesIssueFrontmatter` asserts `issue: "mlorentedev/knowledge#358"` (full slug, not hardcoded `dotfiles#`); `cmd` test asserts `mlorentedev/dotfiles#358`.
+- [x] **AC3** precedence flag > env > origin -> flag: `TestSpecInitBitacoraRepoFlagOverrides`; env: `TestSpecInitWithOpenIssueSetsFrontmatter` (`DOTF_BITACORA_REPO`); origin default: exercised live (this spec scaffolded itself with `issue: "mlorentedev/dotfiles#392"` resolved from origin).
+- [x] **AC4** unresolvable repo errors (no fabricated `#N`) -> `TestSpecInitUnresolvableRepoFails` asserts the error names `--bitacora-repo`.
+- [x] **AC5** suite green -> `go test ./...` all ok; `gofmt -l` clean; `go vet` clean.
+
+## Test status
+
+- `go test ./...` (from `cli/`): `ok` for `internal/cmd` (0.319s), `internal/spec` (0.008s), `internal/initrepo` (0.284s), `cmd/dotf`, `internal/doctor`. No failures.
+- `gofmt -l internal/spec internal/cmd`: empty (clean). `go vet ./...`: clean.
+- Manual smoke (built binary): `dotf spec init --help` lists `--bitacora-repo`; `--force-no-gate` scaffolds with `issue: ""` (no fabrication).
+- **Dogfood**: this spec was scaffolded by the *fixed* binary gated on #392 — output `[INFO] Work-gate OK: mlorentedev/dotfiles#392 is open` and frontmatter `issue: "mlorentedev/dotfiles#392"` (full slug, resolved from origin), proving both symptoms fixed end-to-end.
+- No regressions: existing `spec`/`cmd` tests migrated to the new `Gate`/`Render`/`Scaffold` signatures, all green.
+
+## Decisions made during implementation
+
+- **Default = current-repo origin, not a fixed `mlorentedev/knowledge`.** The issue proposed defaulting to `knowledge`, but that swaps one hardcode for another and breaks the common same-repo gate (a dotfiles spec gated by a dotfiles issue). Origin-resolution is right for same-repo; the flag/env covers cross-repo.
+- **Slug resolved in the `cmd` composition layer**, then passed into the pure `spec` package (reusing `initrepo.OriginRepo`/`ValidRepoSlug`) — avoids a `spec`->`initrepo` dependency.
+- **Errors instead of fabricating** an `issue:` prefix when the repo is unresolvable while gating — no bogus `#N` reaches the proposal.
+
+## Promotion candidates
+
+- [x] Lesson for the repo's `docs/lessons.md`? **yes** — "a migration that *broadens* scope (bitácora: dotfiles repo -> multi-repo Project) leaves single-repo assumptions hardcoded in the tools built against the old shape" (sibling of the incomplete-migration class). Decide at archive.
+- [x] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? no — a bugfix + flag, no architectural shift.
+- [x] New pattern candidate for `00_meta/patterns/`? no — repo-local.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/HARNESS-023-spec-init-bitacora-repo/` -> `specs/archive/HARNESS-023-spec-init-bitacora-repo/`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
Closes #392.

## Problem
`dotf spec init --issue N` assumed the work-gate issue lives in the **dotfiles** repo. The bitácora spans many repos on one GitHub Project, so a cross-repo gate broke twice:
1. **Wrong gate repo** — `gh issue view N` resolved against the *current* repo's default (e.g. `kubelab#104`, a closed unrelated issue) instead of `knowledge#104`.
2. **Hardcoded frontmatter** — the proposal recorded `issue: "dotfiles#N"` regardless of the real repo.

## Fix
- Resolve the issue's repo: `--bitacora-repo owner/repo` flag > `$DOTF_BITACORA_REPO` > current repo's `origin` slug.
- Use it for **both** the gate (`gh issue view --repo`) and the frontmatter (full `owner/repo#N`, not a bare hardcode).
- Error (pointing at `--bitacora-repo`) instead of fabricating a `#N` when unresolvable. The `[INFO] Work-gate OK` line now names the repo.

### Design note
The issue proposed *defaulting to `mlorentedev/knowledge`*; that swaps one hardcode for another and breaks same-repo gating. Default = current-repo origin (correct for the common case); flag/env handle cross-repo.

## Verification
- `go test ./...` green; `gofmt -l` + `go vet` clean.
- Guards: full-slug frontmatter, flag override (cross-repo), env path, unresolvable-repo error.
- **Dogfood**: this PR's own spec (`specs/HARNESS-023-spec-init-bitacora-repo/`) was scaffolded by the fixed binary gated on #392 → `issue: "mlorentedev/dotfiles#392"` (full slug, resolved from origin).

SDD: `specs/HARNESS-023-spec-init-bitacora-repo/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--bitacora-repo` flag to `spec init` command for cross-repository work-gate resolution
  * Added `DOTF_BITACORA_REPO` environment variable support for configuring the bitácora repository

* **Bug Fixes**
  * Improved error handling when repository cannot be resolved during spec initialization
  * Ensured work-gate issue references correctly record the resolved repository in proposal metadata

* **Tests**
  * Added test coverage for bitácora repo flag override and resolution behavior
  * Added test coverage for unresolvable repository error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->