### PR TITLE
docs(spec): resolve CLI-026 open decisions — phased cutover + LF normalization

### DIFF
--- a/specs/CLI-026-dotf-harness-engine/proposal.md
+++ b/specs/CLI-026-dotf-harness-engine/proposal.md
@@ -27,7 +27,7 @@ A new `dotf harness` noun (Go, `cli/internal/harness/`, wired in `cli/internal/c
 - **`dotf harness check`** — offline drift check: enforced regions diffed against `harness/enforced/`; skill records validated to render cleanly. No vault (CI / healthcheck).
 - **`dotf harness check --against-vault`** (vault-present) — flags committed records that are **stale vs the vault SSOT** (`sha(vault skill) != committed record`) — the exact gap that silently drifted ~16 skill records before this spec (PR #511). This is the **upstream** half of the chain; it is a distinct axis from CLI-019/#488, which checks records ↔ deployed `~/.dotfiles` (the downstream half). Together they make `vault → records → deploy` fully observable.
 
-After this PR: one engine, invoked identically on every OS; `setup-windows.ps1` calls `dotf harness deploy`; `scripts/compile-harness.sh` is deleted.
+End state (after PR-B): one engine, invoked identically on every OS; `setup-windows.ps1` calls `dotf harness deploy`; `scripts/compile-harness.sh` is deleted.
 
 ## Out of scope
 
@@ -39,20 +39,20 @@ After this PR: one engine, invoked identically on every OS; `setup-windows.ps1` 
 ## Risks / open questions
 
 - **Behavioral parity is the whole game.** The Go engine must reproduce, exactly: the marker `sha256` (first 16 hex), the GitHub-style slugify, section extraction (body ends at the next same-or-higher-level heading), line-cap assertions, copilot catalog rendering, and skill-frontmatter validation. Any deviation makes `harness check` flag spurious drift on every machine. **Mitigation (MUST resolve before cutover):** a golden-file test that runs both engines against the current vault + records and diffs outputs byte-for-byte; delete `compile-harness.sh` only once that diff is empty.
-- **Line endings.** Go must normalize CRLF→LF on read for vault inputs (the vault has no `.gitattributes`, so its `.md` are CRLF on Windows) and emit LF, independent of platform — the structural fix for the bug PR #511 patched in bash. `[AGENT-DRAFT — review before archive]`
-- **Atomic cutover.** The bash deploy, the `.ps1` `Deploy-SkillRecord` twin, and `compile-harness.sh` must be replaced and `setup-windows.ps1` rewired in one PR, without bricking a mid-upgrade machine. Keep `compile-harness.sh` in-tree until parity is proven, then delete in the same PR. `[AGENT-DRAFT — review before archive]`
-- **Sequencing.** The roadmap places this at PR10 (after vault/spec-gate/secrets/mem). It is self-contained enough to pull forward (it only consumes the manifest + filesystem), but it depends on the `cli/` conventions (cobra wiring, embedded-asset pattern) being stable. **Open decision:** build now (pulled forward) vs. hold for roadmap order? `[AGENT-DRAFT — review before archive]`
+- **Line endings → resolved: normalize in Go.** Go normalizes CRLF→LF on read for vault inputs (the vault has no `.gitattributes`, so its `.md` are CRLF on Windows) and emits LF, independent of platform — the structural fix for the bug PR #511 patched in bash. Chosen over adding a vault `.gitattributes`, which would externalize the fix to another repo and reintroduce the bug if the vault ever drops it.
+- **Cutover → resolved: phased (PR-A → PR-B).** Ship the Go `dotf harness` alongside the bash engine first (**PR-A**: add `cli/internal/harness/` + golden-file parity test; no caller rewired, nothing deleted). Once the parity diff is proven empty, a follow-up (**PR-B**) rewires `setup-windows.ps1` to `dotf harness deploy`, removes the `Deploy-SkillRecord` twin, and deletes `compile-harness.sh`. Chosen over a single atomic PR to shrink blast radius. The cost is two engines co-existing between PR-A and PR-B; the parity test gates PR-B so bash is never trusted past proven divergence, and CLI-019/#488 + `check --against-vault` catch any interim drift.
+- **Sequencing → resolved: hold for roadmap order (PR10).** Build after vault/spec-gate/secrets/mem land, not pulled forward. The interim bash fix (PR #511) already stops the active CRLF drift, so there is no urgency that justifies building on `cli/` conventions while CLI-019 PR-B and CLI-029 PR-B are still churning that surface. This spec is resolved and ready to implement when its slot arrives.
 
 ## Acceptance criteria
 
-Observable outcomes. Each must be testable.
+Observable outcomes. Each must be testable. Tagged by phase per the resolved cutover: **(PR-A)** ships Go alongside bash; **(PR-B)** removes bash and rewires callers.
 
-- [ ] `dotf harness {refresh,deploy,check}` exist; each reproduces its `compile-harness.sh` counterpart's output **byte-for-byte** over the current vault + committed records (golden-file test).
-- [ ] For identical inputs, output is byte-identical (LF, correct marker sha) on Windows and Linux — the winget-jq CRLF class of failure is structurally impossible (no shell word-splitting on tool output). `[AGENT-DRAFT — review before archive]`
-- [ ] `setup-windows.ps1` invokes `dotf harness deploy`; the `Deploy-SkillRecord` block is removed; a guard-grep for the old block is clean.
-- [ ] `scripts/compile-harness.sh` is deleted; no remaining references in `setup-*.sh`/`setup-windows.ps1`/`ci.yml`/profile (guard-grep clean).
-- [ ] `dotf harness check` runs offline (no vault) and is green in CI on a fresh checkout.
-- [ ] `dotf harness check --against-vault` flags a record whose vault source changed but was never refreshed (regression test: mutate a vault skill, assert non-zero exit) — closing the silent-drift gap that motivated PR #511. `[AGENT-DRAFT — review before archive]`
+- [ ] **(PR-A)** `dotf harness {refresh,deploy,check}` exist; each reproduces its `compile-harness.sh` counterpart's output **byte-for-byte** over the current vault + committed records (golden-file test).
+- [ ] **(PR-A)** For identical inputs, output is byte-identical (LF, correct marker sha) on Windows and Linux — the winget-jq CRLF class of failure is structurally impossible (no shell word-splitting on tool output).
+- [ ] **(PR-A)** `dotf harness check` runs offline (no vault) and is green in CI on a fresh checkout.
+- [ ] **(PR-A)** `dotf harness check --against-vault` flags a record whose vault source changed but was never refreshed (regression test: mutate a vault skill, assert non-zero exit) — closing the silent-drift gap that motivated PR #511.
+- [ ] **(PR-B)** `setup-windows.ps1` invokes `dotf harness deploy`; the `Deploy-SkillRecord` block is removed; a guard-grep for the old block is clean.
+- [ ] **(PR-B)** `scripts/compile-harness.sh` is deleted; no remaining references in `setup-*.sh`/`setup-windows.ps1`/`ci.yml`/profile (guard-grep clean).
 
 ## References
 

--- a/specs/CLI-026-dotf-harness-engine/tasks.md
+++ b/specs/CLI-026-dotf-harness-engine/tasks.md
@@ -9,20 +9,33 @@ created: "2026-06-21"
 
 ## Setup
 
-- [ ] Branch created from main: `feat/CLI-026-dotf-harness-engine`
-- [ ] `proposal.md` is complete and acceptance criteria are testable
-- [ ] No open questions left in `proposal.md` "Risks / open questions"
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions" (line-endings, cutover, sequencing resolved 2026-06-21)
+- [ ] Branch created from main for PR-A: `feat/CLI-026-dotf-harness-engine`
+
+> **Status:** spec resolved, held for roadmap order (PR10) per the sequencing decision. Implementation begins when the slot arrives; the steps below are the planned breakdown, not a frozen list.
 
 ## Implementation
 
-> Replace these with the actual steps for this feature. Keep them small (one commit each) and in TDD order.
+> Phased cutover (resolved): PR-A adds the Go engine alongside bash; PR-B removes bash and rewires callers. TDD order, one commit each.
 
-- [ ] Write failing test for <behavior 1>
-- [ ] Implement <module/function> to make it pass
-- [ ] Refactor for clarity (extract, rename, dedupe)
-- [ ] Write failing test for <behavior 2>
-- [ ] Implement to make it pass
-- [ ] ...
+### PR-A — add `dotf harness` alongside bash (no deletion, no caller rewiring)
+
+- [ ] Golden-file fixture: capture current `compile-harness.sh` output over the live vault + records as the parity oracle
+- [ ] Write failing test: `harness refresh` output diffs empty vs the golden fixture (marker sha, slugify, section extraction, line caps)
+- [ ] Implement `cli/internal/harness/` refresh, modeled on `cli/internal/spec/` (embedded-asset + cobra wiring)
+- [ ] Write failing test: CRLF input → LF output, byte-identical on Windows and Linux
+- [ ] Implement CRLF→LF normalization on read; emit LF unconditionally
+- [ ] Implement `harness deploy` (offline render to per-agent `$HOME`) + `harness check` (offline drift)
+- [ ] Write failing test: `check --against-vault` mutates a vault skill → non-zero exit
+- [ ] Implement `check --against-vault` (sha(vault skill) != committed record)
+- [ ] Refactor for clarity; wire `dotf harness` noun in `cli/internal/cmd/`
+
+### PR-B — strangle bash (gated on PR-A parity proven)
+
+- [ ] Rewire `setup-windows.ps1` to call `dotf harness deploy`; delete the `Deploy-SkillRecord` block
+- [ ] `git rm scripts/compile-harness.sh`; repoint `setup-*.sh` / `ci.yml` / profile
+- [ ] Guard-grep: no remaining references to the old block or script
 
 ## Closing
 


### PR DESCRIPTION
Closes the three `[AGENT-DRAFT]` decisions left open when the CLI-026 design proposal merged (#516, tracks #495). No code — spec resolution only.

## Decisions resolved
| Axis | Decision | Rationale |
|------|----------|-----------|
| **Line endings** | Normalize CRLF→LF inside the Go engine | Rejected a vault `.gitattributes` — would externalize the fix and regress if the vault ever drops it. |
| **Cutover** | Phased: **PR-A** (add Go alongside bash + golden-file parity test) → **PR-B** (rewire `setup-windows.ps1`, drop `Deploy-SkillRecord`, delete `compile-harness.sh`) | Smaller blast radius than an atomic cut. PR-B is gated on the parity diff being empty; the interim two-engine window is covered by `check --against-vault` (upstream) + CLI-019/#488 (downstream). |
| **Sequencing** | Hold for roadmap order, not pulled forward | The interim bash fix (#511) already stops the active CRLF drift, so there's no urgency to build on `cli/` conventions while CLI-019/CLI-029 follow-ups are still churning that surface. |

## Changes
- `proposal.md` — three open questions converted to resolved decisions; acceptance criteria tagged **(PR-A)** / **(PR-B)**; "After this PR" → "End state (after PR-B)".
- `tasks.md` — Setup items ticked; Implementation split into PR-A (TDD breakdown) and PR-B (strangle bash).

`status` stays `draft` — the spec is resolved but held for its roadmap slot. No `[AGENT-DRAFT]` tags remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated specification documents clarifying the phased rollout plan for engine improvements, including acceptance criteria and implementation milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->