### PR TITLE
ci: pin action-shellcheck to 2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           done
 
       - name: Check for shellcheck issues (scripts/)
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@2.0.0
         with:
           scandir: './scripts'
           severity: error


### PR DESCRIPTION
## What
`ludeeus/action-shellcheck` was the only action in `.github/workflows/ci.yml` referenced by a floating branch (`@master`); every other action is pinned to a released tag. A change to that branch upstream could break CI with no change on our side.

Pin it to the current latest release, `2.0.0` (verified via `gh api repos/ludeeus/action-shellcheck/releases/latest`).

## Verification
- Confirmed no other `@master` refs remain in `.github/workflows/`.
- 1-line change; spec-gate well under threshold.