### PR TITLE
ci: add concurrency groups to CI and spec-gate workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/spec-gate.yml
+++ b/.github/workflows/spec-gate.yml
@@ -8,6 +8,10 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled, edited]
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   spec-gate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a `concurrency` block to `ci.yml`: keyed by `workflow + ref`, cancels in-progress runs only on `pull_request` events (push-to-main always completes — every mainline commit stays fully tested).
- Adds a `concurrency` block to `spec-gate.yml`: PR-only workflow so `cancel-in-progress: true` is safe and correct.

## Motivation

Without concurrency groups, superseded in-flight runs are never cancelled. Evidence from the issue:
- CI ran twice for PR #423 (both `pull_request` events for the same head).
- `spec-gate` ran 3× for a single commit (push + PR-body edit + label add).
- Primary cost: `test-windows` bills at 2× Linux minutes.

## Test plan

- [ ] Verify CI workflow has `concurrency` block with conditional `cancel-in-progress`.
- [ ] Verify spec-gate workflow has `concurrency` block with `cancel-in-progress: true`.
- [ ] Push two quick commits to a PR branch and confirm only the latest run is active (older auto-cancelled).
- [ ] Confirm a push to `main` is never cancelled by a subsequent event.
- [ ] Confirm no change to which checks are required or their pass/fail semantics.

Closes #430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline efficiency by implementing automatic cancellation of duplicate in-progress workflow runs. When new code changes are pushed or pull requests are updated, prior pending workflow runs are now automatically terminated, reducing unnecessary resource usage and providing faster build feedback during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->