### PR TITLE
feat(mem): Claude session-start adapter + golden gate (CLI-025)

### DIFF
--- a/cli/internal/cmd/mem.go
+++ b/cli/internal/cmd/mem.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/mlorentedev/dotfiles/cli/internal/doctor"
 	"github.com/mlorentedev/dotfiles/cli/internal/env"
 	"github.com/mlorentedev/dotfiles/cli/internal/mem"
 	"github.com/mlorentedev/dotfiles/cli/internal/vault"
@@ -34,58 +37,6 @@ func newMemCmd() *cobra.Command {
 	return cmd
 }
 
-// newMemSessionStartCmd wires the agent-agnostic session-brief core (CLI-025 PR2a),
-// ported from scripts/session-brief.sh. It renders the vault signals — detection,
-// health, spec counts, lessons-staleness, baseline — via --format=stdout|markdown.
-// File-based agents (opencode/agy/copilot) consume this out-of-band; the Claude
-// SessionStart adapter (PR2b) wraps this same core in its additionalContext envelope.
-func newMemSessionStartCmd() *cobra.Command {
-	var format string
-	cmd := &cobra.Command{
-		Use:   "session-start",
-		Short: "Emit the agent-agnostic session-brief (vault signals) for the given --format",
-		Long: "session-start renders the agnostic session-brief core — vault detection,\n" +
-			"vault-health, active/archived spec counts, lessons-staleness, and vault-baseline\n" +
-			"integrity — that file-based agents (opencode/agy/copilot) inject out-of-band.\n" +
-			"The Claude SessionStart hook wraps this same core in its additionalContext\n" +
-			"envelope. Ported from scripts/session-brief.sh (ADR-023, HARNESS-026).",
-		Args:         cobra.NoArgs,
-		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			cwd := os.Getenv("SESSION_BRIEF_CWD")
-			if cwd == "" {
-				cwd, _ = os.Getwd()
-			}
-			brief := mem.Brief(mem.BriefOptions{
-				Cwd:        cwd,
-				ScriptsDir: memScriptsDir(),
-				StaleDays:  14,
-				Now:        time.Now(),
-			})
-			out, err := mem.RenderBrief(brief, format)
-			if err != nil {
-				return err
-			}
-			_, err = fmt.Fprint(cmd.OutOrStdout(), out)
-			return err
-		},
-	}
-	cmd.Flags().StringVar(&format, "format", "", "output format: stdout|markdown")
-	return cmd
-}
-
-// memScriptsDir locates the scripts/ dir hosting the sibling vault-health.sh,
-// resolved from the env-contract (DOTFILES_REPO_DIR) — the Go equivalent of
-// session-brief.sh's $(dirname "$0") sibling lookup. "" when unresolved, which
-// makes vaultHealth emit the same "not found" line the shell does.
-func memScriptsDir() string {
-	repo := env.ResolvePath("DOTFILES_REPO_DIR")
-	if repo == "" {
-		return ""
-	}
-	return filepath.Join(repo, "scripts")
-}
-
 // newMemSessionEndCmd wires the SessionEnd hook. Per the resilience contract a
 // session-end hook must NEVER crash a session, so it reads the payload, persists
 // the handoff record best-effort, and ALWAYS exits 0 — every error is swallowed.
@@ -107,4 +58,117 @@ func newMemSessionEndCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// newMemSessionStartCmd wires the session-start noun (CLI-025), ported from
+// session-brief.sh + claude-session-start.sh. It has two modes:
+//
+//   - `--format=stdout|markdown` renders the agent-agnostic session-brief core
+//     (PR2a) for file-based agents (opencode/agy/copilot), out-of-band.
+//   - no flag = the Claude SessionStart hook: read the hook JSON on stdin and emit
+//     the additionalContext envelope (the agnostic core + the Claude-only injectors).
+func newMemSessionStartCmd() *cobra.Command {
+	var format string
+	cmd := &cobra.Command{
+		Use:   "session-start",
+		Short: "Session-start brief: --format for file-based agents, or the Claude hook envelope",
+		Long: "session-start has two modes. With --format=stdout|markdown it renders the\n" +
+			"agent-agnostic session-brief core (vault detection, health, specs, lessons,\n" +
+			"baseline) that file-based agents (opencode/agy/copilot) inject out-of-band.\n" +
+			"With no --format it is the Claude SessionStart hook: it reads the hook JSON on\n" +
+			"stdin and emits the additionalContext envelope — the same core plus the\n" +
+			"Claude-only injectors. Ported from session-brief.sh + claude-session-start.sh.",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if format != "" {
+				return runSessionBrief(cmd, format)
+			}
+			return runClaudeHook(cmd)
+		},
+	}
+	cmd.Flags().StringVar(&format, "format", "", "stdout|markdown for the agnostic brief; omit for the Claude hook envelope")
+	return cmd
+}
+
+// runSessionBrief renders the agnostic session-brief for a file-based agent.
+func runSessionBrief(cmd *cobra.Command, format string) error {
+	cwd := os.Getenv("SESSION_BRIEF_CWD")
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
+	brief := mem.Brief(mem.BriefOptions{Cwd: cwd, ScriptsDir: memScriptsDir(), StaleDays: 14, Now: time.Now()})
+	out, err := mem.RenderBrief(brief, format)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(cmd.OutOrStdout(), out)
+	return err
+}
+
+// runClaudeHook reads the SessionStart hook JSON on stdin and emits the
+// additionalContext envelope, resolving every path from the env-contract.
+func runClaudeHook(cmd *cobra.Command) error {
+	payload, _ := io.ReadAll(cmd.InOrStdin())
+	cwd := cwdFromPayload(payload)
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
+	home := env.Home()
+	ctx := mem.ClaudeContext(mem.ClaudeContextInput{
+		Cwd:          cwd,
+		Vault:        vault.ResolveVault(),
+		ScriptsDir:   memScriptsDir(),
+		Home:         home,
+		ContractPath: filepath.Join(env.DotfilesDir(home), "env-contract.json"),
+		ClaudeJSON:   filepath.Join(home, ".claude", ".claude.json"),
+		ConfigPath:   memConfigPath(),
+		Now:          time.Now(),
+		DoctorQuick: func() string {
+			var buf bytes.Buffer
+			_, _ = doctor.Run(doctor.Options{Quick: true, Out: &buf})
+			return buf.String()
+		},
+	})
+	out, err := mem.ClaudeEnvelope(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(cmd.OutOrStdout(), out)
+	return err
+}
+
+// cwdFromPayload extracts the hook JSON's .cwd, or "" when absent/malformed.
+func cwdFromPayload(payload []byte) string {
+	var p struct {
+		Cwd string `json:"cwd"`
+	}
+	_ = json.Unmarshal(payload, &p)
+	return p.Cwd
+}
+
+// memScriptsDir locates the scripts/ dir hosting the sibling vault-health.sh,
+// resolved from the env-contract (DOTFILES_REPO_DIR) — the Go equivalent of
+// session-brief.sh's $(dirname "$0") sibling lookup. "" when unresolved, which
+// makes vaultHealth emit the same "not found" line the shell does.
+func memScriptsDir() string {
+	repo := env.ResolvePath("DOTFILES_REPO_DIR")
+	if repo == "" {
+		return ""
+	}
+	return filepath.Join(repo, "scripts")
+}
+
+// memConfigPath resolves session-start-config.json: the SESSION_START_CONFIG
+// override, else <DOTFILES_REPO_DIR>/session-start-config.json (the shell's
+// $SCRIPT_DIR/../session-start-config.json). "" falls back to historical defaults.
+func memConfigPath() string {
+	if c := os.Getenv("SESSION_START_CONFIG"); c != "" {
+		return c
+	}
+	repo := env.ResolvePath("DOTFILES_REPO_DIR")
+	if repo == "" {
+		return ""
+	}
+	return filepath.Join(repo, "session-start-config.json")
 }

--- a/cli/internal/mem/session_start_adapter.go
+++ b/cli/internal/mem/session_start_adapter.go
@@ -1,0 +1,112 @@
+package mem
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// This file is the Claude session-start adapter (CLI-025 PR2b-2b): it composes the
+// agnostic session-brief sb_* emitters (PR2a) and the Claude-only injectors (PR2b-2a)
+// into the hook's additionalContext, in the exact CONTEXT_LINES order of
+// claude-session-start.sh, then wraps it in the SessionStart JSON envelope. The
+// output is contractually byte-equivalent to the shell hook (golden-fixture gated).
+
+// sddReminder is the unconditional Discipline Gate reminder (SDD-001), always first
+// in additionalContext regardless of CWD/vault state. Byte-identical to the shell.
+const sddReminder = "[sdd] Before your first tool call, read `AGENTS.md` at the repo root (or `~/Projects/dotfiles/AGENTS.md` as fallback) and apply its \"Spec-Driven Development\" (including the Discipline Gate) and \"Standing Orders\" sections. SDD applies by default for PR-sized changes (~50-300 LOC, public contract, new dep, multi-PR sequence). Skip ONLY for: typos, comment-only edits, mechanical refactors, bug fixes <20 lines with obvious cause, documentation-only changes. When in doubt, ASK the user."
+
+// lessonsStaleDays is the sb_lessons_staleness threshold (session-brief.sh default).
+const lessonsStaleDays = 14
+
+// ClaudeContextInput injects every path/clock the adapter touches, so the assembly
+// is hermetically testable; the command wiring resolves them from the env-contract.
+type ClaudeContextInput struct {
+	Cwd          string        // hook stdin .cwd
+	Vault        string        // KNOWLEDGE_VAULT (VAULT_PATH)
+	ScriptsDir   string        // hosts vault-health.sh
+	Home         string        // $HOME — roots ~/.claude/projects/<encoded>/memory
+	ContractPath string        // env-contract.json; doctor-drift is gated on its presence
+	ClaudeJSON   string        // ~/.claude/.claude.json
+	ConfigPath   string        // session-start-config.json (SDD-004 thresholds)
+	Now          time.Time     // injected clock for staleness/temperature
+	DoctorQuick  func() string // returns `dotf doctor --quick` output; nil = skip
+}
+
+// ClaudeContext assembles the additionalContext string in claude-session-start.sh's
+// exact order: [sdd] reminder, doctor-drift, (.git: hive + specs + lessons), prepend
+// vault headline, vault-health, auto-memory link, knowledge-health, vault-baseline,
+// memory-temperature, claude.json-size.
+func ClaudeContext(in ClaudeContextInput) string {
+	cfg := loadAdapterConfig(in.ConfigPath)
+	ctx := sddReminder
+
+	// doctor-drift is gated on a deployed env-contract (the hermetic test skips it).
+	if in.DoctorQuick != nil && fileExists(in.ContractPath) {
+		ctx += doctorDrift(in.DoctorQuick())
+	}
+
+	vaultRoot := findVaultRoot(in.Cwd)
+
+	if isDir(filepath.Join(in.Cwd, ".git")) {
+		ctx += hiveProject(in.Cwd, in.Vault)
+		ctx += specs(in.Cwd)
+		ctx += lessonsStaleness(in.Cwd, lessonsStaleDays, in.Now)
+	}
+
+	vaultName := ""
+	if vaultRoot != "" {
+		vaultName = filepath.Base(vaultRoot)
+		ctx = vaultDetect(vaultRoot) + "\n\n" + ctx // prepend the headline + blank line
+	}
+
+	ctx += vaultHealth(vaultRoot, vaultName, in.ScriptsDir)
+	ctx += memorySymlink(in.Cwd, in.Vault, in.Home)
+
+	encoded := encodeProjectPath(in.Cwd)
+	memoryDir := filepath.Join(in.Home, ".claude", "projects", encoded, "memory")
+	ctx += knowledgeHealth(filepath.Join(memoryDir, "MEMORY.md"),
+		cfg.threshold("memory_md_max_lines", 150), cfg.threshold("crystallize_max_days", 14), in.Now)
+	ctx += vaultBaseline(vaultRoot)
+	ctx += memoryTemperature(memoryDir,
+		cfg.threshold("memory_temp_hot_days", 7), cfg.threshold("memory_temp_warm_days", 30),
+		cfg.threshold("memory_temp_cold_days", 60), in.Now)
+	ctx += claudeJSONSize(in.ClaudeJSON, cfg.threshold("claude_json_min_bytes", 10240))
+
+	return ctx
+}
+
+// hookEnvelope is the SessionStart hook output shape. Struct field order pins the
+// JSON key order (a map would randomize it).
+type hookEnvelope struct {
+	HookSpecificOutput struct {
+		HookEventName     string `json:"hookEventName"`
+		AdditionalContext string `json:"additionalContext"`
+	} `json:"hookSpecificOutput"`
+}
+
+// ClaudeEnvelope renders the additionalContext as the SessionStart hook JSON, matching
+// `jq -n` byte-for-byte: 2-space indent, a trailing newline, and — critically — no
+// HTML escaping of <, >, & (Go's json default escapes them; jq does not).
+func ClaudeEnvelope(ctx string) (string, error) {
+	var env hookEnvelope
+	env.HookSpecificOutput.HookEventName = "SessionStart"
+	env.HookSpecificOutput.AdditionalContext = ctx
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(env); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// fileExists reports whether path exists (file or dir).
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/cli/internal/mem/session_start_adapter_golden_test.go
+++ b/cli/internal/mem/session_start_adapter_golden_test.go
@@ -1,0 +1,103 @@
+package mem
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestClaudeAdapterGolden is PR2b-2b's gate: the Go adapter (ClaudeContext +
+// ClaudeEnvelope) must be byte-for-byte identical to the live claude-session-start.sh
+// for the same inputs. This is what lets the shell hook cluster be deleted at PR3.
+//
+// POSIX-only by design (same reason as the session-brief gate: absolute paths render
+// differently under Windows, and the hook is bash). Hermetic: the hook + core are
+// copied into a scriptsDir with NO vault-health.sh (health pins to "not found"), NO
+// deployed env-contract (doctor-drift gated off), NO ensure-memory-symlink helper and
+// no vault memory source (auto-memory is a no-op) — so every run is deterministic.
+func TestClaudeAdapterGolden(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("claude-session-start.sh is POSIX; Windows parity is a separate target")
+	}
+	for _, bin := range []string{"bash", "jq"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s required to run the shell hook", bin)
+		}
+	}
+
+	repo := repoRoot(t)
+	scriptsDir := t.TempDir()
+	copyFile(t, filepath.Join(repo, "scripts", "claude-session-start.sh"), filepath.Join(scriptsDir, "claude-session-start.sh"))
+	copyFile(t, filepath.Join(repo, "scripts", "session-brief.sh"), filepath.Join(scriptsDir, "session-brief.sh"))
+	hook := filepath.Join(scriptsDir, "claude-session-start.sh")
+
+	now := time.Now()
+	vault := t.TempDir()
+
+	scenarios := map[string]string{
+		"bare-outside-vault":  t.TempDir(),
+		"git-repo-hive-specs": newGitHiveCWD(t, vault, now.Add(-100*24*time.Hour)),
+		"inside-vault":        newVaultCWD(t, now.Add(-100*24*time.Hour)),
+	}
+
+	for name, cwd := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			dotfilesDir := t.TempDir() // no env-contract.json -> doctor-drift gated off
+
+			cmd := exec.Command("bash", hook)
+			cmd.Stdin = strings.NewReader(fmt.Sprintf(`{"cwd":%q,"session_id":"golden"}`, cwd))
+			cmd.Env = append(os.Environ(),
+				"HOME="+home,
+				"VAULT_PATH="+vault,
+				"DOTFILES_DIR="+dotfilesDir,
+			)
+			shOut, err := cmd.Output()
+			if err != nil {
+				if ee, ok := err.(*exec.ExitError); ok {
+					t.Fatalf("hook failed: %v\nstderr:\n%s", err, ee.Stderr)
+				}
+				t.Fatalf("hook failed: %v", err)
+			}
+
+			ctx := ClaudeContext(ClaudeContextInput{
+				Cwd: cwd, Vault: vault, ScriptsDir: scriptsDir, Home: home,
+				ContractPath: filepath.Join(dotfilesDir, "env-contract.json"),
+				ClaudeJSON:   filepath.Join(home, ".claude", ".claude.json"),
+				ConfigPath:   filepath.Join(scriptsDir, "..", "session-start-config.json"),
+				Now:          now,
+				DoctorQuick:  nil,
+			})
+			goOut, err := ClaudeEnvelope(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(shOut) != goOut {
+				t.Errorf("golden mismatch:\n--- shell ---\n%s\n--- go ---\n%s", shOut, goOut)
+			}
+		})
+	}
+}
+
+// newGitHiveCWD builds a git repo CWD that triggers the .git block: a hive vault
+// project match (vault/10_projects/<repo>), 1 active + 1 archived spec, and a stale
+// docs/lessons.md.
+func newGitHiveCWD(t *testing.T, vault string, lessonsTime time.Time) string {
+	cwd := filepath.Join(t.TempDir(), "myrepo")
+	mustMkdirAll(t, filepath.Join(cwd, ".git"))
+	mustMkdirAll(t, filepath.Join(cwd, "specs", "SPEC-1"))
+	mustMkdirAll(t, filepath.Join(cwd, "specs", "archive", "OLD-1"))
+	mustMkdirAll(t, filepath.Join(vault, "10_projects", "myrepo")) // hive match
+	lessons := filepath.Join(cwd, "docs", "lessons.md")
+	mustWrite(t, lessons, "lessons\n")
+	if err := os.Chtimes(lessons, lessonsTime, lessonsTime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	return cwd
+}

--- a/cli/internal/mem/session_start_adapter_test.go
+++ b/cli/internal/mem/session_start_adapter_test.go
@@ -1,0 +1,79 @@
+package mem
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClaudeEnvelope(t *testing.T) {
+	t.Run("matches jq shape: 2-space indent + trailing newline", func(t *testing.T) {
+		got, err := ClaudeEnvelope("hello")
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := "{\n  \"hookSpecificOutput\": {\n    \"hookEventName\": \"SessionStart\",\n    \"additionalContext\": \"hello\"\n  }\n}\n"
+		if got != want {
+			t.Errorf("got %q\nwant %q", got, want)
+		}
+	})
+
+	t.Run("does NOT HTML-escape < > & (jq parity)", func(t *testing.T) {
+		got, err := ClaudeEnvelope("recovery: cp <newest-backup> & retry > log")
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Go's json default escapes <>& to < etc.; jq does not. With
+		// SetEscapeHTML(false) the literal phrase survives intact — if any char were
+		// escaped, this exact substring would not appear.
+		if !strings.Contains(got, "cp <newest-backup> & retry > log") {
+			t.Errorf("literal <>& not preserved (HTML-escaped, diverges from jq): %q", got)
+		}
+	})
+}
+
+func TestClaudeContextAssembly(t *testing.T) {
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	scriptsNoHealth := filepath.Join(t.TempDir(), "noscripts") // vault-health.sh absent
+
+	t.Run("sdd reminder is always first; bare CWD appends only health", func(t *testing.T) {
+		ctx := ClaudeContext(ClaudeContextInput{
+			Cwd: t.TempDir(), Vault: t.TempDir(), ScriptsDir: scriptsNoHealth,
+			Home: t.TempDir(), Now: now,
+		})
+		if !strings.HasPrefix(ctx, sddReminder) {
+			t.Errorf("ctx must start with the [sdd] reminder, got: %q", ctx[:min(80, len(ctx))])
+		}
+		if !strings.Contains(ctx, "vault-health.sh not found") {
+			t.Errorf("expected the health 'not found' line, got: %q", ctx)
+		}
+	})
+
+	t.Run("vault CWD prepends the headline before the reminder", func(t *testing.T) {
+		vaultCwd := t.TempDir()
+		mustMkdirAll(t, filepath.Join(vaultCwd, ".obsidian"))
+		ctx := ClaudeContext(ClaudeContextInput{
+			Cwd: vaultCwd, Vault: t.TempDir(), ScriptsDir: scriptsNoHealth,
+			Home: t.TempDir(), Now: now,
+		})
+		if !strings.HasPrefix(ctx, "Obsidian vault detected:") {
+			t.Errorf("headline should be prepended, got: %q", ctx[:min(80, len(ctx))])
+		}
+		if !strings.Contains(ctx, "\n\n"+sddReminder) {
+			t.Errorf("headline should be followed by a blank line then the reminder")
+		}
+	})
+
+	t.Run("doctor-drift is gated off without a contract", func(t *testing.T) {
+		ctx := ClaudeContext(ClaudeContextInput{
+			Cwd: t.TempDir(), Vault: t.TempDir(), ScriptsDir: scriptsNoHealth, Home: t.TempDir(),
+			ContractPath: filepath.Join(t.TempDir(), "absent.json"),
+			DoctorQuick:  func() string { return "  [WARN] should not appear" },
+			Now:          now,
+		})
+		if strings.Contains(ctx, "[doctor]") {
+			t.Errorf("doctor-drift must be skipped when the contract is absent: %q", ctx)
+		}
+	})
+}

--- a/specs/CLI-025-dotf-mem-heal-and-session-start/features.json
+++ b/specs/CLI-025-dotf-mem-heal-and-session-start/features.json
@@ -47,5 +47,12 @@
     "verification": "cd cli && go test ./internal/mem/ -run 'AdapterConfig|Encode|ClaudeJSON|Knowledge|MemoryTemp|DoctorDrift|HiveProject|MemorySymlink'",
     "state": "pending",
     "evidence": ""
+  },
+  {
+    "id": "CLI-025-dotf-mem-heal-and-session-start-f8",
+    "behavior": "dotf mem session-start (no --format) is the Claude SessionStart hook: it assembles the agnostic brief + Claude injectors in claude-session-start.sh's exact CONTEXT_LINES order and emits the additionalContext JSON envelope, byte-equivalent to the shell hook (golden-fixture gated; jq-equivalent encoding with ordered keys and no HTML escaping)",
+    "verification": "cd cli && go test ./internal/mem/ -run 'ClaudeEnvelope|ClaudeContext|Golden'",
+    "state": "pending",
+    "evidence": ""
   }
 ]

--- a/specs/CLI-025-dotf-mem-heal-and-session-start/tasks.md
+++ b/specs/CLI-025-dotf-mem-heal-and-session-start/tasks.md
@@ -82,10 +82,11 @@ created: "2026-06-22"
 
 #### PR2b-2b — Claude adapter assembly + gate
 
-- [ ] Assemble the injectors + the `mem.Brief` (PR2a) `sb_*` blocks in the exact CONTEXT_LINES
-      order, wrap in the `additionalContext` JSON envelope, wire the default `dotf mem
-      session-start` (no `--format`) = the Claude hook path
-- [ ] Golden-fixture byte-equivalence diff vs the live shell hook across the 3 CWDs as the gate
+- [x] Assemble the injectors + the `mem.Brief` (PR2a) `sb_*` blocks in the exact CONTEXT_LINES
+      order, wrap in the `additionalContext` JSON envelope (jq-equivalent: ordered keys, no HTML
+      escaping), wire the default `dotf mem session-start` (no `--format`) = the Claude hook path
+- [x] Golden-fixture byte-equivalence diff vs the live `claude-session-start.sh` across 3 CWDs
+      (POSIX-only gate; runs on the Linux test job)
 
 #### PR3 — cutover + delete
 


### PR DESCRIPTION
## Summary

Closes the Claude session-start adapter (CLI-025 PR2b-2b), the second half of the
session-start convergence. Composes the agnostic `sb_*` brief emitters (PR2a) and the
Claude injectors (PR2b-2a) into the hook's `additionalContext`, then wraps it in the
SessionStart JSON envelope.

- **`ClaudeContext`** — assembles the injectors + brief blocks in `claude-session-start.sh`'s
  **exact** `CONTEXT_LINES` order ([sdd] → doctor-drift → (.git: hive + specs + lessons) →
  prepend vault headline → vault-health → auto-memory → knowledge-health → vault-baseline →
  memory-temperature → claude.json-size).
- **`ClaudeEnvelope`** — renders the envelope matching `jq -n` byte-for-byte: ordered keys
  (struct, not a map) and **no HTML escaping** of `<>&` (Go's json default escapes them).
- **Dual-mode command** — `dotf mem session-start` with `--format=stdout|markdown` is the
  agnostic brief for file-based agents; with no flag it is the Claude hook (reads stdin, emits
  the envelope). `doctor-drift` captures `doctor.Run(Quick)` internally — no subprocess.

## SDD checklist

- [x] Backlog entry — tracked as **CLI-025 (#494)** on the bitácora Project (ADR-018)
- [x] Spec folder included — feature `f8` + ticked tasks `PR2b-2b`
- [x] `proposal.md` has Why / What / Acceptance criteria
- [x] `tasks.md` is in TDD order
- [x] `verification.md` is filled at spec close (multi-PR spec); per-PR evidence is the green CI

## Test plan

- [x] `go test ./internal/mem ./internal/cmd` green (envelope jq-parity, assembly ordering,
      dual-mode command)
- [x] **Golden gate** — `TestClaudeAdapterGolden` diffs the Go output against the live
      `claude-session-start.sh` across 3 CWDs (POSIX-only; runs on the Linux test job)
- [x] Verified locally byte-identical to the shell hook (modulo the Windows `jq` CRLF artifact:
      Windows `jq` emits CRLF, Go emits LF; on Linux both are LF)
- [x] `go build ./...` · `go vet` · `golangci-lint` clean

## Scope

- The hook is **not** cut over and no shell script is deleted yet — that is PR3 (repoint the
  SessionStart hook to `dotf mem session-start`, `git rm` the shell cluster, archive
  HARNESS-026 #405, wire `dotf doctor --fix` to `memlink` for #551).

Refs #494.
