### PR TITLE
docs(spec): reconcile session-brief ownership (HARNESS-026 → CLI-025)

### DIFF
--- a/specs/CLI-025-dotf-mem-heal-and-session-start/proposal.md
+++ b/specs/CLI-025-dotf-mem-heal-and-session-start/proposal.md
@@ -40,11 +40,14 @@ A new `dotf mem` noun with two subcommands, faithful ports of the existing
 behaviour (cross-OS, single implementation):
 
 - **`dotf mem session-start`** — ports the SessionStart aggregator and folds in
-  `session-brief.sh` + `ensure-memory-symlink.sh`: SDD-004 config gate, session-brief
-  core (vault detect/health/specs/lessons-staleness), silent `dotf doctor --quick`
-  drift surfacing, hive project detection, memory-symlink ensure, knowledge health,
-  memory-temperature scan, and the SDD-021 `.claude.json` size monitor. Emits the
-  SessionStart `hookSpecificOutput.additionalContext` JSON.
+  `session-brief.sh` (HARNESS-026's agnostic core) + `ensure-memory-symlink.sh`: SDD-004
+  config gate, session-brief core (vault detect/health/specs/lessons-staleness), silent
+  `dotf doctor --quick` drift surfacing, hive project detection, memory-symlink ensure,
+  knowledge health, memory-temperature scan, and the SDD-021 `.claude.json` size monitor.
+  Emits the SessionStart `hookSpecificOutput.additionalContext` JSON. **Absorbs HARNESS-026's
+  agnostic role**: the Go noun preserves the `--format=stdout|markdown` contract, so the
+  binary — not a shell script — becomes the agnostic session-brief core that opencode/agy/
+  copilot consume (via the HARNESS-001 compiler) and Claude consumes via this hook.
 - **`dotf mem session-end`** — ports `session-handoff` (SessionEnd).
 
 After this work the SessionStart/SessionEnd hooks invoke `dotf mem …` **directly**
@@ -75,18 +78,27 @@ build-then-cutover-then-delete (heal PRs removed — see Scope change above):
 1. **`dotf mem session-end` + direct hook registration + delete `session-handoff.{sh,ps1}`.**
    Small and independent; can land early. The SessionEnd hook command becomes the
    binary path + `mem session-end` (no shim) and both twins are removed outright.
-2. **`dotf mem session-start` (build).** Port the aggregator, folding `session-brief.sh`
-   + `ensure-memory-symlink.sh`. Golden-output test for the `additionalContext` JSON.
-3. **Session-start cutover + delete.** Thin `claude-session-start.{sh,ps1}` to shims;
-   `git rm` session-start + session-brief + ensure-memory-symlink; guard-grep.
+2. **`dotf mem session-start` (build).** Port the aggregator + HARNESS-026's already-shipped
+   `session-brief.sh` (reusing its `--format` contract and reproducing its `sb_*` output) +
+   `ensure-memory-symlink.sh`. Reuse HARNESS-026's 3-CWD byte-equivalence harness as the gate;
+   golden-output test for the `additionalContext` JSON.
+3. **Session-start cutover + delete.** Repoint the SessionStart hook to invoke `dotf mem
+   session-start` directly (no shim, per PR1's decision); `git rm` `claude-session-start.{sh,ps1}`
+   + `session-brief.sh` (HARNESS-026's shell core) + `ensure-memory-symlink.sh`; guard-grep. This
+   is the PR3 that lets HARNESS-026 be archived.
 
 ## Risks / open questions
 
-- **[RESOLVED 2026-06-23] session-brief core stability.** `session-brief.sh` (ADR-023,
-  HARNESS-026) carries unresolved `[AGENT-DRAFT]` tags, so porting it now invites churn.
-  **Decision:** this question gates only `session-start` (PR2/PR3 fold in `session-brief`);
-  `session-end` (PR1) does not touch it. → **PR1 proceeds now; PR2/PR3 are blocked on
-  pinning HARNESS-026 first** and port against a frozen contract.
+- **[RESOLVED 2026-06-23] session-brief core stability — HARNESS-026 is DONE, not a blocker.**
+  Correction: `session-brief.sh` (ADR-023, HARNESS-026) is already **implemented and on main**
+  — the agnostic core, its `sb_*` emitters, the `--format=stdout|markdown` contract, the
+  16-test bats suite, and the 3-CWD byte-equivalence harness all shipped; `claude-session-start.sh`
+  already sources it. (The earlier "unresolved `[AGENT-DRAFT]`" read was a flagger false-positive:
+  `tasks.md` contains that literal string as the *description* of the `sb_specs` emitter, not as an
+  open draft.) → **PR2/PR3 are UNBLOCKED.** HARNESS-026 is the tested **reference to port from**,
+  not a contract to pin. PR2 ports the existing shell core to Go and absorbs its agnostic role
+  (see the What/Decomposition updates below); HARNESS-026's shell `session-brief.sh` is deleted at
+  PR3 cutover, completing the convergence.
 - **[RESOLVED 2026-06-23] PR ordering / sequencing vs the substrate epic (#469).** PR1's
   surface — `session-handoff` writing to `10_projects/<project>/sessions/` — was just
   stabilized by #542 ("write records to the project folder, not 00_meta/sessions"). PR1

--- a/specs/CLI-025-dotf-mem-heal-and-session-start/tasks.md
+++ b/specs/CLI-025-dotf-mem-heal-and-session-start/tasks.md
@@ -34,11 +34,17 @@ created: "2026-06-22"
       `dotf mem session-end`; `git rm scripts/session-handoff.{sh,ps1}`
 - [ ] Guard test (bats): no production caller references `session-handoff`
 
-### PR2/PR3 — `dotf mem session-start` (DEFERRED — blocked on HARNESS-026)
+### PR2/PR3 — `dotf mem session-start` (UNBLOCKED — ports HARNESS-026's shipped shell core)
 
-- [ ] (PR2) Capture golden `additionalContext` fixture from the live shell hook; port the
-      aggregator folding `session-brief.sh` + `ensure-memory-symlink.sh`; byte-equivalence diff
-- [ ] (PR3) Thin `claude-session-start.{sh,ps1}` to shims; `git rm` the cluster; guard-grep
+> HARNESS-026 is DONE on main (`session-brief.sh` + 16 bats + 3-CWD byte-equivalence harness).
+> PR2 ports it to Go; the binary absorbs the agnostic `--format` role; PR3 deletes the shell core.
+
+- [ ] (PR2) Port `session-brief.sh`'s `sb_*` emitters + `--format=stdout|markdown` contract into
+      `cli/internal/mem` (Go), folding `ensure-memory-symlink.sh`; reuse HARNESS-026's 3-CWD
+      byte-equivalence harness + a golden `additionalContext` fixture as the regression gate
+- [ ] (PR3) Repoint the SessionStart hook to `dotf mem session-start` directly (no shim);
+      `git rm` `claude-session-start.{sh,ps1}` + `session-brief.sh` + `ensure-memory-symlink.sh`;
+      guard-grep; then HARNESS-026 (#405) can be archived
 
 ## Closing
 

--- a/specs/HARNESS-026-session-brief-core/proposal.md
+++ b/specs/HARNESS-026-session-brief-core/proposal.md
@@ -13,6 +13,17 @@ template_version: "1.0"
 > First implementation slice of ADR-023 (agnostic session-start). Establishes the
 > `session-brief` core contract and migrates the first signal under it.
 
+> **RECONCILED WITH CLI-025 (2026-06-23).** This spec is **implemented and on main**:
+> `scripts/session-brief.sh` (the agnostic core, its `sb_*` emitters, the
+> `--format=stdout|markdown` contract, the 16-test bats suite, and the 3-CWD byte-equivalence
+> harness) shipped, and `claude-session-start.sh` sources it. Its **mechanism — a POSIX-`sh`
+> core — is interim.** CLI-025 PR2 ports it to Go (`dotf mem session-start`, preserving the
+> `--format` contract) and PR3 deletes the shell core, so the agnostic session-brief core
+> becomes the `dotf` binary (the "eliminate scripts via the CLI" direction). The **design here
+> is the contract CLI-025 PR2 reproduces**; the byte-equivalence harness is reused as PR2's gate.
+> **Archive this spec once CLI-025 PR3 deletes `session-brief.sh`** (keeping it readable until
+> then so PR2 has the reference). See `specs/CLI-025-dotf-mem-heal-and-session-start/proposal.md`.
+
 ## Why
 
 <!-- from issue #405: HARNESS-026: Agnostic session-start: session-brief core + per-agent adapters (ADR-023) -->


### PR DESCRIPTION
Records the architecture decision that the agnostic **session-brief** core (HARNESS-026,
#405) — already shipped on main as the POSIX-sh `scripts/session-brief.sh` — is an
**interim mechanism**: CLI-025 (#494) PR2 ports it to Go (`dotf mem session-start`,
preserving the `--format=stdout|markdown` contract) and PR3 deletes the shell core. The
agnostic core becomes the `dotf` binary, not a shell script.

## Why
- HARNESS-026 is implemented and on main (core + `sb_*` emitters + 16 bats + 3-CWD
  byte-equivalence harness; `claude-session-start.sh` sources it). It is the tested
  **reference to port from**, not a blocker.
- Keeping a shell core would re-introduce the per-OS twin-drift the CLI convergence exists
  to kill. Direct Go invocation (per CLI-025 PR1) is the agnostic end-state.

## Changes (docs only — no code)
- `CLI-025` proposal/tasks: PR2/PR3 reframed `blocked on HARNESS-026` → `ports its shipped
  shell core to Go`; session-start absorbs the agnostic `--format` role; corrects the earlier
  `[AGENT-DRAFT]` flagger false-positive.
- `HARNESS-026` proposal: reconciliation banner; archive once CLI-025 PR3 deletes `session-brief.sh`.

No behavior change. Sequencing: CLI-025 PR2 (Go session-start) is now unblocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

- Updated development specifications for the `dotf mem session-start` command
- Resolved previously identified implementation dependencies
- Clarified the planned approach for upcoming enhancements to session management capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->