### PR TITLE
feat(mem): Claude session-start injectors (CLI-025)

### DIFF
--- a/cli/internal/mem/session_start_config.go
+++ b/cli/internal/mem/session_start_config.go
@@ -1,0 +1,60 @@
+package mem
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// adapterConfig is the SDD-004 session-start-config.json contract: numeric
+// thresholds + per-injector enable flags. It is the Go port of the shell hook's
+// cfg_threshold / cfg_injector_enabled helpers. A missing file, unreadable JSON, or
+// absent key falls back to the historical default so a partial install never breaks
+// SessionStart.
+type adapterConfig struct {
+	Thresholds map[string]int `json:"thresholds"`
+	Injectors  map[string]struct {
+		// Enabled is a pointer so an absent flag ("config silent on this injector")
+		// is distinguishable from an explicit false; absent defaults to enabled.
+		Enabled *bool `json:"enabled"`
+	} `json:"injectors"`
+}
+
+// loadAdapterConfig reads session-start-config.json from path. A missing or
+// malformed file yields a non-nil zero config whose accessors return the defaults —
+// callers never need a nil check.
+func loadAdapterConfig(path string) *adapterConfig {
+	cfg := &adapterConfig{}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cfg
+	}
+	if err := json.Unmarshal(data, cfg); err != nil {
+		return &adapterConfig{} // partial install / corrupt file -> all defaults
+	}
+	return cfg
+}
+
+// threshold returns the configured value for key, or def when the config is absent
+// or the key is missing (cfg_threshold).
+func (c *adapterConfig) threshold(key string, def int) int {
+	if c != nil {
+		if v, ok := c.Thresholds[key]; ok {
+			return v
+		}
+	}
+	return def
+}
+
+// injectorEnabled reports whether the named injector is on. It defaults to true
+// (the historical "all on" behaviour) unless the config explicitly sets it false
+// (cfg_injector_enabled).
+func (c *adapterConfig) injectorEnabled(key string) bool {
+	if c == nil {
+		return true
+	}
+	inj, ok := c.Injectors[key]
+	if !ok || inj.Enabled == nil {
+		return true
+	}
+	return *inj.Enabled
+}

--- a/cli/internal/mem/session_start_config_test.go
+++ b/cli/internal/mem/session_start_config_test.go
@@ -1,0 +1,54 @@
+package mem
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadAdapterConfig(t *testing.T) {
+	cfgJSON := `{
+	  "thresholds": { "memory_md_max_lines": 150, "crystallize_max_days": 14 },
+	  "injectors": {
+	    "doctor_drift": { "enabled": true },
+	    "memory_temperature": { "enabled": false }
+	  }
+	}`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session-start-config.json")
+	mustWrite(t, path, cfgJSON)
+	cfg := loadAdapterConfig(path)
+
+	t.Run("threshold reads a configured value", func(t *testing.T) {
+		if got := cfg.threshold("memory_md_max_lines", 999); got != 150 {
+			t.Errorf("got %d, want 150", got)
+		}
+	})
+
+	t.Run("threshold falls back to default for a missing key", func(t *testing.T) {
+		if got := cfg.threshold("claude_json_min_bytes", 10240); got != 10240 {
+			t.Errorf("got %d, want default 10240", got)
+		}
+	})
+
+	t.Run("injectorEnabled honours an explicit false", func(t *testing.T) {
+		if cfg.injectorEnabled("memory_temperature") {
+			t.Error("memory_temperature should be disabled")
+		}
+	})
+
+	t.Run("injectorEnabled defaults true for an absent injector", func(t *testing.T) {
+		if !cfg.injectorEnabled("claude_json_size") {
+			t.Error("an unlisted injector should default to enabled")
+		}
+	})
+}
+
+func TestLoadAdapterConfigMissingFileUsesDefaults(t *testing.T) {
+	cfg := loadAdapterConfig(filepath.Join(t.TempDir(), "absent.json"))
+	if got := cfg.threshold("memory_md_max_lines", 150); got != 150 {
+		t.Errorf("missing config should yield default, got %d", got)
+	}
+	if !cfg.injectorEnabled("doctor_drift") {
+		t.Error("missing config should default injectors to enabled")
+	}
+}

--- a/cli/internal/mem/session_start_detect.go
+++ b/cli/internal/mem/session_start_detect.go
@@ -1,0 +1,124 @@
+package mem
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/memlink"
+)
+
+// This file ports the Claude session-start "detection" injectors from
+// claude-session-start.sh (CLI-025 PR2b): env-contract drift (doctor --quick), hive
+// project / work-SDK matching, and the auto-memory link. Like the metric injectors,
+// each returns the exact CONTEXT_LINES contribution (with leading framing) or "".
+
+// doctorDrift formats the env-contract drift block from a `dotf doctor --quick`
+// run's output, surfacing only its [WARN]/[FAIL] lines. The block is double-newline
+// framed (it follows the always-present [sdd] reminder). Empty when there is no
+// drift. The caller runs doctor and gates on a deployed contract; this is the pure
+// formatter so it stays unit-testable.
+func doctorDrift(doctorQuickOutput string) string {
+	var drift []string
+	for line := range strings.SplitSeq(doctorQuickOutput, "\n") {
+		if strings.HasPrefix(line, "  [WARN]") || strings.HasPrefix(line, "  [FAIL]") {
+			drift = append(drift, line)
+		}
+	}
+	if len(drift) == 0 {
+		return ""
+	}
+	return "\n\n[doctor] env-contract drift detected (run 'dotf doctor --fix'):\n" + strings.Join(drift, "\n")
+}
+
+// hiveProject emits the hive-vault MCP hint when CWD maps to a vault project: first
+// a personal 10_projects/<repo> match, else a 50_work/45-development work-SDK
+// family/component slug match. Empty when neither matches.
+func hiveProject(cwd, vault string) string {
+	repo := filepath.Base(cwd)
+	if isDir(filepath.Join(vault, "10_projects", repo)) {
+		return hiveProjectBlock(repo)
+	}
+	return workSDKBlock(cwd, vault)
+}
+
+func hiveProjectBlock(repo string) string {
+	return "\n[hive] Project '" + repo + "' found in vault. Use hive-vault MCP tools for on-demand context:" +
+		"\n  - vault_query(project=\"" + repo + "\", section=\"context\") — project overview" +
+		"\n  - vault_query(project=\"" + repo + "\", section=\"tasks\") — active backlog" +
+		"\n  - vault_search(query=\"...\") — search across vault" +
+		"\n  - vault_query(project=\"_meta\", path=\"patterns/...\") — cross-project patterns"
+}
+
+// workSDKBlock matches CWD path segments against vault work-SDK family/component dir
+// slugs. It commits to the first family slug match: a component match yields the
+// component block, otherwise the family-only block. Faithful to the shell's
+// find_work_sdk_project (which returns on the first matching family).
+func workSDKBlock(cwd, vault string) string {
+	devDir := filepath.Join(vault, "50_work", "45-development")
+	if !isDir(devDir) {
+		return ""
+	}
+	cwdSlug := slugify(cwd, true)
+	families, _ := os.ReadDir(devDir)
+	for _, fam := range families {
+		if !fam.IsDir() || !strings.Contains(cwdSlug, slugify(fam.Name(), false)) {
+			continue
+		}
+		comps, _ := os.ReadDir(filepath.Join(devDir, fam.Name()))
+		for _, comp := range comps {
+			if comp.IsDir() && strings.Contains(cwdSlug, slugify(comp.Name(), false)) {
+				return workSDKComponentBlock(fam.Name(), comp.Name())
+			}
+		}
+		return workSDKFamilyBlock(fam.Name()) // family matched, no component
+	}
+	return ""
+}
+
+func workSDKComponentBlock(family, comp string) string {
+	base := "50_work/45-development/" + family + "/" + comp
+	return "\n[hive] Work SDK '" + comp + "' (family: " + family + ") found in vault. Use Hive MCP:" +
+		"\n  - vault_query(project=\"_meta\", path=\"" + base + "/00-context.md\") — project context" +
+		"\n  - vault_query(project=\"_meta\", path=\"" + base + "/memory/MEMORY.md\") — session memory" +
+		"\n  - vault_query(project=\"_meta\", path=\"patterns/workflow-protocol\") — session protocol"
+}
+
+func workSDKFamilyBlock(family string) string {
+	return "\n[hive] Work SDK family '" + family + "' found in vault. Use Hive MCP:" +
+		"\n  - vault_query(project=\"_meta\", path=\"50_work/45-development/" + family + "/00-context.md\") — all repos in family"
+}
+
+// memorySymlink ensures the Claude per-project auto-memory link to the vault source
+// and surfaces the "[auto-memory] Created …" line when it created one. Computes
+// Claude's encoded target path and delegates the OS-agnostic link to memlink.
+func memorySymlink(cwd, vault, home string) string {
+	encoded := encodeProjectPath(cwd)
+	target := filepath.Join(home, ".claude", "projects", encoded, "memory")
+	msg, _ := memlink.Ensure(cwd, target, "", vault)
+	if msg == "" {
+		return ""
+	}
+	return "\n" + msg
+}
+
+// isDir reports whether p exists and is a directory.
+func isDir(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && info.IsDir()
+}
+
+// slugify lowercases s and keeps only [a-z0-9] (plus '/' when keepSlash), mirroring
+// the shell's `tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9[/]'` used for path matching.
+func slugify(s string, keepSlash bool) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case keepSlash && r == '/':
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/cli/internal/mem/session_start_detect_test.go
+++ b/cli/internal/mem/session_start_detect_test.go
@@ -1,0 +1,85 @@
+package mem
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDoctorDrift(t *testing.T) {
+	t.Run("no drift lines → empty", func(t *testing.T) {
+		if got := doctorDrift("all good\n  [OK] env-contract\n"); got != "" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("warn/fail lines are surfaced double-newline framed", func(t *testing.T) {
+		in := "scanning...\n  [WARN] X not in PATH\n  [FAIL] Y missing\ntrailing\n"
+		want := "\n\n[doctor] env-contract drift detected (run 'dotf doctor --fix'):\n  [WARN] X not in PATH\n  [FAIL] Y missing"
+		if got := doctorDrift(in); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+func TestHiveProject(t *testing.T) {
+	t.Run("personal 10_projects match", func(t *testing.T) {
+		vault := t.TempDir()
+		mustMkdirAll(t, filepath.Join(vault, "10_projects", "myrepo"))
+		want := "\n[hive] Project 'myrepo' found in vault. Use hive-vault MCP tools for on-demand context:" +
+			"\n  - vault_query(project=\"myrepo\", section=\"context\") — project overview" +
+			"\n  - vault_query(project=\"myrepo\", section=\"tasks\") — active backlog" +
+			"\n  - vault_search(query=\"...\") — search across vault" +
+			"\n  - vault_query(project=\"_meta\", path=\"patterns/...\") — cross-project patterns"
+		if got := hiveProject("/x/myrepo", vault); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("work-SDK component match", func(t *testing.T) {
+		vault := t.TempDir()
+		mustMkdirAll(t, filepath.Join(vault, "50_work", "45-development", "FamilyX", "CompY"))
+		got := hiveProject("/dev/FamilyX/CompY-repo", vault)
+		if !strings.HasPrefix(got, "\n[hive] Work SDK 'CompY' (family: FamilyX) found in vault. Use Hive MCP:") {
+			t.Errorf("got %q", got)
+		}
+		if !strings.Contains(got, "path=\"50_work/45-development/FamilyX/CompY/memory/MEMORY.md\") — session memory") {
+			t.Errorf("missing component memory line: %q", got)
+		}
+	})
+
+	t.Run("work-SDK family-only match", func(t *testing.T) {
+		vault := t.TempDir()
+		mustMkdirAll(t, filepath.Join(vault, "50_work", "45-development", "FamilyX", "Unrelated"))
+		want := "\n[hive] Work SDK family 'FamilyX' found in vault. Use Hive MCP:" +
+			"\n  - vault_query(project=\"_meta\", path=\"50_work/45-development/FamilyX/00-context.md\") — all repos in family"
+		if got := hiveProject("/dev/FamilyX-thing", vault); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("no match → empty", func(t *testing.T) {
+		if got := hiveProject("/somewhere/else", t.TempDir()); got != "" {
+			t.Errorf("got %q", got)
+		}
+	})
+}
+
+func TestMemorySymlink(t *testing.T) {
+	t.Run("creates the link and surfaces the auto-memory line", func(t *testing.T) {
+		vault := t.TempDir()
+		mustWrite(t, filepath.Join(vault, "10_projects", "proj", "memory", "MEMORY.md"), "x")
+		home := t.TempDir()
+
+		got := memorySymlink("/w/proj", vault, home)
+		if !strings.HasPrefix(got, "\n[auto-memory] Created ") || !strings.HasSuffix(got, " for proj") {
+			t.Errorf("unexpected message: %q", got)
+		}
+	})
+
+	t.Run("no vault source → empty", func(t *testing.T) {
+		if got := memorySymlink("/w/proj", t.TempDir(), t.TempDir()); got != "" {
+			t.Errorf("got %q", got)
+		}
+	})
+}

--- a/cli/internal/mem/session_start_injectors.go
+++ b/cli/internal/mem/session_start_injectors.go
@@ -1,0 +1,139 @@
+package mem
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// This file ports the Claude-specific session-start injectors from
+// claude-session-start.sh (CLI-025 PR2b). Each injector returns the exact text it
+// contributes to the hook's CONTEXT_LINES — including its leading "\n" framing — so
+// the assembly (a later slice) is a thin ordered concatenation and every injector's
+// byte-equivalence is pinned by its own unit test. An injector with nothing to say
+// returns "".
+
+// encodeProjectPath maps a CWD to Claude Code's per-project key by replacing '/'
+// with '-' (the shell's `tr '/' '-'`).
+func encodeProjectPath(cwd string) string {
+	return strings.ReplaceAll(cwd, "/", "-")
+}
+
+// claudeJSONSize warns when ~/.claude/.claude.json has been truncated below
+// threshold bytes (the upstream `claude plugin install` strip bug, SDD-021). Empty
+// when the file is absent or a healthy size.
+func claudeJSONSize(claudeJSON string, threshold int) string {
+	info, err := os.Stat(claudeJSON)
+	if err != nil || info.IsDir() {
+		return ""
+	}
+	size := info.Size()
+	if size > 0 && size < int64(threshold) {
+		return fmt.Sprintf("\n[claude.json] WARNING: ~/.claude/.claude.json is %d bytes (threshold %d). Healthy state is ~75 KB; truncation bug (anthropics/claude-code#59870) reduces it to ~1.5 KB and silently drops subscription state. Recovery: ls -t ~/.claude/backups/.claude.json.backup.* | head -1 && cp <newest-backup> ~/.claude/.claude.json", size, threshold)
+	}
+	return ""
+}
+
+// knowledgeHealth surfaces MEMORY.md size and crystallize-staleness warnings for the
+// project's memory file. Empty when the file is absent. Each warning carries its own
+// leading newline, matching the shell's incremental CONTEXT_LINES appends.
+func knowledgeHealth(memoryFile string, maxLines, staleMaxDays int, now time.Time) string {
+	data, err := os.ReadFile(memoryFile)
+	if err != nil {
+		return ""
+	}
+	var b strings.Builder
+
+	if lineCount := strings.Count(string(data), "\n"); lineCount > maxLines {
+		fmt.Fprintf(&b, "\nMEMORY.md has %d lines (limit: %d) — run /crystallize to trim", lineCount, maxLines)
+	}
+
+	lastDate := lastCrystallized(string(data))
+	switch {
+	case lastDate == "":
+		b.WriteString("\nKnowledge crystallization never run — run: ./scripts/knowledge-crystallize.sh")
+	default:
+		if last, perr := time.Parse("2006-01-02", lastDate); perr == nil {
+			if days := int(now.Sub(last) / (24 * time.Hour)); days > staleMaxDays {
+				fmt.Fprintf(&b, "\nCRYSTALLIZE NEEDED (%d days stale)", days)
+			}
+		}
+	}
+	return b.String()
+}
+
+// lastCrystallized returns the date after the last "## Last Crystallized:" marker
+// (leading whitespace tolerated, BUG-022), or "" when absent.
+func lastCrystallized(content string) string {
+	const marker = "## Last Crystallized:"
+	last := ""
+	sc := bufio.NewScanner(strings.NewReader(content))
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := strings.TrimLeft(sc.Text(), " \t")
+		if rest, ok := strings.CutPrefix(line, marker); ok {
+			last = strings.TrimPrefix(rest, " ")
+		}
+	}
+	return last
+}
+
+// memoryTemperature classifies each non-MEMORY.md file in the project's memory dir
+// as HOT/WARM/COLD/ARCHIVE by mtime, and flags when any file is archive-cold. Empty
+// when the dir is absent or holds no classifiable files.
+func memoryTemperature(memoryDir string, hotDays, warmDays, coldDays int, now time.Time) string {
+	entries, err := os.ReadDir(memoryDir)
+	if err != nil {
+		return ""
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") && e.Name() != "MEMORY.md" {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names) // the shell's glob expands in sorted order
+
+	var report strings.Builder
+	hasArchive := false
+	nowEpoch := now.Unix()
+	for _, name := range names {
+		info, err := os.Stat(filepath.Join(memoryDir, name))
+		if err != nil {
+			continue
+		}
+		daysAgo := int((nowEpoch - info.ModTime().Unix()) / 86400)
+		label := temperatureLabel(daysAgo, hotDays, warmDays, coldDays)
+		if label == "ARCHIVE" {
+			hasArchive = true
+		}
+		fmt.Fprintf(&report, "\n  %s: %s (%dd ago)", label, name, daysAgo)
+	}
+
+	if report.Len() == 0 {
+		return ""
+	}
+	out := "\nMemory temperature:" + report.String()
+	if hasArchive {
+		out += "\nARCHIVE NEEDED: Move memory files >60d old to memory/archive/ and update MEMORY.md index"
+	}
+	return out
+}
+
+// temperatureLabel buckets an age in days against the HOT/WARM/COLD thresholds.
+func temperatureLabel(daysAgo, hotDays, warmDays, coldDays int) string {
+	switch {
+	case daysAgo <= hotDays:
+		return "HOT"
+	case daysAgo <= warmDays:
+		return "WARM"
+	case daysAgo <= coldDays:
+		return "COLD"
+	default:
+		return "ARCHIVE"
+	}
+}

--- a/cli/internal/mem/session_start_injectors.go
+++ b/cli/internal/mem/session_start_injectors.go
@@ -53,8 +53,8 @@ func knowledgeHealth(memoryFile string, maxLines, staleMaxDays int, now time.Tim
 	}
 
 	lastDate := lastCrystallized(string(data))
-	switch {
-	case lastDate == "":
+	switch lastDate {
+	case "":
 		b.WriteString("\nKnowledge crystallization never run — run: ./scripts/knowledge-crystallize.sh")
 	default:
 		if last, perr := time.Parse("2006-01-02", lastDate); perr == nil {

--- a/cli/internal/mem/session_start_injectors_test.go
+++ b/cli/internal/mem/session_start_injectors_test.go
@@ -1,0 +1,128 @@
+package mem
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEncodeProjectPath(t *testing.T) {
+	if got := encodeProjectPath("/home/me/Projects/dotfiles"); got != "-home-me-Projects-dotfiles" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestClaudeJSONSize(t *testing.T) {
+	t.Run("absent file is silent", func(t *testing.T) {
+		if got := claudeJSONSize(filepath.Join(t.TempDir(), "nope.json"), 10240); got != "" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("healthy size is silent", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), ".claude.json")
+		mustWrite(t, p, strings.Repeat("x", 20000))
+		if got := claudeJSONSize(p, 10240); got != "" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("truncated size is flagged byte-exact", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), ".claude.json")
+		mustWrite(t, p, strings.Repeat("x", 100))
+		want := "\n[claude.json] WARNING: ~/.claude/.claude.json is 100 bytes (threshold 10240). Healthy state is ~75 KB; truncation bug (anthropics/claude-code#59870) reduces it to ~1.5 KB and silently drops subscription state. Recovery: ls -t ~/.claude/backups/.claude.json.backup.* | head -1 && cp <newest-backup> ~/.claude/.claude.json"
+		if got := claudeJSONSize(p, 10240); got != want {
+			t.Errorf("got %q", got)
+		}
+	})
+}
+
+func TestKnowledgeHealth(t *testing.T) {
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+
+	t.Run("absent memory file is silent", func(t *testing.T) {
+		if got := knowledgeHealth(filepath.Join(t.TempDir(), "MEMORY.md"), 150, 14, now); got != "" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("never-crystallized marker", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "MEMORY.md")
+		mustWrite(t, p, "a\nb\n")
+		want := "\nKnowledge crystallization never run — run: ./scripts/knowledge-crystallize.sh"
+		if got := knowledgeHealth(p, 150, 14, now); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("over-limit line count is flagged", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "MEMORY.md")
+		mustWrite(t, p, strings.Repeat("line\n", 10)+"## Last Crystallized: 2026-06-23\n")
+		got := knowledgeHealth(p, 5, 14, now)
+		if !strings.HasPrefix(got, "\nMEMORY.md has 11 lines (limit: 5) — run /crystallize to trim") {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("stale crystallize date", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "MEMORY.md")
+		mustWrite(t, p, "## Last Crystallized: 2026-06-01\n")
+		want := "\nCRYSTALLIZE NEEDED (22 days stale)"
+		if got := knowledgeHealth(p, 150, 14, now); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("fresh crystallize date is silent", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "MEMORY.md")
+		mustWrite(t, p, "## Last Crystallized: 2026-06-23\n")
+		if got := knowledgeHealth(p, 150, 14, now); got != "" {
+			t.Errorf("got %q", got)
+		}
+	})
+}
+
+func TestMemoryTemperature(t *testing.T) {
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+
+	t.Run("absent dir is silent", func(t *testing.T) {
+		if got := memoryTemperature(filepath.Join(t.TempDir(), "nope"), 7, 30, 60, now); got != "" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("classifies by age and flags archive-cold", func(t *testing.T) {
+		dir := t.TempDir()
+		ages := map[string]int{"archive.md": 90, "cold.md": 45, "hot.md": 0, "warm.md": 15}
+		for name, days := range ages {
+			p := filepath.Join(dir, name)
+			mustWrite(t, p, "x")
+			mt := now.Add(-time.Duration(days) * 24 * time.Hour)
+			if err := os.Chtimes(p, mt, mt); err != nil {
+				t.Fatalf("chtimes: %v", err)
+			}
+		}
+		mustWrite(t, filepath.Join(dir, "MEMORY.md"), "x") // must be excluded
+
+		got := memoryTemperature(dir, 7, 30, 60, now)
+		for _, want := range []string{
+			"\nMemory temperature:",
+			"\n  ARCHIVE: archive.md (90d ago)",
+			"\n  COLD: cold.md (45d ago)",
+			"\n  HOT: hot.md (0d ago)",
+			"\n  WARM: warm.md (15d ago)",
+			"\nARCHIVE NEEDED: Move memory files >60d old to memory/archive/ and update MEMORY.md index",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("missing %q in %q", want, got)
+			}
+		}
+		// MEMORY.md must not be classified as a temperature entry ("  LABEL: name (Nd ago)").
+		// (It still appears in the ARCHIVE NEEDED guidance text, which is fine.)
+		if strings.Contains(got, "MEMORY.md (") {
+			t.Errorf("MEMORY.md should be excluded from the temperature list: %q", got)
+		}
+	})
+}

--- a/specs/CLI-025-dotf-mem-heal-and-session-start/features.json
+++ b/specs/CLI-025-dotf-mem-heal-and-session-start/features.json
@@ -40,5 +40,12 @@
     "verification": "cd cli && go test ./internal/memlink/",
     "state": "pending",
     "evidence": ""
+  },
+  {
+    "id": "CLI-025-dotf-mem-heal-and-session-start-f7",
+    "behavior": "The Claude session-start injectors (SDD-004 config reader, claude.json-size, knowledge-health, memory-temperature, doctor-drift, hive/work-SDK detect, auto-memory link) each produce their exact CONTEXT_LINES contribution, ported byte-equivalent from claude-session-start.sh",
+    "verification": "cd cli && go test ./internal/mem/ -run 'AdapterConfig|Encode|ClaudeJSON|Knowledge|MemoryTemp|DoctorDrift|HiveProject|MemorySymlink'",
+    "state": "pending",
+    "evidence": ""
   }
 ]

--- a/specs/CLI-025-dotf-mem-heal-and-session-start/tasks.md
+++ b/specs/CLI-025-dotf-mem-heal-and-session-start/tasks.md
@@ -73,12 +73,19 @@ created: "2026-06-22"
       `cli/internal/memlink` (resolution + symlink/junction create), consumed next by the adapter
       and by `dotf doctor --fix` (#551).
 
-#### PR2b-2 — Claude adapter
+#### PR2b-2a — Claude adapter injectors (this PR)
 
-- [ ] Port the Claude-only injectors + the `additionalContext` JSON envelope; golden-fixture diff
-      vs the live shell hook across the 3 CWDs as the gate
-- [ ] Wire the default `dotf mem session-start` (no `--format`) = the Claude hook path, composing
-      `mem.Brief` (PR2a) + `memlink.Ensure` (PR2b-1)
+- [x] Port the Claude-only injectors as pure functions, each returning its exact CONTEXT_LINES
+      contribution: SDD-004 config reader, `claude.json-size`, `knowledge-health`,
+      `memory-temperature`, `doctor-drift`, `hive`/`work-SDK` detect, `auto-memory` link
+      (delegates to `memlink.Ensure`). Table-tested byte-exact.
+
+#### PR2b-2b — Claude adapter assembly + gate
+
+- [ ] Assemble the injectors + the `mem.Brief` (PR2a) `sb_*` blocks in the exact CONTEXT_LINES
+      order, wrap in the `additionalContext` JSON envelope, wire the default `dotf mem
+      session-start` (no `--format`) = the Claude hook path
+- [ ] Golden-fixture byte-equivalence diff vs the live shell hook across the 3 CWDs as the gate
 
 #### PR3 — cutover + delete
 


### PR DESCRIPTION
## Summary

Ports the Claude-specific session-start injectors from `claude-session-start.sh` to Go
(`cli/internal/mem`), as the first half of the session-start adapter (CLI-025 PR2b-2a). Each
injector is a pure function returning its **exact** `CONTEXT_LINES` contribution (with leading
framing); the assembly that orders them + the `additionalContext` envelope + the golden
byte-equivalence gate land in the follow-up (PR2b-2b), so the hook is not cut over here.

- **SDD-004 config reader** — thresholds + per-injector flags from `session-start-config.json`,
  falling back to historical defaults on a partial install (the `cfg_threshold` / `cfg_injector_enabled` port).
- **Metric injectors** — `claude.json-size` (truncation-bug warning), `knowledge-health`
  (MEMORY.md size + crystallize staleness), `memory-temperature` (HOT/WARM/COLD/ARCHIVE by mtime).
- **Detection injectors** — `doctor-drift` (formats the `[WARN]`/`[FAIL]` lines from
  `doctor --quick`), `hive` project / `work-SDK` family-component slug match, and `auto-memory`
  link (delegates to `memlink.Ensure`).

## SDD checklist

- [x] Backlog entry — tracked as **CLI-025 (#494)** on the bitácora Project (ADR-018)
- [x] Spec folder included — feature `f7` + tasks `PR2b-2a`/`PR2b-2b` split
- [x] `proposal.md` has Why / What / Acceptance criteria
- [x] `tasks.md` is in TDD order
- [x] `verification.md` is filled at spec close (multi-PR spec); per-PR evidence is the green CI

## Test plan

- [x] `go test ./internal/mem/` green (every injector table-tested, byte-exact assertions)
- [x] `go build ./...` · `go vet` · `golangci-lint` clean
- n/a bats / shellcheck — no `.sh` / `.bats` changed

## Scope

- Pure functions, used by their unit tests; the assembly that wires them into the hook is PR2b-2b.
  No hook repointed, no shell script deleted (that is the PR3 cutover).

Refs #494.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced `session-start` context helpers that surface project detection, `MEMORY.md` health, and memory temperature/archiving guidance during CLI startup.
  * Added support for configuration-driven injector behavior with safe fallbacks.
* **Bug Fixes**
  * Improved detection for matching the correct vault/work-SDK location and improved handling when memory or markers are missing or stale.
* **Tests**
  * Added automated coverage for config parsing, project detection, memory linking, and generated context formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->