### PR TITLE
fix(setup): enforce versions.conf pins as minimums, not presence or exact match

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -52,9 +52,29 @@ log_error() {
 exit_error() {
     message=$1
     code=${2:-1} # Default exit code is 1
-    
+
     log_error "$message"
     exit $code
+}
+
+# version_gte: is an installed version at least the pinned minimum?
+# versions.conf pins are MINIMUMS, not exact pins (REFACTOR-013): an install
+# gate must upgrade when installed < pin, and leave a NEWER install untouched
+# (an exact-match `!=` reconcile would downgrade it). Pure semver compare via
+# `sort -V`; no external deps.
+# Input:  $1 - installed version (e.g. "1.16.2"), $2 - pinned minimum
+# Returns: 0 if installed >= minimum (satisfied), 1 if installed < minimum
+#          (needs install/upgrade). Empty minimum -> 0 (no pin = anything OK);
+#          empty installed -> 1 (nothing there = needs install).
+# Usage:   version_gte "$installed" "$PIN" || install_or_upgrade
+version_gte() {
+    installed="$1"
+    minimum="$2"
+    [ -z "$minimum" ] && return 0
+    [ -z "$installed" ] && return 1
+    [ "$installed" = "$minimum" ] && return 0
+    # installed >= minimum iff the minimum sorts as the lower of the two.
+    [ "$(printf '%s\n%s\n' "$installed" "$minimum" | sort -V | head -n1)" = "$minimum" ]
 }
 
 # Silent check functions (for conditionals and shell startup)

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -655,27 +655,28 @@ if ! command -v opencode >/dev/null 2>&1 && [ ! -x "$OPENCODE_BINARY" ]; then
         log_warning "opencode install failed — re-run setup or install manually (https://opencode.ai/docs/)"
     fi
 elif [ -n "$OPENCODE_VERSION" ]; then
-    # REFACTOR-011: presence is not convergence. An installed opencode whose
-    # version drifted from the versions.conf pin was previously skipped as
-    # "already installed", leaving healthcheck flagging drift on every run.
+    # REFACTOR-011/013: presence is not convergence, and the pin is a MINIMUM.
+    # An opencode OLDER than the pin was previously skipped as "already
+    # installed"; an exact-match reconcile would conversely DOWNGRADE a newer
+    # install. Upgrade only when installed < pin (version_gte), never downgrade.
     opencode_cmd="opencode"
     command -v opencode >/dev/null 2>&1 || opencode_cmd="$OPENCODE_BINARY"
     installed_opencode=$("$opencode_cmd" --version 2>/dev/null | head -1 | awk '{print $NF}')
-    if [ "$installed_opencode" != "$OPENCODE_VERSION" ]; then
-        log_info "opencode ${installed_opencode:-unknown} drifted from pinned $OPENCODE_VERSION, converging..."
+    if ! version_gte "$installed_opencode" "$OPENCODE_VERSION"; then
+        log_info "opencode ${installed_opencode:-unknown} below pinned minimum $OPENCODE_VERSION, upgrading..."
         curl -fsSL https://opencode.ai/install | bash -s -- --version "$OPENCODE_VERSION" || true
         # Re-query instead of trusting the installer exit code: when the
         # PATH-resolved binary comes from another package manager (npm
         # global), the installer converges its own copy but the shadowing
         # install keeps winning -- that is not convergence.
         converged_opencode=$("$opencode_cmd" --version 2>/dev/null | head -1 | awk '{print $NF}')
-        if [ "$converged_opencode" = "$OPENCODE_VERSION" ]; then
-            log_success "opencode converged to $OPENCODE_VERSION"
+        if version_gte "$converged_opencode" "$OPENCODE_VERSION"; then
+            log_success "opencode upgraded to ${converged_opencode:-$OPENCODE_VERSION} (>= $OPENCODE_VERSION)"
         else
             log_warning "opencode still ${converged_opencode:-unknown} after install of $OPENCODE_VERSION: another install shadows it in PATH (e.g. npm global); converge that install instead"
         fi
     else
-        log_info "opencode already installed (pinned $OPENCODE_VERSION)"
+        log_info "opencode already installed (${installed_opencode:-unknown} >= $OPENCODE_VERSION)"
     fi
 else
     log_info "opencode already installed"
@@ -731,12 +732,12 @@ if command -v npm >/dev/null 2>&1; then
         fi
     else
         INSTALLED_YARN=$(yarn --version 2>/dev/null | head -1)
-        if [ -n "$YARN_PINNED" ] && [ "$INSTALLED_YARN" != "$YARN_PINNED" ]; then
-            log_info "yarn version drift (installed=$INSTALLED_YARN pinned=$YARN_PINNED) — reconciling..."
+        if [ -n "$YARN_PINNED" ] && ! version_gte "$INSTALLED_YARN" "$YARN_PINNED"; then
+            log_info "yarn $INSTALLED_YARN below pinned minimum $YARN_PINNED — upgrading..."
             if npm install -g "yarn@$YARN_PINNED" >/dev/null 2>&1; then
-                log_success "yarn reconciled to $YARN_PINNED"
+                log_success "yarn upgraded to $YARN_PINNED"
             else
-                log_warning "yarn reconcile failed — run: npm install -g yarn@$YARN_PINNED"
+                log_warning "yarn upgrade failed — run: npm install -g yarn@$YARN_PINNED"
             fi
         else
             log_info "yarn already installed: $INSTALLED_YARN"
@@ -770,7 +771,20 @@ if command -v npm >/dev/null 2>&1; then
             log_warning "pi install failed — run: npm install -g --ignore-scripts --prefix \"\$HOME/.local\" $PI_PKG"
         fi
     else
-        log_info "pi already installed ($PI_BIN)"
+        # REFACTOR-013: the pin is a MINIMUM. Presence alone left an outdated pi
+        # in place forever (it was only ever WARNed by healthcheck, #474, never
+        # converged here). Upgrade when installed < pin; leave a newer pi alone.
+        installed_pi=$("$PI_BIN" --version 2>/dev/null | head -1 | awk '{print $NF}')
+        if [ -n "$PI_VERSION" ] && ! version_gte "$installed_pi" "$PI_VERSION"; then
+            log_info "pi ${installed_pi:-unknown} below pinned minimum $PI_VERSION — upgrading..."
+            if npm install -g --ignore-scripts --prefix "$HOME/.local" "@earendil-works/pi-coding-agent@$PI_VERSION" >/dev/null 2>&1; then
+                log_success "pi upgraded to $PI_VERSION"
+            else
+                log_warning "pi upgrade failed — run: npm install -g --ignore-scripts --prefix \"\$HOME/.local\" @earendil-works/pi-coding-agent@$PI_VERSION"
+            fi
+        else
+            log_info "pi already installed ($PI_BIN, ${installed_pi:-unknown} >= ${PI_VERSION:-any})"
+        fi
     fi
 else
     log_warning "npm not found — skipping pi install (install Node.js, then re-run setup)"

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -87,6 +87,23 @@ function Write-Success { param([string]$Message) Write-Host "[SUCCESS] $Message"
 function Write-Warn { param([string]$Message) Write-Host "[WARNING] $Message" -ForegroundColor Yellow }
 function Write-Err { param([string]$Message) Write-Host "[ERROR] $Message" -ForegroundColor Red }
 
+function Test-VersionAtLeast {
+    # versions.conf pins are MINIMUMS (REFACTOR-013): an install gate must
+    # upgrade when installed < pin and leave a NEWER install untouched (an
+    # exact-match `-ne` reconcile would downgrade it). Returns $true when
+    # $Installed >= $Minimum. Empty minimum -> $true (no pin); empty installed
+    # -> $false (needs install). Non-semver strings fall back to string equality
+    # so a tag that does not parse as [version] never throws.
+    param([string]$Installed, [string]$Minimum)
+    if ([string]::IsNullOrWhiteSpace($Minimum)) { return $true }
+    if ([string]::IsNullOrWhiteSpace($Installed)) { return $false }
+    try {
+        return ([version]$Installed -ge [version]$Minimum)
+    } catch {
+        return ($Installed -eq $Minimum)
+    }
+}
+
 function Ensure-Directory {
     param([string]$Path)
     if (-not (Test-Path $Path)) {
@@ -350,26 +367,26 @@ if ($wingetCmd) {
                 Write-Warn "Failed to install $($tool.Name): $_"
             }
         } elseif ($tool.ContainsKey('Version') -and $tool.Version) {
-            # REFACTOR-011: presence is not convergence. A pinned tool whose
-            # installed version drifted from versions.conf was previously
-            # skipped as "already installed", leaving healthcheck flagging
-            # version drift on every run. Converge it to the pin.
+            # REFACTOR-011/013: presence is not convergence, and the pin is a
+            # MINIMUM. A tool OLDER than the pin was skipped as "already
+            # installed"; an exact-match `-ne` reconcile would conversely
+            # DOWNGRADE a newer install. Upgrade only when installed < pin.
             $installedVer = ((& $tool.Cmd --version 2>&1 | Select-Object -First 1) -split '\s+')[-1]
-            if ($installedVer -ne $tool.Version) {
-                Write-Info "$($tool.Name) $installedVer drifted from pinned $($tool.Version), converging..."
+            if (-not (Test-VersionAtLeast $installedVer $tool.Version)) {
+                Write-Info "$($tool.Name) $installedVer below pinned minimum $($tool.Version), upgrading..."
                 & winget install $tool.Id --version $tool.Version --accept-package-agreements --accept-source-agreements --force 2>$null | Out-Null
                 # Re-query instead of trusting winget's exit code: when the
                 # PATH-resolved binary comes from another package manager (npm
                 # global, scoop), winget converges its own copy but the
                 # shadowing install keeps winning -- that is not convergence.
                 $postVer = ((& $tool.Cmd --version 2>&1 | Select-Object -First 1) -split '\s+')[-1]
-                if ($postVer -eq $tool.Version) {
-                    Write-Success "$($tool.Name) converged to $($tool.Version)"
+                if (Test-VersionAtLeast $postVer $tool.Version) {
+                    Write-Success "$($tool.Name) upgraded to $postVer (>= $($tool.Version))"
                 } else {
                     Write-Warn "$($tool.Name) still $postVer after winget install $($tool.Version): another install shadows it in PATH (e.g. npm global, scoop); converge that install instead"
                 }
             } else {
-                Write-Info "$($tool.Name) already installed (pinned $($tool.Version))"
+                Write-Info "$($tool.Name) already installed ($installedVer >= $($tool.Version))"
             }
         } else {
             Write-Info "$($tool.Name) already installed"
@@ -980,10 +997,10 @@ if (Get-Command npm -ErrorAction SilentlyContinue) {
         }
     } else {
         $yarnInstalled = (& yarn --version 2>$null | Select-Object -First 1)
-        if ($yarnVersion -and $yarnInstalled -ne $yarnVersion) {
-            Write-Info "yarn version drift (installed=$yarnInstalled pinned=$yarnVersion) - reconciling..."
+        if ($yarnVersion -and -not (Test-VersionAtLeast $yarnInstalled $yarnVersion)) {
+            Write-Info "yarn $yarnInstalled below pinned minimum $yarnVersion - upgrading..."
             & npm install -g $yarnPkg 2>$null | Out-Null
-            Write-Success "yarn reconciled to $yarnVersion"
+            Write-Success "yarn upgraded to $yarnVersion"
         } else {
             Write-Info "yarn already installed: $yarnInstalled"
         }
@@ -1021,16 +1038,17 @@ if (Get-Command npm -ErrorAction SilentlyContinue) {
             Write-Warn "pi install failed - run: npm install -g --ignore-scripts $piPkg"
         }
     } else {
-        # Check for version drift and reinstall if pinned version differs.
+        # REFACTOR-013: pin is a MINIMUM — upgrade only when installed < pin so
+        # a newer pi is never downgraded by an exact-match reconcile.
         $piVerRaw = (& pi --version 2>&1 | Out-String)
         $piCurrent = if ($piVerRaw -match '(\d+\.\d+\.\d+)') { $Matches[1] } else { '' }
-        if ($piVersion -and $piCurrent -and ($piCurrent -ne $piVersion)) {
-            Write-Info "pi $piCurrent drifted from pinned $piVersion; reinstalling"
+        if ($piVersion -and $piCurrent -and -not (Test-VersionAtLeast $piCurrent $piVersion)) {
+            Write-Info "pi $piCurrent below pinned minimum $piVersion; upgrading"
             & npm install -g --ignore-scripts "@earendil-works/pi-coding-agent@$piVersion" 2>$null | Out-Null
             if (Get-Command pi -ErrorAction SilentlyContinue) {
-                Write-Success "pi reinstalled at pinned $piVersion"
+                Write-Success "pi upgraded to pinned $piVersion"
             } else {
-                Write-Warn "pi reinstall failed - run: npm install -g --ignore-scripts @earendil-works/pi-coding-agent@$piVersion"
+                Write-Warn "pi upgrade failed - run: npm install -g --ignore-scripts @earendil-works/pi-coding-agent@$piVersion"
             }
         } else {
             Write-Info "pi already installed"

--- a/specs/REFACTOR-013-version-minimum-enforcement/proposal.md
+++ b/specs/REFACTOR-013-version-minimum-enforcement/proposal.md
@@ -1,0 +1,73 @@
+---
+id: "REFACTOR-013-version-minimum-enforcement"
+type: spec
+status: active
+created: "2026-06-20"
+issue: 479
+tags: [spec, proposal, setup, versions, cross-os-parity, refactor]
+template_version: "1.0"
+---
+
+# REFACTOR-013 — version pins as minimums (not presence, not exact)
+
+> Extends [[REFACTOR-011]] (version-manifest). REFACTOR-011 made opencode
+> *converge* to the pin; this spec generalizes the contract to **minimum**
+> semantics across the pinned-install gates and removes the two ways the
+> installers still violate it.
+
+## Why
+
+`versions.conf` pins are documented as **minimum** versions, but two install
+patterns break that contract:
+
+**Defect A — presence-only gates never upgrade.** A tool gated solely on
+`command -v X` / `-x $BIN` is reported "already installed" even when the
+installed copy is *older* than the pin, so it is never converged. This is the
+user-reported symptom ("if it finds an old one it keeps it"). Worst case: `pi`
+on Linux (`setup-linux.sh`), whose drift was only ever *warned* by healthcheck
+(#474), never fixed.
+
+**Defect B — exact-match reconcile downgrades.** The opencode/yarn/pi reconcile
+blocks compare with `!=` (shell) / `-ne` (PowerShell). A version *newer* than
+the pin reads as drift and is **downgraded** to the pin — the opposite of a
+minimum.
+
+Both directions contradict "pins are minimums". The fix is a single semver
+comparator used by every gate: upgrade iff `installed < pin`, no-op iff
+`installed >= pin`.
+
+## What
+
+A shared minimum-version comparator + rewired gates:
+
+- `scripts/utils.sh`: new `version_gte "$installed" "$pin"` (pure `sort -V`;
+  empty pin → satisfied, empty installed → needs install).
+- `setup-windows.ps1`: new `Test-VersionAtLeast` helper (uses the native
+  `[version]` type, already used for the hive `-ge` check; falls back to string
+  equality for non-semver tags so it never throws).
+- `setup-linux.sh`: `opencode` and `yarn` switch `!=` → `! version_gte`; `pi`
+  gains a below-minimum upgrade branch (was presence-only).
+- `setup-windows.ps1`: `opencode` (tools loop), `yarn`, and `pi` switch
+  `-ne` → `-not (Test-VersionAtLeast …)`.
+
+### Out of scope (deliberate)
+
+- `bats`, `obsidian` on Linux install *latest*, not the pinned version — the
+  pin is not wired into their install command, so they are a different (weaker)
+  case. Converting them means choosing whether to pin the install too; tracked
+  as a follow-up, not bundled here.
+- `AGE_VERSION` / `EZA_VERSION` / `ZOXIDE_VERSION` are explicitly
+  Windows-CI-only download pins (see the `versions.conf` comment); Linux
+  installs these by other means and ignores the pins. Not minimum-enforced.
+
+## Acceptance criteria
+
+- **AC1** `version_gte` returns 0 for equal, 0 for newer, 1 for older; numeric
+  not lexical (`1.10.0 >= 1.9.0`); empty-pin → 0; empty-installed → 1.
+- **AC2** `Test-VersionAtLeast` mirrors AC1 and never throws on a non-semver tag.
+- **AC3** No install gate compares a pinned tool's version with `!=` / `-ne`;
+  the downgrade path is gone (regression-asserted).
+- **AC4** `pi` on Linux upgrades when installed < pin (no longer presence-only).
+- **AC5** A newer-than-pin install is left untouched on both OSes (no downgrade).
+- **AC6** `setup-linux.sh` passes `bash -n`; `setup-windows.ps1` passes
+  PSScriptAnalyzer (Error+Warning) and parses clean.

--- a/specs/REFACTOR-013-version-minimum-enforcement/tasks.md
+++ b/specs/REFACTOR-013-version-minimum-enforcement/tasks.md
@@ -1,0 +1,27 @@
+---
+id: "REFACTOR-013-version-minimum-enforcement"
+type: tasks
+status: active
+created: "2026-06-20"
+template_version: "1.0"
+---
+
+# Tasks — REFACTOR-013
+
+- [x] **T1** Add `version_gte` to `scripts/utils.sh` (pure `sort -V`; empty-pin
+      and empty-installed edge cases). → AC1
+- [x] **T2** Add `tests/version-gte.bats` covering equal / newer / older /
+      numeric-not-lexical / component-count / empty-pin / empty-installed. → AC1
+- [x] **T3** `setup-linux.sh`: opencode `!=` → `! version_gte`; keep the
+      shadowing-install re-query. → AC3, AC5
+- [x] **T4** `setup-linux.sh`: yarn `!=` → `! version_gte`. → AC3, AC5
+- [x] **T5** `setup-linux.sh`: pi gains a below-minimum upgrade branch (was
+      presence-only `[ ! -x $PI_BIN ]`). → AC4, AC5
+- [x] **T6** `setup-windows.ps1`: add `Test-VersionAtLeast` helper. → AC2
+- [x] **T7** `setup-windows.ps1`: opencode tools loop, yarn, pi switch `-ne` →
+      `-not (Test-VersionAtLeast …)`. → AC3, AC5
+- [x] **T8** Update regression tests that asserted the old `!=` / `-ne` strings
+      (`tests/opencode.bats`, `tests/setup-windows.bats`) to assert the new
+      comparator AND the absence of the exact-match form. → AC3
+- [x] **T9** Verify: `bash -n setup-linux.sh`, PSScriptAnalyzer on
+      `setup-windows.ps1`, full bats suite. → AC6

--- a/specs/REFACTOR-013-version-minimum-enforcement/verification.md
+++ b/specs/REFACTOR-013-version-minimum-enforcement/verification.md
@@ -1,0 +1,34 @@
+---
+id: "REFACTOR-013-version-minimum-enforcement"
+type: verification
+status: active
+created: "2026-06-20"
+template_version: "1.0"
+---
+
+# Verification — REFACTOR-013
+
+| AC | Evidence | Result |
+|----|----------|--------|
+| AC1 | `tests/version-gte.bats` — 8/8 pass (equal, newer, older, `1.10.0>=1.9.0`, `1.2<1.2.0`, empty-pin, empty-installed, `1.22.22>=1.22.9`). | ✅ |
+| AC2 | `Test-VersionAtLeast` unit cases via pwsh — 10/10 (incl. `weird-tag` non-semver → string fallback, no throw). | ✅ |
+| AC3 | `tests/opencode.bats` test 7 + `tests/setup-windows.bats` test 51 assert the new comparator AND `! grep` the removed `!=` / `-ne` form. Both pass. | ✅ |
+| AC4 | `setup-linux.sh` pi block: added below-minimum upgrade branch (was `[ ! -x $PI_BIN ]` presence-only). | ✅ |
+| AC5 | `version_gte`/`Test-VersionAtLeast` return satisfied for newer-than-pin → reconcile branch is skipped (no downgrade). | ✅ |
+| AC6 | `bash -n setup-linux.sh` OK; `setup-windows.ps1` parses clean + PSScriptAnalyzer (Error,Warning) → no issues. | ✅ |
+
+## Test run (local, Windows git-bash)
+
+- `version-gte.bats` 8/8, `opencode.bats` 45/45, `setup-windows.bats` 108/108.
+- `setup-linux.bats` 79/80 — the single failure is `setup-linux.sh valid zsh
+  syntax`, which fails only because **zsh is not installed on this dev machine**
+  (`zsh: command not found`); it fails identically on the unmodified `main`
+  tree, and CI installs zsh (`.github/workflows/ci.yml`), so it passes there.
+  `version_gte` is POSIX-only (`printf` / `sort -V` / `head` / `[ ]`).
+
+## Notes
+
+- bats/obsidian (Linux install *latest*, pin not wired into the install) and the
+  Windows-CI-only AGE/EZA/ZOXIDE download pins are out of scope per the proposal.
+- The authoritative gate is CI (Linux + windows-latest), where zsh and real
+  symlinks exist.

--- a/tests/opencode.bats
+++ b/tests/opencode.bats
@@ -44,11 +44,13 @@ setup() {
     ! grep -q 'ensure_line_in_file.*OPENCODE_PATH_LINE' "$SETUP_SCRIPT"
 }
 
-@test "setup-linux.sh converges a drifted opencode to the versions.conf pin (REFACTOR-011)" {
-    # Presence is not convergence: an opencode older than OPENCODE_VERSION was
-    # previously skipped as "already installed", leaving healthcheck flagging
-    # version drift on every run.
-    grep -q 'installed_opencode" != "$OPENCODE_VERSION' "$SETUP_SCRIPT"
+@test "setup-linux.sh upgrades a below-minimum opencode to the versions.conf pin (REFACTOR-011/013)" {
+    # Presence is not convergence, and the pin is a MINIMUM: an opencode older
+    # than OPENCODE_VERSION was skipped as "already installed", while an exact
+    # != reconcile would downgrade a newer install. Gate on version_gte so only
+    # an older opencode triggers an upgrade.
+    grep -q 'version_gte "$installed_opencode" "$OPENCODE_VERSION"' "$SETUP_SCRIPT"
+    ! grep -q 'installed_opencode" != "$OPENCODE_VERSION' "$SETUP_SCRIPT"
     # Convergence is verified by re-query, not by installer exit code: a
     # shadowing install (npm global) would otherwise produce a false SUCCESS.
     grep -q 'shadows it in PATH' "$SETUP_SCRIPT"

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -323,11 +323,13 @@ setup() {
     grep -qF 'SST.opencode' "$PS1_SCRIPT"
 }
 
-@test "setup-windows.ps1 converges a drifted opencode to the versions.conf pin (REFACTOR-011)" {
-    # Presence is not convergence: an opencode older than OPENCODE_VERSION was
-    # previously skipped as "already installed", leaving healthcheck flagging
-    # version drift on every run.
-    grep -qF '$installedVer -ne $tool.Version' "$PS1_SCRIPT"
+@test "setup-windows.ps1 upgrades a below-minimum opencode to the versions.conf pin (REFACTOR-011/013)" {
+    # Presence is not convergence, and the pin is a MINIMUM: an opencode older
+    # than OPENCODE_VERSION was skipped as "already installed", while an exact
+    # -ne reconcile would downgrade a newer install. Gate on Test-VersionAtLeast
+    # so only a below-minimum opencode triggers an upgrade.
+    grep -qF 'Test-VersionAtLeast $installedVer $tool.Version' "$PS1_SCRIPT"
+    ! grep -qF '$installedVer -ne $tool.Version' "$PS1_SCRIPT"
     grep -qE 'winget install \$tool\.Id --version \$tool\.Version' "$PS1_SCRIPT"
     # Convergence is verified by re-query, not by winget's exit code: a
     # shadowing install (npm global, scoop) would otherwise produce a false

--- a/tests/version-gte.bats
+++ b/tests/version-gte.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# REFACTOR-013: version_gte is the shared minimum-version comparator used by the
+# install gates in setup-linux.sh. versions.conf pins are MINIMUMS: upgrade when
+# installed < pin, leave a newer install untouched (no downgrade). These tests
+# pin the semver semantics so a future edit can't silently reintroduce the
+# exact-match (== / !=) behavior that downgraded newer tools.
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    source "$DOTFILES_DIR/scripts/utils.sh"
+}
+
+@test "version_gte: equal versions are satisfied" {
+    run version_gte "1.16.2" "1.16.2"
+    [ "$status" -eq 0 ]
+}
+
+@test "version_gte: a newer install satisfies the minimum (no downgrade)" {
+    run version_gte "1.17.0" "1.16.2"
+    [ "$status" -eq 0 ]
+}
+
+@test "version_gte: an older install does NOT satisfy the minimum (needs upgrade)" {
+    run version_gte "1.15.9" "1.16.2"
+    [ "$status" -eq 1 ]
+}
+
+@test "version_gte: compares numerically, not lexically (1.10.0 >= 1.9.0)" {
+    run version_gte "1.10.0" "1.9.0"
+    [ "$status" -eq 0 ]
+}
+
+@test "version_gte: differing component counts (1.2 < 1.2.0)" {
+    run version_gte "1.2" "1.2.0"
+    [ "$status" -eq 1 ]
+}
+
+@test "version_gte: empty minimum means any version is OK (no pin)" {
+    run version_gte "0.1.0" ""
+    [ "$status" -eq 0 ]
+}
+
+@test "version_gte: empty installed means needs install" {
+    run version_gte "" "1.16.2"
+    [ "$status" -eq 1 ]
+}
+
+@test "version_gte: two-digit minor/patch sort correctly (1.22.22 >= 1.22.9)" {
+    run version_gte "1.22.22" "1.22.9"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #479. Spec: `specs/REFACTOR-013-version-minimum-enforcement/`.

## Problem
`versions.conf` pins are documented as **minimum** versions, but two install patterns violated that:

- **Defect A — presence-only gates never upgrade.** A tool gated only on `command -v` / `-x $BIN` was reported 'already installed' even when *older* than the pin. Worst case: `pi` on Linux, only ever WARNed by healthcheck (#474), never converged. **This is the user-reported symptom** ('if it finds an old one it keeps it').
- **Defect B — exact-match reconcile downgrades.** `opencode`/`yarn`/`pi` compared with `!=` (shell) / `-ne` (PowerShell), so a version *newer* than the pin was treated as drift and **downgraded** to the pin.

## Fix
Single minimum comparator wired into every pinned-install gate — upgrade iff `installed < pin`, no-op iff `installed >= pin`:

| Layer | Change |
|---|---|
| `scripts/utils.sh` | new `version_gte` (pure `sort -V`; empty-pin → satisfied, empty-installed → needs install) |
| `setup-windows.ps1` | new `Test-VersionAtLeast` (native `[version] -ge`, string fallback for non-semver tags → never throws) |
| `setup-linux.sh` | `opencode` + `yarn`: `!=` → `! version_gte`; `pi`: new below-minimum upgrade branch (was presence-only) |
| `setup-windows.ps1` | `opencode` (tools loop) + `yarn` + `pi`: `-ne` → `-not (Test-VersionAtLeast …)` |

## Out of scope (see spec)
- `bats`/`obsidian` on Linux install *latest* (pin not wired into the install command) — a different, weaker case, tracked as follow-up.
- `AGE`/`EZA`/`ZOXIDE` pins are explicitly Windows-CI download pins (versions.conf comment); not minimum-enforced on Linux.

## Verification
- `tests/version-gte.bats` — 8/8 (equal, newer, older, `1.10.0>=1.9.0` numeric, `1.2<1.2.0`, empty-pin, empty-installed, `1.22.22>=1.22.9`).
- `Test-VersionAtLeast` — 10/10 pwsh cases incl. non-semver fallback (no throw).
- Regression tests in `opencode.bats` (7) + `setup-windows.bats` (51) now assert the comparator **and** `! grep` the removed `!=`/`-ne` form.
- `bash -n setup-linux.sh` OK; `setup-windows.ps1` PSScriptAnalyzer (Error,Warning) → no issues; parses clean.
- Local `setup-linux.bats` 79/80: the one failure is `valid zsh syntax`, which fails only because zsh is absent on the dev machine (identical on `main`); CI installs zsh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated version reconciliation logic for setup scripts to enforce minimum-version semantics instead of exact-match comparisons, preventing unnecessary downgrades when installed versions exceed minimum pins.
  * Applied to opencode, yarn, and pi tools on both Linux and Windows platforms.

* **Tests**
  * Added comprehensive test coverage for new version comparison behavior.
  * Updated existing tests to validate minimum-version enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->