### PR TITLE
fix(ci): rewrite add-to-project with GraphQL API

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -32,7 +32,26 @@ jobs:
       # PRs: use gh CLI directly (the action doesn't support PRs)
       - name: Add PR to project
         if: github.event_name == 'pull_request'
-        run: |
-          gh project item-add 1 --owner mlorentedev --url "${{ github.event.pull_request.html_url }}"
         env:
           GH_TOKEN: ${{ secrets.BITACORA_PAT }}
+        run: |
+          # Get the project ID
+          PROJECT_ID=$(gh api graphql -f query='
+            query { user(login: "mlorentedev") { projectV2(number: 1) { id } } }
+          ' --jq '.data.user.projectV2.id')
+          # Get the PR node ID
+          PR_NODE_ID=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} --json id --jq '.id')
+          if [ -z "$PROJECT_ID" ] || [ -z "$PR_NODE_ID" ]; then
+            echo "Failed to resolve project ID or PR node ID"
+            echo "PROJECT_ID=$PROJECT_ID PR_NODE_ID=$PR_NODE_ID"
+            exit 1
+          fi
+          # Add the PR to the project
+          gh api graphql -f query='
+            mutation($project: ID!, $contentId: ID!) {
+              addProjectV2ItemById(input: {projectId: $project, contentId: $contentId}) {
+                item { id }
+              }
+            }
+          ' -f project="$PROJECT_ID" -f contentId="$PR_NODE_ID"

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -151,7 +151,7 @@ else
     log_info "Creating functions.zsh file..."
     cat > "$DOTFILES_DIR/.zsh/functions.zsh" << EOF
 
-# Source the utils.sh and setup-gh-secrets.sh scripts
+# Source the utils.sh script
 . "$DOTFILES_DIR/scripts/utils.sh"
 
 EOF


### PR DESCRIPTION
## Why

`gh project item-add` fails in CI with "unknown owner type" despite correct token scopes.

## What

Replace with direct GraphQL mutation: resolve project ID + PR node ID, then call addProjectV2ItemById.

Also removes stale setup-gh-secrets.sh reference from setup-linux.sh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined Linux setup documentation in the generated Zsh setup content.
* **CI / Automation**
  * Updated the “Add PR to project” workflow to use GitHub’s GraphQL API, improving how pull requests are added to the project board and adding validation for required IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->