### PR TITLE
docs: refresh README structure tree and drop retired aider

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,27 +48,35 @@ admin needed; some changes show after an Explorer restart.
 ```text
 ├── setup-linux.sh              # Linux setup (symlinks); macOS planned
 ├── setup-windows.ps1           # Windows setup (copies)
+├── cli/                        # `dotf` Go CLI (doctor, init, env, spec) — primary user-facing tool
 ├── scripts/                    # Shell utilities (NOT on PATH — see Human entrypoints below)
 │   ├── utils.sh                # Shared function library (sourced by other scripts)
 │   ├── load-secrets.sh / .ps1  # Secrets → env vars (sourced at login)
 │   ├── init-project.ps1        # Windows project scaffolder (Linux: `dotf init`)
 │   ├── healthcheck.ps1         # Windows post-setup verification (Linux: `dotf doctor`)
 │   ├── vault.sh                # Vault tooling dispatcher
-│   └── …                       # 31 more scripts (hooks, CI helpers, secret tools)
+│   └── …                       # ~50 scripts total (hooks, CI helpers, secret tools)
 ├── sensitive/                  # Encrypted secrets
 │   ├── env-mapping.conf        # ENV_VAR=filename mapping
 │   └── *.secret.age            # Encrypted files (tracked)
 ├── AGENTS.md                   # Cross-agent SSOT (canonical system prompt)
-├── ai/
+├── ai/                         # Per-agent config overlays (thin pointers to AGENTS.md)
 │   ├── claude/CLAUDE.md        # Claude Code extensions (pointer to AGENTS.md)
 │   ├── agy/AGY.md              # Gemini/AGY extensions (pointer to AGENTS.md)
 │   ├── copilot/                # Copilot extensions (pointer to AGENTS.md)
-│   ├── opencode/opencode.jsonc # OpenCode config (Go + OpenRouter providers + MCP)
-│   └── harness/skills/         # 31 shared AI skills (deployed by compile-harness)
+│   ├── opencode/opencode.jsonc # OpenCode config (providers + MCP)
+│   └── …                       # pi, hermes, nan
+├── harness/                    # Compiled AI-skill records (generated from the vault by compile-harness.sh)
+├── docs/                       # Docs-as-code: architecture.md, adr/, runbooks/, troubleshooting/, lessons.md
+├── specs/                      # Spec-Driven Development feature folders (+ archive/)
+├── git-hooks/                  # Global pre-commit/pre-push dispatcher (GUARD-001)
+├── systemd/                    # Linux self-update + hive timers/services
+├── windows/                    # Windows-specific assets (hive supervisor, upgrade)
+├── .github/                    # CI workflows (lint, test, spec-gate)
 ├── ssh/                        # SSH config + public key
 ├── powershell/profile.ps1      # Windows PowerShell profile
-├── tests/*.bats                # BATS test suite
-└── .zsh/                       # Zsh modules
+├── tests/                      # BATS + Pester test suite
+└── .zsh/                       # Zsh modules (aliases, functions)
 ```
 
 ## Human entrypoints
@@ -151,7 +159,7 @@ dotfiles-sync --secrets-only        # Only sync sensitive/ files
 ### Diagnostics
 
 ```bash
-hc                                  # Run healthcheck (versions, paths, symlinks, env vars)
+dotf doctor                         # Healthcheck: versions, paths, symlinks, env vars (`hc` on Windows)
 dch                                 # Drift check: repo vs ~/.dotfiles deploy dir
 profile-shell                       # Measure shell startup time (zsh default)
 profile-shell --shell bash --detail # Per-function breakdown via zprof/xtrace

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@
 
 | Directory | Purpose |
 |---|---|
-| `ai/` | Per-agent configuration sources (claude, opencode, copilot, pi, agy, hermes, aider, nan) deployed by setup; thin overlays over the `AGENTS.md` SSOT |
+| `ai/` | Per-agent configuration sources (claude, opencode, copilot, pi, agy, hermes, nan) deployed by setup; thin overlays over the `AGENTS.md` SSOT |
 | `cli/` | The `dotf` Go CLI — own module (`go.mod`), own release pipeline (goreleaser). See layout below |
 | `docs/` | Build/operate knowledge: `adr/`, `runbooks/`, `troubleshooting/`, `lessons.md`, this file |
 | `git-hooks/` | Global git hooks deployed via `core.hooksPath` (GUARD-001) — the memory-sink guard (`pre-commit`) plus per-type chain dispatchers that re-exec the repo-local `.git/hooks/<type>` so local guards (gitleaks) survive |


### PR DESCRIPTION
## What

Documentation freshness fixes surfaced by a repo audit.

### README.md
- Structure tree was ~50% incomplete and showed `harness/` nested under `ai/` when it actually lives at the repo root. Added the missing top-level dirs (`cli/`, `docs/`, `specs/`, `git-hooks/`, `systemd/`, `windows/`, `.github/`), moved `harness/` out, and corrected stale file counts.
- The Diagnostics block listed `hc` as a Linux command, but `hc` only exists in the PowerShell profile (`powershell/profile.ps1`). On Linux the healthcheck is `dotf doctor`; the example now points at the real command.

### docs/architecture.md
- The `ai/` row still listed the retired `aider` agent (sunset in AI-011; `ai/aider/` no longer exists on disk). Removed it.

## Verification
- `bats tests/architecture-md.bats` — 5/5 pass (incl. 'every real top-level dir is declared').
- `bats tests/docs-drift.bats` — 5/5 pass.
- spec-gate: 22 production LOC < 50 threshold.