### PR TITLE
fix(tools): pin sops to current stable 3.13.1

### DIFF
--- a/cli/internal/cmd/tools_test.go
+++ b/cli/internal/cmd/tools_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 )
 
-const testCatalog = `{"tools":[{"name":"sops","version":"3.9.0","profile":"full",` +
+const testCatalog = `{"tools":[{"name":"sops","version":"3.13.1","profile":"full",` +
 	`"source":{"type":"github-release","repo":"getsops/sops","asset":{` +
 	`"linux":"sops-v{version}.linux.{goarch}","darwin":"sops-v{version}.darwin.{goarch}",` +
-	`"windows":"sops-v{version}.exe"}}}]}`
+	`"windows":"sops-v{version}.{goarch}.exe"}}}]}`
 
 func TestToolsList(t *testing.T) {
 	dir := t.TempDir()
@@ -23,7 +23,7 @@ func TestToolsList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tools list: %v", err)
 	}
-	for _, want := range []string{"sops", "3.9.0", "full"} {
+	for _, want := range []string{"sops", "3.13.1", "full"} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("output missing %q\n%s", want, stdout)
 		}

--- a/cli/internal/tools/catalog.go
+++ b/cli/internal/tools/catalog.go
@@ -34,8 +34,9 @@ type Source struct {
 	Repo string `json:"repo"`
 	// Asset maps GOOS -> a release-asset filename template. A per-OS map (not a
 	// single template) is required because release naming is irregular across OSes
-	// — e.g. sops is "sops-v{version}.linux.{goarch}" but just "sops-v{version}.exe"
-	// on Windows. Templates expand {version} and {goarch}.
+	// — e.g. sops is "sops-v{version}.linux.{goarch}" but "sops-v{version}.{goarch}.exe"
+	// on Windows (no OS token, arch before .exe). Templates expand {version} and
+	// {goarch}.
 	Asset map[string]string `json:"asset"`
 }
 

--- a/cli/internal/tools/catalog_test.go
+++ b/cli/internal/tools/catalog_test.go
@@ -10,7 +10,7 @@ const sampleCatalog = `{
   "tools": [
     {
       "name": "sops",
-      "version": "3.9.0",
+      "version": "3.13.1",
       "profile": "full",
       "source": {
         "type": "github-release",
@@ -18,7 +18,7 @@ const sampleCatalog = `{
         "asset": {
           "linux": "sops-v{version}.linux.{goarch}",
           "darwin": "sops-v{version}.darwin.{goarch}",
-          "windows": "sops-v{version}.exe"
+          "windows": "sops-v{version}.{goarch}.exe"
         }
       }
     }
@@ -43,7 +43,7 @@ func TestLoad(t *testing.T) {
 		t.Fatalf("tools = %d, want 1", len(cat.Tools))
 	}
 	got := cat.Tools[0]
-	if got.Name != "sops" || got.Version != "3.9.0" || got.Profile != "full" {
+	if got.Name != "sops" || got.Version != "3.13.1" || got.Profile != "full" {
 		t.Fatalf("unexpected tool: %+v", got)
 	}
 	if got.Source.Type != "github-release" || got.Source.Repo != "getsops/sops" {
@@ -62,21 +62,21 @@ func TestLoad_Errors(t *testing.T) {
 
 func TestAssetName(t *testing.T) {
 	tool := Tool{
-		Version: "3.9.0",
+		Version: "3.13.1",
 		Source: Source{Asset: map[string]string{
 			"linux":   "sops-v{version}.linux.{goarch}",
 			"darwin":  "sops-v{version}.darwin.{goarch}",
-			"windows": "sops-v{version}.exe",
+			"windows": "sops-v{version}.{goarch}.exe",
 		}},
 	}
 	cases := []struct {
 		goos, goarch, want string
 	}{
-		{"linux", "amd64", "sops-v3.9.0.linux.amd64"},
-		{"linux", "arm64", "sops-v3.9.0.linux.arm64"},
-		{"darwin", "arm64", "sops-v3.9.0.darwin.arm64"},
-		{"windows", "amd64", "sops-v3.9.0.exe"}, // irregular: no goos/goarch in the name
-		{"plan9", "amd64", ""},                  // unsupported OS → empty
+		{"linux", "amd64", "sops-v3.13.1.linux.amd64"},
+		{"linux", "arm64", "sops-v3.13.1.linux.arm64"},
+		{"darwin", "arm64", "sops-v3.13.1.darwin.arm64"},
+		{"windows", "amd64", "sops-v3.13.1.amd64.exe"}, // irregular: goarch before .exe, no OS token
+		{"plan9", "amd64", ""},                         // unsupported OS → empty
 	}
 	for _, tc := range cases {
 		if got := tool.AssetName(tc.goos, tc.goarch); got != tc.want {

--- a/packages.json
+++ b/packages.json
@@ -2,7 +2,7 @@
   "tools": [
     {
       "name": "sops",
-      "version": "3.9.0",
+      "version": "3.13.1",
       "profile": "full",
       "source": {
         "type": "github-release",
@@ -10,7 +10,7 @@
         "asset": {
           "linux": "sops-v{version}.linux.{goarch}",
           "darwin": "sops-v{version}.darwin.{goarch}",
-          "windows": "sops-v{version}.exe"
+          "windows": "sops-v{version}.{goarch}.exe"
         }
       }
     }

--- a/specs/CLI-029-dotf-tools-catalog/proposal.md
+++ b/specs/CLI-029-dotf-tools-catalog/proposal.md
@@ -37,11 +37,11 @@ Two PRs under #506:
 
 ```json
 { "tools": [ {
-  "name": "sops", "version": "3.9.0", "profile": "full",
+  "name": "sops", "version": "3.13.1", "profile": "full",
   "source": { "type": "github-release", "repo": "getsops/sops",
     "asset": { "linux": "sops-v{version}.linux.{goarch}",
                "darwin": "sops-v{version}.darwin.{goarch}",
-               "windows": "sops-v{version}.exe" } } } ] }
+               "windows": "sops-v{version}.{goarch}.exe" } } } ] }
 ```
 
 **Design refinement (pre-flight materialized):** the approved single-template `asset` was changed to a **per-OS map**. Release naming is irregular — sops is `sops-v{version}.linux.{goarch}` but just `sops-v{version}.exe` on Windows (no OS/arch in the name). A single template cannot express both; the map can. Same concept, correct detail.

--- a/specs/CLI-029-dotf-tools-catalog/tasks.md
+++ b/specs/CLI-029-dotf-tools-catalog/tasks.md
@@ -25,7 +25,7 @@ created: "2026-06-21"
 
 ## PR-B — installer (separate PR, closes #506)
 
-- [ ] Verify the exact sops release asset + checksum filenames against the live getsops/sops v3.9.0 release
+- [ ] Verify the exact sops release asset + checksum filenames against the live getsops/sops v3.13.1 release (asset names confirmed in PR-A; checksum file is `sops-v{version}.checksums.txt`)
 - [ ] `dotf tools install [name]`: download asset + checksums, verify sha256, place in `~/.local/bin`, chmod; install-if-missing + upgrade-if-below-pin; offline/404 → non-fatal
 - [ ] Testable download seam (no network in tests); table-driven tests for resolve/verify/reconcile
 - [ ] Wire `dotf tools install` into setup (best-effort, non-fatal) so sops lands on machines

--- a/specs/CLI-029-dotf-tools-catalog/verification.md
+++ b/specs/CLI-029-dotf-tools-catalog/verification.md
@@ -8,11 +8,11 @@ created: "2026-06-21"
 ## Evidence (PR-A)
 
 - [x] **Catalog parses** → `packages.json` + `tools.Load`; `TestLoad` asserts the sops entry, `TestLoad_Errors` covers missing + invalid JSON.
-- [x] **Per-OS asset resolution** → `Tool.AssetName`; `TestAssetName` covers linux/darwin (amd64+arm64), the irregular Windows `sops-v3.9.0.exe`, and an unsupported OS → "".
+- [x] **Per-OS asset resolution** → `Tool.AssetName`; `TestAssetName` covers linux/darwin (amd64+arm64), the irregular Windows `sops-v3.13.1.amd64.exe` (arch before `.exe`, no OS token), and an unsupported OS → "".
 - [x] **`dotf tools list` works** → smoke output on this Windows box:
   ```
   NAME  VERSION  PROFILE  ASSET (windows/amd64)
-  sops  3.9.0    full     sops-v3.9.0.exe
+  sops  3.13.1   full     sops-v3.13.1.amd64.exe
   ```
 - [x] **Absent-catalog error** → `dotf tools list` errors clearly when `DOTFILES_DIR/packages.json` is missing.
 


### PR DESCRIPTION
## What

Pins the `sops` catalog entry to current stable **3.13.1** and fixes the Windows asset template to `sops-v{version}.{goarch}.exe`.

## Why this is a separate PR

This change was authored on the CLI-029 branch (`993b45a`) and approved, but **#508 squash-merged at the pre-bump head** (`703ceb4`, the errcheck fix), so `main` shipped sops **3.9.0** with the old `sops-v{version}.exe` template. This re-applies the lost commit (cherry-picked) onto current `main`.

## Why the bump matters

- 3.9.0 was 4 minors stale (current stable: 3.13.1).
- **sops changed its Windows asset naming after 3.9.0**: 3.9.0 ships `sops-v3.9.0.exe` (no arch), 3.13.1 ships `sops-v3.13.1.amd64.exe` (per-arch). The catalog's `sops-v{version}.exe` template was correct only for 3.9.0 and would silently break the CLI-029 installer (PR-B) on any bump. Encoding `{goarch}.exe` keeps the pin and the template in agreement.

Verified live against `getsops/sops`: linux/darwin `sops-v{v}.{os}.{arch}`, Windows `sops-v{v}.{arch}.exe`, checksums `sops-v{v}.checksums.txt`.

## Verify

`go -C cli test ./internal/tools/... ./internal/cmd/...` → ok
