### PR TITLE
fix(session-handoff): write session records to the project folder, not 00_meta/sessions

### DIFF
--- a/docs/adr/adr-014-cross-agent-session-memory-bridge.md
+++ b/docs/adr/adr-014-cross-agent-session-memory-bridge.md
@@ -13,6 +13,13 @@ created: "2026-05-31"
 
 > Drives `MEMORY-001` (GH [#117](https://github.com/mlorentedev/dotfiles/issues/117)); builds on `HANDOFF-001` (the `/handoff` skill) and the SDD-008 deploy engine (ADR-013).
 
+> **Update (2026-06-22):** the session-record **location** specified below (`00_meta/sessions/`) was
+> superseded by **HARNESS-031** (`feedback_sessions_in_project_folder`): records now live in
+> `10_projects/<project>/sessions/`, enforced by `vault-validate.py` §9 and written there by the
+> `/handoff` skill. The `session-handoff.{sh,ps1}` bridge was updated to match (it already resolves
+> the project at `10_projects/<project>/`). The rest of this ADR — the bridge mechanism, the
+> trigger model, and the record schema — stands unchanged.
+
 ## Status
 
 Accepted

--- a/scripts/session-handoff.ps1
+++ b/scripts/session-handoff.ps1
@@ -4,7 +4,7 @@
 # Mirror of session-handoff.sh. Wired to Claude Code's SessionEnd hook: reads the
 # hook JSON on stdin, locates the project's MEMORY.md, and archives the /handoff
 # '## Session Handoff' block into an append-only record:
-#     $VAULT_PATH/00_meta/sessions/<date>-<project>-claude.md
+#     $VAULT_PATH/10_projects/<project>/sessions/<date>-<project>-claude.md
 # The agent authors (via /handoff); this hook only persists.
 #
 # Resilience contract: a session-end hook must NEVER crash a session. Every
@@ -44,7 +44,7 @@ if ([string]::IsNullOrWhiteSpace($blockText)) { exit 0 }
 # 5. Append a durable, timestamped session record.
 $date = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
 if ([string]::IsNullOrEmpty($sid)) { $sid = 'unknown' }
-$outDir = Join-Path $vault '00_meta\sessions'
+$outDir = Join-Path $vault "10_projects\$project\sessions"
 New-Item -ItemType Directory -Force -Path $outDir | Out-Null
 $out = Join-Path $outDir "$date-$project-claude.md"
 

--- a/scripts/session-handoff.sh
+++ b/scripts/session-handoff.sh
@@ -4,7 +4,7 @@
 # Wired to Claude Code's `SessionEnd` hook. Reads the hook JSON on stdin and
 # ARCHIVES the `## Session Handoff` block that the /handoff skill wrote into the
 # project's MEMORY.md into an append-only record:
-#     $VAULT_PATH/00_meta/sessions/<date>-<project>-claude.md
+#     $VAULT_PATH/10_projects/<project>/sessions/<date>-<project>-claude.md
 # The agent authors the handoff (via /handoff, with reasoning); this hook only
 # persists it as durable cross-session history.
 #
@@ -41,7 +41,7 @@ block="$(awk '
 
 # 5. Append a durable, timestamped session record.
 date="$(date -u +%Y-%m-%d)"
-out_dir="$VAULT_PATH/00_meta/sessions"
+out_dir="$VAULT_PATH/10_projects/$project/sessions"
 mkdir -p "$out_dir" 2>/dev/null || exit 0
 out="$out_dir/$date-$project-claude.md"
 

--- a/tests/session-handoff.bats
+++ b/tests/session-handoff.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 # MEMORY-001: session-handoff.sh — the Claude SessionEnd bridge (ADR-014).
 # It ARCHIVES the `## Session Handoff` block that /handoff wrote into a project's
-# MEMORY.md into an append-only record under 00_meta/sessions/. The agent reasons
+# MEMORY.md into an append-only record under 10_projects/<project>/sessions/. The agent reasons
 # (via /handoff); the hook persists. Fixture-driven — no real vault, CI-safe.
 
 setup() {
@@ -10,7 +10,7 @@ setup() {
     VAULT="$(mktemp -d)"
     PROJ_PARENT="$(mktemp -d)"
     PROJ="$PROJ_PARENT/myproj"
-    mkdir -p "$PROJ" "$VAULT/00_meta/sessions" "$VAULT/10_projects/myproj/memory"
+    mkdir -p "$PROJ" "$VAULT/10_projects/myproj/memory"
     export VAULT_PATH="$VAULT"
     PAYLOAD="$VAULT/payload.json"
 }
@@ -34,7 +34,7 @@ EOF
     write_payload sess-123
     run bash -c "'$SCRIPT' < '$PAYLOAD'"
     [ "$status" -eq 0 ]
-    rec="$(find "$VAULT/00_meta/sessions" -name '*-myproj-claude.md')"
+    rec="$(find "$VAULT/10_projects/myproj/sessions" -name '*-myproj-claude.md')"
     [ -n "$rec" ]
     grep -q 'session_id: sess-123' "$rec"
     grep -q 'built the thing' "$rec"
@@ -47,14 +47,14 @@ EOF
     write_payload sess-1
     run bash -c "'$SCRIPT' < '$PAYLOAD'"
     [ "$status" -eq 0 ]
-    [ -z "$(find "$VAULT/00_meta/sessions" -name '*.md')" ]
+    [ -z "$(find "$VAULT/10_projects/myproj/sessions" -name '*.md' 2>/dev/null)" ]
 }
 
 @test "AC2b: no MEMORY.md at all -> clean exit, no record" {
     write_payload sess-1
     run bash -c "'$SCRIPT' < '$PAYLOAD'"
     [ "$status" -eq 0 ]
-    [ -z "$(find "$VAULT/00_meta/sessions" -name '*.md' 2>/dev/null)" ]
+    [ -z "$(find "$VAULT/10_projects/myproj/sessions" -name '*.md' 2>/dev/null)" ]
 }
 
 @test "usage: no stdin payload / empty -> clean no-op (never crashes a session)" {


### PR DESCRIPTION
## Problem

The `SessionEnd` bridge (`scripts/session-handoff.{sh,ps1}`, ADR-014 / MEMORY-001) hardcoded the
session-record output to `$VAULT_PATH/00_meta/sessions/`. But **HARNESS-031**
(`feedback_sessions_in_project_folder`) later moved session records to `10_projects/<project>/sessions/`
— that is where the `/handoff` skill writes, what `vault-validate.py` check 9 enforces, and the
convention every project (ts-bridge, nan-video-pipeline, kubelab, iris, knowledge) already follows.

The hook was never updated, so every Claude session end dropped a record in `00_meta/sessions/` that
the validator then flags as misplaced. (Observed: two stray `*-knowledge-claude.md` records had
accumulated there.)

## Fix

The bridge already resolves the project at `10_projects/<project>/` (it reads `MEMORY.md` from there
and no-ops if absent), so aligning the output is a one-line change per script:

- `session-handoff.sh`  → `out_dir="$VAULT_PATH/10_projects/$project/sessions"`
- `session-handoff.ps1` → `$outDir = Join-Path $vault "10_projects\$project\sessions"`
- `tests/session-handoff.bats` → assertions now check `10_projects/myproj/sessions/`
- `docs/adr/adr-014-...` → supersession note (placement → HARNESS-031); the bridge mechanism,
  trigger model, and record schema are unchanged.

## Verification

`bats tests/session-handoff.bats` — 4/4 pass (archives to the project folder; trivial / missing /
empty inputs remain clean no-ops).

The stray records already sitting in the vault's `00_meta/sessions/` are relocated separately (vault repo).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture decision record with clarification on session record storage organization.

* **Bug Fixes**
  * Corrected session record storage location to align with project-based organizational structure, ensuring consistency across all platforms.

* **Tests**
  * Updated test suite to validate session record placement in the new project-relative structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->