### PR TITLE
chore(spec): scaffold CLI-025 dotf mem heal + session-start/end

### DIFF
--- a/specs/CLI-025-dotf-mem-heal-and-session-start/proposal.md
+++ b/specs/CLI-025-dotf-mem-heal-and-session-start/proposal.md
@@ -1,0 +1,124 @@
+---
+id: "CLI-025-dotf-mem-heal-and-session-start"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-22"
+issue: "mlorentedev/dotfiles#494"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# CLI-025-dotf-mem-heal-and-session-start
+
+> AUDIT-007 Phase B / PR9 — build the `dotf mem` noun so the claude-mem heal +
+> session-start/end hook cluster collapses from twin shell scripts into one Go
+> implementation. Parent: `docs/adr/audit-007-cli-convergence-state.md`.
+
+## Why
+
+<!-- from issue #494: CLI-025: dotf mem — heal + session-start/end, thin the hooks, delete 4+ scripts -->
+
+`mem` is the largest unmigrated shell cluster in the CLI convergence: **8 scripts,
+~1615 lines** — `claude-mem-heal.{sh,ps1}` (the claude-mem plugin self-heal),
+`claude-session-start.{sh,ps1}` (the SessionStart aggregator), `session-handoff.{sh,ps1}`
+(the SessionEnd twin), plus `session-brief.sh` and `ensure-memory-symlink.sh`
+(sourced/overlapping singletons). They are cross-OS twins that **drift**: the
+Windows `.ps1` lacks the BUG-019 context-hook neuter, so a live Windows gap exists
+today. Per ADR-020/021, every twin pair must converge to one Go noun; building
+`dotf mem` kills the drift, closes the Windows gap, and lets the hooks shrink to
+thin shims.
+
+## What
+
+A new `dotf mem` noun with three subcommands, faithful ports of the existing
+behaviour (cross-OS, single implementation):
+
+- **`dotf mem heal`** — ports `claude-mem-heal`: `ensure_marketplace_compat_symlink`,
+  `heal_mcp_json`, `heal_zod`, `heal_hooks_json` (preserving the `sed -n 1p` drain
+  from the EPIPE fix #242, **not** `head -n1`), `neuter_context_hook` (BUG-019), and
+  the v13 cascade over both the cache-version dir and the marketplace junction.
+- **`dotf mem session-start`** — ports the SessionStart aggregator and folds in
+  `session-brief.sh` + `ensure-memory-symlink.sh`: SDD-004 config gate, session-brief
+  core (vault detect/health/specs/lessons-staleness), silent `dotf doctor --quick`
+  drift surfacing, hive project detection, memory-symlink ensure, knowledge health,
+  memory-temperature scan, and the SDD-021 `.claude.json` size monitor. Emits the
+  SessionStart `hookSpecificOutput.additionalContext` JSON.
+- **`dotf mem session-end`** — ports `session-handoff` (SessionEnd).
+
+After this work the SessionStart/SessionEnd hooks (`claude-session-start.{sh,ps1}`
+and the SessionEnd registration) are **thin shims** that `exec dotf mem …`, and the
+8-script cluster is deleted. Building the heal in Go closes the BUG-019 Windows gap
+for free (one implementation, both OSes).
+
+## Out of scope
+
+- The memory **content** model — vault writes, MEMORY.md authoring, junction
+  topology. That is the substrate epic (#469), not this noun.
+- Changing any hook **semantics**. This is a faithful port; observable output
+  (the SessionStart `additionalContext`) must stay byte-equivalent.
+- Upstream `thedotmack/claude-mem` behaviour. `heal` stays a resilient patcher of
+  upstream's shapes (Option A from spec #242), never a self-emitted template.
+- The hook **registration/deploy** mechanics in `setup-*` beyond repointing them
+  at the shims (full setup→`dotf setup` is CLI-028).
+
+## Decomposition (strangler-fig — this is NOT one atomic PR)
+
+~1615 LOC across 8 scripts and a per-session hot path → multiple atomic PRs, each
+build-then-cutover-then-delete:
+
+1. **`dotf mem heal` (build + test, no deletes).** Port the heal cluster to
+   `cli/internal/mem`. Cross-OS table tests over hooks.json/mcp.json/zod fixtures
+   incl. the EPIPE `sed -n 1p` guard and the BUG-019 neuter. Closes the Windows gap
+   on build.
+2. **Heal cutover + delete.** Repoint the self-heal call site + `setup-{linux,windows}`
+   to `dotf mem heal`; `git rm claude-mem-heal.{sh,ps1}`; guard-grep.
+3. **`dotf mem session-end` + shim + delete `session-handoff.{sh,ps1}`.** Small and
+   independent; can land early.
+4. **`dotf mem session-start` (build).** Port the aggregator, folding `session-brief.sh`
+   + `ensure-memory-symlink.sh`. Golden-output test for the `additionalContext` JSON.
+5. **Session-start cutover + delete.** Thin `claude-session-start.{sh,ps1}` to shims;
+   `git rm` session-start + session-brief + ensure-memory-symlink; guard-grep.
+
+## Risks / open questions
+
+- **[OPEN] session-brief core stability.** `session-brief.sh` (ADR-023, HARNESS-026)
+  is the richest piece, and HARNESS-026-session-brief-core still carries unresolved
+  `[AGENT-DRAFT]` tags (flagged at this session's start). Porting an unstable surface
+  invites churn. **Decide:** port it as-is now, or pin HARNESS-026 first and port in
+  PR4 against a frozen contract?
+- **[OPEN] PR ordering / sequencing vs the substrate epic (#469).** Does any #469
+  work touch the same session-start emission, risking a collision? Confirm before
+  scheduling PR4/5.
+- **Per-session hot path.** The hooks run on **every** session start; a Go binary's
+  cold-start must stay under the shell baseline. `dotf doctor --quick` was already
+  optimised for this (CLI-013) — reuse that bar; measure.
+- **Output equivalence.** The SessionStart `additionalContext` must be byte-equivalent
+  to the shell version (Claude consumes it). Capture a golden fixture from the live
+  shell hook before porting; diff in the test.
+- **EPIPE regression.** Go does not inherit Node's `SIGPIPE→SIG_IGN`, but the
+  *deployed* `hooks.json` still needs the `sed -n 1p` drain — `dotf mem heal` must keep
+  emitting it (and normalising any `head -n1` left on older machines), per #242.
+- **`.mcp.json` race follow-up.** #242 left the `.mcp.json` `head -n1` unfixed (lower
+  blast radius). Fold the same drain into the Go `heal_mcp_json` port, or keep deferred?
+
+## Acceptance criteria
+
+Spec-level (each sub-PR carries its own testable ACs in `tasks.md`):
+
+- [ ] `dotf mem {heal, session-start, session-end}` implemented in `cli/internal/mem`,
+  cross-OS, table-tested.
+- [ ] The SessionStart/SessionEnd hooks are thin shims (`exec dotf mem …`), no business
+  logic.
+- [ ] The 8-script cluster is deleted and a guard-grep pins that no production caller
+  references any of them.
+- [ ] BUG-019 context-hook neuter is present on Windows (the current gap is closed),
+  proven by a Windows-path test.
+- [ ] The SessionStart `additionalContext` output is byte-equivalent to the retired
+  shell hook (golden-fixture diff).
+
+## References
+
+- Parent roadmap: `docs/adr/audit-007-cli-convergence-state.md` (row 9, completeness-gap rows for session-handoff/brief/symlink)
+- EPIPE predecessor (resolved + archived): `specs/archive/2026-05-27-claude-mem-heal-consumer-epipe/` (PR #242) — keep the `sed -n 1p` drain + Option-A sed-patch architecture
+- Heal-lineage predecessors: `specs/archive/BUG-016/017-claude-mem-heal-*`
+- Related: substrate epic #469 (memory content — distinct from this noun)

--- a/specs/CLI-025-dotf-mem-heal-and-session-start/tasks.md
+++ b/specs/CLI-025-dotf-mem-heal-and-session-start/tasks.md
@@ -1,0 +1,55 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-06-22"
+---
+
+# Tasks - CLI-025-dotf-mem-heal-and-session-start
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+
+## Setup
+
+- [ ] Branch created from main: `feat/CLI-025-dotf-mem-heal-and-session-start`
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+> Replace these with the actual steps for this feature. Keep them small (one commit each) and in TDD order.
+
+- [ ] Write failing test for <behavior 1>
+- [ ] Implement <module/function> to make it pass
+- [ ] Refactor for clarity (extract, rename, dedupe)
+- [ ] Write failing test for <behavior 2>
+- [ ] Implement to make it pass
+- [ ] ...
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
+- [ ] Type checks pass
+- [ ] Lint passes
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
+
+Minimal `features.json` skeleton (drop into `<repo>/specs/CLI-025-dotf-mem-heal-and-session-start/features.json`):
+
+```json
+[
+  {
+    "id": "CLI-025-dotf-mem-heal-and-session-start-f1",
+    "behavior": "<one-line copy of an acceptance criterion>",
+    "verification": "<single shell command; exit 0 means pass>",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/CLI-025-dotf-mem-heal-and-session-start/verification.md
+++ b/specs/CLI-025-dotf-mem-heal-and-session-start/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-06-22"
+---
+
+# Verification - CLI-025-dotf-mem-heal-and-session-start
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/CLI-025-dotf-mem-heal-and-session-start/` -> `specs/archive/CLI-025-dotf-mem-heal-and-session-start/`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
Scaffold the `dotf mem` noun spec (AUDIT-007 Phase B / PR9, work-gated on #494).

This PR is the spec scaffold + drafted proposal only — no production code. It lays
out the strangler-fig decomposition into 5 atomic sub-PRs and flags the open design
questions that gate `tasks.md`.

## What `dotf mem` will absorb
8 scripts / ~1615 LOC: `claude-mem-heal.{sh,ps1}`, `claude-session-start.{sh,ps1}`,
`session-handoff.{sh,ps1}`, `session-brief.sh`, `ensure-memory-symlink.sh`. Building
the heal in Go closes a live Windows gap (the `.ps1` lacks the BUG-019 context-hook
neuter).

## Decomposition (each sub-PR build -> cutover -> delete)
1. `dotf mem heal` (build + test, no deletes)
2. heal cutover + delete `claude-mem-heal.{sh,ps1}`
3. `dotf mem session-end` + shim + delete `session-handoff.{sh,ps1}`
4. `dotf mem session-start` (build; folds session-brief + ensure-memory-symlink)
5. session-start cutover + delete the cluster

## Open questions (in the proposal)
- session-brief / HARNESS-026 stability (still `[AGENT-DRAFT]`) — port as-is vs freeze first
- ordering vs the substrate epic #469

Refs #494


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specification and task documentation for upcoming CLI memory operations and session management enhancements, including scope definition, acceptance criteria, implementation guidelines, and verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->