### PR TITLE
feat(harness): harden ADR-025 cross-machine path resolution end-to-end (HARNESS-027, #457)

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -49,6 +49,12 @@ export EDITOR=nano
 # (per-machine overrides), rendered by `dotf env generate`. DOTFILES_DIR is
 # bootstrapped first because it locates the file. Must be set before secrets.
 export DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.dotfiles}"
+# Zero-touch: auto-render paths.sh on first run when missing and dotf is on PATH
+# (a fresh machine self-configures without a manual `dotf env generate`). Silent +
+# best-effort; the bootstrap fallback below covers any failure.
+if [ ! -f "$DOTFILES_DIR/paths.sh" ] && command -v dotf >/dev/null 2>&1; then
+    dotf env generate >/dev/null 2>&1 || true
+fi
 if [ -f "$DOTFILES_DIR/paths.sh" ]; then
     . "$DOTFILES_DIR/paths.sh"
 else

--- a/.zshrc
+++ b/.zshrc
@@ -21,6 +21,12 @@ export EDITOR=nano
 # (per-machine overrides), rendered by `dotf env generate`. DOTFILES_DIR is
 # bootstrapped first because it locates the file. Must be set before secrets.
 export DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.dotfiles}"
+# Zero-touch: auto-render paths.sh on first run when missing and dotf is on PATH
+# (a fresh machine self-configures without a manual `dotf env generate`). Silent +
+# best-effort; the bootstrap fallback below covers any failure.
+if [ ! -f "$DOTFILES_DIR/paths.sh" ] && command -v dotf >/dev/null 2>&1; then
+    dotf env generate >/dev/null 2>&1 || true
+fi
 if [ -f "$DOTFILES_DIR/paths.sh" ]; then
     . "$DOTFILES_DIR/paths.sh"
 else

--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ Non-sensitive, per-machine shell config (a host-only `PATH` prepend, a VM-only a
 
 > **`.local` is not for secrets.** API keys, tokens and credentials always go through the age system above (`sensitive/*.secret.age` + `env-mapping.conf`), never a `.local` file.
 
+### Cross-machine paths (ADR-025)
+
+Structural paths (vault, repo, agent homes) resolve through a cascade, so the **same repo works on every machine** without editing tracked files:
+
+```
+env var  →  ~/.config/dotfiles/machine.json (per-machine override)  →  env-contract.json default[OS]
+```
+
+**To change where a path points:**
+
+| You want to… | Edit | Then |
+|---|---|---|
+| Relocate something on **this machine** (e.g. the vault moved) | `~/.config/dotfiles/machine.json` | `dotf env generate` → open a new shell |
+| Change the **default for all machines** | `env-contract.json` (the `default` block) | commit → on each machine `dotf env generate` (or re-run setup) |
+
+`dotf env generate` renders `~/.dotfiles/paths.{sh,ps1}` (sourced by your shell profile); **never edit those — they carry a `DO NOT EDIT` header.** Verify with `dotf doctor` (asserts no drift) or `dotf env path VAULT_PATH` (prints the resolved value). `machine.json` is gitignored and holds **only** the keys this machine overrides — copy `machine.json.example` to start. Full rationale: [`docs/adr/adr-025-cross-machine-path-resolution.md`](docs/adr/adr-025-cross-machine-path-resolution.md).
+
 ### AI Tools
 
 ```bash

--- a/cli/internal/doctor/checks_deploy.go
+++ b/cli/internal/doctor/checks_deploy.go
@@ -19,10 +19,21 @@ import (
 func checkSymlinks(sys *System, rep *Report) {
 	rep.Section("Key symlinks")
 	home := sys.home()
+	win := sys.GOOS == "windows"
+	// POSIX shell rc files have no Windows equivalent (pwsh uses $PROFILE) — skip
+	// them there instead of reporting a false "missing".
+	posixOnly := map[string]bool{
+		".zshrc": true, ".bashrc": true,
+		".zsh/aliases.zsh": true, ".zsh/functions.zsh": true,
+	}
 	for _, rel := range []string{
 		".dotfiles", ".zshrc", ".bashrc",
 		".zsh/aliases.zsh", ".zsh/functions.zsh", ".ssh/config",
 	} {
+		if win && posixOnly[rel] {
+			rep.Skip(rel + " (POSIX-only; Windows uses $PROFILE)")
+			continue
+		}
 		p := filepath.Join(home, rel)
 		switch {
 		case isSymlink(p) && pathExists(p):
@@ -233,6 +244,10 @@ func checkSecrets(sys *System, cfg *Config, rep *Report) {
 // matches the repo source (copy-deploy drift check, ADR-012).
 func checkTmux(sys *System, cfg *Config, rep *Report) {
 	rep.Section("tmux")
+	if sys.GOOS == "windows" {
+		rep.Skip("tmux (Linux-only by design; use WSL if needed)")
+		return
+	}
 	if !sys.has("tmux") {
 		rep.Fail("tmux not installed (run: sudo apt install -y tmux)")
 		return

--- a/cli/internal/doctor/checks_test.go
+++ b/cli/internal/doctor/checks_test.go
@@ -126,6 +126,52 @@ func TestCheckVersionMatch(t *testing.T) {
 	}
 }
 
+// TestOSGatingSkipsLinuxOnlyChecksOnWindows exercises the GOOS seam: on Windows
+// the POSIX-only checks SKIP instead of emitting false failures.
+func TestOSGatingSkipsLinuxOnlyChecksOnWindows(t *testing.T) {
+	winSys := func() *System {
+		s := newSys(map[string]string{}, []string{"git"}, nil)
+		s.GOOS = "windows"
+		return s
+	}
+
+	t.Run("tmux skips", func(t *testing.T) {
+		var b bytes.Buffer
+		rep := capture(&b)
+		checkTmux(winSys(), &Config{}, rep)
+		if rep.Failures() != 0 || !strings.Contains(b.String(), "Linux-only") {
+			t.Errorf("tmux must SKIP on Windows\n%s", b.String())
+		}
+	})
+
+	t.Run("version match skips versioned dirs", func(t *testing.T) {
+		var b bytes.Buffer
+		rep := capture(&b)
+		checkVersionMatch(winSys(), &Config{Versions: map[string]string{"JAVA_VERSION": "21.0.4"}}, rep)
+		if rep.Failures() != 0 {
+			t.Errorf("versioned-dir checks must SKIP on Windows\n%s", b.String())
+		}
+	})
+
+	t.Run("core tools skip posix-only", func(t *testing.T) {
+		var b bytes.Buffer
+		rep := capture(&b)
+		checkCoreTools(winSys(), &Contract{}, rep)
+		if !strings.Contains(b.String(), "zsh (POSIX-only") || !strings.Contains(b.String(), "direnv (POSIX-only") {
+			t.Errorf("zsh/direnv must SKIP as POSIX-only on Windows\n%s", b.String())
+		}
+	})
+
+	t.Run("tool-home vars skip when unset", func(t *testing.T) {
+		var b bytes.Buffer
+		rep := capture(&b)
+		checkToolHomeEnvVars(winSys(), rep)
+		if rep.Failures() != 0 {
+			t.Errorf("tool-home vars must SKIP when unset on Windows\n%s", b.String())
+		}
+	})
+}
+
 func TestCheckSymlinks(t *testing.T) {
 	home := t.TempDir()
 	// Valid symlink: ~/.zshrc -> a real target.

--- a/cli/internal/doctor/checks_tools.go
+++ b/cli/internal/doctor/checks_tools.go
@@ -12,14 +12,23 @@ var coreTools = []string{
 	"direnv", "node", "npm", "zoxide", "docker", "kubectl", "terraform",
 }
 
+// posixOnlyTools are absent on Windows by design — skip them there instead of
+// reporting a false failure (Windows uses pwsh, not zsh; direnv is POSIX-shell).
+var posixOnlyTools = map[string]bool{"zsh": true, "direnv": true}
+
 // checkCoreTools reproduces healthcheck section 1: the core toolchain is on
 // PATH. Names already version-checked by the contract (git, jq) are skipped here
 // to avoid double-reporting — the consolidation the two twins never did.
 func checkCoreTools(sys *System, c *Contract, rep *Report) {
 	rep.Section("Core tools in PATH")
 	covered := contractBinaryNames(c)
+	win := sys.GOOS == "windows"
 	for _, tool := range coreTools {
 		if covered[tool] {
+			continue
+		}
+		if win && posixOnlyTools[tool] {
+			rep.Skip(tool + " (POSIX-only; not expected on Windows)")
 			continue
 		}
 		if sys.has(tool) {
@@ -98,22 +107,29 @@ var versionMatches = []versionedDir{
 // version to the pin: a drift is a WARN, not a FAIL.
 func checkVersionMatch(sys *System, cfg *Config, rep *Report) {
 	rep.Section("Version match (versions.conf)")
-	appsHome := sys.env("APPS_HOME", filepath.Join(sys.home(), "Applications"))
-
-	for _, v := range versionMatches {
-		want := cfg.Versions[v.key]
-		if want == "" {
-			rep.Skip(v.name + " version (not set in versions.conf)")
-			continue
-		}
-		dir := filepath.Join(appsHome, v.dirPrefix+want)
-		if isDir(dir) {
-			rep.Pass(fmt.Sprintf("%s version %s (directory exists)", v.name, want))
-		} else {
-			rep.Fail(fmt.Sprintf("%s expected version %s but directory missing: %s", v.name, want, dir))
+	if sys.GOOS == "windows" {
+		// Windows installs these via winget, not ~/Applications/<tool>-<version>,
+		// so the versioned-dir check does not apply (parity with healthcheck.ps1
+		// section 3, which skips when APPS_HOME is unset).
+		rep.Skip("versioned tool dirs (Windows uses winget, not APPS_HOME)")
+	} else {
+		appsHome := sys.env("APPS_HOME", filepath.Join(sys.home(), "Applications"))
+		for _, v := range versionMatches {
+			want := cfg.Versions[v.key]
+			if want == "" {
+				rep.Skip(v.name + " version (not set in versions.conf)")
+				continue
+			}
+			dir := filepath.Join(appsHome, v.dirPrefix+want)
+			if isDir(dir) {
+				rep.Pass(fmt.Sprintf("%s version %s (directory exists)", v.name, want))
+			} else {
+				rep.Fail(fmt.Sprintf("%s expected version %s but directory missing: %s", v.name, want, dir))
+			}
 		}
 	}
 
+	// yarn is npm-global (cross-platform) — always checked.
 	pin := cfg.Versions["YARN_VERSION"]
 	switch {
 	case !sys.has("yarn"):
@@ -141,10 +157,15 @@ var toolHomeVars = []string{
 // set. Unset is a FAIL (the RC files are expected to export them).
 func checkToolHomeEnvVars(sys *System, rep *Report) {
 	rep.Section("Tool-home environment variables")
+	win := sys.GOOS == "windows"
 	for _, v := range toolHomeVars {
-		if sys.Getenv(v) != "" {
+		switch {
+		case sys.Getenv(v) != "":
 			rep.Pass(v + " is set")
-		} else {
+		case win:
+			// Linux-deploy vars; optional on Windows (winget-managed toolchains).
+			rep.Skip(v + " (optional on Windows — Linux-deploy var)")
+		default:
 			rep.Fail(v + " is not set")
 		}
 	}

--- a/cli/internal/doctor/system.go
+++ b/cli/internal/doctor/system.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -42,6 +43,10 @@ type System struct {
 	// Now returns the current time (time.Now in production). A clock seam keeps
 	// "days until expiry" deterministic under test.
 	Now func() time.Time
+	// GOOS is the target OS (runtime.GOOS in production). A seam so OS-gated
+	// checks (skip POSIX-only tools / tmux / shell-rc symlinks on Windows) are
+	// table-testable; the zero value "" behaves like a POSIX host.
+	GOOS string
 }
 
 // realSystem wires System to the live OS.
@@ -69,7 +74,8 @@ func realSystem() *System {
 			defer func() { _ = resp.Body.Close() }()
 			return resp.StatusCode, resp.Header, nil
 		},
-		Now: time.Now,
+		Now:  time.Now,
+		GOOS: runtime.GOOS,
 	}
 }
 

--- a/cli/internal/env/env.go
+++ b/cli/internal/env/env.go
@@ -114,6 +114,18 @@ func MachinePath(home string) string {
 // deployed copy), then by walking up from the current directory (so the CLI
 // works from inside a checkout). Returns "" when none is found.
 func ResolveContractPath() string {
+	// Prefer the repo's contract when DOTFILES_REPO_DIR points at a real checkout.
+	// On a dev machine the checkout is fresher than the deployed copy under
+	// ~/.dotfiles, so this prevents the stale-deployed-copy drift where a relocated
+	// repo keeps generating from an out-of-date ~/.dotfiles/env-contract.json. Read
+	// with os.Getenv (not ResolvePath): ResolvePath calls back into here, so going
+	// through the cascade would recurse. A non-existent path (stale value) just
+	// falls through to the deployed copy below.
+	if repo := os.Getenv("DOTFILES_REPO_DIR"); repo != "" {
+		if p := filepath.Join(repo, "env-contract.json"); fileExists(p) {
+			return p
+		}
+	}
 	home := Home()
 	if p := filepath.Join(DotfilesDir(home), "env-contract.json"); fileExists(p) {
 		return p

--- a/cli/internal/env/env_test.go
+++ b/cli/internal/env/env_test.go
@@ -120,3 +120,34 @@ func TestGenerateWriteIdempotentAndCheck(t *testing.T) {
 		t.Error("expected drift after manual edit")
 	}
 }
+
+func TestResolveContractPathPrefersRepoCheckout(t *testing.T) {
+	// A valid DOTFILES_REPO_DIR checkout wins over the deployed copy, so a dev
+	// machine never generates from a stale ~/.dotfiles/env-contract.json.
+	repo := t.TempDir()
+	want := filepath.Join(repo, "env-contract.json")
+	if err := os.WriteFile(want, []byte(`{"env_vars":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DOTFILES_REPO_DIR", repo)
+
+	if got := ResolveContractPath(); got != want {
+		t.Errorf("ResolveContractPath() = %q, want repo copy %q", got, want)
+	}
+}
+
+func TestResolveContractPathRepoMissingFallsThrough(t *testing.T) {
+	// DOTFILES_REPO_DIR set but carrying no contract (or a stale/non-existent path)
+	// must NOT short-circuit — resolution falls through to the deployed copy.
+	t.Setenv("DOTFILES_REPO_DIR", t.TempDir()) // empty dir: no env-contract.json
+	deployed := t.TempDir()
+	want := filepath.Join(deployed, "env-contract.json")
+	if err := os.WriteFile(want, []byte(`{"env_vars":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DOTFILES_DIR", deployed)
+
+	if got := ResolveContractPath(); got != want {
+		t.Errorf("ResolveContractPath() = %q, want deployed copy %q", got, want)
+	}
+}

--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -207,6 +207,12 @@ function prompt {
 # bootstrapped first because it locates the generated file itself.
 if (-not $env:DOTFILES_DIR) { $env:DOTFILES_DIR = "$env:USERPROFILE\.dotfiles" }
 $DotfPathsFile = Join-Path $env:DOTFILES_DIR 'paths.ps1'
+# Zero-touch: auto-render paths.ps1 on first run when it is missing and dotf is on
+# PATH (a fresh machine self-configures without a manual `dotf env generate`).
+# Best-effort + silent; the bootstrap fallback below covers any failure.
+if (-not (Test-Path $DotfPathsFile) -and (Get-Command dotf -ErrorAction SilentlyContinue)) {
+    & dotf env generate 2>$null | Out-Null
+}
 if (Test-Path $DotfPathsFile) {
     . $DotfPathsFile
 } else {

--- a/scripts/healthcheck.ps1
+++ b/scripts/healthcheck.ps1
@@ -378,7 +378,11 @@ foreach ($tool in $optionalTools) {
 # ==================================================
 Write-Section '7/12' 'Knowledge Vault'
 
-$vaultDir = if ($env:VAULT_DIR) { $env:VAULT_DIR } else { Join-Path $env:USERPROFILE 'Projects\knowledge' }
+# ADR-025: VAULT_PATH is the contract var (set by paths.ps1 from env-contract.json
+# + machine.json). The old code read $env:VAULT_DIR — a name that never existed in
+# the contract — so it always fell through to the hardcoded default and FAILed once
+# the vault was relocated. Fall back to the contract's Windows default only.
+$vaultDir = if ($env:VAULT_PATH) { $env:VAULT_PATH } else { Join-Path $env:USERPROFILE 'Projects\knowledge' }
 
 if (Test-Path -LiteralPath $vaultDir -PathType Container) {
     Write-Pass "Vault directory exists ($vaultDir)"

--- a/scripts/init-project.ps1
+++ b/scripts/init-project.ps1
@@ -118,7 +118,11 @@ if (Test-Path "$ClaudeHome\skills") {
 # KNOWLEDGE VAULT INTEGRATION
 # ============================================================================
 
-$KnowledgeHome = "$env:USERPROFILE\Projects\knowledge"
+# ADR-025: VAULT_PATH is the contract seam (set by paths.ps1 from machine.json +
+# env-contract.json). Fall back to the contract's Windows DEFAULT only — never this
+# machine's relocated path; "Workspace" is an override owned by VAULT_PATH, not a
+# baked-in default for every machine.
+$KnowledgeHome = if ($env:VAULT_PATH) { $env:VAULT_PATH } else { Join-Path $env:USERPROFILE 'Projects\knowledge' }
 $ProjectBaseName = Split-Path -Leaf $ProjectRoot
 $ProjectKbDir = "$KnowledgeHome\10_projects\$ProjectBaseName"
 
@@ -151,13 +155,13 @@ created: "$Today"
 - **Key Tools:**
 
 ## Critical Links
-- **Repository:** ~/Projects/$ProjectBaseName
+- **Repository:** $ProjectRoot
 - **Production:**
 
 ## Knowledge Structure
 Per [[pattern-knowledge-placement]]: build/operate docs live in the **repo**; this store keeps only decide/personal layers. Do NOT seed vault-local 30-architecture/, 40-runbooks/, 50-troubleshooting/, 90-lessons.md.
 
-**In the repo** (~/Projects/$ProjectBaseName/): docs/adr/, docs/runbooks/, docs/troubleshooting/, docs/lessons.md, specs/<id>/.
+**In the repo** ($ProjectRoot/): docs/adr/, docs/runbooks/, docs/troubleshooting/, docs/lessons.md, specs/<id>/.
 
 **In this store:** [[10-roadmap]] (strategy), [[11-tasks]] (strategic backlog), [[memory/MEMORY]] (AI memory).
 

--- a/scripts/install-dotf.ps1
+++ b/scripts/install-dotf.ps1
@@ -91,7 +91,11 @@ function Install-Dotf {
 
         # Idempotence: skip when the pinned version is already on PATH.
         if (Get-Command dotf -ErrorAction SilentlyContinue) {
-            $current = ((& dotf version 2>$null) -split '\s+')[-1]
+            # `dotf version` may print to stderr, so capture both streams (2>&1)
+            # and pull the semver out with a regex — robust to the stream and to
+            # empty output (StrictMode makes `@()[-1]` throw, so never index blind).
+            $verRaw = (& dotf version 2>&1 | Out-String)
+            $current = if ($verRaw -match '(\d+\.\d+\.\d+)') { $Matches[1] } else { '' }
             if ($current -eq $Version) {
                 Write-Host "dotf $Version already installed; skipping"
                 return $true

--- a/scripts/install-dotf.sh
+++ b/scripts/install-dotf.sh
@@ -85,7 +85,10 @@ install_dotf() {
     _dotf_archname="$(_dotf_arch "$(uname -m)")" || return 1
 
     if command_exists dotf; then
-        _dotf_current="$(dotf version 2>/dev/null | awk '{print $NF}')"
+        # `dotf version` may print to stderr, so capture both streams (2>&1) and
+        # extract the semver — robust to the stream and to empty output (parity
+        # with install-dotf.ps1; root cause: dotf writes version to stderr).
+        _dotf_current="$(dotf version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
         if [ "$_dotf_current" = "$version" ]; then
             log_info "dotf $version already installed; skipping"
             return 0

--- a/scripts/vault-health.sh
+++ b/scripts/vault-health.sh
@@ -21,7 +21,10 @@ fi
 
 # Defaults
 VAULT_NAME="${VAULT_NAME:-knowledge}"
-VAULT_DIR="${VAULT_DIR:-$HOME/Projects/knowledge}"
+# VAULT_DIR is the internal handoff from session-brief.sh (already resolved). When
+# run standalone, fall back to the ADR-025 contract seam VAULT_PATH, then the
+# contract's POSIX default. (VAULT_DIR wins so the session-brief handoff is intact.)
+VAULT_DIR="${VAULT_DIR:-${VAULT_PATH:-$HOME/Projects/knowledge}}"
 VERBOSE=false
 OBSIDIAN_CMD="obsidian --no-sandbox"
 

--- a/specs/HARNESS-027-adr025-hardening/features.json
+++ b/specs/HARNESS-027-adr025-hardening/features.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "HARNESS-027-adr025-hardening-f1",
+    "behavior": "install-dotf.ps1/.sh read `dotf version` from both streams and regex-extract the semver, so the idempotence check is robust to stderr output and StrictMode-safe.",
+    "verification": "bats tests/install-dotf-ps1.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-027-adr025-hardening-f2",
+    "behavior": "ResolveContractPath prefers the repo's env-contract.json when DOTFILES_REPO_DIR is a valid checkout, and falls through when it is absent.",
+    "verification": "cd cli && go test ./internal/env/...",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-027-adr025-hardening-f3",
+    "behavior": "dotf doctor OS-gates POSIX-only checks behind a mockable System.GOOS seam: they SKIP on Windows, Linux behavior unchanged.",
+    "verification": "cd cli && go test ./internal/doctor/...",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/HARNESS-027-adr025-hardening/proposal.md
+++ b/specs/HARNESS-027-adr025-hardening/proposal.md
@@ -1,0 +1,74 @@
+---
+id: "HARNESS-027-adr025-hardening"
+type: spec
+status: verifying # draft | implementing | verifying | archived
+created: "2026-06-19"
+issue: "mlorentedev/dotfiles#457"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# HARNESS-027-adr025-hardening
+
+> Close the cross-machine path seam end-to-end — the consumers and tooling that
+> ADR-025 shipped the mechanism for, but never wired to it.
+
+## Why
+
+<!-- from issue #457 -->
+
+Deploying ADR-025 on a real Windows machine (vault relocated to `~/Projects/Workspace/`)
+surfaced a cluster of **pre-existing** gaps: the path-resolution mechanism worked, but
+several consumers and tools still read hardcoded paths or the wrong variable, and one
+real bug blocked `dotf` from self-upgrading. None are regressions from ADR-025 — they
+are deuda the rigorous deploy made visible (the "linterna" effect). This hardens the
+seam so the mechanism is authoritative, not merely present.
+
+## What
+
+- **`scripts/install-dotf.ps1` + `.sh`** — `dotf version` prints to **stderr**; the
+  idempotence check read stdout (empty), and under PowerShell StrictMode `[-1]` on the
+  empty array threw, aborting the install (dotf stuck at 0.6.0 vs pinned 0.7.0). Capture
+  both streams (`2>&1`) + regex-extract the semver; parity fix in the `.sh`.
+- **`scripts/healthcheck.ps1` + `scripts/vault-health.sh`** — read `VAULT_PATH` (the
+  ADR-025 seam) instead of the never-existed `VAULT_DIR` / a hardcoded default.
+- **`scripts/init-project.ps1`** — VAULT_PATH fallback uses the contract default (not
+  this machine's relocated `Workspace` path); the generated context template emits the
+  real `$ProjectRoot` instead of a baked-in `~/Projects/Workspace/...` layout.
+- **`powershell/profile.ps1` + `.bashrc` + `.zshrc`** — auto-run `dotf env generate`
+  when `paths.{sh,ps1}` is missing and dotf is on PATH (zero-touch: a fresh machine
+  self-configures with no manual step).
+- **`cli/internal/env/env.go`** — `ResolveContractPath` prefers the repo's
+  `env-contract.json` when `DOTFILES_REPO_DIR` is a valid checkout, eliminating the
+  stale-deployed-copy drift where a relocated repo generated from an out-of-date
+  `~/.dotfiles` contract.
+- **`cli/internal/doctor/`** — OS-gate the POSIX-only checks (zsh/direnv, shell-rc
+  symlinks, tmux, `~/Applications` version dirs, Linux tool-home vars) behind a
+  mockable `System.GOOS` seam so they SKIP on Windows instead of false failures.
+- **`README.md`** — a "Cross-machine paths" section: where paths are changed
+  (`machine.json` vs `env-contract.json`) + `dotf env generate`.
+
+## Out of scope
+
+- **Vault→CLI template re-vendor drift** (`TestEmbeddedTemplatesMatchVault`) — a
+  separate pre-existing drift; its own ticket.
+- **Skills / AGENTS.md / guardrails audit** — the recurring-session-error thread; its
+  own dedicated session.
+- **hive overhaul** (#450) and hive self-contained install (hive repo).
+
+## Acceptance criteria
+
+- [x] install-dotf idempotence reads the version robustly (stderr/stdout); StrictMode-safe;
+      `.sh` parity. bats `.ps1` green.
+- [x] healthcheck / vault-health / init-project resolve the vault via `VAULT_PATH`; no
+      hardcoded machine layout in generated output.
+- [x] Shell profiles auto-generate `paths.{sh,ps1}` on a fresh machine.
+- [x] `ResolveContractPath` prefers a valid repo checkout; covered by tests.
+- [x] `dotf doctor` SKIPs POSIX-only checks on Windows via a mockable `GOOS` seam;
+      Linux behavior unchanged (existing tests pass); new Windows-path tests added.
+- [x] README documents the path-change workflow.
+
+## References
+
+- ADR-025 (`docs/adr/adr-025-cross-machine-path-resolution.md`)
+- Surfaced during WIN-006 (#451) deploy · work-gate: `mlorentedev/dotfiles#457`

--- a/specs/HARNESS-027-adr025-hardening/tasks.md
+++ b/specs/HARNESS-027-adr025-hardening/tasks.md
@@ -1,0 +1,32 @@
+---
+tags: [spec, tasks]
+created: "2026-06-19"
+---
+
+# Tasks - HARNESS-027-adr025-hardening
+
+> One PR off main. Closes #457. Surfaced during the ADR-025 / WIN-006 deploy.
+
+## Setup
+- [x] Branch `feat/adr025-path-hardening` off `origin/main` (release 0.7.0).
+
+## Implementation
+- [x] `install-dotf.ps1` + `.sh`: read `dotf version` from both streams + regex semver (StrictMode-safe).
+- [x] `healthcheck.ps1` + `vault-health.sh`: resolve vault via `VAULT_PATH` + contract default.
+- [x] `init-project.ps1`: contract-default fallback; template emits `$ProjectRoot`.
+- [x] `profile.ps1` + `.bashrc` + `.zshrc`: auto-`dotf env generate` when `paths.*` missing.
+- [x] `cli/internal/env/env.go`: `ResolveContractPath` prefers a valid `DOTFILES_REPO_DIR` checkout (+ tests).
+- [x] `cli/internal/doctor/`: `System.GOOS` seam; OS-gate POSIX-only checks (+ Windows tests).
+- [x] `README.md`: "Cross-machine paths" section.
+
+## Closing
+- [x] `gofmt` + `go vet` clean; `go test ./internal/env ./internal/doctor` green.
+- [x] Changed `.ps1` parse clean; PSScriptAnalyzer (CI settings) = 0.
+- [x] `bats tests/install-dotf-ps1.bats` green (12/12).
+- [ ] PR opened referencing this spec folder; closes #457; CI green.
+
+## Notes
+- Template-drift `go test` failures are vault-present-only (CI skips them, ADR-013) — out of scope.
+
+## Machine-readable features
+`features.json` is emitted alongside; the harness sets `"state": "passing"` after a green `verification` command.

--- a/specs/HARNESS-027-adr025-hardening/verification.md
+++ b/specs/HARNESS-027-adr025-hardening/verification.md
@@ -1,0 +1,54 @@
+---
+tags: [spec, verification]
+created: "2026-06-19"
+---
+
+# Verification - HARNESS-027-adr025-hardening
+
+## Evidence
+
+- [x] **install-dotf** → `scripts/install-dotf.ps1` + `.sh` capture `dotf version 2>&1` and
+  regex-extract the semver. Root cause confirmed empirically on this machine:
+  `dotf version` → STDOUT empty, STDERR `dotf version 0.6.0`. `bats tests/install-dotf-ps1.bats` → **12/12**.
+- [x] **vault consumers** → `healthcheck.ps1` (L381) + `vault-health.sh` (L24) + `init-project.ps1`
+  (L121) resolve `VAULT_PATH` with the contract default as fallback; no hardcoded machine layout.
+- [x] **zero-touch profile** → `profile.ps1` / `.bashrc` / `.zshrc` gate `dotf env generate` on
+  `paths.*` missing + dotf on PATH. Verified: a simulated fresh login resolves
+  `VAULT_PATH`/`DOTFILES_REPO_DIR`/`HIVE_VAULT_PATH` to the Workspace values from `paths.ps1`
+  with NO User-scope env (stopgap retired).
+- [x] **resolver prefer-repo** → `env.go ResolveContractPath`. Tests `TestResolveContractPathPrefersRepoCheckout`
+  + `TestResolveContractPathRepoMissingFallsThrough`. `go test ./internal/env` green.
+- [x] **doctor Windows parity** → `System.GOOS` seam (`system.go`); `checkCoreTools`,
+  `checkVersionMatch`, `checkToolHomeEnvVars`, `checkSymlinks`, `checkTmux` SKIP on Windows.
+  `TestOSGatingSkipsLinuxOnlyChecksOnWindows` covers 4 functions; existing Linux tests unchanged.
+  `go test ./internal/doctor` green.
+- [x] **README** → "Cross-machine paths (ADR-025)" section added.
+
+## Test status
+
+- `go build ./...` ok; `gofmt -l` clean; `go vet ./...` exit 0.
+- `go test ./internal/env ./internal/doctor` → ok.
+- Changed `.ps1` parse OK; PSSA (CI settings, Error+Warning) = 0 on all four.
+- `bats tests/install-dotf-ps1.bats` → 12 ok / 0 failed.
+
+## Decisions made during implementation
+
+- **`runtime.GOOS` → `System.GOOS` seam.** First cut used `runtime.GOOS` directly; it broke
+  existing doctor tests when run on Windows (they assume Linux behavior). Fix: inject the OS via
+  `System.GOOS` (zero value `""` = POSIX), so CI-Linux tests are untouched and Windows-path tests
+  set `GOOS="windows"` explicitly.
+- **install-dotf reads both streams.** Robust to `dotf version` going to stderr (0.6.0) OR stdout
+  (0.7.0 source); the regex extract is StrictMode-safe regardless.
+
+## Promotion candidates
+
+- [ ] Lesson for `docs/lessons.md`? **yes** — "OS-conditional code must inject the OS (mockable
+  seam), or it breaks the test suite the moment it runs on the other OS."
+- [ ] Lesson — "a release binary may print `version` to stderr; installers that grep stdout
+  silently never detect 'already installed' and (under StrictMode) crash."
+
+## Archive checklist
+
+- [ ] PR merged, closes #457; CI green.
+- [ ] `proposal.md` `status: archived`; folder → `specs/archive/HARNESS-027-adr025-hardening/`.
+- [ ] Bitácora #457 → Done.


### PR DESCRIPTION
## What

Hardens the ADR-025 cross-machine path seam **end-to-end** — wiring the consumers and tooling the mechanism shipped for but never read, plus a real install-blocker surfaced by the WIN-006 deploy on a real Windows machine. None are ADR-025 regressions; they are pre-existing debt the rigorous deploy made visible.

Spec: `specs/HARNESS-027-adr025-hardening/` · Closes #457.

## Changes

- **install-dotf.ps1/.sh** — `dotf version` prints to **stderr**; the idempotence check read stdout (empty) → StrictMode `[-1]` on the empty array threw → install aborted (dotf stuck at 0.6.0 vs pinned 0.7.0). Capture both streams + regex-extract the semver; `.sh` parity.
- **healthcheck.ps1 / vault-health.sh / init-project.ps1** — resolve the vault via `VAULT_PATH` (the seam), contract default as fallback; drop the hardcoded machine layout from init-project's generated template.
- **profile.ps1 / .bashrc / .zshrc** — auto-run `dotf env generate` when `paths.{sh,ps1}` is missing and dotf is on PATH (a fresh machine self-configures).
- **env.go** — `ResolveContractPath` prefers the repo `env-contract.json` when `DOTFILES_REPO_DIR` is a valid checkout, ending the stale-deployed-copy drift.
- **dotf doctor** — OS-gate POSIX-only checks (zsh/direnv, shell-rc symlinks, tmux, ~/Applications dirs, Linux tool-home vars) behind a mockable `System.GOOS` seam → SKIP on Windows instead of false failures.
- **README** — "Cross-machine paths" section: where paths are changed.

## Verification

- `go build` / `gofmt -l` / `go vet` clean; `go test ./internal/env ./internal/doctor` green (incl. new prefer-repo + Windows OS-gating tests).
- Changed `.ps1` parse clean; PSScriptAnalyzer (CI settings) = 0; `bats tests/install-dotf-ps1.bats` 12/12.
- The only `go test ./...` failures are `TestEmbeddedTemplatesMatchVault` (vault-present-only; CI skips them, ADR-013).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shell profiles now auto-generate configuration if missing on first run.
  * VAULT_PATH environment variable support for externalized Knowledge Vault locations.
  * Windows healthchecks skip POSIX-only validations instead of failing.

* **Bug Fixes**
  * Version detection in install scripts now captures both output streams for robust parsing.

* **Documentation**
  * Added cross-machine path configuration guide to README explaining per-machine overrides and contract variables.

* **Tests**
  * Added Windows compatibility tests for CLI healthchecks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->