### PR TITLE
Stop the ambient secret export; wrap AI CLIs via dotf secrets run

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -70,11 +70,21 @@ else
 fi
 
 # AI provider endpoints — NaN community (primary, OpenAI-compatible).
-# API key in $NAN_API_KEY (loaded by load-secrets.sh from sensitive/nan.api-key.secret.age).
+# API key in $NAN_API_KEY - injected on demand via `dotf secrets run` (see below), not the ambient shell.
 export NAN_BASE_URL="https://api.nan.builders/v1"
 
-# Load encrypted secrets as environment variables
-[[ -f "$DOTFILES_DIR/scripts/load-secrets.sh" ]] && source "$DOTFILES_DIR/scripts/load-secrets.sh"
+# Secrets are NOT auto-loaded into the ambient shell (ADR-028 "not always
+# exposed"). On demand: `dotf secrets run -- <cmd>` injects the decrypted secrets
+# into that child process only. The AI CLIs that read their keys from the
+# environment are wrapped to launch through it, so the secret lives only in their
+# process, never this shell. No `--only` -> full mapped set (parity with the old
+# ambient export). Recursion-safe: dotf resolves the real binary on PATH, not
+# this function.
+if command -v dotf >/dev/null 2>&1; then
+    opencode() { dotf secrets run -- opencode "$@"; }
+    pi() { dotf secrets run -- pi "$@"; }
+    agy() { dotf secrets run -- agy "$@"; }
+fi
 export APPS_HOME="$HOME/Applications"
 export NINJA_HOME="$HOME/.console-ninja"
 

--- a/.zshrc
+++ b/.zshrc
@@ -48,11 +48,21 @@ export GEMINI_HOME="$HOME/.gemini"
 # exports here clobbered that, so they were removed.
 
 # AI provider endpoints — NaN community (primary, OpenAI-compatible).
-# API key in $NAN_API_KEY (loaded by load-secrets.sh from sensitive/nan.api-key.secret.age).
+# API key in $NAN_API_KEY - injected on demand via `dotf secrets run` (see below), not the ambient shell.
 export NAN_BASE_URL="https://api.nan.builders/v1"
 
-# Load encrypted secrets as environment variables
-[[ -f "$DOTFILES_DIR/scripts/load-secrets.sh" ]] && source "$DOTFILES_DIR/scripts/load-secrets.sh"
+# Secrets are NOT auto-loaded into the ambient shell (ADR-028 "not always
+# exposed"). On demand: `dotf secrets run -- <cmd>` injects the decrypted secrets
+# into that child process only. The AI CLIs that read their keys from the
+# environment are wrapped to launch through it, so the secret lives only in their
+# process, never this shell. No `--only` -> full mapped set (parity with the old
+# ambient export). Recursion-safe: dotf resolves the real binary on PATH, not
+# this function.
+if command -v dotf >/dev/null 2>&1; then
+    opencode() { dotf secrets run -- opencode "$@"; }
+    pi() { dotf secrets run -- pi "$@"; }
+    agy() { dotf secrets run -- agy "$@"; }
+fi
 export APPS_HOME="$HOME/Applications"
 export NINJA_HOME="$HOME/.console-ninja"
 

--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -12,7 +12,7 @@ Set-Alias -Name c -Value claude
 Set-Alias -Name g -Value agy
 
 # AI provider endpoints -- NaN community (primary, OpenAI-compatible).
-# API key in $env:NAN_API_KEY (loaded by load-secrets.ps1 from sensitive/nan.api-key.secret.age).
+# API key in $env:NAN_API_KEY -- injected on demand via `dotf secrets run` (wrappers below), not the ambient session.
 $env:NAN_BASE_URL = 'https://api.nan.builders/v1'
 
 # OpenCode (primary AI coding agent -- install is admin-only on Windows, so
@@ -214,18 +214,21 @@ if (Test-Path $DotfPathsFile) {
 }
 
 # AI provider endpoint -- NaN community (primary, OpenAI-compatible).
-# Mirrors NAN_BASE_URL set in .bashrc/.zshrc. API key comes from the
-# load-secrets.ps1 sourcing below (sensitive/nan.api-key.secret.age).
+# Mirrors NAN_BASE_URL set in .bashrc/.zshrc. The API key is injected on demand
+# via `dotf secrets run` (see the wrappers below), not the ambient session.
 $env:NAN_BASE_URL = 'https://api.nan.builders/v1'
 
-# Load encrypted secrets as environment variables (cross-OS parity with .bashrc:62-63).
-# load-secrets.ps1 decrypts sensitive/*.secret.age via age and sets each value
-# with SetEnvironmentVariable(..., 'Process') -- session-scoped, never persisted
-# to the user registry. Mandatory for opencode (reads {env:NAN_API_KEY} from
-# opencode.jsonc) and agy (reads ANTHROPIC_API_KEY etc. from environment).
-$_secretsScript = Join-Path $env:DOTFILES_DIR 'scripts\load-secrets.ps1'
-if (Test-Path -LiteralPath $_secretsScript) { . $_secretsScript }
-Remove-Variable -Name _secretsScript -ErrorAction SilentlyContinue
+# Secrets are NOT auto-loaded into the ambient session (ADR-028 "not always
+# exposed"). On demand: `dotf secrets run -- <cmd>` injects the decrypted secrets
+# into that child process only. The AI CLIs that read their keys from the
+# environment are wrapped to launch through it, so the secret lives only in their
+# process, never this session. Recursion-safe: dotf resolves the real binary on
+# PATH, not this function.
+if (Get-Command dotf -ErrorAction SilentlyContinue) {
+    function opencode { dotf secrets run -- opencode @args }
+    function pi { dotf secrets run -- pi @args }
+    function agy { dotf secrets run -- agy @args }
+}
 
 # ============================================================================
 # STARTUP MESSAGE

--- a/specs/CLI-024-secrets-no-ambient/proposal.md
+++ b/specs/CLI-024-secrets-no-ambient/proposal.md
@@ -1,0 +1,52 @@
+---
+id: "CLI-024-secrets-no-ambient"
+type: spec
+status: implementing
+created: "2026-06-25"
+issue: "dotfiles#493"
+tags: [spec, proposal, secrets, shell, adr-028]
+template_version: "1.0"
+---
+
+# CLI-024-secrets-no-ambient
+
+> Phase 1b of ADR-028: retire the login-time ambient secrets export from the interactive shells, migrating the consumers that read keys from the environment to launch via `dotf secrets run` (Phase 1a, #579). **Stacked on `feat/secrets-run-jit` — must merge after #579 and after a `dotf` redeploy that ships `dotf secrets run`.**
+
+## Why
+
+`.bashrc`/`.zshrc`/`profile.ps1` source `load-secrets` at every login, exporting ~30 decrypted secrets into the ambient environment of every shell. That is the exposure ADR-028's "not always exposed" objective targets. Phase 1a added the on-demand primitive (`dotf secrets run`); this phase removes the ambient export and routes the consumers through it.
+
+## What
+
+- Remove the `source load-secrets.sh` line from `.bashrc` and `.zshrc`, and the `load-secrets.ps1` dot-source block from `profile.ps1`.
+- Replace it with **launcher wrappers** for the AI CLIs that read their keys from the environment (audited: opencode `{env:NAN_API_KEY}`, pi `{env:NAN_API_KEY}`, agy `${OPENROUTER_API_KEY}` + its MCP children):
+  - POSIX: `opencode() { dotf secrets run -- opencode "$@"; }` (likewise `pi`, `agy`), guarded by `command -v dotf`.
+  - PowerShell: `function opencode { dotf secrets run -- opencode @args }` (likewise), guarded by `Get-Command dotf`.
+- **Parity injection** (no `--only`): each wrapped tool sees the same secret set it saw from the ambient export, but now scoped to its own process — zero risk of omitting a key.
+- **Recursion-safe**: `dotf` is a child process that resolves the real binary on PATH via `exec.Command`, blind to the shell function — so the wrapper never calls itself.
+- Update `tests/powershell-profile.bats` (the two assertions that encoded the old sourcing parity) to assert the new contract.
+
+## Out of scope (deferred follow-ups)
+
+- **`setup-{linux,windows}` eager-load** of load-secrets (a provisioning-time, non-interactive context) is left intact — its consumers are setup-internal and it is not the daily interactive exposure. Migrating it (and any setup block that reads ambient keys) is a separate ticket.
+- **Deleting `load-secrets.{sh,ps1}`** — the later full-convergence step of #493; kept for now (manual fallback + the setup eager-load still uses it).
+- **`--only` scoping per tool** — a later optimisation once the registry (Phase 2) maps consumers to keys.
+
+## Risks / open questions
+
+- **R1 — hard dependency on #579 + a `dotf` redeploy.** The wrappers call `dotf secrets run`; until the new `dotf` is on PATH the wrappers (guarded by `command -v dotf`) still launch the tool, but keyless. *Mitigation:* merge after #579; the `command -v dotf` guard avoids breaking the shell when dotf is absent.
+- **R2 — a consumer not in the audit loses its key.** *Mitigation:* parity injection (full set) covers any key the tool previously saw; the audit (opencode/pi/agy + their MCP children; root MCP servers consume no secrets; CI uses Actions secrets) found no other interactive ambient consumer.
+- **R3 — `dotf secrets run` failing (no age key) now blocks the tool launch** (fail-loud) where the ambient export would have launched it keyless. *Mitigation:* acceptable and more honest; `dotf doctor` (Phase 0) surfaces a missing age key.
+
+## Acceptance criteria
+
+- [ ] **AC1** — `.bashrc`/`.zshrc` no longer `source load-secrets.sh`; `profile.ps1` no longer dot-sources `load-secrets.ps1`. *Verify:* grep + the updated bats.
+- [ ] **AC2** — opencode/pi/agy are wrapped to launch via `dotf secrets run` in all three RC files, guarded by a dotf-presence check. *Verify:* bats + grep.
+- [ ] **AC3** — the RC files parse cleanly and are ASCII (`bash -n`, pwsh parser, no non-ASCII in shell files). *Verify:* `bash -n`, PS parser, grep.
+- [ ] **AC4** — `tests/powershell-profile.bats` passes with the new contract; no other test asserts the removed sourcing. *Verify:* `bats tests/powershell-profile.bats`.
+
+## References
+
+- Issue: dotfiles#493; ADR: adr-028 (Phase 1b)
+- Builds on: #579 (Phase 1a `dotf secrets run`), #578 (Phase 0 provisioning + doctor)
+- Audit: opencode `ai/opencode/opencode.jsonc`, pi `ai/pi/models.json`, agy `ai/agy/mcp_servers.json`; root `mcp-servers.json` (no secret env)

--- a/specs/CLI-024-secrets-no-ambient/verification.md
+++ b/specs/CLI-024-secrets-no-ambient/verification.md
@@ -1,0 +1,39 @@
+---
+tags: [spec, verification, secrets, shell]
+created: "2026-06-25"
+---
+
+# Verification - CLI-024-secrets-no-ambient
+
+> Phase 1b. Branch `feat/secrets-no-ambient-export` (stacked on `feat/secrets-run-jit`).
+
+## AC1/AC2 — sourcing removed, wrappers added
+
+- `.bashrc`/`.zshrc`: the `source load-secrets.sh` line is replaced by `opencode()/pi()/agy()` wrappers calling `dotf secrets run`, guarded by `command -v dotf`.
+- `profile.ps1`: the `load-secrets.ps1` dot-source block is replaced by `function opencode/pi/agy { dotf secrets run -- … @args }`, guarded by `Get-Command dotf`.
+
+## AC3 — RC files parse cleanly + ASCII
+
+- `bash -n .bashrc` / `bash -n .zshrc` → OK.
+- `profile.ps1` → PowerShell parser: 0 errors (850 tokens).
+- No non-ASCII introduced in the shell RC (an em-dash + `→` I first added were replaced with ASCII).
+
+## AC4 — bats green with the new contract
+
+`bats tests/powershell-profile.bats` → **14/14 ok**, including the two rewritten assertions:
+
+```
+ok 7 profile.ps1 does NOT auto-source load-secrets and wraps AI CLIs via dotf secrets run (ADR-028)
+ok 8 parity: neither .bashrc nor profile.ps1 auto-loads secrets; both wrap the AI CLIs
+ok 14 profile.ps1 valid PowerShell syntax (if pwsh available)
+```
+
+No other test asserts the removed sourcing (`grep -rn` over `tests/`): `setup-windows.bats:76` asserts the **setup eager-load** (left intact — out of scope), and `load-secrets.bats` tests the **script** (untouched).
+
+## Deferred (noted in proposal)
+
+- setup-{linux,windows} eager-load migration; deleting the load-secrets twins; per-tool `--only` scoping.
+
+## Merge gate
+
+Stacked on #579 — merge **after** #579 and after a `dotf` redeploy shipping `dotf secrets run`.

--- a/tests/powershell-profile.bats
+++ b/tests/powershell-profile.bats
@@ -52,20 +52,22 @@ setup() {
     ! grep -qF "'Projects\\dotfiles\\scripts\\nan-debug.sh'" "$PROFILE_SCRIPT"
 }
 
-# --- Secrets sourcing (cross-OS parity: .bashrc sources load-secrets.sh) ---
+# --- On-demand secrets (ADR-028: no ambient export; wrap AI CLIs via dotf secrets run) ---
 
-@test "profile.ps1 sources load-secrets.ps1 (cross-OS parity with .bashrc)" {
-    # .bashrc:63 sources load-secrets.sh. PowerShell parity requires profile.ps1
-    # to dot-source load-secrets.ps1 so $env:NAN_API_KEY / OPENROUTER_API_KEY /
-    # etc. are populated for opencode (reads {env:NAN_API_KEY} from opencode.jsonc),
-    # agy, and copilot. Without this, opencode.jsonc references resolve to empty.
-    grep -qE 'load-secrets\.ps1' "$PROFILE_SCRIPT"
-    grep -qF 'Test-Path -LiteralPath' "$PROFILE_SCRIPT"
+@test "profile.ps1 does NOT auto-source load-secrets and wraps AI CLIs via dotf secrets run (ADR-028)" {
+    # ADR-028 "not always exposed": secrets are NOT loaded into the ambient
+    # session. opencode (reads {env:NAN_API_KEY} from opencode.jsonc), pi and agy
+    # are wrapped to launch through `dotf secrets run`, so the secret lives only
+    # in their child process — never the session.
+    ! grep -qE 'load-secrets\.ps1' "$PROFILE_SCRIPT"
+    grep -qE 'function opencode \{ dotf secrets run' "$PROFILE_SCRIPT"
 }
 
-@test "parity: load-secrets sourced in both .bashrc and profile.ps1" {
-    grep -qE 'load-secrets\.sh' "$DOTFILES_DIR/.bashrc"
-    grep -qE 'load-secrets\.ps1' "$PROFILE_SCRIPT"
+@test "parity: neither .bashrc nor profile.ps1 auto-loads secrets; both wrap the AI CLIs" {
+    ! grep -qE 'source .*load-secrets\.sh' "$DOTFILES_DIR/.bashrc"
+    ! grep -qE 'load-secrets\.ps1' "$PROFILE_SCRIPT"
+    grep -qE 'opencode\(\) \{ dotf secrets run' "$DOTFILES_DIR/.bashrc"
+    grep -qE 'function opencode \{ dotf secrets run' "$PROFILE_SCRIPT"
 }
 
 # --- Cross-OS oc behaviour (intentional asymmetry, documented) ---


### PR DESCRIPTION
Phase 1b of ADR-028. Completes the "not always exposed" objective: removes the login-time `load-secrets` ambient export from the interactive shells and routes the consumers that read keys from the environment through `dotf secrets run` (Phase 1a, #579, now merged).

## What

- Remove `source load-secrets.sh` from `.bashrc`/`.zshrc` and the `load-secrets.ps1` dot-source block from `profile.ps1`.
- Replace it with launcher wrappers for the AI CLIs that read keys from the env — **audited**: opencode (`{env:NAN_API_KEY}`), pi (`{env:NAN_API_KEY}`), agy (`${OPENROUTER_API_KEY}` + its MCP children). Root MCP servers (`hive`/`context7`/`sequential-thinking`) consume no secrets; CI uses Actions secrets — neither affected.
  - POSIX: `opencode() { dotf secrets run -- opencode "$@"; }` (also `pi`, `agy`), guarded by `command -v dotf`.
  - PowerShell: `function opencode { dotf secrets run -- opencode @args }` (also `pi`, `agy`), guarded by `Get-Command dotf`.
- **Parity injection** (no `--only`): each wrapped tool sees the same secret set it had from the ambient export, now scoped to its own process — zero risk of omitting a key.
- **Recursion-safe**: `dotf` is a child process that resolves the real binary on PATH (`exec.Command`), blind to the shell function.

## Verification

- `bash -n .bashrc` / `.zshrc` → OK; `profile.ps1` PowerShell parser → 0 errors; RC additions are ASCII.
- `bats tests/powershell-profile.bats` → **14/14**, including the two assertions rewritten from the old sourcing-parity contract to the new wrapper contract.
- No other test asserts the removed sourcing (`setup-windows.bats` covers the setup eager-load, left intact; `load-secrets.bats` tests the untouched script).
- Evidence: `specs/CLI-024-secrets-no-ambient/verification.md`.

## Operational note

Requires a `dotf` redeploy shipping `dotf secrets run` (now on main via #579) before the wrappers function. The `command -v dotf` / `Get-Command dotf` guards mean a machine without it still launches the tool (keyless) rather than erroring the shell.

## Out of scope (follow-ups)

- The `setup-{linux,windows}` eager-load (provisioning context, not the daily interactive exposure) — left intact.
- Deleting the `load-secrets.{sh,ps1}` twins — the later full-convergence step of #493.
- Per-tool `--only` scoping (needs the Phase 2 registry).

Refs #493. Do not auto-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI CLI tools now run with secrets injected only when launched, instead of loading them into the current shell session.
  * Added shell wrappers for common AI commands across Bash, Zsh, and PowerShell.

* **Bug Fixes**
  * Reduced the chance of exposing sensitive credentials in interactive environments.
  * Improved consistency across shell profiles by aligning secret handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->