### PR TITLE
feat(guard): complete GUARD-001 single-sink (gitignore, global install, AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,7 @@ Two layers, declared by [ADR-020](docs/adr/adr-020-tooling-cli-go-convergence.md
 **LANGUAGE:** All Vault content MUST be in English.
 **COMMIT POLICY:** **Autonomous agents** (no human in the loop) may commit autonomously **only within their vault workspace `80_agents/`** — that sandbox is theirs; everywhere else (code repos + the rest of the vault) they stage only and leave commits for human approval. **Interactive / in-session agents** stage by default and commit / push / open PRs **when the user asks** (e.g. this repo's PR-per-feature flow).
 **REPO DOCS:** Repos on the knowledge-placement model keep `docs/` (with `docs/adr/`) in-repo and may keep a root `CHANGELOG.md`. This **supersedes the older blanket "never create `docs/`" stance** (closes CHORE-002). Still avoid ad-hoc `TODO.md` — tasks live in `specs/` + the backlog.
+**MEMORY SINGLE-SINK (GUARD-001):** The vault is the **only** sink for agent memory — `MEMORY.md`, `memory/`, and session handoffs/journals live there and nowhere else. **Hive is the memory API over the vault**: read and write memory through Hive, never by committing memory files into a code repo. A global `core.hooksPath` pre-commit guard rejects `MEMORY.md` / `memory/` in any non-vault repo, and `dotf init` bakes the matching `.gitignore`; never bypass it with `--no-verify` to sink memory into a repo.
 
 ### Phase 1: Context Sync (Read First)
 

--- a/cli/internal/doctor/checks_guard.go
+++ b/cli/internal/doctor/checks_guard.go
@@ -1,0 +1,67 @@
+package doctor
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// checkGuardHooks verifies the GUARD-001 memory-sink dispatcher is wired
+// machine-wide via git's global core.hooksPath. The dispatcher (the tracked
+// git-hooks/ dir under DOTFILES_DIR, shipped in #409) only runs in a repo when
+// core.hooksPath points at it — so this check is what actually ACTIVATES the
+// guard; without it the dispatcher is inert.
+//
+// Safety-first, because a global core.hooksPath has machine-wide blast radius:
+// an unrelated pre-existing value is NEVER clobbered. It is surfaced as a WARN so
+// the human resolves the conflict deliberately. Only an unset hooksPath is wired
+// (and only under --fix); an already-correct one is a no-op (idempotent re-run).
+func checkGuardHooks(sys *System, cfg *Config, rep *Report, fix bool) {
+	rep.Section("GUARD memory-sink hooks")
+
+	target := filepath.Join(cfg.DotfilesDir, "git-hooks")
+
+	// Wiring core.hooksPath at a dir without the dispatcher would point git at a
+	// missing hook — refuse and tell the user to deploy first.
+	if !pathExists(filepath.Join(target, "pre-commit")) {
+		rep.Fail("dispatcher not found at " + target + " — run dotfiles setup to deploy git-hooks/")
+		return
+	}
+
+	current := gitGlobalHooksPath(sys)
+	switch {
+	case current == target:
+		rep.Pass("core.hooksPath wired to the GUARD dispatcher")
+	case current == "":
+		if !fix {
+			rep.Fail("core.hooksPath unset — GUARD memory-sink guard inactive; run `dotf doctor --fix`")
+			return
+		}
+		if err := setGitGlobalHooksPath(sys, target); err != nil {
+			rep.Fail(fmt.Sprintf("could not wire core.hooksPath: %v", err))
+			return
+		}
+		rep.Fix("wired core.hooksPath → " + target)
+	default:
+		// Unrelated pre-existing value: preserve it, never clobber.
+		rep.Warn(fmt.Sprintf("core.hooksPath is %s (not the GUARD dispatcher) — preserving it; "+
+			"GUARD inactive. Point it at %s, or chain the dispatcher from your hooks, manually.", current, target))
+	}
+}
+
+// gitGlobalHooksPath returns the global core.hooksPath, or "" when unset.
+// `git config --global --get` exits non-zero for an absent key, which the System
+// fake/real both surface as an error — mapped here to "".
+func gitGlobalHooksPath(sys *System) string {
+	out, err := sys.CommandOutput("git", "config", "--global", "--get", "core.hooksPath")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+
+// setGitGlobalHooksPath wires the dispatcher dir machine-wide.
+func setGitGlobalHooksPath(sys *System, target string) error {
+	_, err := sys.CommandOutput("git", "config", "--global", "core.hooksPath", target)
+	return err
+}

--- a/cli/internal/doctor/checks_guard.go
+++ b/cli/internal/doctor/checks_guard.go
@@ -29,10 +29,10 @@ func checkGuardHooks(sys *System, cfg *Config, rep *Report, fix bool) {
 	}
 
 	current := gitGlobalHooksPath(sys)
-	switch {
-	case current == target:
+	switch current {
+	case target:
 		rep.Pass("core.hooksPath wired to the GUARD dispatcher")
-	case current == "":
+	case "":
 		if !fix {
 			rep.Fail("core.hooksPath unset — GUARD memory-sink guard inactive; run `dotf doctor --fix`")
 			return

--- a/cli/internal/doctor/checks_guard_test.go
+++ b/cli/internal/doctor/checks_guard_test.go
@@ -1,0 +1,148 @@
+package doctor
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// recordingGit is a System whose CommandOutput records every invocation and
+// answers `git config --global --get core.hooksPath` from a fixed value, so the
+// AC5 idempotence + no-clobber contract can be asserted on the exact commands
+// issued (not just the report text).
+type recordingGit struct {
+	getValue string // value returned for the --get probe
+	unset    bool   // true → probe exits non-zero (key absent)
+	calls    []string
+}
+
+func (g *recordingGit) system() *System {
+	return &System{
+		Getenv:   func(string) string { return "" },
+		LookPath: func(n string) (string, error) { return "/usr/bin/" + n, nil },
+		CommandOutput: func(name string, args ...string) (string, error) {
+			full := name + " " + strings.Join(args, " ")
+			g.calls = append(g.calls, full)
+			if name == "git" && len(args) >= 4 && args[2] == "--get" {
+				if g.unset {
+					return "", errors.New("exit status 1")
+				}
+				return g.getValue + "\n", nil
+			}
+			return "", nil // the write succeeds
+		},
+	}
+}
+
+func (g *recordingGit) issued(cmd string) bool {
+	for _, c := range g.calls {
+		if c == cmd {
+			return true
+		}
+	}
+	return false
+}
+
+func guardCfg(t *testing.T, withDispatcher bool) (*Config, string) {
+	t.Helper()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "git-hooks")
+	if withDispatcher {
+		writeExec(t, filepath.Join(target, "pre-commit"))
+	}
+	return &Config{DotfilesDir: dir}, target
+}
+
+func TestCheckGuardHooks_MissingDispatcherFails(t *testing.T) {
+	cfg, _ := guardCfg(t, false) // dispatcher NOT deployed
+	g := &recordingGit{unset: true}
+	var buf bytes.Buffer
+	rep := capture(&buf)
+
+	checkGuardHooks(g.system(), cfg, rep, true)
+
+	if rep.Failures() != 1 {
+		t.Fatalf("missing dispatcher must FAIL once, got %d", rep.Failures())
+	}
+	if !strings.Contains(buf.String(), "dispatcher not found") {
+		t.Errorf("want 'dispatcher not found', got: %s", buf.String())
+	}
+	if g.issued("git config --global core.hooksPath " + filepath.Join(cfg.DotfilesDir, "git-hooks")) {
+		t.Error("must not wire hooksPath when the dispatcher is absent")
+	}
+}
+
+func TestCheckGuardHooks_UnsetFailsWithoutFix(t *testing.T) {
+	cfg, target := guardCfg(t, true)
+	g := &recordingGit{unset: true}
+	var buf bytes.Buffer
+	rep := capture(&buf)
+
+	checkGuardHooks(g.system(), cfg, rep, false)
+
+	if rep.Failures() != 1 {
+		t.Fatalf("unset hooksPath must FAIL in check mode, got %d", rep.Failures())
+	}
+	if g.issued("git config --global core.hooksPath " + target) {
+		t.Error("check mode must never write; --fix is required to wire")
+	}
+}
+
+func TestCheckGuardHooks_UnsetWiredOnFix(t *testing.T) {
+	cfg, target := guardCfg(t, true)
+	g := &recordingGit{unset: true}
+	var buf bytes.Buffer
+	rep := capture(&buf)
+
+	checkGuardHooks(g.system(), cfg, rep, true)
+
+	if rep.Failures() != 0 {
+		t.Fatalf("--fix on an unset hooksPath must not FAIL, got %d", rep.Failures())
+	}
+	if !g.issued("git config --global core.hooksPath " + target) {
+		t.Errorf("--fix must wire core.hooksPath → %s; calls: %v", target, g.calls)
+	}
+	if !strings.Contains(buf.String(), "wired core.hooksPath") {
+		t.Errorf("want a FIX line, got: %s", buf.String())
+	}
+}
+
+func TestCheckGuardHooks_AlreadyWiredIsIdempotent(t *testing.T) {
+	cfg, target := guardCfg(t, true)
+	g := &recordingGit{getValue: target}
+	var buf bytes.Buffer
+	rep := capture(&buf)
+
+	checkGuardHooks(g.system(), cfg, rep, true) // fix=true, but already wired
+
+	if rep.Failures() != 0 {
+		t.Fatalf("already-wired must PASS, got %d", rep.Failures())
+	}
+	if g.issued("git config --global core.hooksPath " + target) {
+		t.Error("idempotent: must NOT re-write an already-correct hooksPath")
+	}
+	if !strings.Contains(buf.String(), "wired to the GUARD dispatcher") {
+		t.Errorf("want the wired PASS, got: %s", buf.String())
+	}
+}
+
+func TestCheckGuardHooks_UnrelatedIsPreservedNotClobbered(t *testing.T) {
+	cfg, target := guardCfg(t, true)
+	g := &recordingGit{getValue: "/home/u/.my-hooks"}
+	var buf bytes.Buffer
+	rep := capture(&buf)
+
+	checkGuardHooks(g.system(), cfg, rep, true) // fix=true, but a foreign hooksPath exists
+
+	if rep.Failures() != 0 {
+		t.Fatalf("a foreign hooksPath is advisory (WARN), not a FAIL, got %d", rep.Failures())
+	}
+	if g.issued("git config --global core.hooksPath " + target) {
+		t.Error("must NOT clobber an unrelated pre-existing core.hooksPath")
+	}
+	if !strings.Contains(buf.String(), "preserving it") {
+		t.Errorf("want a preserve WARN, got: %s", buf.String())
+	}
+}

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -80,6 +80,7 @@ func Run(opts Options) (int, error) {
 		checkOptionalTools(sys, cfg, contract, rep)
 		checkVault(sys, rep)
 		checkSecrets(sys, cfg, rep)
+		checkGuardHooks(sys, cfg, rep, opts.Fix)
 		checkTmux(sys, cfg, rep)
 		checkOpenCode(sys, cfg, rep)
 		checkHarnessDrift(sys, cfg, rep)

--- a/cli/internal/initrepo/scaffold_test.go
+++ b/cli/internal/initrepo/scaffold_test.go
@@ -52,6 +52,26 @@ func TestScaffoldCreatesStructureAndFiles(t *testing.T) {
 	}
 }
 
+func TestScaffoldGitignoreHasMemorySinkBlock(t *testing.T) {
+	// GUARD-001 AC4: a fresh repo is born convention-correct — its .gitignore
+	// excludes the memory-sink artifacts so MEMORY.md / memory/ can never be
+	// committed to a code repo (memory lives only in the vault).
+	root := filepath.Join(t.TempDir(), "myproj")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Scaffold(root); err != nil {
+		t.Fatalf("Scaffold: %v", err)
+	}
+
+	gitignore := readFile(t, filepath.Join(root, ".gitignore"))
+	for _, want := range []string{"MEMORY.md", "memory/"} {
+		if !strings.Contains(gitignore, want) {
+			t.Errorf(".gitignore must ignore %q (single-sink convention):\n%s", want, gitignore)
+		}
+	}
+}
+
 func TestScaffoldEnvContractIsValidJSON(t *testing.T) {
 	root := t.TempDir()
 	if _, err := Scaffold(root); err != nil {

--- a/cli/internal/initrepo/templates/gitignore
+++ b/cli/internal/initrepo/templates/gitignore
@@ -29,3 +29,9 @@ Thumbs.db
 htmlcov/
 .pytest_cache/
 coverage.out
+
+# Memory sink (single-sink convention, GUARD-001): agent memory lives only in
+# the vault, never committed to a code repo. The global core.hooksPath pre-commit
+# guard blocks these too; this born-correct ignore is the belt-and-suspenders.
+MEMORY.md
+memory/

--- a/specs/GUARD-001-memory-sink-precommit/features.json
+++ b/specs/GUARD-001-memory-sink-precommit/features.json
@@ -23,21 +23,21 @@
   {
     "id": "GUARD-001-f4",
     "behavior": "dotf init scaffolds a .gitignore block ignoring MEMORY.md and memory/",
-    "verification": "go test ./cli/internal/initrepo/ -run TestScaffoldGitignoreMemoryBlock",
+    "verification": "cd cli && go test ./internal/initrepo/ -run TestScaffoldGitignoreHasMemorySinkBlock",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "GUARD-001-f5",
-    "behavior": "Global core.hooksPath install is idempotent and preserves an unrelated existing hooksPath",
-    "verification": "bats tests/guard-install.bats -f 'idempotent'",
+    "behavior": "dotf doctor wires core.hooksPath at the dispatcher idempotently, preserves an unrelated existing hooksPath (no clobber), and only writes under --fix",
+    "verification": "cd cli && go test ./internal/doctor/ -run TestCheckGuardHooks",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "GUARD-001-f6",
-    "behavior": "AGENTS.md states the single-sink rule once (no Hive-note duplication)",
-    "verification": "grep -q 'single sink' AGENTS.md",
+    "behavior": "AGENTS.md states the memory single-sink rule once (vault = only sink; Hive = the memory API)",
+    "verification": "bats tests/agents-md.bats -f 'memory single-sink rule'",
     "state": "pending",
     "evidence": ""
   }

--- a/specs/GUARD-001-memory-sink-precommit/tasks.md
+++ b/specs/GUARD-001-memory-sink-precommit/tasks.md
@@ -22,12 +22,12 @@ created: "2026-06-16"
 - [x] Failing bats: same artifact inside a vault fixture (sentinel present) → expect exit 0 (AC2) — **RED** → **GREEN**
 - [x] Failing bats: chaining — fixture repo with a pre-existing local `pre-commit` hook; assert both the GUARD and the local hook execute, local hook not clobbered (AC3) — **RED**
 - [x] Implement chaining: dispatcher execs the repo-local hook after the guard passes (R1 decision) → **GREEN** (AC3)
-- [ ] Failing Go test: `initrepo` scaffold output `.gitignore` contains the `MEMORY.md` / `memory/` block (AC4) — **RED**
-- [ ] Implement the gitignore block in `cli/internal/initrepo/scaffold.go` → **GREEN** (AC4)
-- [ ] Failing bats: idempotent install (setup / `dotf doctor`) — first run wires `core.hooksPath` + places the dispatcher; re-run is a no-op; an unrelated pre-existing `core.hooksPath` is preserved, not clobbered (AC5) — **RED**
-- [ ] Implement the install/repair function (wire `git config --global core.hooksPath`, place the dispatcher, idempotent) → **GREEN** (AC5)
-- [ ] AGENTS.md: add the single-sink rule once (vault = only memory sink; Hive = the memory API over it) + grep assertion (AC6)
-- [ ] Refactor for clarity; cross-OS parity assert (R5 — POSIX hook runs under Git-for-Windows `sh`); no `.ps1` hook mirror needed
+- [x] Failing Go test: `initrepo` scaffold `.gitignore` contains the `MEMORY.md` / `memory/` block (AC4) — `TestScaffoldGitignoreHasMemorySinkBlock`
+- [x] Implement the gitignore block — added to the embedded `cli/internal/initrepo/templates/gitignore` (the scaffold copies it verbatim) → **GREEN** (AC4)
+- [x] Failing Go test: `dotf doctor` install is idempotent — wires `core.hooksPath` only when unset (under `--fix`); re-run on an already-correct value is a no-op; an unrelated pre-existing `core.hooksPath` is preserved, not clobbered (AC5) — `TestCheckGuardHooks_*` (5 cases)
+- [x] Implement the install/repair check `checkGuardHooks` in `cli/internal/doctor/checks_guard.go` (wire `git config --global core.hooksPath` at the deployed `git-hooks/`, fail-fast if the dispatcher is undeployed) → **GREEN** (AC5). *Chosen over a bats end-to-end so CI never mutates a real `~/.gitconfig`; the `System` injection covers the full contract.*
+- [x] AGENTS.md: added the **MEMORY SINGLE-SINK (GUARD-001)** rule once (vault = only memory sink; Hive = the memory API over it) + `tests/agents-md.bats` grep assertion (AC6)
+- [x] Cross-OS parity: AC4/5/6 add no new shell — AC4 is a template, AC5 is Go (`dotf doctor`, cross-compiled), AC6 is docs; the POSIX dispatcher from #409 is unchanged (R5 holds, no `.ps1` mirror needed)
 
 ## Closing
 

--- a/specs/GUARD-001-memory-sink-precommit/verification.md
+++ b/specs/GUARD-001-memory-sink-precommit/verification.md
@@ -5,7 +5,7 @@ created: "2026-06-16"
 
 # Verification - GUARD-001-memory-sink-precommit
 
-> Status: **implementing** — this PR ships the AC1/AC2/AC3 mechanism + tests; AC4/AC5/AC6 are follow-up (same #398).
+> Status: **verifying** — #409 shipped AC1/AC2/AC3 (the dispatcher + chaining). This follow-up PR completes AC4 (gitignore), AC5 (idempotent `dotf doctor` install), AC6 (AGENTS.md rule) and closes #398.
 
 ## Evidence
 
@@ -14,15 +14,17 @@ Map every acceptance criterion from `proposal.md` to concrete proof (commit hash
 - [x] AC1 (reject in non-vault repo) -> bats `tests/guard-memory-sink.bats::"AC1: rejects MEMORY.md committed to a non-vault repo"` (+ `memory/` path + normal-file-allowed variants)
 - [x] AC2 (allow in vault) -> bats `tests/guard-memory-sink.bats::"AC2: allows MEMORY.md inside the vault (sentinel .obsidian/)"` + `"AC2: allows MEMORY.md when repo root == VAULT_PATH"`
 - [x] AC3 (chaining preserves local hook) -> bats `tests/guard-memory-sink.bats::"AC3: chains to repo-local .git/hooks/pre-commit (both run)"` (+ failure-propagation + no-local-hook variants)
-- [ ] AC4 (dotf init gitignore block) -> Go `initrepo.TestScaffoldGitignoreMemoryBlock` — **follow-up**
-- [ ] AC5 (idempotent install) -> bats `guard-install.bats::idempotent + preserves existing hooksPath` — **follow-up**
-- [ ] AC6 (AGENTS.md single-sink) -> grep assertion in CI / bats — **follow-up**
+- [x] AC4 (dotf init gitignore block) -> Go `initrepo.TestScaffoldGitignoreHasMemorySinkBlock` (scaffolded `.gitignore` ignores `MEMORY.md` + `memory/`)
+- [x] AC5 (idempotent install) -> Go `doctor.TestCheckGuardHooks_*` (5 cases: missing-dispatcher FAIL · unset→FAIL in check / FIX-wires under `--fix` · already-wired no-op · unrelated preserved-not-clobbered)
+- [x] AC6 (AGENTS.md single-sink) -> bats `tests/agents-md.bats::"AGENTS.md states the memory single-sink rule (GUARD-001, AC6)"`
 
 ## Test status
 
-- Test suite: `bats tests/guard-memory-sink.bats` -> 8/8 ok (AC1 reject ×2 + allow; AC2 vault sentinel + VAULT_PATH; AC3 chain runs + propagates failure + runs without local hook)
-- Drift guard: `bats tests/architecture-md.bats` -> 5/5 ok (`git-hooks/` declared in `docs/architecture.md`)
-- No regressions in existing test suite: yes (only the two affected guards run here; full suite runs in CI `test` job)
+- AC1-3 suite (from #409): `bats tests/guard-memory-sink.bats` -> 8/8 ok
+- AC4: `cd cli && go test ./internal/initrepo/` -> ok (`TestScaffoldGitignoreHasMemorySinkBlock` + existing scaffold tests)
+- AC5: `cd cli && go test ./internal/doctor/` -> ok (5 new `TestCheckGuardHooks` cases); `go vet ./...` clean; full `go test ./...` -> all packages ok
+- AC6: `bats tests/agents-md.bats` -> ok; `bats tests/compile-harness.bats` -> 0 failures (the AGENTS.md edit did not break the HARNESS SSOT/compiler)
+- No regressions: yes — full CLI suite + the affected bats suites all green.
 
 ## Decisions made during implementation
 
@@ -30,6 +32,7 @@ Brief log of non-obvious trade-offs or course corrections taken during the work.
 
 - R1 (chaining): **DECIDED 2026-06-16 — Option A, multi-hook chaining dispatcher.** Global `core.hooksPath` (dotfiles `.gitconfig`) → tracked `git-hooks/` dir with one dispatcher per hook type (`pre-commit`/`commit-msg`/`prepare-commit-msg`/`pre-push`); each runs its global concern then execs the literal `<toplevel>/.git/hooks/<type>`. Per-repo layer installed as a stable `.git/hooks/<type>` calling `pre-commit run` (not `pre-commit install`, whose location the global hooksPath would hijack).
 - R2 (vault detection): recommendation = sentinel (`.obsidian/` at repo root) + `$VAULT_PATH` fallback — confirm as built.
+- AC5 (install, this PR): the global `core.hooksPath` is **never clobbered** when it already points elsewhere — a machine-wide setting has too much blast radius to overwrite silently. An unrelated value is a WARN (preserve + tell the human); only an unset one is wired, and only under `--fix`; an already-correct value is a no-op. Implemented as a `dotf doctor` check (Go, `System`-injected) rather than a bats end-to-end so CI never mutates a real `~/.gitconfig`.
 
 ## Promotion candidates
 

--- a/tests/agents-md.bats
+++ b/tests/agents-md.bats
@@ -10,6 +10,14 @@ setup() {
     [[ -f "$AGENTS_MD" ]]
 }
 
+@test "AGENTS.md states the memory single-sink rule (GUARD-001, AC6)" {
+    grep -qF 'MEMORY SINGLE-SINK' "$AGENTS_MD"
+    grep -qF 'only' "$AGENTS_MD"
+    grep -qF 'Hive is the memory API' "$AGENTS_MD"
+    grep -qF 'core.hooksPath' "$AGENTS_MD"
+    grep -qF 'MEMORY.md' "$AGENTS_MD"
+}
+
 @test "AGENTS.md has Spec-Driven Development H2 section (pre-existing, regression guard)" {
     grep -qE '^## Spec-Driven Development$' "$AGENTS_MD"
 }


### PR DESCRIPTION
## What

Completes the cross-agent memory single-sink convention on top of the #409 dispatcher, finishing GUARD-001's acceptance criteria.

- **AC5 — global activation (`dotf doctor`).** `checkGuardHooks` wires the dispatcher machine-wide via `git config --global core.hooksPath`, pointing at the deployed `git-hooks/` dir. This is what makes #409 actually run — until it is wired, the dispatcher is inert. **Safety-first:** an unrelated pre-existing `core.hooksPath` is **never clobbered** (a global hooksPath has machine-wide blast radius) — it is surfaced as a WARN; only an *unset* value is wired, and only under `--fix`; an already-correct value is a no-op. If the dispatcher is not deployed, the check fails fast instead of pointing git at a missing hook.
- **AC4 — born-correct repos (`dotf init`).** The scaffolded `.gitignore` now carries a `MEMORY.md` / `memory/` block, so a fresh repo can never commit memory artifacts even before the global guard is installed.
- **AC6 — the rule, stated once.** AGENTS.md gains a **MEMORY SINGLE-SINK (GUARD-001)** principle: the vault is the only memory sink, Hive is the memory API over it, and the global guard + gitignore enforce it — never bypass with `--no-verify`.

## Why AC5 is a Go `dotf doctor` check, not a bats install test

The contract (idempotent · wire-only-when-unset · preserve-unrelated · fail-on-undeployed) is fully covered by 5 `System`-injected unit tests that assert the exact git commands issued — without ever mutating a real `~/.gitconfig` in CI.

## Tests

- AC5: `cd cli && go test ./internal/doctor/ -run TestCheckGuardHooks` — 5 cases (missing-dispatcher FAIL · unset→FAIL in check / FIX-wires under `--fix` · already-wired no-op · unrelated preserved-not-clobbered).
- AC4: `cd cli && go test ./internal/initrepo/ -run TestScaffoldGitignoreHasMemorySinkBlock`.
- AC6: `bats tests/agents-md.bats`; `bats tests/compile-harness.bats` confirms the AGENTS.md edit did not break the HARNESS SSOT.
- Full `go test ./...` + `go vet` clean; pre-commit suite green.

Spec: `specs/GUARD-001-memory-sink-precommit/` (AC4/5/6 ticked, verification updated). Closes #398.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The doctor command now verifies the pre-commit hook “memory single-sink” wiring and can automatically configure `core.hooksPath` when needed (idempotent; won’t clobber unrelated existing settings).

* **Documentation**
  * Updated the agent memory guidance to enforce the “memory single-sink” rule (vault-only storage; Hive as the memory API).

* **Chores**
  * Project initialization now updates `.gitignore` to exclude `MEMORY.md` and the `memory/` directory from commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->