### PR TITLE
fix(doctor): resolve PAT from any mapped env alias, not just the first

### DIFF
--- a/cli/internal/doctor/checks_pat.go
+++ b/cli/internal/doctor/checks_pat.go
@@ -23,11 +23,12 @@ const (
 )
 
 // patSecret is a GitHub PAT-backed mapping: the age-blob filename (the dedupe
-// key — github.token is mapped by two env vars) and a representative env var to
-// read the live token value from.
+// key) plus every env var that maps to it. github.token is mapped by BOTH
+// GITHUB_PERSONAL_ACCESS_TOKEN and RELEASE_TOKEN, so all aliases are kept — any
+// one being exported is enough to probe the token (the first non-empty wins).
 type patSecret struct {
-	filename string // e.g. "github.token"
-	envVar   string // e.g. "GITHUB_PERSONAL_ACCESS_TOKEN"
+	filename string   // e.g. "github.token"
+	envVars  []string // e.g. ["GITHUB_PERSONAL_ACCESS_TOKEN", "RELEASE_TOKEN"]
 }
 
 // checkPATExpiry probes each GitHub PAT-backed secret for liveness + days to
@@ -48,62 +49,87 @@ func checkPATExpiry(sys *System, cfg *Config, rep *Report) {
 	}
 
 	warnDays := patWarnDays(sys, rep)
-
 	for _, s := range secrets {
-		token := sys.Getenv(s.envVar)
-		if token == "" {
-			rep.Skip(fmt.Sprintf("%s (%s) not in environment — run secrets_refresh", s.filename, s.envVar))
-			continue
-		}
+		probePATSecret(sys, s, warnDays, rep)
+	}
+}
 
-		status, hdr, err := sys.HTTPGet(githubAPIUser, map[string]string{
-			"Authorization": "Bearer " + token,
-			"Accept":        "application/vnd.github+json",
-			"User-Agent":    "dotf-doctor",
-		})
-		switch {
-		case err != nil:
-			rep.Warn(fmt.Sprintf("%s: could not reach api.github.com (%v) — liveness check skipped", s.filename, err))
-			continue
-		case status == http.StatusUnauthorized:
-			rep.Fail(fmt.Sprintf("%s: token invalid or expired (HTTP 401) — rotate it", s.filename))
-			continue
-		case status != http.StatusOK:
-			rep.Warn(fmt.Sprintf("%s: unexpected HTTP %d from api.github.com — liveness inconclusive", s.filename, status))
-			continue
+// resolvePATToken returns the first non-empty value among the secret's env
+// aliases. github.token is mapped by both GITHUB_PERSONAL_ACCESS_TOKEN and
+// RELEASE_TOKEN; either being exported is enough to probe it, so a single unset
+// alias never produces a false SKIP.
+func resolvePATToken(sys *System, s patSecret) string {
+	for _, v := range s.envVars {
+		if val := sys.Getenv(v); val != "" {
+			return val
 		}
+	}
+	return ""
+}
 
+// probePATSecret runs the liveness probe for one secret and reports its outcome.
+// Split out of checkPATExpiry to keep both within the < 40-line / < 10-complexity
+// budget (AGENTS.md). HTTP 401 → FAIL (the only non-zero-exit branch); transport
+// error or non-200 → WARN; 200 hands off to reportPATExpiry for the expiry math.
+func probePATSecret(sys *System, s patSecret, warnDays int, rep *Report) {
+	token := resolvePATToken(sys, s)
+	if token == "" {
+		rep.Skip(fmt.Sprintf("%s (%s) not in environment — run secrets_refresh", s.filename, strings.Join(s.envVars, ", ")))
+		return
+	}
+
+	status, hdr, err := sys.HTTPGet(githubAPIUser, map[string]string{
+		"Authorization": "Bearer " + token,
+		"Accept":        "application/vnd.github+json",
+		"User-Agent":    "dotf-doctor",
+	})
+	switch {
+	case err != nil:
+		rep.Warn(fmt.Sprintf("%s: could not reach api.github.com (%v) — liveness check skipped", s.filename, err))
+	case status == http.StatusUnauthorized:
+		rep.Fail(fmt.Sprintf("%s: token invalid or expired (HTTP 401) — rotate it", s.filename))
+	case status != http.StatusOK:
+		rep.Warn(fmt.Sprintf("%s: unexpected HTTP %d from api.github.com — liveness inconclusive", s.filename, status))
+	default:
 		// 200 OK: the token authenticates. Worst case from here is "rotate soon"
 		// (WARN), never FAIL — a token that just succeeded is not dead.
-		raw := strings.TrimSpace(hdr.Get(patExpiryHeader))
-		if raw == "" {
-			rep.Pass(fmt.Sprintf("%s: valid, no expiry set", s.filename))
-			continue
-		}
-		exp, perr := parsePATExpiry(raw)
-		if perr != nil {
-			rep.Warn(fmt.Sprintf("%s: valid, but could not parse expiry %q — %v", s.filename, raw, perr))
-			continue
-		}
+		reportPATExpiry(s.filename, hdr, sys.Now(), warnDays, rep)
+	}
+}
 
-		day := exp.Format("2006-01-02")
-		days := int(exp.Sub(sys.Now()).Hours() / 24)
-		switch {
-		case days <= 0:
-			rep.Warn(fmt.Sprintf("%s: at/just past its stated expiry (%s) but still accepted — rotate now", s.filename, day))
-		case days <= warnDays:
-			rep.Warn(fmt.Sprintf("%s: expires in %d day(s) (%s) — rotate soon", s.filename, days, day))
-		default:
-			rep.Pass(fmt.Sprintf("%s: valid, expires in %d day(s) (%s)", s.filename, days, day))
-		}
+// reportPATExpiry classifies the expiry header on a 200 response: absent header
+// (non-expiring token) → PASS; at/past expiry → WARN; within warnDays → WARN;
+// otherwise PASS with the runway.
+func reportPATExpiry(filename string, hdr http.Header, now time.Time, warnDays int, rep *Report) {
+	raw := strings.TrimSpace(hdr.Get(patExpiryHeader))
+	if raw == "" {
+		rep.Pass(fmt.Sprintf("%s: valid, no expiry set", filename))
+		return
+	}
+	exp, err := parsePATExpiry(raw)
+	if err != nil {
+		rep.Warn(fmt.Sprintf("%s: valid, but could not parse expiry %q — %v", filename, raw, err))
+		return
+	}
+
+	day := exp.Format("2006-01-02")
+	days := int(exp.Sub(now).Hours() / 24)
+	switch {
+	case days <= 0:
+		rep.Warn(fmt.Sprintf("%s: at/just past its stated expiry (%s) but still accepted — rotate now", filename, day))
+	case days <= warnDays:
+		rep.Warn(fmt.Sprintf("%s: expires in %d day(s) (%s) — rotate soon", filename, days, day))
+	default:
+		rep.Pass(fmt.Sprintf("%s: valid, expires in %d day(s) (%s)", filename, days, day))
 	}
 }
 
 // githubPATSecrets parses env-mapping.conf and returns the unique github.*
-// PAT-backed secrets, one per .age filename (github.token is mapped by both
-// GITHUB_PERSONAL_ACCESS_TOKEN and RELEASE_TOKEN — probed once). The first env
-// var seen for a filename is the representative value source. A missing or
-// unreadable mapping yields nil (checkSecrets owns the "mapping exists" assertion).
+// PAT-backed secrets, one per .age filename, each carrying ALL of its env
+// aliases (github.token is mapped by both GITHUB_PERSONAL_ACCESS_TOKEN and
+// RELEASE_TOKEN — kept together so it is probed once but resolvable from either).
+// A missing or unreadable mapping yields nil (checkSecrets owns the "mapping
+// exists" assertion).
 func githubPATSecrets(cfg *Config) []patSecret {
 	mapping := filepath.Join(cfg.DotfilesDir, "sensitive", "env-mapping.conf")
 	raw, err := os.ReadFile(mapping)
@@ -111,7 +137,7 @@ func githubPATSecrets(cfg *Config) []patSecret {
 		return nil
 	}
 
-	seen := map[string]bool{}
+	idx := map[string]int{} // filename → index into out
 	var out []patSecret
 	for _, line := range strings.Split(string(raw), "\n") {
 		line = strings.TrimSpace(line)
@@ -129,11 +155,15 @@ func githubPATSecrets(cfg *Config) []patSecret {
 			fname = strings.TrimSpace(fname)
 			varName = strings.TrimPrefix(varName, "@")
 		}
-		if !strings.HasPrefix(fname, "github.") || seen[fname] {
+		if !strings.HasPrefix(fname, "github.") {
 			continue
 		}
-		seen[fname] = true
-		out = append(out, patSecret{filename: fname, envVar: varName})
+		if i, ok := idx[fname]; ok {
+			out[i].envVars = append(out[i].envVars, varName)
+			continue
+		}
+		idx[fname] = len(out)
+		out = append(out, patSecret{filename: fname, envVars: []string{varName}})
 	}
 	return out
 }

--- a/cli/internal/doctor/checks_pat_test.go
+++ b/cli/internal/doctor/checks_pat_test.go
@@ -134,6 +134,34 @@ func TestCheckPATExpiry_ProbesEachFilenameOnce(t *testing.T) {
 	}
 }
 
+// TestCheckPATExpiry_FallsBackToSecondAlias guards the alias-resolution fix:
+// github.token is mapped by both GITHUB_PERSONAL_ACCESS_TOKEN and RELEASE_TOKEN.
+// When only the SECOND alias is exported, the token must still be probed — a
+// single unset alias must not yield a false SKIP.
+func TestCheckPATExpiry_FallsBackToSecondAlias(t *testing.T) {
+	mapping := "GITHUB_PERSONAL_ACCESS_TOKEN=github.token\n" +
+		"RELEASE_TOKEN=github.token\n"
+
+	sys := newSys(map[string]string{"RELEASE_TOKEN": "tok"}, nil, nil) // first alias unset
+	sys.Now = func() time.Time { return fixedTestNow }
+	var calls int
+	sys.HTTPGet = func(string, map[string]string) (int, http.Header, error) {
+		calls++
+		return http.StatusOK, http.Header{}, nil
+	}
+
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	checkPATExpiry(sys, patCfg(t, mapping), rep)
+
+	if calls != 1 {
+		t.Fatalf("a set fallback alias must be probed, not SKIPped; got %d probe(s)\n%s", calls, buf.String())
+	}
+	if strings.Contains(buf.String(), "not in environment") {
+		t.Fatalf("must not report SKIP when a fallback alias is set\n%s", buf.String())
+	}
+}
+
 // TestCheckPATExpiry_QuickSkipsProbe covers AC4: the SessionStart hot path
 // (--quick) must stay fork-free and offline, so a full Run with Quick:true makes
 // zero HTTP probes even with a token in the environment.

--- a/cli/internal/doctor/system.go
+++ b/cli/internal/doctor/system.go
@@ -10,6 +10,7 @@
 package doctor
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
@@ -55,7 +56,7 @@ func realSystem() *System {
 		HTTPGet: func(url string, headers map[string]string) (int, http.Header, error) {
 			req, err := http.NewRequest(http.MethodGet, url, nil)
 			if err != nil {
-				return 0, nil, err
+				return 0, nil, fmt.Errorf("build request %q: %w", url, err)
 			}
 			for k, v := range headers {
 				req.Header.Set(k, v)
@@ -63,7 +64,7 @@ func realSystem() *System {
 			client := &http.Client{Timeout: 5 * time.Second}
 			resp, err := client.Do(req)
 			if err != nil {
-				return 0, nil, err
+				return 0, nil, fmt.Errorf("GET %q: %w", url, err)
 			}
 			defer func() { _ = resp.Body.Close() }()
 			return resp.StatusCode, resp.Header, nil

--- a/specs/OPS-009-pat-expiry-preflight/verification.md
+++ b/specs/OPS-009-pat-expiry-preflight/verification.md
@@ -12,7 +12,7 @@ created: "2026-06-17"
 
 ## Evidence
 
-- [x] **AC1** (one probe per unique `github.*` filename) → `TestCheckPATExpiry_ProbesEachFilenameOnce`: `github.token` mapped by both `GITHUB_PERSONAL_ACCESS_TOKEN` and `RELEASE_TOKEN`, plus a non-github `dockerhub.token`; asserts the recording `HTTPGet` is called **exactly once**.
+- [x] **AC1** (one probe per unique `github.*` filename) → `TestCheckPATExpiry_ProbesEachFilenameOnce`: `github.token` mapped by both `GITHUB_PERSONAL_ACCESS_TOKEN` and `RELEASE_TOKEN`, plus a non-github `dockerhub.token`; asserts the recording `HTTPGet` is called **exactly once**. `TestCheckPATExpiry_FallsBackToSecondAlias` further asserts that when only the *second* alias is exported the token is still probed (no false SKIP) — `patSecret` keeps every alias and resolves the first non-empty one.
 - [x] **AC2** (classification on every branch) → `TestCheckPATExpiry_Classification` table, one row per branch: HTTP 401 → FAIL (`Failures()==1`); expiry ≤ threshold → WARN; valid+runway → PASS; token env-unset → SKIP; network error → WARN; plus 200/no-header → PASS, unexpected 500 → WARN, at/past-expiry-but-200 → WARN.
 - [x] **AC3** (threshold default 14, override via `DOTF_PAT_EXPIRY_WARN_DAYS`) → table rows: a fixed 20-day runway is **PASS** at the default 14 and flips to **WARN** under `DOTF_PAT_EXPIRY_WARN_DAYS=30`; a non-numeric override (`abc`) falls back to 14 and emits a WARN.
 - [x] **AC4** (not invoked under `--quick`) → `TestCheckPATExpiry_QuickSkipsProbe`: `Run(Options{Quick:true})` with a token in env and a recording `HTTPGet` → **zero** HTTP calls.
@@ -23,7 +23,7 @@ created: "2026-06-17"
 ## Test status
 
 - `go test ./...` (from `cli/`) → all packages `ok` (`internal/doctor` included).
-- `go test ./internal/doctor/ -run TestCheckPATExpiry -v` → 4 tests / 15 subtests, all PASS.
+- `go test ./internal/doctor/ -run TestCheckPATExpiry -v` → 5 test functions (11 classification subtests + 4 scenario tests), all PASS.
 - `go vet ./internal/doctor/` → clean (the two `unused parameter: sys` infos are pre-existing on `loadContractSection`/`checkSecrets`, not this change).
 - `actionlint .github/workflows/pat-expiry.yml` → clean.
 - `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pat-expiry.yml'))"` → valid; `bash -n` on the extracted `run` block → clean.
@@ -37,11 +37,14 @@ created: "2026-06-17"
 - **Action does its own probe (no shell-out to the binary):** `Report.ExitCode()` is non-zero only on FAIL, so WARN ("expiring soon") is invisible to exit status — `dotf doctor` could not signal "expiring" to CI. The workflow re-implements the ~15-line probe instead; the duplication is deliberate and documented (R5/R7).
 - **Issue dedupe:** a fixed `pat-expiry` label + stable per-secret title (`PAT expiry: <NAME>`); an existing open issue is **commented**, not duplicated, so a weekly cron never spams (R6). The label is created idempotently (`gh label create --force`) before the first `gh issue create`.
 - **Injection-safe workflow:** every `${{ }}` (the `warn_days` dispatch input, the three secrets, `GITHUB_TOKEN`) is bound through the job `env:` block and consumed as a quoted `${VAR}` in `run:`; no untrusted event field is interpolated into the script. Token names are hardcoded literals.
+- **Multi-alias resolution (post-review):** CodeRabbit flagged that the original dedupe kept only the first env alias per `.age` filename, so a shell with only `RELEASE_TOKEN` (not `GITHUB_PERSONAL_ACCESS_TOKEN`) set would falsely SKIP `github.token`. Fixed: `patSecret.envVars` now holds all aliases and `resolvePATToken` probes the first non-empty one. `checkPATExpiry` was also split into `probePATSecret` + `reportPATExpiry` to stay within the AGENTS.md < 40-line / < 10-complexity budget, and the `realSystem` `HTTPGet` errors are now wrapped with the URL.
+- **Deviation — `context.Context` not threaded through `System` (AGENTS.md "propagate context in all I/O"):** the 5s client timeout already bounds the only network call, and `doctor.Run` has no cancellable parent context; adding it to `HTTPGet` alone (while `LookPath`/`CommandOutput` stay context-free) would be an inconsistent partial change. Deferred to a seam-wide refactor — see promotion candidate below.
 
 ## Promotion candidates
 
 - [ ] Vault pattern `secrets-rotation` (cross-repo): "every repo with PAT-backed Actions secrets needs an expiry preflight — detect before the red CI run, dedupe the reminder by label+title". Generalises beyond dotfiles.
 - [ ] Lesson for `docs/lessons.md`: "a WARN that doesn't move the exit code can't be observed by CI via the tool's status — give the CI surface its own probe rather than shelling out" (the R7 generalisation).
+- [ ] Follow-up ticket (REFACTOR): thread `context.Context` through the whole `doctor.System` seam (`HTTPGet` + `CommandOutput`) and propagate from `doctor.Run`, satisfying the AGENTS.md I/O-context rule consistently rather than per-method.
 
 ## Archive checklist
 


### PR DESCRIPTION
## What

Follow-up to #427 (merged), applying the actionable CodeRabbit review findings
that landed after the squash-merge. Branch is current `main` + a single fix
commit.

### Fix (correctness) — resolve a PAT from any of its mapped env aliases

`githubPATSecrets` deduped `github.*` secrets by `.age` filename but kept only
the **first** env alias, and `checkPATExpiry` probed only that one. `github.token`
is mapped by both `GITHUB_PERSONAL_ACCESS_TOKEN` and `RELEASE_TOKEN`
(`sensitive/env-mapping.conf:10-11`), so a shell that exports only the second
alias would falsely report the token as **SKIP** and never probe it.

`patSecret` now carries every alias (`envVars []string`); `resolvePATToken`
returns the first non-empty value. Covered by
`TestCheckPATExpiry_FallsBackToSecondAlias`.

### Cleanups (from the same review)

- Split `checkPATExpiry` into `probePATSecret` + `reportPATExpiry` so each stays
  within the AGENTS.md < 40-line / complexity-10 budget.
- Wrap the `realSystem` `HTTPGet` errors with the request URL.

## Not applied (with rationale, recorded in verification.md)

- **Thread `context.Context` through `System`** — deferred to a seam-wide
  refactor; the 5s client timeout already bounds the only network call, and
  adding context to `HTTPGet` alone (while `LookPath`/`CommandOutput` stay
  context-free) would be an inconsistent partial change.
- **Consolidate the scenario tests into one table** — they exercise genuinely
  different setups (`Run` with `--quick` vs direct `checkPATExpiry` calls);
  forcing one table reduces clarity. The classification path is already
  table-driven.

## Verification

- `go test ./...` — all packages green; `TestCheckPATExpiry*` includes the new
  alias-fallback test.
- `go vet` / `gofmt` clean.
- Diff is limited to the four review-touched files (no release/version files).

Refs #427 · OPS-009


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitHub PAT expiry checking to correctly resolve tokens mapped to multiple environment variables.
  * Improved error handling for network connectivity issues in authentication checks with clearer error messages.

* **Tests**
  * Added validation for token resolution across multiple environment variable aliases.

* **Documentation**
  * Updated verification documentation for PAT expiry checking procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->