### PR TITLE
feat(setup): install dotf from the published release binary on Windows (WIN-006, #451)

### DIFF
--- a/scripts/install-dotf.ps1
+++ b/scripts/install-dotf.ps1
@@ -32,9 +32,6 @@ param(
     [string]$BaseUrl = 'https://github.com/mlorentedev/dotfiles/releases/download'
 )
 
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
-
 # Map the host architecture to the goreleaser arch token, or $null when
 # unsupported (the analogue of install-dotf.sh's `return 1`).
 function Get-DotfArch {
@@ -73,6 +70,13 @@ function Install-Dotf {
         [string]$Dest = (Join-Path $env:USERPROFILE '.local\bin'),
         [string]$BaseUrl = 'https://github.com/mlorentedev/dotfiles/releases/download'
     )
+
+    # Function-scoped, so dot-sourcing this script (setup-windows.ps1 does
+    # `. install-dotf.ps1`) never leaks Stop/StrictMode into the caller's scope —
+    # only this function's body runs strict. Also required for the try/catch below
+    # to catch non-terminating errors regardless of the caller's preference.
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
 
     $work = $null
     try {

--- a/scripts/install-dotf.ps1
+++ b/scripts/install-dotf.ps1
@@ -1,0 +1,137 @@
+<#
+.SYNOPSIS
+    Fetch, verify, and install the `dotf` CLI release binary on Windows.
+
+.DESCRIPTION
+    The ADR-020 bootstrap step for Windows (WIN-006): download the pinned `dotf`
+    release zip from GitHub, verify its sha256 against the release checksums.txt,
+    and install dotf.exe to ~/.local/bin — user-space, no admin. The PowerShell
+    twin of scripts/install-dotf.sh.
+
+    Dot-sourced by setup-windows.ps1 (which then calls Install-Dotf); also runnable
+    standalone to (re)install or upgrade. DOTF_VERSION is the pinned version
+    (versions.conf SSOT); the function takes version/dest/base as parameters so
+    bats can drive it against a file:// fixture with no network.
+
+.PARAMETER Version
+    dotf version to install. Defaults to $env:DOTF_VERSION, then the DOTF_VERSION
+    line in versions.conf.
+
+.EXAMPLE
+    # One-line bootstrap — no clone, no admin:
+    irm https://raw.githubusercontent.com/mlorentedev/dotfiles/main/scripts/install-dotf.ps1 | iex
+
+.EXAMPLE
+    # From a checkout:
+    . .\scripts\install-dotf.ps1 ; Install-Dotf
+#>
+[CmdletBinding()]
+param(
+    [string]$Version,
+    [string]$Dest = (Join-Path $env:USERPROFILE '.local\bin'),
+    [string]$BaseUrl = 'https://github.com/mlorentedev/dotfiles/releases/download'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Map the host architecture to the goreleaser arch token, or $null when
+# unsupported (the analogue of install-dotf.sh's `return 1`).
+function Get-DotfArch {
+    [CmdletBinding()]
+    param([string]$Arch = $env:PROCESSOR_ARCHITECTURE)
+    switch ($Arch) {
+        'AMD64' { 'amd64'; break }
+        'ARM64' { 'arm64'; break }
+        default { $null }
+    }
+}
+
+# Resolve the pinned version: explicit arg, then $env:DOTF_VERSION, then the
+# DOTF_VERSION line in versions.conf (the SSOT). Mirrors install-dotf.sh.
+function Get-DotfVersion {
+    [CmdletBinding()]
+    param([string]$Version)
+    if ($Version) { return $Version }
+    if ($env:DOTF_VERSION) { return $env:DOTF_VERSION }
+    $versionsConf = Join-Path $PSScriptRoot '..\versions.conf'
+    if (Test-Path $versionsConf) {
+        $match = Select-String -Path $versionsConf -Pattern '^DOTF_VERSION=(.+)$' | Select-Object -First 1
+        if ($match) { return $match.Matches[0].Groups[1].Value.Trim() }
+    }
+    return $null
+}
+
+# Idempotently install the pinned dotf release. No-op when the pinned version is
+# already on PATH; converges on drift. Returns $true on success, $false on any
+# download/verify error (no binary left in Dest). Never throws — setup wires it
+# `if (-not (Install-Dotf)) { Write-Warn ... }`, the analogue of `|| log_warning`.
+function Install-Dotf {
+    [CmdletBinding()]
+    param(
+        [string]$Version,
+        [string]$Dest = (Join-Path $env:USERPROFILE '.local\bin'),
+        [string]$BaseUrl = 'https://github.com/mlorentedev/dotfiles/releases/download'
+    )
+
+    $work = $null
+    try {
+        $Version = Get-DotfVersion -Version $Version
+        if (-not $Version) {
+            throw 'no version given (set DOTF_VERSION in versions.conf)'
+        }
+        $arch = Get-DotfArch
+        if (-not $arch) {
+            throw "unsupported arch: $env:PROCESSOR_ARCHITECTURE"
+        }
+
+        # Idempotence: skip when the pinned version is already on PATH.
+        if (Get-Command dotf -ErrorAction SilentlyContinue) {
+            $current = ((& dotf version 2>$null) -split '\s+')[-1]
+            if ($current -eq $Version) {
+                Write-Host "dotf $Version already installed; skipping"
+                return $true
+            }
+            if ($current) { Write-Host "dotf $current drifted from pinned $Version; converging" }
+        }
+
+        $artifact = "dotf_${Version}_windows_${arch}.zip"
+        $work = Join-Path ([System.IO.Path]::GetTempPath()) ('dotf-' + [System.IO.Path]::GetRandomFileName())
+        New-Item -ItemType Directory -Force -Path $work | Out-Null
+
+        Invoke-WebRequest -Uri "$BaseUrl/v$Version/$artifact" -OutFile (Join-Path $work $artifact) -UseBasicParsing
+        Invoke-WebRequest -Uri "$BaseUrl/v$Version/checksums.txt" -OutFile (Join-Path $work 'checksums.txt') -UseBasicParsing
+
+        $entry = Select-String -Path (Join-Path $work 'checksums.txt') -Pattern ([regex]::Escape($artifact)) | Select-Object -First 1
+        if (-not $entry) {
+            throw "$artifact not listed in checksums.txt"
+        }
+        $expected = (($entry.Line -split '\s+') | Where-Object { $_ })[0].ToLower()
+        $actual = (Get-FileHash -Path (Join-Path $work $artifact) -Algorithm SHA256).Hash.ToLower()
+        if ($expected -ne $actual) {
+            throw "checksum mismatch for $artifact (want $expected, got $actual)"
+        }
+
+        Expand-Archive -Path (Join-Path $work $artifact) -DestinationPath $work -Force
+        $exe = Join-Path $work 'dotf.exe'
+        if (-not (Test-Path $exe)) {
+            throw "dotf.exe not found in $artifact"
+        }
+        New-Item -ItemType Directory -Force -Path $Dest | Out-Null
+        Copy-Item -Path $exe -Destination (Join-Path $Dest 'dotf.exe') -Force
+        Write-Host "dotf $Version installed to $Dest\dotf.exe"
+        return $true
+    } catch {
+        Write-Warning "install-dotf: $($_.Exception.Message)"
+        return $false
+    } finally {
+        if ($work) { Remove-Item -Recurse -Force -Path $work -ErrorAction SilentlyContinue }
+    }
+}
+
+# Standalone run-guard: install when EXECUTED, not when dot-sourced.
+# $MyInvocation.InvocationName is '.' under dot-sourcing (setup-windows.ps1 does
+# `. install-dotf.ps1`, which must only define the functions).
+if ($MyInvocation.InvocationName -ne '.') {
+    $null = Install-Dotf -Version $Version -Dest $Dest -BaseUrl $BaseUrl
+}

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -501,6 +501,21 @@ if (-not ($claudeCmd -and $npxCmd)) {
     }
 }
 
+# dotf CLI (ADR-020 / WIN-006): install the pinned release binary into ~/.local/bin
+# (user-space, no admin) — the PowerShell twin of setup-linux.sh sourcing
+# install-dotf.sh. goreleaser already publishes the Windows zip, so nothing is
+# compiled. Makes the `dotf env path` / `dotf env generate` steps below resolve
+# automatically; non-fatal, like the Linux side (`install_dotf || log_warning`).
+$installDotfScript = Join-Path $PSScriptRoot 'scripts\install-dotf.ps1'
+if (Test-Path $installDotfScript) {
+    . $installDotfScript
+    if (-not (Install-Dotf)) {
+        Write-Warn "dotf installation failed (continuing; the env steps below auto-skip)"
+    }
+} else {
+    Write-Warn "scripts\install-dotf.ps1 not found; skipping dotf install"
+}
+
 # Phase C daemon supervision (HIVE-118 / hive#176). Install the supervised
 # `hive serve` Scheduled Task now that the MCP loop's prerequisite installed/upgraded
 # the tool. Gated on hive-vault >= 1.32.0 via the package version (NOT by probing

--- a/specs/WIN-006-windows-dotf-install/features.json
+++ b/specs/WIN-006-windows-dotf-install/features.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "WIN-006-windows-dotf-install-f1",
+    "behavior": "install-dotf.ps1 exists, defines Install-Dotf/Get-DotfArch/Get-DotfVersion, fetches the windows zip + verifies sha256, installs user-space to ~/.local/bin, is idempotent, and has a standalone run-guard.",
+    "verification": "bats tests/install-dotf-ps1.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "WIN-006-windows-dotf-install-f2",
+    "behavior": "setup-windows.ps1 dot-sources install-dotf.ps1 and calls Install-Dotf before the dotf env steps; both files parse clean.",
+    "verification": "pwsh -NoProfile -Command \"$null=[System.Management.Automation.Language.Parser]::ParseFile('setup-windows.ps1',[ref]$null,[ref]$null); $null=[System.Management.Automation.Language.Parser]::ParseFile('scripts/install-dotf.ps1',[ref]$null,[ref]$null); if($?){exit 0}else{exit 1}\"",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/WIN-006-windows-dotf-install/proposal.md
+++ b/specs/WIN-006-windows-dotf-install/proposal.md
@@ -1,0 +1,45 @@
+---
+id: "WIN-006-windows-dotf-install"
+type: spec
+status: verifying # draft | implementing | verifying | archived
+created: "2026-06-18"
+issue: "mlorentedev/dotfiles#451"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# WIN-006-windows-dotf-install
+
+> The Windows half of the `dotf` bootstrap — closes the gap that forced a manual `go build` during the ADR-025 deploy.
+
+## Why
+
+<!-- from issue #451: setup-windows.ps1 should install dotf from the published release binary (parity with install-dotf.sh) -->
+
+`setup-windows.ps1` does **not** install the `dotf` CLI — it only runs `dotf env generate` *if dotf is already on PATH*. On Linux/macOS, `setup-linux.sh` sources `scripts/install-dotf.sh`, which downloads the goreleaser release binary, verifies its sha256, and installs it to `~/.local/bin` — no compiler. So a Windows user was forced to build dotf from source (Go ≥1.26), which is a kludge and impossible without a working toolchain or admin rights. goreleaser **already publishes Windows binaries** (`dotf_<v>_windows_amd64.zip` / `_arm64.zip`), so nothing is compiled — the gap is purely the missing download step, which **blocks the ADR-025 cross-machine path mechanism from activating on Windows**.
+
+## What
+
+- **`scripts/install-dotf.ps1`** — the PowerShell twin of `install-dotf.sh`:
+  - `Get-DotfArch` (PROCESSOR_ARCHITECTURE → amd64/arm64), `Get-DotfVersion` (arg → `$env:DOTF_VERSION` → versions.conf).
+  - `Install-Dotf`: fetch `dotf_${version}_windows_${arch}.zip` + `checksums.txt`, verify sha256 (`Get-FileHash`), `Expand-Archive`, place `dotf.exe` in `~/.local/bin` (**user-space, no admin**). Idempotent (skip when the pinned version is on PATH; converge on drift). Never throws — returns `$true`/`$false`.
+  - Standalone run-guard (`$MyInvocation.InvocationName -ne '.'`): installs when **executed** (incl. `irm … | iex`), only defines functions when **dot-sourced**.
+- **`setup-windows.ps1`** dot-sources it + calls `Install-Dotf` (non-fatal, mirroring `install_dotf || log_warning`) **before** the `dotf env path` / `dotf env generate` steps, so the whole ADR-025 chain activates automatically.
+
+## Out of scope
+
+- **The full `curl | bash` zero-state bootstrap** (clone + setup) — that is `IDEAS-005` (#139), the umbrella; WIN-006 is a building block it consumes.
+- **Bumping `DOTF_VERSION`** — release-please owns it (now `0.6.0` on main, which already carries `dotf env`).
+- **file://-fixture behavioral bats** — PowerShell's `Invoke-WebRequest` has no `file://` support, so the `.sh` test's fixture path can't be mirrored; covered instead by the real-release smoke + the `.sh` mirror.
+
+## Acceptance criteria
+
+- [x] `install-dotf.ps1` fetches + verifies (sha256) + installs `dotf.exe` to `~/.local/bin`; idempotent; standalone **and** dot-sourceable (run-guard skips on `.`).
+- [x] `setup-windows.ps1` installs dotf automatically (non-fatal) before the env steps; parse + PSScriptAnalyzer (CI settings) clean.
+- [x] Real-release smoke: running the script installs `dotf 0.6.0`; `dotf version` + `dotf env path VAULT_PATH` resolve. Structural bats green.
+
+## References
+
+- Parity source: `scripts/install-dotf.sh` + `tests/install-dotf.bats`
+- Consumers: ADR-020 (CLI bootstrap: shell fetches binary, Go owns logic) · ADR-025 (`dotf env` — the cross-machine path mechanism this unblocks on Windows)
+- Work-gate: `mlorentedev/dotfiles#451` · umbrella: `IDEAS-005` (#139, curl-bash bootstrap)

--- a/specs/WIN-006-windows-dotf-install/tasks.md
+++ b/specs/WIN-006-windows-dotf-install/tasks.md
@@ -1,0 +1,26 @@
+---
+tags: [spec, tasks]
+created: "2026-06-18"
+---
+
+# Tasks - WIN-006-windows-dotf-install
+
+> One PR off main. Closes #451. Surfaced during the ADR-025 deploy (#446/#450).
+
+## Setup
+- [x] Branch `feat/win-install-dotf` off the latest `origin/main` (release 0.6.0, `DOTF_VERSION=0.6.0`).
+
+## Implementation
+- [x] `scripts/install-dotf.ps1`: `Get-DotfArch`, `Get-DotfVersion`, `Install-Dotf` (fetch+sha256+extract→`~/.local/bin`, idempotent, never-throws), standalone run-guard.
+- [x] Wire `setup-windows.ps1`: dot-source + `Install-Dotf` (non-fatal) before the hive/`dotf env` steps.
+- [x] `tests/install-dotf-ps1.bats`: structural + convention (the repo's .ps1 test style).
+
+## Closing
+- [x] `install-dotf.ps1` + `setup-windows.ps1` parse clean; PSScriptAnalyzer (CI `.PSScriptAnalyzerSettings.psd1`) = 0.
+- [x] Dot-source guard: dot-sourcing defines `Install-Dotf` without auto-installing.
+- [x] Real smoke: `.\scripts\install-dotf.ps1` installs `dotf 0.6.0`; `dotf version` + `dotf env path VAULT_PATH` OK.
+- [x] `bats tests/install-dotf-ps1.bats` → 11/11 green.
+- [ ] PR opened referencing this spec folder; closes #451.
+
+## Machine-readable features
+`features.json` is emitted alongside; the harness sets `"state": "passing"` after a green `verification` command.

--- a/specs/WIN-006-windows-dotf-install/verification.md
+++ b/specs/WIN-006-windows-dotf-install/verification.md
@@ -1,0 +1,36 @@
+---
+tags: [spec, verification]
+created: "2026-06-18"
+---
+
+# Verification - WIN-006-windows-dotf-install
+
+## Evidence
+
+- [x] **AC1 — fetch/verify/install** → `scripts/install-dotf.ps1`. **Real-release smoke** (this machine): `.\scripts\install-dotf.ps1` → `dotf 0.6.0 installed to C:\Users\mlorente\.local\bin\dotf.exe`; `dotf version` → `dotf version 0.6.0`; `dotf env path VAULT_PATH` → `C:\Users\mlorente\Projects\Workspace\knowledge` (machine.json resolved). User-space `~/.local/bin`, no admin.
+- [x] **AC2 — setup wiring + lint** → `setup-windows.ps1` dot-sources + `Install-Dotf` (non-fatal) before the hive/`dotf env` block. `Parser::ParseFile` clean on both files; `Invoke-ScriptAnalyzer -Settings .PSScriptAnalyzerSettings.psd1 -Severity Error,Warning` = **0** on both.
+- [x] **AC3 — bats + guard** → `bats tests/install-dotf-ps1.bats` → **11/11**. Dot-source guard: `pwsh -c '. .\scripts\install-dotf.ps1'` defines `Install-Dotf` **without** auto-installing (run-guard `$MyInvocation.InvocationName -ne '.'`).
+
+## Test status
+
+- `install-dotf.ps1` parse OK; PSSA (CI settings) = 0 warnings/errors.
+- `setup-windows.ps1` parse OK; PSSA (CI settings) = 0.
+- `bats tests/install-dotf-ps1.bats` → 11 ok / 0 failed.
+- Real binary smoke: dotf 0.6.0 installed + functional (`version`, `env path`).
+
+## Decisions made during implementation
+
+- **No `file://` behavioral bats.** PowerShell `Invoke-WebRequest` has no `file://` scheme, so the `install-dotf.sh` fixture-driven download tests can't be mirrored in bats. Coverage is the structural/convention bats (repo .ps1 convention) + the real-release smoke + the fact that the verify/extract logic is a line-for-line mirror of the bats-tested `.sh`.
+- **`Install-Dotf` never throws** — returns `$true`/`$false` so setup wires it `if (-not (Install-Dotf)) { Write-Warn }`, the analogue of `install_dotf || log_warning`. EA=Stop is set inside the function (not leaked to the dot-sourcing caller).
+- **Run-guard, not auto-run-on-source.** Dot-sourcing (`. install-dotf.ps1`) only defines functions; executing (`.\install-dotf.ps1`, `irm | iex`) installs — so setup dot-sources + calls explicitly, and the one-liner still works.
+
+## Promotion candidates
+
+- [ ] Lesson for `docs/lessons.md`? **maybe** — "a release binary that goreleaser already builds is worthless until each OS's setup actually downloads it; the gap reads as 'needs Go' but it's just a missing fetch step."
+
+## Archive checklist
+
+- [ ] PR merged, closes #451.
+- [ ] Deploy verified: a clean `setup-windows.ps1` run installs dotf with no manual step.
+- [ ] `proposal.md` `status: archived`; folder → `specs/archive/WIN-006-windows-dotf-install/`.
+- [ ] Bitácora #451 → Done.

--- a/tests/install-dotf-ps1.bats
+++ b/tests/install-dotf-ps1.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# Tests for scripts/install-dotf.ps1 — the Windows dotf release fetch/verify/install
+# (WIN-006). PowerShell twin of install-dotf.sh. Structural + convention checks (the
+# repo's .ps1 test style — see healthcheck-ps1.bats; PowerShell's Invoke-WebRequest
+# has no file:// support, so the .sh's fixture-driven behavioral path can't be
+# mirrored here). Behavioral correctness is the direct mirror of install-dotf.sh
+# (bats-tested on Linux) plus a real-release smoke during the WIN-006 verification.
+
+setup() {
+    SCRIPTS_DIR="$BATS_TEST_DIRNAME/../scripts"
+    PS1="$SCRIPTS_DIR/install-dotf.ps1"
+    SETUP_WIN="$BATS_TEST_DIRNAME/../setup-windows.ps1"
+}
+
+@test "install-dotf.ps1 exists" {
+    [ -f "$PS1" ]
+}
+
+@test "has comment-based help (.SYNOPSIS / .DESCRIPTION / .EXAMPLE)" {
+    grep -q '\.SYNOPSIS' "$PS1"
+    grep -q '\.DESCRIPTION' "$PS1"
+    grep -q '\.EXAMPLE' "$PS1"
+}
+
+@test "defines Install-Dotf, Get-DotfArch, Get-DotfVersion" {
+    grep -qE 'function +Install-Dotf' "$PS1"
+    grep -qE 'function +Get-DotfArch' "$PS1"
+    grep -qE 'function +Get-DotfVersion' "$PS1"
+}
+
+@test "uses advanced functions ([CmdletBinding()])" {
+    grep -q '\[CmdletBinding()\]' "$PS1"
+}
+
+@test "installs user-space into ~/.local/bin (no admin)" {
+    grep -qF '.local\bin' "$PS1"
+}
+
+@test "fetches the windows zip and verifies sha256 (parity with install-dotf.sh)" {
+    grep -qF 'dotf_${Version}_windows_${arch}.zip' "$PS1"
+    grep -qF 'checksums.txt' "$PS1"
+    grep -qF 'Get-FileHash' "$PS1"
+    grep -qF 'checksum mismatch' "$PS1"
+}
+
+@test "maps amd64 + arm64 arch tokens" {
+    grep -qF 'amd64' "$PS1"
+    grep -qF 'arm64' "$PS1"
+}
+
+@test "idempotent: skips when the pinned version is already on PATH" {
+    grep -qF 'already installed; skipping' "$PS1"
+}
+
+@test "resolves DOTF_VERSION from env then versions.conf" {
+    grep -qF 'DOTF_VERSION' "$PS1"
+    grep -qF 'versions.conf' "$PS1"
+}
+
+@test "standalone run-guard installs when executed, not when dot-sourced" {
+    grep -qF 'MyInvocation.InvocationName' "$PS1"
+}
+
+@test "setup-windows.ps1 dot-sources install-dotf.ps1 and calls Install-Dotf" {
+    grep -qF 'install-dotf.ps1' "$SETUP_WIN"
+    grep -qF 'Install-Dotf' "$SETUP_WIN"
+}


### PR DESCRIPTION
## What
Closes #451. The Windows half of the `dotf` bootstrap — closes the gap that forced a manual `go build` during the ADR-025 deploy.

`setup-windows.ps1` only ran `dotf env generate` *if dotf was already on PATH*; Windows had no installer (Linux has `install-dotf.sh`, which fetches the goreleaser binary — no compiler). goreleaser already publishes the Windows zip, so the gap was purely the missing download step.

## Changes
- **`scripts/install-dotf.ps1`** — PowerShell twin of `install-dotf.sh`: fetch `dotf_<v>_windows_<arch>.zip` + `checksums.txt`, verify sha256 (`Get-FileHash`), extract `dotf.exe` to `~/.local/bin` (**user-space, no admin**), idempotent, never-throws, standalone run-guard + dot-sourceable.
- **`setup-windows.ps1`** — dot-sources it + calls `Install-Dotf` (non-fatal) before the `dotf env` steps → the ADR-025 path mechanism activates with **no manual build / no Go / no admin**.
- **`tests/install-dotf-ps1.bats`** — structural + convention (repo .ps1 style).

## Verification
- Real-release smoke: `.\scripts\install-dotf.ps1` → installed dotf 0.6.0; `dotf version` + `dotf env path VAULT_PATH` resolve.
- parse + PSScriptAnalyzer (CI `.PSScriptAnalyzerSettings.psd1`) = **0** on both `.ps1`; bats **11/11**; dot-source guard verified (defines without auto-installing).

## Out of scope
The full `curl | bash` zero-state bootstrap (`IDEAS-005` #139) — the umbrella; WIN-006 is a building block it consumes.

Spec: `specs/WIN-006-windows-dotf-install/`. Closes #451.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Windows users can now install the dotf CLI via an installer script that downloads the pinned release, verifies SHA-256 checksums, extracts `dotf.exe`, and installs to the user’s `~/.local/bin` directory.
  * Windows initialization now automatically attempts dotf CLI installation (non-fatally) before proceeding with dotf environment generation.

* **Tests**
  * Added a Bats test suite covering installer behavior, version selection, architecture mapping, and integration with setup.

* **Documentation**
  * Added Windows installation specification and verification evidence for the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->