### PR TITLE
fix(shell): rename gp->gpr (collision) and source utils.sh declaratively

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -127,15 +127,9 @@ alias g='agy'
 alias c='claude'
 alias obsidian='obsidian --no-sandbox'
 
-function gp() {
-    local prompt_file="$HOME/.gemini/prompts/$1.md"
-    shift
-    if [ ! -f "$prompt_file" ]; then
-        echo "❌ Error: Prompt not found at $prompt_file"
-        return 1
-    fi
-    agy -i "$(cat "$prompt_file")"$'\n\n'"$*"
-}
+# Gemini saved-prompt helper `gpr` lives in .zsh/functions.sh (shared bash/zsh,
+# sourced below). It was renamed from `gp` to stop colliding with the
+# `gp=git pull` git alias.
 
 # qq / qf: bash quick-question wrappers. `_qq_call` lives in .zsh/functions.sh
 # (REFACTOR-010, shared with zsh). Bash leaves `foo?` literal when no match

--- a/.profile
+++ b/.profile
@@ -26,15 +26,10 @@ if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
 
-# set Utils file
-UTILS_FILE="$HOME/.dotfiles/scripts/utils.sh"
-if [ -f "$UTILS_FILE" ]; then
-    # Add the sourcing of utils.sh to the .bashrc or .zshrc file
-    if ! grep -q "source $UTILS_FILE" "$HOME/.bashrc" && ! grep -q "source $UTILS_FILE" "$HOME/.zshrc"; then
-        echo "source $UTILS_FILE" >> "$HOME/.bashrc"
-        echo "source $UTILS_FILE" >> "$HOME/.zshrc"
-    fi
-fi
+# utils.sh is sourced declaratively from .zsh/functions.sh (loaded by both
+# .bashrc and .zshrc). This file no longer appends a `source utils.sh` line to
+# the user's rc files at login — that runtime mutation of deployed files was
+# non-idempotent and fought the copy-deploy strategy (ADR-012).
 
 # set PATH and EDITOR
 export PATH="$HOME/bin:$PATH"

--- a/.zsh/functions.sh
+++ b/.zsh/functions.sh
@@ -156,3 +156,29 @@ _qq_call() {
 # `ocfull` is the opt-in full mode (MCP tool-use: Hive vault writes, etc.).
 oc() { opencode --pure "$@"; }
 ocfull() { opencode "$@"; }
+
+# ---------------------------------------------------------------------------
+# gpr: run a saved Gemini/AGY prompt. Shared bash/zsh (REFACTOR-010 style).
+# Was duplicated as `gp` in both .bashrc and .zshrc, where it COLLIDED with the
+# `gp=git pull` alias (in zsh the alias won at call time, so the helper was
+# unreachable). Renamed to `gpr` and centralized here: one definition, no
+# collision.
+#   gpr <prompt-name> [extra args]   -> ~/.gemini/prompts/<prompt-name>.md
+gpr() {
+    [ -z "${1:-}" ] && { printf 'usage: gpr <prompt-name> [args]\n' >&2; return 1; }
+    local prompt_file="$HOME/.gemini/prompts/$1.md"
+    shift
+    if [ ! -f "$prompt_file" ]; then
+        printf 'gpr: prompt not found at %s\n' "$prompt_file" >&2
+        return 1
+    fi
+    agy -i "$(cat "$prompt_file")"$'\n\n'"$*"
+}
+
+# Shared utility library (log_*, version_gte, deploy_file, …). Sourced from this
+# single shared entrypoint so BOTH bash and zsh get it — replaces the old
+# ~/.profile runtime mutation that appended `source utils.sh` to the user's rc
+# files on every login (non-declarative; mutated deployed files).
+if [ -f "$HOME/.dotfiles/scripts/utils.sh" ]; then
+    . "$HOME/.dotfiles/scripts/utils.sh"
+fi

--- a/.zsh/functions.sh
+++ b/.zsh/functions.sh
@@ -172,7 +172,7 @@ gpr() {
         printf 'gpr: prompt not found at %s\n' "$prompt_file" >&2
         return 1
     fi
-    agy -i "$(cat "$prompt_file")"$'\n\n'"$*"
+    agy -i "$(< "$prompt_file")"$'\n\n'"$*"
 }
 
 # Shared utility library (log_*, version_gte, deploy_file, …). Sourced from this
@@ -180,5 +180,6 @@ gpr() {
 # ~/.profile runtime mutation that appended `source utils.sh` to the user's rc
 # files on every login (non-declarative; mutated deployed files).
 if [ -f "$HOME/.dotfiles/scripts/utils.sh" ]; then
+    # shellcheck source=/dev/null
     . "$HOME/.dotfiles/scripts/utils.sh"
 fi

--- a/.zsh/functions.zsh
+++ b/.zsh/functions.zsh
@@ -16,7 +16,6 @@ sshmux() {
     ssh -t "$1" "tmux new-session -A -s ${2:-main}"
 }
 
-# Source utility functions from dotfiles
-if [ -f "$HOME/.dotfiles/scripts/utils.sh" ]; then
-    source "$HOME/.dotfiles/scripts/utils.sh"
-fi
+# utils.sh is sourced from the shared .zsh/functions.sh (loaded by both .zshrc
+# and .bashrc), so it is intentionally NOT sourced here — keeping it in one place
+# avoids double-sourcing in zsh and gives bash the same library declaratively.

--- a/.zshrc
+++ b/.zshrc
@@ -107,16 +107,9 @@ alias g='agy'
 alias c='claude'
 alias obsidian='obsidian --no-sandbox'
 
-# Gemini Helper Function
-function gp() {
-    local prompt_file="$HOME/.gemini/prompts/$1.md"
-    shift
-    if [ ! -f "$prompt_file" ]; then
-        echo "❌ Error: Prompt not found at $prompt_file"
-        return 1
-    fi
-    agy -i "$(cat "$prompt_file")"$'\n\n'"$*"
-}
+# Gemini saved-prompt helper `gpr` lives in .zsh/functions.sh (shared bash/zsh,
+# sourced below). Renamed from `gp` so it no longer collides with the
+# `gp=git pull` alias from aliases.zsh (the alias won, leaving the helper dead).
 
 # Claude Code - use slash commands inside session:
 #   claude

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ env var  →  ~/.config/dotfiles/machine.json (per-machine override)  →  env-c
 dotf init my-project --stack python  # Scaffold a new fully-practiced repo
 claude                               # Start Claude Code session
 > /audit src/auth.py                 # Use skills via slash commands
-gp audit "$(cat src/main.py)"       # Gemini prompt function
+gpr audit "$(cat src/main.py)"      # Gemini saved-prompt helper (~/.gemini/prompts/audit.md)
 oc                                   # OpenCode TUI (Go subscription, DeepSeek V4 Pro default)
 qq por que tardas tanto?             # one-shot question (no quotes needed in zsh) -> qwen3.6-plus (ES-friendly)
 qf explain the C10k problem         # one-shot question -> deepseek-v4-flash (faster, technical)

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -139,23 +139,12 @@ if [ -f "$CURRENT_DIR/scripts/load-secrets.sh" ]; then
 fi
 
 
-# Update functions.zsh to source utils.sh if not already done
-if [ -f "$DOTFILES_DIR/.zsh/functions.zsh" ]; then
-    if ! grep -q "source.*utils.sh" "$DOTFILES_DIR/.zsh/functions.zsh"; then
-        log_info "Appending utils.sh source to existing functions.zsh..."
-        printf '\n# Source utility functions\n. %s/scripts/utils.sh\n' "$DOTFILES_DIR" >> "$DOTFILES_DIR/.zsh/functions.zsh"
-    else
-        log_info "functions.zsh already sources utils.sh, skipping"
-    fi
-else
-    log_info "Creating functions.zsh file..."
-    cat > "$DOTFILES_DIR/.zsh/functions.zsh" << EOF
-
-# Source the utils.sh script
-. "$DOTFILES_DIR/scripts/utils.sh"
-
-EOF
-fi
+# utils.sh is sourced declaratively from .zsh/functions.sh (loaded by both
+# ~/.bashrc and ~/.zshrc), so setup no longer mutates the deployed functions.zsh
+# to append a `. utils.sh` line. That deploy-time mutation made the deployed copy
+# drift from the repo source, so the check_deployed assertion below failed. One
+# shared entrypoint gives bash AND zsh the library without ever editing a
+# deployed file (REFACTOR-010 / "presence is not convergence").
 
 # Create a bash_aliases file for bash
 log_info "Creating bash_aliases file..."

--- a/tests/shell-wrapper-dedup.bats
+++ b/tests/shell-wrapper-dedup.bats
@@ -60,3 +60,33 @@ setup() {
     run zsh -c ". '$REPO_ROOT/.zsh/functions.sh'; type _qq_call >/dev/null && type oc >/dev/null && type ocfull >/dev/null"
     [ "$status" -eq 0 ]
 }
+
+# --- AC6: Gemini helper renamed gp -> gpr (no collision with `gp=git pull`) ---
+
+@test "AC6: gpr is the Gemini helper, defined once in functions.sh" {
+    run grep -lE '^gpr\(\)' "$REPO_ROOT/.zsh/functions.sh" "$REPO_ROOT/.zsh/aliases.zsh" "$REPO_ROOT/.bashrc" "$REPO_ROOT/.zshrc"
+    [ "$output" = "$REPO_ROOT/.zsh/functions.sh" ]
+}
+
+@test "AC6: the colliding gemini 'function gp()' no longer exists in any rc file" {
+    ! grep -qE '^(function )?gp\(\)' "$REPO_ROOT/.bashrc" "$REPO_ROOT/.zshrc" "$REPO_ROOT/.zsh/functions.sh"
+}
+
+# --- AC7: utils.sh sourced declaratively; .profile no longer mutates rc files ---
+
+@test "AC7: functions.sh sources utils.sh (shared bash/zsh entrypoint)" {
+    grep -qE 'scripts/utils\.sh' "$REPO_ROOT/.zsh/functions.sh"
+}
+
+@test "AC7: .profile no longer appends 'source utils.sh' to ~/.bashrc or ~/.zshrc" {
+    ! grep -qE '>>[[:space:]]*"\$HOME/\.(bashrc|zshrc)"' "$REPO_ROOT/.profile"
+}
+
+@test "AC7: version_gte resolves after sourcing functions.sh (bash, via utils.sh)" {
+    tmph="$(mktemp -d)"
+    mkdir -p "$tmph/.dotfiles/scripts"
+    cp "$REPO_ROOT/scripts/utils.sh" "$tmph/.dotfiles/scripts/"
+    run env HOME="$tmph" bash -c ". '$REPO_ROOT/.zsh/functions.sh'; type version_gte >/dev/null && type gpr >/dev/null"
+    rm -rf "$tmph"
+    [ "$status" -eq 0 ]
+}

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -262,8 +262,8 @@ setup() {
     zsh -c ". '$DOTFILES_DIR/scripts/utils.sh'"
 }
 
-@test "functions.zsh references utils.sh" {
-    grep -q 'utils.sh' "$DOTFILES_DIR/.zsh/functions.zsh"
+@test "functions.sh sources utils.sh (shared bash/zsh entrypoint)" {
+    grep -q 'utils\.sh' "$DOTFILES_DIR/.zsh/functions.sh"
 }
 
 # =============================================================================


### PR DESCRIPTION
Shell-config hygiene from the repo audit. Two fixes:

### 1. `gp` -> `gpr` (name collision)
The Gemini saved-prompt helper was `function gp()` in **both** `.bashrc` and `.zshrc`, colliding with the `gp=git pull` alias:
- in **zsh** the alias won at call time, so the helper was **unreachable** (dead code);
- in **bash** the function shadowed git-pull — so `gp` meant *different things per shell*.

Renamed to `gpr`, centralized as a single shared definition in `.zsh/functions.sh` (sourced by both shells, REFACTOR-010 style), removed the duplicate `function gp()` from both rc files, and updated the README example.

### 2. `.profile` no longer mutates the user's rc files
`.profile` appended `source utils.sh` to the deployed `~/.bashrc` / `~/.zshrc` **on every login** — a non-idempotent runtime edit that fought the copy-deploy strategy (ADR-012). `utils.sh` is now sourced from the shared `.zsh/functions.sh`, so **both** bash and zsh get it declaratively. Removed the `.profile` mutation block and the now-redundant copy in `functions.zsh`.

> Before: bash got `utils.sh` *only* via the `.profile` append (`functions.sh` didn't source it). The move makes the shared entrypoint the single source.

## Verification
- `tests/shell-wrapper-dedup.bats` — 13/13 (new AC6: gpr defined once, no `gp()` remains; AC7: functions.sh sources utils.sh, .profile no longer appends, version_gte resolves after sourcing functions.sh in bash). zsh AC skips locally (no zsh), covered by CI.
- `bash -n` clean on .bashrc/.profile/functions.sh; the only local bats failures are the pre-existing `zsh -n` checks (zsh absent on dev machine; identical on `main`).

## SDD skip rationale
Mechanical shell-config dedup + a rename: no new public contract, no new dependency, no algorithmic change. The Gemini helper keeps identical behavior under a non-colliding name, and utils.sh sourcing moves from a runtime `.profile` mutation to the existing shared entrypoint. Invariants are locked by the added bats regression tests rather than a design spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Renamed the Gemini saved-prompt helper from `gp` to `gpr`, avoiding conflicts with existing `gp=git pull`-style aliases.
  * Centralized shared utility sourcing via `functions.sh`, removing dynamic edits to shell startup files and preventing duplicate sourcing.

* **Documentation**
  * Updated Gemini “audit” example and related comments to use `gpr`.

* **Tests**
  * Added/updated Bats coverage to verify `gpr` is defined once, no `gp()` remains, and the shared utilities are correctly available after initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->