### PR TITLE
fix(ci): deterministic Windows tool install — age, eza, zoxide (BUG-025/024)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,28 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install age (needed before setup for the secrets sandbox)
-        run: choco install age.portable -y --no-progress
+      # Deterministic age install. `choco install age.portable` reported success
+      # but intermittently left age-keygen unresolvable on PATH in the next step
+      # (chocolatey shim/PATH propagation flake), false-reddening unrelated PRs
+      # (BUG-025; sibling of the eza flake BUG-024/#414). Fetch the pinned
+      # official release instead, wire it onto PATH explicitly, and verify both
+      # binaries resolve here so a layout change fails loudly at install time —
+      # not as a cryptic "age-keygen not recognized" downstream.
+      - name: Install age (deterministic release — choco-shim flake guard, BUG-025)
+        shell: pwsh
+        run: |
+          $ver = ((Get-Content versions.conf | Select-String '^AGE_VERSION=').Line -split '=', 2)[1]
+          if (-not $ver) { throw "AGE_VERSION missing from versions.conf" }
+          $ver = $ver.Trim()
+          $url = "https://github.com/FiloSottile/age/releases/download/v$ver/age-v$ver-windows-amd64.zip"
+          $dest = "$env:USERPROFILE\age-dist"
+          Invoke-WebRequest -Uri $url -OutFile age.zip
+          Expand-Archive -Path age.zip -DestinationPath $dest -Force
+          $ageDir = Join-Path $dest 'age'
+          Add-Content $env:GITHUB_PATH $ageDir
+          # Guard the guard: fail here if the binaries are not where we expect.
+          & (Join-Path $ageDir 'age.exe') --version
+          & (Join-Path $ageDir 'age-keygen.exe') --version
 
       - name: Sandbox secrets + minimal vault
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,11 +170,38 @@ jobs:
           DOTFILES_REPO_DIR: ${{ github.workspace }}
         run: .\setup-windows.ps1
 
-      - name: Ensure core tools (winget-less runner fallback)
+      # Deterministic eza + zoxide install. `choco install` left them
+      # unresolvable on PATH for the healthcheck step (BUG-024/#414, the same
+      # chocolatey shim/PATH flake as age). Fetch the pinned official releases,
+      # extract onto a single dir wired into $GITHUB_PATH, and verify both
+      # resolve here. jq is preinstalled on the runner, so it keeps a choco
+      # fallback only if genuinely absent.
+      - name: Ensure core tools (deterministic eza/zoxide — flake guard, BUG-024)
         shell: pwsh
         run: |
-          $missing = @('jq', 'eza', 'zoxide') | Where-Object { -not (Get-Command $_ -ErrorAction SilentlyContinue) }
-          if ($missing) { choco install @missing -y --no-progress }
+          function Read-Pin($key) {
+            $line = (Get-Content versions.conf | Select-String "^$key=").Line
+            if (-not $line) { throw "$key missing from versions.conf" }
+            return ($line -split '=', 2)[1].Trim()
+          }
+          $bin = "$env:USERPROFILE\ci-tools"
+          New-Item -ItemType Directory -Force $bin | Out-Null
+
+          $ezaVer = Read-Pin 'EZA_VERSION'
+          Invoke-WebRequest "https://github.com/eza-community/eza/releases/download/v$ezaVer/eza.exe_x86_64-pc-windows-gnu.zip" -OutFile eza.zip
+          Expand-Archive eza.zip -DestinationPath $bin -Force
+
+          $zoxVer = Read-Pin 'ZOXIDE_VERSION'
+          Invoke-WebRequest "https://github.com/ajeetdsouza/zoxide/releases/download/v$zoxVer/zoxide-$zoxVer-x86_64-pc-windows-msvc.zip" -OutFile zoxide.zip
+          Expand-Archive zoxide.zip -DestinationPath $bin -Force
+
+          Add-Content $env:GITHUB_PATH $bin
+
+          if (-not (Get-Command jq -ErrorAction SilentlyContinue)) { choco install jq -y --no-progress }
+
+          # Guard the guard: fail here if the extracted binaries are not present.
+          & "$bin\eza.exe" --version
+          & "$bin\zoxide.exe" --version
 
       - name: Run healthcheck.ps1
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       # official release instead, wire it onto PATH explicitly, and verify both
       # binaries resolve here so a layout change fails loudly at install time —
       # not as a cryptic "age-keygen not recognized" downstream.
-      - name: Install age (deterministic release — choco-shim flake guard, BUG-025)
+      - name: Install age (deterministic release + registry PATH — BUG-025)
         shell: pwsh
         run: |
           $ver = ((Get-Content versions.conf | Select-String '^AGE_VERSION=').Line -split '=', 2)[1]
@@ -134,6 +134,16 @@ jobs:
           Expand-Archive -Path age.zip -DestinationPath $dest -Force
           $ageDir = Join-Path $dest 'age'
           Add-Content $env:GITHUB_PATH $ageDir
+          # setup-windows.ps1 rebuilds $env:PATH from the Machine+User registry
+          # (dropping process-level $GITHUB_PATH additions), so age must ALSO live
+          # on the registry PATH or load-secrets.ps1 silently returns without
+          # exporting NAN_API_KEY — leaving pi's models.json {env:...} placeholder
+          # unresolved at deploy time. choco's age went onto the Machine PATH and
+          # survived that rebuild; this restores the property via the User PATH.
+          $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+          if ($userPath -notlike "*$ageDir*") {
+            [Environment]::SetEnvironmentVariable('PATH', "$userPath;$ageDir", 'User')
+          }
           # Guard the guard: fail here if the binaries are not where we expect.
           & (Join-Path $ageDir 'age.exe') --version
           & (Join-Path $ageDir 'age-keygen.exe') --version

--- a/versions.conf
+++ b/versions.conf
@@ -8,9 +8,13 @@ PYTHON_VERSION=3.12.6
 MINIKUBE_VERSION=1.34.0
 GO_VERSION=1.26.0
 BATS_VERSION=1.13.0
-# AGE_VERSION pins the deterministic age release the Windows CI secrets sandbox
-# downloads (Linux CI uses apt). Removes the choco-shim PATH flake (BUG-025).
+# AGE_VERSION / EZA_VERSION / ZOXIDE_VERSION pin the deterministic release
+# binaries the Windows CI downloads instead of choco-installing, which left them
+# unresolvable on PATH between steps (BUG-025 age, BUG-024 eza/zoxide). Linux CI
+# and the dev-machine setup install these by other means and ignore these pins.
 AGE_VERSION=1.3.1
+EZA_VERSION=0.23.4
+ZOXIDE_VERSION=0.9.9
 OBSIDIAN_VERSION=1.12.4
 OPENCODE_VERSION=1.16.2
 YARN_VERSION=1.22.22

--- a/versions.conf
+++ b/versions.conf
@@ -8,6 +8,9 @@ PYTHON_VERSION=3.12.6
 MINIKUBE_VERSION=1.34.0
 GO_VERSION=1.26.0
 BATS_VERSION=1.13.0
+# AGE_VERSION pins the deterministic age release the Windows CI secrets sandbox
+# downloads (Linux CI uses apt). Removes the choco-shim PATH flake (BUG-025).
+AGE_VERSION=1.3.1
 OBSIDIAN_VERSION=1.12.4
 OPENCODE_VERSION=1.16.2
 YARN_VERSION=1.22.22


### PR DESCRIPTION
## What

Replaces the flaky `choco install` of **age**, **eza**, and **zoxide** in the `test-windows` job with deterministic fetches of their pinned official releases (`AGE_VERSION` / `EZA_VERSION` / `ZOXIDE_VERSION` in `versions.conf`), each wired explicitly onto `$GITHUB_PATH` and `--version`-verified in the same step. jq keeps a choco fallback only when genuinely absent (it is preinstalled on the runner).

## Why

`choco install` reports success but intermittently leaves the binary unresolvable on PATH in the next step (chocolatey shim/PATH-propagation flake on hosted runners), false-reddening unrelated PRs.

- **age** (BUG-025/#424): false-reddened the secret-rotation PR #423 — `The term 'age-keygen' is not recognized`. The *same commit* passed `test-windows` on its first run and failed on a re-trigger → environmental flake, not a code defect.
- **eza + zoxide** (BUG-024/#414): `FAIL: eza not in PATH` / `zoxide not in PATH` in `healthcheck.ps1`. Surfaced again on this PR's own first run once the age fix unblocked the job (it produced `PASS: age found`).

## How it's robust

- **Pinned + deterministic:** official GitHub releases, versions from the `versions.conf` SSOT — no chocolatey CDN / shim dependency.
- **Explicit PATH:** extracted dirs appended to `$GITHUB_PATH`, so downstream steps resolve the binaries without relying on choco's machine-PATH refresh.
- **Guard the guard:** each tool's `--version` runs in its install step, so a future release-layout change fails loudly *there* with a clear cause — not as a cryptic downstream error.
- Archive layouts verified before pushing (eza zip → `eza.exe`; zoxide zip → `zoxide.exe`; age zip → `age/age.exe` + `age/age-keygen.exe`).

## Verification

- `versions-conf.bats`: 14/14 green (semver pattern accepts the new pins; sources under bash + zsh).
- `ci.yml` parses as valid YAML (5 jobs intact).
- End-to-end Windows validation runs on this PR's own `test-windows` job.

## SDD skip rationale

CI-only change. It replaces non-deterministic chocolatey installs with pinned release downloads in the `test-windows` job — no production code, no public contract, no new runtime dependency, purely infra-flake hardening. A full `specs/` lifecycle would be ceremony disproportionate to a tool-install fix; the work is tracked by BUG-025 (#424) and BUG-024 (#414), which this PR closes.

Closes #424. Closes #414.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Windows CI pipeline with deterministic pinned tool versions for improved build reliability and consistency across test environments.
  * Added version configuration for enhanced control over CI dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->