### PR TITLE
docs(spec): GUARD-001 memory-sink pre-commit (single-sink keystone)

### DIFF
--- a/specs/GUARD-001-memory-sink-precommit/features.json
+++ b/specs/GUARD-001-memory-sink-precommit/features.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "GUARD-001-f1",
+    "behavior": "Committing MEMORY.md (or a memory/ path) to a non-vault repo is rejected with a vault-pointing message",
+    "verification": "bats tests/guard-memory.bats -f 'rejects MEMORY.md in non-vault repo'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-001-f2",
+    "behavior": "Committing the same memory artifact inside the vault is allowed",
+    "verification": "bats tests/guard-memory.bats -f 'allows MEMORY.md in vault'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-001-f3",
+    "behavior": "A pre-existing local pre-commit hook still runs after the guard (chaining, no clobber)",
+    "verification": "bats tests/guard-memory.bats -f 'runs guard and local pre-commit'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-001-f4",
+    "behavior": "dotf init scaffolds a .gitignore block ignoring MEMORY.md and memory/",
+    "verification": "go test ./cli/internal/initrepo/ -run TestScaffoldGitignoreMemoryBlock",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-001-f5",
+    "behavior": "Global core.hooksPath install is idempotent and preserves an unrelated existing hooksPath",
+    "verification": "bats tests/guard-install.bats -f 'idempotent'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-001-f6",
+    "behavior": "AGENTS.md states the single-sink rule once (no Hive-note duplication)",
+    "verification": "grep -q 'single sink' AGENTS.md",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/GUARD-001-memory-sink-precommit/proposal.md
+++ b/specs/GUARD-001-memory-sink-precommit/proposal.md
@@ -1,0 +1,62 @@
+---
+id: "GUARD-001-memory-sink-precommit"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-16"
+issue: "dotfiles#398"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, memory, single-sink, git-hooks, cross-agent]
+template_version: "1.0"
+---
+
+# GUARD-001-memory-sink-precommit
+
+> **Naming**: file lives at `<repo>/specs/GUARD-001-memory-sink-precommit/proposal.md`. Keystone of the cross-agent single-sink memory convention (decided 2026-06-16, D1–D4).
+
+## Why
+
+<!-- from issue #398: GUARD: global pre-commit blocking memory artifacts in non-vault repos (cross-agent single-sink) -->
+
+The single-sink convention says agent memory lives **only** in the vault — never in a code repo or machine-local dir. But nothing enforces it. Every guard today is either vault-scoped (gitleaks on the vault) or per-repo opt-in: `dotf init` scaffolds a `.pre-commit-config.yaml`, so the guard exists only in repos that went through the scaffolder. The leak that motivated this (a non-Claude agent committed `MEMORY.md` into the ts-bridge repo root, recovered via ts-bridge#147) happened precisely in a repo that **never ran `dotf init`** — so no local guard could have caught it. Until a machine-wide, agent-agnostic guard exists, the convention is a documented wish, not an invariant, and memory will keep leaking out of the sink.
+
+## What
+
+A machine-wide git guard that makes it impossible to commit memory artifacts to any repository that is not the vault.
+
+- **Global `pre-commit` dispatcher** installed via `core.hooksPath` (machine-wide `git config --global`). On every commit in every repo: detect whether the repo is the vault; if not, reject the commit when staged paths include memory artifacts (`MEMORY.md`, a `memory/` directory, or `00_meta/sessions/` records), with a message pointing the author to the vault as the only sink. Then **chain** to the repo-local hook so existing per-repo guards (gitleaks) still run.
+- **`dotf init` gitignore block**: every newly-scaffolded repo is born convention-correct with `MEMORY.md` and `memory/` ignored (defence in depth — stops accidental `git add`).
+- **Idempotent install**: setup / `dotf doctor` wires and repairs the global `core.hooksPath` without clobbering an existing one.
+- **AGENTS.md** states the single-sink rule once (Hive is the memory *API* over the same sink — no duplicated wording).
+
+After this PR: `git commit` staging `MEMORY.md` in any non-vault repo is rejected; the same commit in the vault succeeds; a repo with a pre-existing gitleaks hook runs **both** the GUARD and gitleaks; new `dotf init` repos already ignore the artifacts.
+
+## Out of scope
+
+- **Per-agent session-end hooks** (`MEMORY-001-mirror`) — those *feed* the sink; this *guards* it. Sibling task, separate spec.
+- **The obsidian-git-bypasses-gitleaks vault issue** (knowledge#114) — that is vault-internal (the vault is the *allowed* repo); this guard is about *non-vault* repos. Different threat surface.
+- **Server-side / CI enforcement** — the true backstop for `--no-verify` and libgit2/isomorphic-git bypass. Noted as a follow-up; local hooks are the first line, not the only line.
+- **Recovering already-leaked memory** — ts-bridge / iris / nan recoveries are done (34/34 symlinked).
+
+## Risks / open questions
+
+- **R1 — `core.hooksPath` vs. the per-repo `pre-commit` framework (load-bearing). ✅ DECIDED (2026-06-16): Option A — multi-hook chaining dispatcher.** A global `core.hooksPath` makes *every* repo resolve **all** hook types to the global dir, disabling per-repo `.git/hooks/` machine-wide — and `pre-commit install` respects `core.hooksPath`, so it would write into the global dir and clobber the per-repo gitleaks guard. **Resolution:** declare the global `core.hooksPath` in dotfiles `.gitconfig` (IaC) pointing at a tracked `git-hooks/` dir holding **one dispatcher per hook type** the ecosystem uses (`pre-commit`, `commit-msg`, `prepare-commit-msg`, `pre-push`). Each dispatcher runs its global concern (only `pre-commit` carries the memory guard) and then execs the **literal** `<toplevel>/.git/hooks/<type>` if present. Mechanical note for implementation: because the framework's `pre-commit install` would target the global dir, the per-repo layer is installed as a stable `.git/hooks/<type>` that calls `pre-commit run --hook-stage <stage>` — the dispatcher chains to that literal path, not to the `core.hooksPath`-resolved one. So `install-precommit.sh` / `dotf init` write the local hook to `.git/hooks/` directly rather than relying on `pre-commit install`'s location.
+- **R2 — vault detection.** How the hook knows "this is the vault" (to allow): (a) repo root == `$VAULT_PATH` (`$HOME/Projects/knowledge`) — simple but path-coupled; (b) a sentinel at repo root (`.obsidian/` dir or a `.vault-root` marker) — cross-machine robust; (c) remote-URL match. **Recommendation:** sentinel (`.obsidian/` present at repo root), with `$VAULT_PATH` as fallback — robust across machines, no hardcoded path in the hot path.
+- **R3 — bypass paths.** `--no-verify`, libgit2/isomorphic-git tools (obsidian-git), and fresh clones before the hook is wired all skip a local hook. **Mitigation:** gitignore as defence in depth + a documented CI backstop (follow-up); a deliberate `--no-verify` is outside the threat model (the convention is for honest agents, not adversaries).
+- **R4 — false positives.** A repo that legitimately needs a file named `MEMORY.md`. **Mitigation:** the match is narrow (root-level `MEMORY.md`, `memory/` dirs, session-record shape) and `--no-verify` is the documented escape hatch with user approval.
+- **R5 — cross-OS.** `core.hooksPath` + a POSIX hook script work on both Linux and Git-for-Windows (git invokes the hook via its bundled `sh`). The gitignore + `dotf init` parts are already cross-OS Go. No `.ps1` mirror needed for the hook itself; assert parity in tests.
+
+## Acceptance criteria
+
+- [ ] **AC1** — Committing `MEMORY.md` (or a `memory/` path) to a non-vault repo is rejected (exit ≠ 0) with a message naming the vault. *Verify:* bats fixture repo.
+- [ ] **AC2** — Committing the same memory artifact inside the vault is allowed (exit 0). *Verify:* bats fixture with the vault sentinel.
+- [ ] **AC3** — In a repo with a pre-existing local pre-commit hook (e.g. gitleaks), both the GUARD and the local hook run; neither is clobbered. *Verify:* bats chaining fixture.
+- [ ] **AC4** — `dotf init` writes the `MEMORY.md` / `memory/` gitignore block. *Verify:* Go test on scaffold output.
+- [ ] **AC5** — The global hook installs idempotently (setup / `dotf doctor`); re-running is a no-op and never clobbers an unrelated existing `core.hooksPath`. *Verify:* bats idempotence.
+- [ ] **AC6** — AGENTS.md states the single-sink rule once (no Hive-note duplication). *Verify:* grep assertion.
+
+## References
+
+- Issue: dotfiles#398 (work-gate)
+- Sibling specs: `MEMORY-001-cross-agent-session-bridge` (feeds the sink, Claude core shipped), `MEMORY-001-mirror` (per-agent hooks, draft)
+- Vault decisions: single-sink D1–D4 (handoff 2026-06-16); ts-bridge recovery (ts-bridge#147)
+- Related: knowledge#114 (obsidian-git bypasses gitleaks — vault-internal, distinct surface)
+- Existing infra (build on, do not duplicate): `scripts/install-precommit.sh`, `cli/internal/initrepo/` (gitleaks `.pre-commit-config.yaml` scaffold), `scripts/claude-session-start.sh` (memory symlink — to be extracted, sibling task)

--- a/specs/GUARD-001-memory-sink-precommit/tasks.md
+++ b/specs/GUARD-001-memory-sink-precommit/tasks.md
@@ -1,0 +1,46 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-06-16"
+---
+
+# Tasks - GUARD-001-memory-sink-precommit
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+
+## Setup
+
+- [x] Branch created from main: `feat/guard-memory-sink`
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [x] **R1 settled** (2026-06-16): Option A — multi-hook chaining dispatcher under a global `core.hooksPath` (dotfiles `.gitconfig`); one dispatcher per hook type, each execs the literal `.git/hooks/<type>`; per-repo layer installed as `.git/hooks/<type>` calling `pre-commit run`
+
+## Implementation (TDD)
+
+> The guard is a single POSIX `pre-commit` dispatcher under a tracked `git-hooks/` dir; setup/`dotf doctor` point `core.hooksPath` at it. Keep each step one commit.
+
+- [ ] Failing bats: in a non-vault fixture repo, `git commit` staging `MEMORY.md` → expect non-zero exit + vault message (AC1) — **RED**
+- [ ] Implement the dispatcher core: vault detection (sentinel `.obsidian/` + `$VAULT_PATH` fallback, R2) + staged-path scan (`MEMORY.md`, `memory/`, session-record shape, R4) + reject → **GREEN** (AC1)
+- [ ] Failing bats: same artifact inside a vault fixture (sentinel present) → expect exit 0 (AC2) — **RED** → **GREEN**
+- [ ] Failing bats: chaining — fixture repo with a pre-existing local `pre-commit` hook; assert both the GUARD and the local hook execute, local hook not clobbered (AC3) — **RED**
+- [ ] Implement chaining: dispatcher execs the repo-local hook after the guard passes (R1 decision) → **GREEN** (AC3)
+- [ ] Failing Go test: `initrepo` scaffold output `.gitignore` contains the `MEMORY.md` / `memory/` block (AC4) — **RED**
+- [ ] Implement the gitignore block in `cli/internal/initrepo/scaffold.go` → **GREEN** (AC4)
+- [ ] Failing bats: idempotent install (setup / `dotf doctor`) — first run wires `core.hooksPath` + places the dispatcher; re-run is a no-op; an unrelated pre-existing `core.hooksPath` is preserved, not clobbered (AC5) — **RED**
+- [ ] Implement the install/repair function (wire `git config --global core.hooksPath`, place the dispatcher, idempotent) → **GREEN** (AC5)
+- [ ] AGENTS.md: add the single-sink rule once (vault = only memory sink; Hive = the memory API over it) + grep assertion (AC6)
+- [ ] Refactor for clarity; cross-OS parity assert (R5 — POSIX hook runs under Git-for-Windows `sh`); no `.ps1` hook mirror needed
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [ ] Type checks pass (`go build ./...`)
+- [ ] Lint passes (shellcheck on the hook + `golangci-lint`)
+- [ ] No unrelated changes in the diff (no scope creep — symlink extraction #8 and per-agent hooks #7 are sibling tickets, NOT this PR)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder + issue #398
+
+## Machine-readable features
+
+`features.json` is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence`.
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit 0, may set that terminal state. Reviewers reject PRs where `features.json` has `passing` entries with empty `evidence`.

--- a/specs/GUARD-001-memory-sink-precommit/verification.md
+++ b/specs/GUARD-001-memory-sink-precommit/verification.md
@@ -1,0 +1,45 @@
+---
+tags: [spec, verification, templates]
+created: "2026-06-16"
+---
+
+# Verification - GUARD-001-memory-sink-precommit
+
+> Status: **draft** — this PR ships the spec (design). Evidence is filled during the implementation PR.
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] AC1 (reject in non-vault repo) -> bats `guard-memory.bats::rejects MEMORY.md in non-vault repo`
+- [ ] AC2 (allow in vault) -> bats `guard-memory.bats::allows MEMORY.md in vault (sentinel)`
+- [ ] AC3 (chaining preserves local hook) -> bats `guard-memory.bats::runs guard and local pre-commit`
+- [ ] AC4 (dotf init gitignore block) -> Go `initrepo.TestScaffoldGitignoreMemoryBlock`
+- [ ] AC5 (idempotent install) -> bats `guard-install.bats::idempotent + preserves existing hooksPath`
+- [ ] AC6 (AGENTS.md single-sink) -> grep assertion in CI / bats
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>` (filled at implementation)
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work.
+
+- R1 (chaining): **DECIDED 2026-06-16 — Option A, multi-hook chaining dispatcher.** Global `core.hooksPath` (dotfiles `.gitconfig`) → tracked `git-hooks/` dir with one dispatcher per hook type (`pre-commit`/`commit-msg`/`prepare-commit-msg`/`pre-push`); each runs its global concern then execs the literal `<toplevel>/.git/hooks/<type>`. Per-repo layer installed as a stable `.git/hooks/<type>` calling `pre-commit run` (not `pre-commit install`, whose location the global hooksPath would hijack).
+- R2 (vault detection): recommendation = sentinel (`.obsidian/` at repo root) + `$VAULT_PATH` fallback — confirm as built.
+
+## Promotion candidates
+
+- [ ] Lesson for `docs/lessons.md`? Likely yes — "per-repo hooks can't enforce a machine-wide invariant; `core.hooksPath` + a chaining dispatcher is the agnostic keystone" (the ts-bridge leak root cause).
+- [ ] ADR-worthy decision for `docs/adr/adr-XXX.md`? Candidate — the single-sink enforcement mechanism (global hooksPath dispatcher) is an architecture choice; consider an ADR if R1's chaining design proves non-obvious.
+- [ ] New pattern for `00_meta/patterns/`? Only if the global-dispatcher-with-chaining recurs beyond memory (e.g. reused for secret-scanning). Defer.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/GUARD-001-memory-sink-precommit/` -> `specs/archive/GUARD-001-memory-sink-precommit/`
+- [ ] Backlog entry (issue #398) ticked / closed with PR link
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
Scaffolds the design spec for the cross-agent single-sink memory guard. Closes the keystone gap behind #398.

## Context

The single-sink convention says agent memory lives only in the vault. Today's guards are either vault-scoped (gitleaks) or per-repo opt-in (`dotf init` scaffolds `.pre-commit-config.yaml`). The leak that motivated this (a `MEMORY.md` committed into the ts-bridge repo, recovered via ts-bridge#147) happened in a repo that never ran `dotf init`, so no local guard existed. Nothing machine-wide enforces the convention.

## What this PR is

Design only (proposal + tasks + verification + features.json). Implementation is a downstream PR, per the MEMORY-001 spec-first precedent.

The guard: a global `pre-commit` dispatcher via `core.hooksPath` that detects whether the repo is the vault (sentinel `.obsidian/`) and rejects memory artifacts (`MEMORY.md`, `memory/`, session records) otherwise, then chains to the repo-local hook so gitleaks still runs. Plus a `.gitignore` block baked into `dotf init` and the single-sink rule in AGENTS.md.

## Key design decision (R1, settled)

A global `core.hooksPath` disables per-repo `.git/hooks/` for **all** hook types machine-wide. Since the ecosystem installs `prepare-commit-msg`, `commit-msg` and `pre-push` (SDD gate), the guard cannot be a single hook — it is a **multi-hook chaining dispatcher**: one dispatcher per hook type, each running its global concern then exec-ing the literal `.git/hooks/<type>`. The per-repo layer is installed as a stable `.git/hooks/<type>` calling `pre-commit run`, so the framework's install location (which the global hooksPath would hijack) is not relied upon.

## Acceptance criteria

6 ACs (reject in non-vault, allow in vault, chaining preserves local hook, `dotf init` gitignore, idempotent install, AGENTS.md single-sink), each mapped to a bats/Go check in `features.json`.

Refs #398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specification and implementation documentation for a Git pre-commit guard mechanism that prevents memory artifacts from being accidentally committed to non-vault repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->