### PR TITLE
Secrets registry: registry.yaml mapping SSOT + dotf secrets ls/show; run reads it

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -2,7 +2,10 @@ module github.com/mlorentedev/dotfiles/cli
 
 go 1.26.0
 
-require github.com/spf13/cobra v1.10.2
+require (
+	github.com/spf13/cobra v1.10.2
+	go.yaml.in/yaml/v3 v3.0.4
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -6,5 +6,7 @@ github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -66,7 +66,7 @@ func newSecretsLsCmd() *cobra.Command {
 			w := cmd.OutOrStdout()
 			for i := range reg.Secrets {
 				s := &reg.Secrets[i]
-				fmt.Fprintf(w, "%-26s %-9s %s\n", s.ID, s.Plane, strings.Join(s.Vars(), ","))
+				_, _ = fmt.Fprintf(w, "%-26s %-9s %s\n", s.ID, s.Plane, strings.Join(s.Vars(), ","))
 			}
 			return nil
 		},
@@ -98,7 +98,7 @@ func newSecretsShowCmd() *cobra.Command {
 				return err
 			}
 			_, val, _ := strings.Cut(kv[0], "=") // EnvFor scrubs newlines → capture-friendly
-			fmt.Fprint(cmd.OutOrStdout(), val)
+			_, _ = fmt.Fprint(cmd.OutOrStdout(), val)
 			return nil
 		},
 	}
@@ -110,6 +110,9 @@ func showSource(reg *secrets.Registry, idOrVar string) (name, src string, err er
 	s := reg.Lookup(idOrVar)
 	if s == nil {
 		return "", "", fmt.Errorf("unknown secret %q (try `dotf secrets ls`)", idOrVar)
+	}
+	if !s.AgeBacked() {
+		return "", "", fmt.Errorf("%q uses the %s backend, not yet supported (ADR-028 Phase 3)", s.ID, s.Backend)
 	}
 	if s.Expose.File != nil {
 		return "", "", fmt.Errorf("%q is a file secret; use `dotf secrets run --only %s -- <cmd>`", s.ID, s.ID)

--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -22,16 +22,106 @@ func newSecretsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "secrets",
 		Short: "On-demand secrets — inject into a child process, never the shell (ADR-028)",
-		Long: "secrets decrypts the age-encrypted secrets mapped in sensitive/env-mapping.conf\n" +
-			"and exposes them on demand. `run` injects them into one child process only, so\n" +
-			"they never live in the ambient shell environment (ADR-028 Phase 1).",
+		Long: "secrets reads the registry (secrets/registry.yaml) and exposes the mapped\n" +
+			"secrets on demand. `run` injects them into one child process only (never the\n" +
+			"ambient shell); `show` prints one value; `ls` lists ids (ADR-028 §2).",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
 	}
 	cmd.AddCommand(newSecretsRunCmd())
+	cmd.AddCommand(newSecretsLsCmd())
+	cmd.AddCommand(newSecretsShowCmd())
 	return cmd
+}
+
+// registryPath resolves secrets/registry.yaml (the mapping SSOT); a var so tests
+// can point it at a fixture. ageDecryptor is the decrypt seam (nil → AgeDecrypt).
+var (
+	registryPath = func() string { return filepath.Join(env.DotfilesDir(env.Home()), "secrets", "registry.yaml") }
+	ageDecryptor secrets.Decryptor
+)
+
+func loadRegistry() (*secrets.Registry, error) {
+	data, err := os.ReadFile(registryPath())
+	if err != nil {
+		return nil, fmt.Errorf("read registry: %w", err)
+	}
+	return secrets.ParseRegistry(data)
+}
+
+// newSecretsLsCmd lists registry ids with plane + exposed vars — never values.
+func newSecretsLsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:          "ls",
+		Short:        "List registry secret ids with plane and exposed vars (no values)",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			reg, err := loadRegistry()
+			if err != nil {
+				return err
+			}
+			w := cmd.OutOrStdout()
+			for i := range reg.Secrets {
+				s := &reg.Secrets[i]
+				fmt.Fprintf(w, "%-26s %-9s %s\n", s.ID, s.Plane, strings.Join(s.Vars(), ","))
+			}
+			return nil
+		},
+	}
+}
+
+// newSecretsShowCmd prints one secret's decrypted value to stdout (no trailing
+// newline, for `KEY=$(dotf secrets show <id>)`). Single-env secrets only — file
+// and multi-var secrets must go through `run` (a value to stdout would be ambiguous).
+func newSecretsShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:          "show <id>",
+		Short:        "Print one secret's decrypted value to stdout, no trailing newline",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reg, err := loadRegistry()
+			if err != nil {
+				return err
+			}
+			name, src, err := showSource(reg, args[0])
+			if err != nil {
+				return err
+			}
+			secretsDir := filepath.Join(env.DotfilesDir(env.Home()), "sensitive")
+			loader := &secrets.Loader{SecretsDir: secretsDir, KeyPath: ageKeyPath(), Decrypt: ageDecryptor}
+			kv, err := loader.EnvFor([]secrets.Entry{{Var: name, File: src}}, nil)
+			if err != nil {
+				return err
+			}
+			_, val, _ := strings.Cut(kv[0], "=") // EnvFor scrubs newlines → capture-friendly
+			fmt.Fprint(cmd.OutOrStdout(), val)
+			return nil
+		},
+	}
+}
+
+// showSource picks the single env var + age source `show` will decrypt, rejecting
+// file and multi-var secrets with guidance to use `run`.
+func showSource(reg *secrets.Registry, idOrVar string) (name, src string, err error) {
+	s := reg.Lookup(idOrVar)
+	if s == nil {
+		return "", "", fmt.Errorf("unknown secret %q (try `dotf secrets ls`)", idOrVar)
+	}
+	if s.Expose.File != nil {
+		return "", "", fmt.Errorf("%q is a file secret; use `dotf secrets run --only %s -- <cmd>`", s.ID, s.ID)
+	}
+	if len(s.Expose.Env.Vars) != 1 {
+		return "", "", fmt.Errorf("%q exposes %d vars; use `dotf secrets run --only %s -- <cmd>`", s.ID, len(s.Expose.Env.Vars), s.ID)
+	}
+	v := s.Expose.Env.Vars[0]
+	if src = v.Age; src == "" {
+		src = s.Age
+	}
+	return v.Name, src, nil
 }
 
 func newSecretsRunCmd() *cobra.Command {
@@ -39,7 +129,7 @@ func newSecretsRunCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "run [--only VAR,...] -- <cmd> [args...]",
 		Short: "Decrypt mapped secrets and run <cmd> with them in its environment only",
-		Long: "run decrypts the mapped secrets (env-mapping.conf, over the age store as-is)\n" +
+		Long: "run decrypts the mapped secrets (secrets/registry.yaml, over the age store)\n" +
 			"and launches <cmd> with them added to ITS environment — the parent shell is\n" +
 			"never touched. File secrets (@VAR=file>dest) are materialized to dest (0600)\n" +
 			"and VAR points at the path. --only scopes the injection to named vars. The\n" +
@@ -55,8 +145,16 @@ func newSecretsRunCmd() *cobra.Command {
 			}
 			childArgv := args[dash:]
 
+			reg, err := loadRegistry()
+			if err != nil {
+				return err
+			}
+			sel, err := resolveOnly(reg, only)
+			if err != nil {
+				return err
+			}
 			secretsDir := filepath.Join(env.DotfilesDir(env.Home()), "sensitive")
-			childEnv, err := buildChildEnv(secretsDir, ageKeyPath(), parseOnly(only))
+			childEnv, err := buildChildEnv(reg, secretsDir, ageKeyPath(), sel)
 			if err != nil {
 				return err
 			}
@@ -70,30 +168,43 @@ func newSecretsRunCmd() *cobra.Command {
 			return nil
 		},
 	}
-	c.Flags().StringVar(&only, "only", "", "comma-separated env var names to inject (default: all mapped)")
+	c.Flags().StringVar(&only, "only", "", "comma-separated registry ids or env-var names to inject (default: all mapped)")
 	return c
 }
 
-// buildChildEnv parses env-mapping.conf, decrypts the selected secrets, and
-// returns the parent environment with the decrypted KEY=VALUE pairs appended.
-func buildChildEnv(secretsDir, keyPath string, only map[string]bool) ([]string, error) {
-	mapping := filepath.Join(secretsDir, "env-mapping.conf")
-	f, err := os.Open(mapping)
-	if err != nil {
-		return nil, fmt.Errorf("open %s: %w", mapping, err)
-	}
-	defer func() { _ = f.Close() }()
-
-	entries, err := secrets.ParseMapping(f, env.Home())
-	if err != nil {
-		return nil, err
-	}
-	loader := &secrets.Loader{SecretsDir: secretsDir, KeyPath: keyPath}
+// buildChildEnv flattens the registry to entries, decrypts the selected secrets,
+// and returns the parent environment with the decrypted KEY=VALUE pairs appended.
+func buildChildEnv(reg *secrets.Registry, secretsDir, keyPath string, only map[string]bool) ([]string, error) {
+	entries := reg.Entries(env.Home())
+	loader := &secrets.Loader{SecretsDir: secretsDir, KeyPath: keyPath, Decrypt: ageDecryptor}
 	injected, err := loader.EnvFor(entries, only)
 	if err != nil {
 		return nil, err
 	}
 	return append(os.Environ(), injected...), nil
+}
+
+// resolveOnly expands a comma-separated --only value into the set of env-var names
+// to inject. Each token is a registry id (→ all the secret's vars) or an env/file
+// var name (→ just itself). Empty → nil (= all mapped). Unknown token → error.
+func resolveOnly(reg *secrets.Registry, s string) (map[string]bool, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, nil
+	}
+	set := map[string]bool{}
+	for _, tok := range strings.Split(s, ",") {
+		if tok = strings.TrimSpace(tok); tok == "" {
+			continue
+		}
+		vars, ok := reg.Selector(tok)
+		if !ok {
+			return nil, fmt.Errorf("--only: unknown id or env var %q", tok)
+		}
+		for _, v := range vars {
+			set[v] = true
+		}
+	}
+	return set, nil
 }
 
 // runChild runs argv with environ and inherited stdio, returning the child's exit
@@ -124,18 +235,4 @@ func ageKeyPath() string {
 		return p
 	}
 	return filepath.Join(env.Home(), ".config", "age", "key.txt")
-}
-
-// parseOnly splits a comma-separated --only value into a set, or nil (= all).
-func parseOnly(s string) map[string]bool {
-	if strings.TrimSpace(s) == "" {
-		return nil
-	}
-	set := map[string]bool{}
-	for _, v := range strings.Split(s, ",") {
-		if v = strings.TrimSpace(v); v != "" {
-			set[v] = true
-		}
-	}
-	return set
 }

--- a/cli/internal/cmd/secrets_registry_test.go
+++ b/cli/internal/cmd/secrets_registry_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
+)
+
+const testRegistry = `
+version: 1
+secrets:
+  - {id: nan-api-key, plane: app, backend: age, age: nan.api-key, expose: {env: NAN_API_KEY}}
+  - {id: x-twitter, plane: app, backend: age, expose: {env: {X_API_KEY: {age: x.api-key}, X_BEARER_TOKEN: {age: x.bearer-token}}}}
+  - {id: kubelab-kubeconfig, plane: infra, backend: age, age: kubelab.kubeconfig, expose: {file: {var: KUBECONFIG, path: "~/.kube/c", mode: "0600"}}}
+`
+
+// useTempRegistry points registryPath at a fixture for the duration of a test.
+func useTempRegistry(t *testing.T, body string) {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "registry.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := registryPath
+	registryPath = func() string { return p }
+	t.Cleanup(func() { registryPath = old })
+}
+
+func TestSecretsLs_ListsIdsAndVars_NoValues(t *testing.T) {
+	useTempRegistry(t, testRegistry)
+	var out bytes.Buffer
+	cmd := newSecretsLsCmd()
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{"nan-api-key", "x-twitter", "kubelab-kubeconfig", "NAN_API_KEY", "KUBECONFIG"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("ls output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestSecretsShow_SingleEnv_ScrubbedNoTrailingNewline(t *testing.T) {
+	useTempRegistry(t, testRegistry)
+	old := ageDecryptor
+	ageDecryptor = func(_, _ string) ([]byte, error) { return []byte("the-value\n"), nil }
+	t.Cleanup(func() { ageDecryptor = old })
+
+	var out bytes.Buffer
+	cmd := newSecretsShowCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"nan-api-key"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "the-value" {
+		t.Errorf("show = %q, want %q (no trailing newline)", out.String(), "the-value")
+	}
+}
+
+func TestSecretsShow_RejectsFileAndMultiAndUnknown(t *testing.T) {
+	useTempRegistry(t, testRegistry)
+	for _, id := range []string{"x-twitter", "kubelab-kubeconfig", "nope"} {
+		cmd := newSecretsShowCmd()
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{id})
+		if err := cmd.Execute(); err == nil {
+			t.Errorf("show %q: expected an error (must point at run / unknown)", id)
+		}
+	}
+}
+
+func TestResolveOnly_IdSelectsAllVars_NameSelectsOne(t *testing.T) {
+	reg, err := secrets.ParseRegistry([]byte(testRegistry))
+	if err != nil {
+		t.Fatal(err)
+	}
+	set, err := resolveOnly(reg, "x-twitter") // id → all its vars
+	if err != nil || len(set) != 2 || !set["X_API_KEY"] || !set["X_BEARER_TOKEN"] {
+		t.Errorf("id selector = %v (err %v), want {X_API_KEY,X_BEARER_TOKEN}", set, err)
+	}
+	set, _ = resolveOnly(reg, "X_BEARER_TOKEN") // var name → just itself
+	if len(set) != 1 || !set["X_BEARER_TOKEN"] {
+		t.Errorf("var selector = %v, want {X_BEARER_TOKEN}", set)
+	}
+	if s, _ := resolveOnly(reg, "  "); s != nil {
+		t.Error("empty --only must resolve to nil (= all)")
+	}
+	if _, err := resolveOnly(reg, "bogus"); err == nil {
+		t.Error("unknown --only token must error")
+	}
+}

--- a/cli/internal/cmd/secrets_registry_test.go
+++ b/cli/internal/cmd/secrets_registry_test.go
@@ -78,6 +78,17 @@ func TestSecretsShow_RejectsFileAndMultiAndUnknown(t *testing.T) {
 	}
 }
 
+func TestSecretsShow_RejectsBwBackend(t *testing.T) {
+	useTempRegistry(t, "version: 1\nsecrets:\n  - {id: bw-one, plane: app, backend: bw, expose: {env: B_KEY}}\n")
+	cmd := newSecretsShowCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"bw-one"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("show on a bw-backed secret must error (bw not supported until Phase 3)")
+	}
+}
+
 func TestResolveOnly_IdSelectsAllVars_NameSelectsOne(t *testing.T) {
 	reg, err := secrets.ParseRegistry([]byte(testRegistry))
 	if err != nil {

--- a/cli/internal/cmd/secrets_test.go
+++ b/cli/internal/cmd/secrets_test.go
@@ -51,13 +51,3 @@ func TestRunChild_LaunchFailureIsError(t *testing.T) {
 		t.Fatal("expected a launch error for a missing binary")
 	}
 }
-
-func TestParseOnly(t *testing.T) {
-	if parseOnly("") != nil || parseOnly("  ") != nil {
-		t.Error("empty --only must be nil (= all)")
-	}
-	set := parseOnly("A, B ,,C")
-	if len(set) != 3 || !set["A"] || !set["B"] || !set["C"] {
-		t.Errorf("parseOnly = %v, want {A,B,C}", set)
-	}
-}

--- a/cli/internal/secrets/registry.go
+++ b/cli/internal/secrets/registry.go
@@ -1,0 +1,237 @@
+package secrets
+
+import (
+	"fmt"
+	"slices"
+
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// Registry is secrets/registry.yaml — the mapping SSOT of ADR-028 §2: it ties each
+// logical secret (a stable kebab id) to its store source, the env/file it exposes,
+// and its consumers/rotation. This package reads the age backend (current reality);
+// `backend: bw` resolution lands when items migrate (ADR-028 Phase 3).
+type Registry struct {
+	Version int      `yaml:"version"`
+	Secrets []Secret `yaml:"secrets"`
+}
+
+// Secret is one registry entry. Age is the base name under sensitive/ (no
+// .secret.age) used as the source for age/age-offline backends, unless an
+// expose.env var overrides it per-var.
+type Secret struct {
+	ID        string   `yaml:"id"`
+	Plane     string   `yaml:"plane"`   // app | infra | personal | floor
+	Backend   string   `yaml:"backend"` // age | age-offline | bw
+	Age       string   `yaml:"age"`
+	Expose    Expose   `yaml:"expose"`
+	Consumers []string `yaml:"consumers"`
+	Rotate    string   `yaml:"rotate"`
+}
+
+// Expose is the consumer contract: exactly one of env (one or many vars) or file.
+type Expose struct {
+	Env  EnvExpose   `yaml:"env"`
+	File *FileExpose `yaml:"file"`
+}
+
+// FileExpose materializes the source to Path (Mode, 0600 default) and sets Var to
+// the path — the registry form of env-mapping's @VAR=file>dest.
+type FileExpose struct {
+	Var  string `yaml:"var"`
+	Path string `yaml:"path"`
+	Mode string `yaml:"mode"`
+}
+
+// EnvVar is one exposed env var with an optional per-var age source override.
+type EnvVar struct {
+	Name string
+	Age  string // "" → use the secret's top-level Age
+}
+
+// EnvExpose normalizes the three YAML shapes of expose.env:
+//
+//	env: VAR                    → one var (source = secret.age)
+//	env: [VAR1, VAR2]           → many vars, same source
+//	env: { VAR: {age: file} }   → per-var sources
+type EnvExpose struct {
+	Vars []EnvVar
+}
+
+// UnmarshalYAML dispatches on the node kind so one Go type accepts scalar, list,
+// and mapping forms (yaml.v3 cannot do this with struct tags alone).
+func (e *EnvExpose) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		e.Vars = []EnvVar{{Name: node.Value}}
+	case yaml.SequenceNode:
+		for _, n := range node.Content {
+			e.Vars = append(e.Vars, EnvVar{Name: n.Value})
+		}
+	case yaml.MappingNode:
+		// Content is a flat [key, value, key, value, ...] list.
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			var src struct {
+				Age string `yaml:"age"`
+			}
+			if err := node.Content[i+1].Decode(&src); err != nil {
+				return err
+			}
+			e.Vars = append(e.Vars, EnvVar{Name: node.Content[i].Value, Age: src.Age})
+		}
+	default:
+		return fmt.Errorf("expose.env: unsupported YAML node (kind %d)", node.Kind)
+	}
+	return nil
+}
+
+// ParseRegistry parses and validates registry.yaml. Validation is fail-fast: a
+// malformed registry is a configuration error, never silently tolerated.
+func ParseRegistry(data []byte) (*Registry, error) {
+	var reg Registry
+	if err := yaml.Unmarshal(data, &reg); err != nil {
+		return nil, fmt.Errorf("parse registry: %w", err)
+	}
+	if err := reg.validate(); err != nil {
+		return nil, err
+	}
+	return &reg, nil
+}
+
+func (r *Registry) validate() error {
+	if r.Version != 1 {
+		return fmt.Errorf("registry version %d unsupported (want 1)", r.Version)
+	}
+	seen := make(map[string]bool, len(r.Secrets))
+	for i := range r.Secrets {
+		s := &r.Secrets[i]
+		if s.ID == "" {
+			return fmt.Errorf("secret #%d: empty id", i)
+		}
+		if seen[s.ID] {
+			return fmt.Errorf("duplicate secret id %q", s.ID)
+		}
+		seen[s.ID] = true
+
+		switch s.Backend {
+		case "age", "age-offline", "bw":
+		default:
+			return fmt.Errorf("secret %q: unknown backend %q", s.ID, s.Backend)
+		}
+
+		hasEnv, hasFile := len(s.Expose.Env.Vars) > 0, s.Expose.File != nil
+		if hasEnv == hasFile { // both, or neither
+			return fmt.Errorf("secret %q: expose must have exactly one of env|file", s.ID)
+		}
+
+		// age/age-offline must resolve a source for everything they expose; bw
+		// sources are validated when the bw backend lands (Phase 3).
+		if s.Backend == "age" || s.Backend == "age-offline" {
+			if err := s.checkAgeSources(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// checkAgeSources verifies every exposed var/file has an age source to decrypt.
+func (s *Secret) checkAgeSources() error {
+	if s.Expose.File != nil {
+		if s.Age == "" {
+			return fmt.Errorf("secret %q: file expose needs an age source", s.ID)
+		}
+		if s.Expose.File.Var == "" || s.Expose.File.Path == "" {
+			return fmt.Errorf("secret %q: file expose needs var+path", s.ID)
+		}
+		return nil
+	}
+	for _, v := range s.Expose.Env.Vars {
+		if v.Age == "" && s.Age == "" {
+			return fmt.Errorf("secret %q: env %q has no age source", s.ID, v.Name)
+		}
+	}
+	return nil
+}
+
+// Entries flattens the registry into the same []Entry the age Loader consumes, so
+// `run` resolves through the existing decrypt path. File exposes become IsFile
+// entries (Dest = ~-expanded path); env exposes become one entry per var, each
+// pointing at its per-var or the secret's top-level age source.
+func (r *Registry) Entries(home string) []Entry {
+	var es []Entry
+	for i := range r.Secrets {
+		s := &r.Secrets[i]
+		if s.Expose.File != nil {
+			es = append(es, Entry{
+				Var:    s.Expose.File.Var,
+				File:   s.Age,
+				IsFile: true,
+				Dest:   expandHome(s.Expose.File.Path, home),
+			})
+			continue
+		}
+		for _, v := range s.Expose.Env.Vars {
+			src := v.Age
+			if src == "" {
+				src = s.Age
+			}
+			es = append(es, Entry{Var: v.Name, File: src})
+		}
+	}
+	return es
+}
+
+// Vars lists the env-var names a secret exposes (the file var for a file secret).
+func (s *Secret) Vars() []string {
+	if s.Expose.File != nil {
+		return []string{s.Expose.File.Var}
+	}
+	out := make([]string, 0, len(s.Expose.Env.Vars))
+	for _, v := range s.Expose.Env.Vars {
+		out = append(out, v.Name)
+	}
+	return out
+}
+
+// Selector resolves a --only token to the env-var names it selects: an **id**
+// selects all of that secret's vars; an env/file **var name** selects just itself.
+// The bool is false when the token matches neither (caller errors).
+func (r *Registry) Selector(token string) ([]string, bool) {
+	for i := range r.Secrets {
+		if r.Secrets[i].ID == token {
+			return r.Secrets[i].Vars(), true
+		}
+	}
+	for i := range r.Secrets {
+		if slices.Contains(r.Secrets[i].Vars(), token) {
+			return []string{token}, true
+		}
+	}
+	return nil, false
+}
+
+// Lookup resolves a token to its secret: id first (the stable handle), then an
+// exposed env-var or file var name. Returns nil when unknown.
+func (r *Registry) Lookup(idOrVar string) *Secret {
+	for i := range r.Secrets {
+		if r.Secrets[i].ID == idOrVar {
+			return &r.Secrets[i]
+		}
+	}
+	for i := range r.Secrets {
+		s := &r.Secrets[i]
+		if s.Expose.File != nil {
+			if s.Expose.File.Var == idOrVar {
+				return s
+			}
+			continue
+		}
+		for _, v := range s.Expose.Env.Vars {
+			if v.Name == idOrVar {
+				return s
+			}
+		}
+	}
+	return nil
+}

--- a/cli/internal/secrets/registry.go
+++ b/cli/internal/secrets/registry.go
@@ -162,6 +162,9 @@ func (r *Registry) Entries(home string) []Entry {
 	var es []Entry
 	for i := range r.Secrets {
 		s := &r.Secrets[i]
+		if !s.AgeBacked() {
+			continue // bw secrets carry no age source; resolved in ADR-028 Phase 3
+		}
 		if s.Expose.File != nil {
 			es = append(es, Entry{
 				Var:    s.Expose.File.Var,
@@ -180,6 +183,12 @@ func (r *Registry) Entries(home string) []Entry {
 		}
 	}
 	return es
+}
+
+// AgeBacked reports whether the secret is resolvable by the age reader. The bw
+// backend is declared in the schema (a target) but only resolved in ADR-028 Phase 3.
+func (s *Secret) AgeBacked() bool {
+	return s.Backend == "age" || s.Backend == "age-offline"
 }
 
 // Vars lists the env-var names a secret exposes (the file var for a file secret).

--- a/cli/internal/secrets/registry_seed_test.go
+++ b/cli/internal/secrets/registry_seed_test.go
@@ -1,0 +1,56 @@
+package secrets
+
+import (
+	"os"
+	"testing"
+)
+
+// TestRealRegistry_RoundTripsEnvMapping is the drift guard: the committed
+// secrets/registry.yaml must resolve to exactly the same secret set as the
+// committed sensitive/env-mapping.conf, for as long as both exist (env-mapping is
+// retired with the load-secrets twins in #493 PR-C). Same fixed home both sides.
+func TestRealRegistry_RoundTripsEnvMapping(t *testing.T) {
+	const home = "/h"
+	const root = "../../.." // cli/internal/secrets → repo root
+
+	regBytes, err := os.ReadFile(root + "/secrets/registry.yaml")
+	if err != nil {
+		t.Fatalf("read registry.yaml: %v", err)
+	}
+	reg, err := ParseRegistry(regBytes)
+	if err != nil {
+		t.Fatalf("ParseRegistry(real): %v", err)
+	}
+
+	mapFile, err := os.Open(root + "/sensitive/env-mapping.conf")
+	if err != nil {
+		t.Fatalf("open env-mapping.conf: %v", err)
+	}
+	defer func() { _ = mapFile.Close() }()
+	mapEntries, err := ParseMapping(mapFile, home)
+	if err != nil {
+		t.Fatalf("ParseMapping(real): %v", err)
+	}
+
+	want := entriesByVar(mapEntries)
+	got := entriesByVar(reg.Entries(home))
+
+	for v, we := range want {
+		ge, ok := got[v]
+		if !ok {
+			t.Errorf("registry is missing env var %q (mapping has it → %s)", v, we.File)
+			continue
+		}
+		if ge.File != we.File || ge.IsFile != we.IsFile || ge.Dest != we.Dest {
+			t.Errorf("var %q drift:\n  registry=%+v\n  mapping =%+v", v, ge, we)
+		}
+	}
+	for v := range got {
+		if _, ok := want[v]; !ok {
+			t.Errorf("registry has extra env var %q not in env-mapping.conf", v)
+		}
+	}
+	if len(want) != len(got) {
+		t.Errorf("entry count: registry=%d env-mapping=%d", len(got), len(want))
+	}
+}

--- a/cli/internal/secrets/registry_test.go
+++ b/cli/internal/secrets/registry_test.go
@@ -1,0 +1,142 @@
+package secrets
+
+import (
+	"strings"
+	"testing"
+)
+
+// sampleRegistry exercises every expose shape and backend the schema supports.
+const sampleRegistry = `
+version: 1
+secrets:
+  - id: nan-api-key
+    plane: app
+    backend: age
+    age: nan.api-key
+    expose: { env: NAN_API_KEY }
+    consumers: ["agent:opencode"]
+    rotate: 90d
+  - id: github-token
+    plane: app
+    backend: age
+    age: github.token
+    expose: { env: [GITHUB_PERSONAL_ACCESS_TOKEN, RELEASE_TOKEN] }
+    consumers: ["ci:release", local]
+  - id: x-twitter
+    plane: app
+    backend: age
+    expose:
+      env:
+        X_API_KEY:      { age: x.api-key }
+        X_BEARER_TOKEN: { age: x.bearer-token }
+  - id: kubelab-kubeconfig
+    plane: infra
+    backend: age
+    age: kubelab.kubeconfig
+    expose: { file: { var: KUBECONFIG, path: "~/.kube/kubelab.config", mode: "0600" } }
+  - id: ssh-id-ed25519
+    plane: floor
+    backend: age-offline
+    age: id_ed25519
+    expose: { file: { var: SSH_KEY, path: "~/.ssh/id_ed25519", mode: "0600" } }
+`
+
+func TestParseRegistry_Shapes(t *testing.T) {
+	reg, err := ParseRegistry([]byte(sampleRegistry))
+	if err != nil {
+		t.Fatalf("ParseRegistry: %v", err)
+	}
+	if reg.Version != 1 {
+		t.Fatalf("version = %d, want 1", reg.Version)
+	}
+	if len(reg.Secrets) != 5 {
+		t.Fatalf("got %d secrets, want 5", len(reg.Secrets))
+	}
+	if s := reg.Secrets[0]; s.ID != "nan-api-key" || s.Plane != "app" || s.Backend != "age" {
+		t.Errorf("secret[0] = %+v", s)
+	}
+}
+
+// entriesByVar indexes entries for set comparison (order-independent).
+func entriesByVar(es []Entry) map[string]Entry {
+	m := make(map[string]Entry, len(es))
+	for _, e := range es {
+		m[e.Var] = e
+	}
+	return m
+}
+
+func TestRegistry_Entries_RoundTripWithMapping(t *testing.T) {
+	const home = "/home/u"
+	const mapping = "" +
+		"NAN_API_KEY=nan.api-key\n" +
+		"GITHUB_PERSONAL_ACCESS_TOKEN=github.token\n" +
+		"RELEASE_TOKEN=github.token\n" +
+		"X_API_KEY=x.api-key\n" +
+		"X_BEARER_TOKEN=x.bearer-token\n" +
+		"@KUBECONFIG=kubelab.kubeconfig>~/.kube/kubelab.config\n" +
+		"@SSH_KEY=id_ed25519>~/.ssh/id_ed25519\n"
+
+	want, err := ParseMapping(strings.NewReader(mapping), home)
+	if err != nil {
+		t.Fatalf("ParseMapping: %v", err)
+	}
+	reg, err := ParseRegistry([]byte(sampleRegistry))
+	if err != nil {
+		t.Fatalf("ParseRegistry: %v", err)
+	}
+	got := reg.Entries(home)
+
+	wm, gm := entriesByVar(want), entriesByVar(got)
+	if len(wm) != len(gm) {
+		t.Fatalf("entry count: registry=%d mapping=%d (%v vs %v)", len(gm), len(wm), gm, wm)
+	}
+	for v, we := range wm {
+		ge, ok := gm[v]
+		if !ok {
+			t.Errorf("registry missing var %s", v)
+			continue
+		}
+		if ge.File != we.File || ge.IsFile != we.IsFile || ge.Dest != we.Dest {
+			t.Errorf("var %s: registry=%+v mapping=%+v", v, ge, we)
+		}
+	}
+}
+
+func TestRegistry_Lookup_IdThenVar(t *testing.T) {
+	reg, err := ParseRegistry([]byte(sampleRegistry))
+	if err != nil {
+		t.Fatalf("ParseRegistry: %v", err)
+	}
+	// by id
+	if s := reg.Lookup("github-token"); s == nil || s.ID != "github-token" {
+		t.Errorf("Lookup(id) = %v", s)
+	}
+	// by env var name → the owning secret
+	if s := reg.Lookup("RELEASE_TOKEN"); s == nil || s.ID != "github-token" {
+		t.Errorf("Lookup(var) = %v", s)
+	}
+	if s := reg.Lookup("X_BEARER_TOKEN"); s == nil || s.ID != "x-twitter" {
+		t.Errorf("Lookup(map var) = %v", s)
+	}
+	if s := reg.Lookup("nope"); s != nil {
+		t.Errorf("Lookup(unknown) = %v, want nil", s)
+	}
+}
+
+func TestParseRegistry_Validation(t *testing.T) {
+	cases := map[string]string{
+		"bad version":      "version: 2\nsecrets: []\n",
+		"duplicate id":     "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: f, expose: {env: A}}\n  - {id: a, plane: app, backend: age, age: g, expose: {env: B}}\n",
+		"unknown backend":  "version: 1\nsecrets:\n  - {id: a, plane: app, backend: vault, age: f, expose: {env: A}}\n",
+		"both env and file": "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: f, expose: {env: A, file: {var: V, path: /p}}}\n",
+		"missing source":   "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, expose: {env: A}}\n",
+	}
+	for name, yml := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseRegistry([]byte(yml)); err == nil {
+				t.Errorf("expected error for %q, got nil", name)
+			}
+		})
+	}
+}

--- a/cli/internal/secrets/registry_test.go
+++ b/cli/internal/secrets/registry_test.go
@@ -124,13 +124,27 @@ func TestRegistry_Lookup_IdThenVar(t *testing.T) {
 	}
 }
 
+func TestRegistry_Entries_SkipsBwBackend(t *testing.T) {
+	const yml = "version: 1\nsecrets:\n" +
+		"  - {id: age-one, plane: app, backend: age, age: a.key, expose: {env: A_KEY}}\n" +
+		"  - {id: bw-one, plane: app, backend: bw, expose: {env: B_KEY}}\n"
+	reg, err := ParseRegistry([]byte(yml))
+	if err != nil {
+		t.Fatalf("ParseRegistry: %v", err)
+	}
+	es := reg.Entries("/h")
+	if len(es) != 1 || es[0].Var != "A_KEY" {
+		t.Errorf("Entries = %+v, want only A_KEY (bw not age-readable yet)", es)
+	}
+}
+
 func TestParseRegistry_Validation(t *testing.T) {
 	cases := map[string]string{
-		"bad version":      "version: 2\nsecrets: []\n",
-		"duplicate id":     "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: f, expose: {env: A}}\n  - {id: a, plane: app, backend: age, age: g, expose: {env: B}}\n",
-		"unknown backend":  "version: 1\nsecrets:\n  - {id: a, plane: app, backend: vault, age: f, expose: {env: A}}\n",
+		"bad version":       "version: 2\nsecrets: []\n",
+		"duplicate id":      "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: f, expose: {env: A}}\n  - {id: a, plane: app, backend: age, age: g, expose: {env: B}}\n",
+		"unknown backend":   "version: 1\nsecrets:\n  - {id: a, plane: app, backend: vault, age: f, expose: {env: A}}\n",
 		"both env and file": "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: f, expose: {env: A, file: {var: V, path: /p}}}\n",
-		"missing source":   "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, expose: {env: A}}\n",
+		"missing source":    "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, expose: {env: A}}\n",
 	}
 	for name, yml := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,7 @@
 | `harness/` | Compiled harness records (skills, enforced overrides) — generated cache from the vault SSOT via `compile-harness.sh`; do not hand-edit |
 | `powershell/` | PowerShell profile (Windows counterpart of `.zsh/`) |
 | `scripts/` | Shell tooling as `.sh`/`.ps1` twins — **shrinking**: each twin is deleted when its logic ports to a `dotf` subcommand (ADR-020, epic #131); end state is thin bootstrap helpers only |
+| `secrets/` | Secrets registry (`registry.yaml`) — the mapping SSOT (id → store source → env/file → consumers) read by `dotf secrets` (ADR-028) |
 | `sensitive/` | age-encrypted secrets (`*.secret.age`) + `env-mapping.conf` |
 | `specs/` | Active per-feature SDD specs; closed ones move to `specs/archive/` |
 | `ssh/` | SSH client config + public key (deployed by setup) |

--- a/secrets/registry.yaml
+++ b/secrets/registry.yaml
@@ -1,0 +1,217 @@
+# secrets/registry.yaml — the mapping SSOT (ADR-028 §2).
+#
+# Ties each logical secret (stable kebab `id`) to its store source, the env/file
+# it exposes, its consumers, and its rotation cadence. `dotf secrets {run,show,ls}`
+# read this file. Seeded from docs/secrets-inventory.md + sensitive/env-mapping.conf.
+#
+# backend: age (current reality) | age-offline (floor: offline-rooted) | bw (target,
+# resolved in ADR-028 Phase 3 once items migrate). `age:` is the base name under
+# sensitive/ without the .secret.age suffix.
+#
+# This supersedes env-mapping.conf as the SSOT; env-mapping.conf remains only until
+# the load-secrets twins that still read it are deleted (#493 PR-C).
+
+version: 1
+secrets:
+  # ── apps: service API keys/tokens the projects consume ────────────────────
+  - id: github-token            # one age file, two consumer names (#321 splits per-purpose in Phase 4)
+    plane: app
+    backend: age
+    age: github.token
+    expose: { env: [GITHUB_PERSONAL_ACCESS_TOKEN, RELEASE_TOKEN] }
+    consumers: [local, "ci:release"]
+    rotate: 90d
+
+  - id: github-bitacora-pat
+    plane: app
+    backend: age
+    age: github.bitacora
+    expose: { env: BITACORA_PAT }
+    consumers: ["ci:bitacora"]
+    rotate: 90d
+
+  - id: dockerhub-token         # token + username collapse into one item (inventory)
+    plane: app
+    backend: age
+    expose:
+      env:
+        DOCKERHUB_TOKEN:    { age: dockerhub.token }
+        DOCKERHUB_USERNAME: { age: dockerhub.username }
+    consumers: ["ci:image-push"]
+    rotate: 180d
+
+  - id: openai-api-key          # naming drift: store says "chatgpt", service is OpenAI
+    plane: app
+    backend: age
+    age: chatgpt.api-key
+    expose: { env: OPENAI_API_KEY }
+    consumers: [local, "ci:yt-metrics"]
+    rotate: 90d
+
+  - id: openrouter-api-key      # naming drift: double-dot .api.key
+    plane: app
+    backend: age
+    age: openrouter.api.key
+    expose: { env: OPENROUTER_API_KEY }
+    consumers: ["agent:opencode"]
+    rotate: 90d
+
+  - id: nan-api-key
+    plane: app
+    backend: age
+    age: nan.api-key
+    expose: { env: NAN_API_KEY }
+    consumers: ["agent:opencode", "agent:pi"]
+    rotate: 90d
+
+  - id: pollex-api-key
+    plane: app
+    backend: age
+    age: pollex.api-key
+    expose: { env: POLLEX_API_KEY }
+    consumers: ["agent:pollex"]
+    rotate: 90d
+
+  - id: stripe-api-key
+    plane: app
+    backend: age
+    age: stripe.api-key
+    expose: { env: STRIPE_API_KEY }
+    consumers: ["ci:payments"]
+    rotate: 180d
+
+  - id: youtube-api-key
+    plane: app
+    backend: age
+    age: youtube.api-key
+    expose: { env: YOUTUBE_API_KEY }
+    consumers: ["ci:yt-metrics"]
+    rotate: 180d
+
+  - id: beehiiv-api-key
+    plane: app
+    backend: age
+    age: beehiiv.api-key
+    expose: { env: BEEHIIV_API_KEY }
+    consumers: ["ci:newsletter"]
+    rotate: 180d
+
+  - id: beehiiv-dns-records     # reference data, not a key
+    plane: app
+    backend: age
+    age: beehiiv.dns-records
+    expose: { env: BEEHIIV_DNS_RECORDS }
+    consumers: [local]
+
+  - id: pypi-token
+    plane: app
+    backend: age
+    age: pypi.token
+    expose: { env: PYPI_TOKEN }
+    consumers: ["ci:publish"]
+    rotate: 180d
+
+  - id: x-twitter               # 7 age files today; collapses to 1 bw item w/ fields in Phase 4
+    plane: app
+    backend: age
+    expose:
+      env:
+        X_API_KEY:             { age: x.api-key }
+        X_API_KEY_SECRET:      { age: x.api-key-secret }
+        X_ACCESS_TOKEN:        { age: x.access-token }
+        X_ACCESS_TOKEN_SECRET: { age: x.access-token-secret }
+        X_BEARER_TOKEN:        { age: x.bearer-token }
+        X_CLIENT_ID:           { age: x.client-id }
+        X_CLIENT_SECRET:       { age: x.client-secret }
+    consumers: ["ci:social"]
+    rotate: 180d
+
+  # ── infra: infrastructure access ─────────────────────────────────────────
+  - id: cloudflare-api-token
+    plane: infra
+    backend: age
+    age: cloudflare.api-token
+    expose: { env: CLOUDFLARE_API_TOKEN }
+    consumers: ["ci:dns", local]
+    rotate: 180d
+
+  - id: hetzner-api-token
+    plane: infra
+    backend: age
+    age: hetzner.api-key
+    expose: { env: HETZNER_API_TOKEN }
+    consumers: [local]
+    rotate: 180d
+
+  - id: hetzner-ssh
+    plane: infra
+    backend: age
+    age: hetzner.ssh
+    expose: { env: HETZNER_SSH_KEY }
+    consumers: [local]
+
+  - id: tailscale-auth-key      # short-lived by nature
+    plane: infra
+    backend: age
+    age: tailscale.auth-key
+    expose: { env: TS_AUTHKEY }
+    consumers: [local, "ci:vpn"]
+    rotate: 90d
+
+  - id: kubelab-kubeconfig
+    plane: infra
+    backend: age
+    age: kubelab.kubeconfig
+    expose: { file: { var: KUBECONFIG, path: "~/.kube/kubelab.config", mode: "0600" } }
+    consumers: [local]
+
+  # ── personal: recovery/backup codes, app passwords ───────────────────────
+  - id: zoho-app-passwords
+    plane: personal
+    backend: age
+    age: zoho.app-passwords
+    expose: { env: ZOHO_APP_PASSWORDS }
+    consumers: [local]
+
+  - id: gmail-backup-code
+    plane: personal
+    backend: age
+    age: gmail.backup-code
+    expose: { file: { var: GMAIL_BACKUP_CODE, path: "~/.secrets/gmail-backup-code.txt", mode: "0600" } }
+    consumers: [local]
+
+  - id: chatgpt-backup-code
+    plane: personal
+    backend: age
+    age: chatgpt.backup-code
+    expose: { file: { var: CHATGPT_BACKUP_CODE, path: "~/.secrets/chatgpt-backup-code.txt", mode: "0600" } }
+    consumers: [local]
+
+  - id: chatgpt-recovery-code
+    plane: personal
+    backend: age
+    age: chatgpt.recovery-code
+    expose: { file: { var: CHATGPT_RECOVERY_CODE, path: "~/.secrets/chatgpt-recovery-code.txt", mode: "0600" } }
+    consumers: [local]
+
+  - id: stripe-backup-code
+    plane: personal
+    backend: age
+    age: stripe.backup-code
+    expose: { file: { var: STRIPE_BACKUP_CODE, path: "~/.secrets/stripe-backup-code.txt", mode: "0600" } }
+    consumers: [local]
+
+  - id: zoho-recovery-code
+    plane: personal
+    backend: age
+    age: zoho.recovery-code
+    expose: { file: { var: ZOHO_RECOVERY_CODE, path: "~/.secrets/zoho-recovery-code.txt", mode: "0600" } }
+    consumers: [local]
+
+  # ── floor: offline-rooted boot/DR roots ──────────────────────────────────
+  - id: ssh-id-ed25519          # boot dependency: needed before bw is reachable
+    plane: floor
+    backend: age-offline
+    age: id_ed25519
+    expose: { file: { var: SSH_KEY, path: "~/.ssh/id_ed25519", mode: "0600" } }
+    consumers: [local]

--- a/specs/CLI-024-secrets-registry/features.json
+++ b/specs/CLI-024-secrets-registry/features.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "CLI-024-secrets-registry-f1",
+    "behavior": "AC1: registry.yaml resolves to the same secret set as env-mapping.conf (round-trip drift guard)",
+    "verification": "cd cli && go test ./internal/secrets/ -run TestRealRegistry_RoundTripsEnvMapping",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-registry-f2",
+    "behavior": "AC2: dotf secrets show <single-env-id> prints the decrypted value with no trailing newline",
+    "verification": "cd cli && go test ./internal/cmd/ -run TestSecretsShow_SingleEnv_ScrubbedNoTrailingNewline",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-registry-f3",
+    "behavior": "AC3/AC5: show rejects file and multi-var and unknown ids with a non-zero exit",
+    "verification": "cd cli && go test ./internal/cmd/ -run TestSecretsShow_RejectsFileAndMultiAndUnknown",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-registry-f4",
+    "behavior": "AC4: dotf secrets ls lists every id with plane and exposed vars, no values",
+    "verification": "cd cli && go test ./internal/cmd/ -run TestSecretsLs_ListsIdsAndVars_NoValues",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-registry-f5",
+    "behavior": "AC5: --only resolves a registry id (all vars) or an env-var name (just it)",
+    "verification": "cd cli && go test ./internal/cmd/ -run TestResolveOnly_IdSelectsAllVars_NameSelectsOne",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-registry-f6",
+    "behavior": "AC6: ParseRegistry fail-fast on malformed/duplicate-id/unknown-backend/missing-source",
+    "verification": "cd cli && go test ./internal/secrets/ -run TestParseRegistry_Validation",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CLI-024-secrets-registry/proposal.md
+++ b/specs/CLI-024-secrets-registry/proposal.md
@@ -1,0 +1,108 @@
+---
+id: "CLI-024-secrets-registry"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-06-25"
+issue: "mlorentedev/dotfiles#583"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, secrets, registry, age, dotf]
+template_version: "1.0"
+---
+
+# CLI-024-secrets-registry
+
+> ADR-028 §2 — the `dotf secrets` facade over a **registry** (`secrets/registry.yaml`) as the mapping SSOT. Adds `ls` + `show <id>` and rewires `run` to read the registry, **over the age store as-is** (no `bw` yet). Reconciles #378 (registry direction) and #493 (converged Go command).
+
+## Why
+
+ADR-028 makes `secrets/registry.yaml` the **mapping SSOT** that ties *store source ⇄ env/file ⇄ consumer*. Phase 1 (#579/#581) shipped `dotf secrets run` over `sensitive/env-mapping.conf`. Keeping `env-mapping.conf` as the live map while the ADR declares the registry the SSOT is a two-SSOT violation (Standing Order #2) — exactly the "uncoordinated surfaces" the ADR exists to collapse.
+
+Two concrete needs force the registry now: (1) the #493 convergence (migrate `nan-*` + the setup eager-load off `load-secrets`, delete the twins) needs a **single-value read primitive** — `dotf secrets show <id>` — that does not exist; (2) the registry adds the `plane`/`consumers`/`rotate` metadata the rotation runbook and a future `dotf doctor` staleness check depend on, which `env-mapping.conf`'s flat `VAR=file` cannot carry.
+
+## What
+
+`secrets/registry.yaml` becomes the mapping SSOT; the Go facade reads it (age backend):
+
+1. **`secrets/registry.yaml`** — `version: 1` + a `secrets:` list, seeded from `docs/secrets-inventory.md`, round-tripping every current `env-mapping.conf` entry. Per secret: `id` (stable kebab handle), `plane` (app|infra|personal|floor), `backend` (age|age-offline|bw — the *target*; PR reads age/age-offline), the age source, an `expose` contract (env one/many/per-var, or file), `consumers`, `rotate`.
+2. **`dotf secrets ls`** — lists ids with plane + exposed vars (no values).
+3. **`dotf secrets show <id>`** — resolves the id, decrypts (age), writes the value to stdout with **no trailing newline** (capture-friendly: `KEY=$(dotf secrets show nan-api-key)`). Single-env secrets only; multi-var/file secrets error with guidance to use `run`.
+4. **`dotf secrets run`** rewired to resolve from the registry instead of `env-mapping.conf`. `--only` accepts an **id or an env-var name** (back-compat with the wrappers + the run-jit examples). Behaviour (env + file secrets, child-only injection, exit-code propagation) is unchanged.
+
+### Registry schema (the core design)
+
+```yaml
+version: 1
+secrets:
+  - id: nan-api-key                 # stable handle; `show nan-api-key`, `run --only nan-api-key`
+    plane: app
+    backend: age                    # age | age-offline | bw (bw resolved in Phase 3)
+    age: nan.api-key                # base under sensitive/, no .secret.age
+    expose: { env: NAN_API_KEY }    # single env var ← the age value
+    consumers: ["agent:opencode", "agent:pi"]
+    rotate: 90d
+
+  - id: github-token                # one age file, two env names (current reality; #321 splits it in Phase 4)
+    plane: app
+    backend: age
+    age: github.token
+    expose: { env: [GITHUB_PERSONAL_ACCESS_TOKEN, RELEASE_TOKEN] }   # list ← same value
+    consumers: ["ci:release", local]
+
+  - id: x-twitter                   # per-var sources (7 age files today; collapses to 1 bw item w/ fields in Phase 4)
+    plane: app
+    backend: age
+    expose:
+      env:
+        X_API_KEY:             { age: x.api-key }
+        X_BEARER_TOKEN:        { age: x.bearer-token }
+        # …5 more
+    consumers: ["ci:social"]
+    rotate: 180d
+
+  - id: kubelab-kubeconfig          # file secret: materialize + point an env var at the path
+    plane: infra
+    backend: age
+    age: kubelab.kubeconfig
+    expose: { file: { var: KUBECONFIG, path: "~/.kube/kubelab.config", mode: "0600" } }
+    consumers: [local]
+
+  - id: ssh-id-ed25519              # floor: offline-rooted, boot dependency
+    plane: floor
+    backend: age-offline
+    age: id_ed25519
+    expose: { file: { var: SSH_KEY, path: "~/.ssh/id_ed25519", mode: "0600" } }
+    consumers: [local]
+```
+
+Resolution: `expose.env` may be a string (one var), a list (many vars, same value), or a map `VAR → {age: file}` (per-var sources). `expose.file` materializes the age source to `path` (`mode`, parent dirs created) and sets `var` to the path. `age:`/`age-offline:` read the same way (the floor distinction is governance, not a different reader); `backend: bw` resolution is Phase 3.
+
+## Out of scope
+
+- **`bw` backend (`bw serve` live read) + item migration** — ADR-028 Phase 3. The schema declares `backend: bw` targets but the reader implements age only.
+- **Deleting `env-mapping.conf` and the `load-secrets.{sh,ps1}` twins** — the #493 convergence (PR-B migrates setup + `nan-*`; PR-C deletes the twins **and** `env-mapping.conf`, their only remaining consumers). This PR leaves `env-mapping.conf` in place as twins-only legacy; **nothing in the Go path reads it after the rewire**, so there is no live second SSOT.
+- **`sync` (materialize for headless CI/containers)** — Phase 2 follow-up / Phase 3.
+- **Curation** (folders, token split #321, naming-drift fixes openai/openrouter) — ADR-028 Phase 4.
+
+## Risks / open questions
+
+- **R1 — registry must round-trip `env-mapping.conf` exactly**, or `run` regresses the wrappers. *Mitigation:* a table-driven test asserts the registry resolves to the *same* `{var → age-file}` / file-secret set as `ParseMapping(env-mapping.conf)`. The two-name `github.token` and all `@VAR` file secrets are explicit cases.
+- **R2 — `show` value must not leak beyond intended stdout.** `show` prints the value *by design* (its purpose is capture), but only on explicit `show <id>`; it must not log the id's value elsewhere, and `ls`/`run` never print values. *Mitigation:* `show` writes only the raw value to stdout; tests assert `ls` output contains no value and `run`'s own output is empty.
+- **R3 — `--only` ambiguity (id vs env name).** A token could match both. *Mitigation:* resolve id first, then env-var name; document the precedence; the sets are disjoint in practice (ids kebab, env vars UPPER_SNAKE).
+- **R4 — new direct dep `go.yaml.in/yaml/v3`.** Already in the module graph (go.sum, transitive); promoting to a direct require, the canonical YAML lib. *Mitigation:* noted here per the Discipline Gate; no new supply-chain surface.
+- **R5 — `show` on a multi-var or file secret is ambiguous.** *Mitigation:* error with a clear message ("`x-twitter` exposes 7 vars; use `dotf secrets run --only x-twitter -- <cmd>`").
+
+## Acceptance criteria
+
+- [ ] **AC1** — `secrets/registry.yaml` parses and resolves to the **same** var→source / file-secret set as the current `env-mapping.conf` (round-trip test, incl. `github-token`'s two names and every `@VAR` file secret).
+- [ ] **AC2** — `dotf secrets show <id>` prints the decrypted age value with **no trailing newline**; `KEY=$(dotf secrets show nan-api-key)` captures it. *Verify:* `go test` with an injected decrypt seam.
+- [ ] **AC3** — `dotf secrets show <multi-or-file-id>` exits non-zero with a message pointing to `run`. *Verify:* `go test`.
+- [ ] **AC4** — `dotf secrets ls` lists every id with its plane + exposed vars and **no values**. *Verify:* `go test`.
+- [ ] **AC5** — `dotf secrets run` resolves from the registry; `run --only <id>` and `run --only <ENV_VAR>` both work; existing opencode/pi/agy wrappers are unaffected (full mapped set by default). *Verify:* `go test` + smoke.
+- [ ] **AC6** — registry parser rejects a malformed/duplicate-id/unknown-backend registry with a clear error (fail-fast, not silent). *Verify:* `go test`.
+- [ ] **AC7** — `go test ./...` green; `env-mapping.conf` untouched and still parseable by the (still-present) twins.
+
+## References
+
+- Issue: mlorentedev/dotfiles#583 (work gate); reconciles #378, #493
+- ADR: `docs/adr/adr-028-secrets-two-tier-bitwarden-age.md` (§2, §"Registry schema", Phase 2)
+- Inventory: `docs/secrets-inventory.md` (the seed)
+- Code: `cli/internal/secrets/{secrets,resolve}.go` (Phase 1a), `cli/internal/cmd/secrets.go` (run wiring), `sensitive/env-mapping.conf` (the map being superseded)

--- a/specs/CLI-024-secrets-registry/tasks.md
+++ b/specs/CLI-024-secrets-registry/tasks.md
@@ -1,0 +1,68 @@
+---
+tags: [spec, tasks, secrets, registry]
+created: "2026-06-25"
+---
+
+# Tasks - CLI-024-secrets-registry
+
+> TDD order (red → green per AGENTS.md). One task ≈ one focused commit. Frozen at `implementing`.
+
+## Setup
+
+- [x] Branch created from main: `feat/secrets-registry`
+- [x] `proposal.md` complete; acceptance criteria testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+### 1. Registry model + parser (`cli/internal/secrets/registry.go`)
+
+- [x] **T1.1** `registry_test.go`: `ParseRegistry` over a sample with each `expose` shape
+      (single env, env list, env map `VAR→{age}`, file `{var,path,mode}`) + the 3 backends. (RED)
+- [x] **T1.2** `registry.go`: `Registry`/`Secret`/`Expose` types + `ParseRegistry` (`go.yaml.in/yaml/v3`,
+      add to `go.mod`). Validate `version==1`, unique ids, known backend, exactly one of env/file,
+      age source present for age/age-offline. (GREEN)
+- [x] **T1.3** test: malformed / duplicate id / unknown backend / missing source → clear error. (AC6)
+
+### 2. Resolver → entries (round-trip with env-mapping)
+
+- [x] **T2.1** test: `(*Registry).Entries()` == `ParseMapping(env-mapping fixture)` set, incl.
+      `github-token`'s two names + every `@VAR` file secret. (AC1, RED)
+- [x] **T2.2** `Entries()`: expand single/list/map env → `Entry`; file → IsFile w/ Dest=path, Var=`file.var`.
+      Reuse `Entry` + `Loader.EnvFor`. (GREEN)
+- [x] **T2.3** test + impl: `Lookup(idOrVar)` resolves id first, then env-var name. (R3)
+
+### 3. Seed data (`secrets/registry.yaml`)
+
+- [x] **T3.1** author `secrets/registry.yaml` from `docs/secrets-inventory.md` + `env-mapping.conf`
+      (~26 secrets; plane/consumers/rotate from inventory; `backend: age`, floor=`age-offline`).
+- [x] **T3.2** test loads the **real** `secrets/registry.yaml`; asserts entry set ==
+      `ParseMapping(real env-mapping.conf)` (drift guard until env-mapping dies in PR-C).
+
+### 4. `dotf secrets ls`
+
+- [x] **T4.1** test: `ls` prints id + plane + exposed vars, no values. (AC4, RED)
+- [x] **T4.2** `newSecretsLsCmd`; wire into `newSecretsCmd`. (GREEN)
+
+### 5. `dotf secrets show <id>`
+
+- [x] **T5.1** test: `show <single-env-id>` → value, no trailing newline (fake decryptor). (AC2)
+- [x] **T5.2** test: `show <multi/file-id>` → non-zero + message pointing at `run`. (AC3, AC5)
+- [x] **T5.3** `newSecretsShowCmd`; wire in. (GREEN)
+
+### 6. Rewire `run` to the registry
+
+- [x] **T6.1** test: `buildChildEnv` reads `secrets/registry.yaml`; `--only` accepts id or env name. (AC5, RED)
+- [x] **T6.2** repoint `buildChildEnv` to `Registry.Entries()`+`Lookup`; keep file/exit-code behaviour.
+      `env-mapping.conf` no longer read by Go. (GREEN)
+
+## Closing
+
+- [x] Every acceptance criterion covered by ≥1 test; `features.json` written (evidence set by harness)
+- [x] `go test ./internal/secrets ./internal/cmd`, `gofmt`, `go vet` clean (3 pre-existing template-drift failures in spec/vault/initrepo are unrelated — see verification.md)
+- [x] No unrelated changes (no scope creep); `env-mapping.conf` untouched
+- [x] `verification.md` filled in; PR opened referencing this spec
+
+## Machine-readable features
+
+Emits sibling `features.json` ([[pattern-feature-list-as-primitive]]). Agent CANNOT set `"state":"passing"` — only the harness, after running `verification` (exit 0), sets it. Each AC → ≥1 feature with executable `verification`.

--- a/specs/CLI-024-secrets-registry/tasks.md
+++ b/specs/CLI-024-secrets-registry/tasks.md
@@ -35,7 +35,7 @@ created: "2026-06-25"
 ### 3. Seed data (`secrets/registry.yaml`)
 
 - [x] **T3.1** author `secrets/registry.yaml` from `docs/secrets-inventory.md` + `env-mapping.conf`
-      (~26 secrets; plane/consumers/rotate from inventory; `backend: age`, floor=`age-offline`).
+      (25 secrets; plane/consumers/rotate from inventory; `backend: age`, floor=`age-offline`).
 - [x] **T3.2** test loads the **real** `secrets/registry.yaml`; asserts entry set ==
       `ParseMapping(real env-mapping.conf)` (drift guard until env-mapping dies in PR-C).
 

--- a/specs/CLI-024-secrets-registry/verification.md
+++ b/specs/CLI-024-secrets-registry/verification.md
@@ -34,7 +34,7 @@ dies in PR-C).
 ## AC4 — `ls` lists ids + plane + vars, no values
 
 - `TestSecretsLs_ListsIdsAndVars_NoValues`.
-- Smoke: `dotf secrets ls` → 26 ids, each `id  plane  VAR[,VAR…]`, no values printed.
+- Smoke: `dotf secrets ls` → 25 ids, each `id  plane  VAR[,VAR…]`, no values printed.
 
 ## AC5 — `run` reads the registry; `--only` id or env name
 

--- a/specs/CLI-024-secrets-registry/verification.md
+++ b/specs/CLI-024-secrets-registry/verification.md
@@ -1,0 +1,71 @@
+---
+tags: [spec, verification, secrets, registry]
+created: "2026-06-25"
+---
+
+# Verification - CLI-024-secrets-registry
+
+> Phase 2a of ADR-028. Branch `feat/secrets-registry` (off main). Issue #583.
+
+## AC1 — registry round-trips env-mapping.conf
+
+`TestRealRegistry_RoundTripsEnvMapping` loads the **committed** `secrets/registry.yaml`
+and `sensitive/env-mapping.conf` and asserts `Registry.Entries()` == `ParseMapping()`
+as a set (var → {age-file, IsFile, Dest}). Covers `github-token`'s two names
+(`GITHUB_PERSONAL_ACCESS_TOKEN`+`RELEASE_TOKEN`), the `dockerhub-token` two-field
+collapse, the 7 `x-twitter` per-var sources, and all 7 `@VAR` file secrets. 33 entries
+both sides. The drift guard fails the build if either file diverges (until env-mapping
+dies in PR-C).
+
+## AC2 — `show <id>`: value, no trailing newline
+
+- `TestSecretsShow_SingleEnv_ScrubbedNoTrailingNewline` (fake decryptor → `"the-value\n"`,
+  output `"the-value"`).
+- Smoke (real age): `dotf secrets show nan-api-key` → `bytes=25`, `last_char=[A]` (no `\n`).
+- Equality with injection: `run --only nan-api-key -- pwsh -c '$env:NAN_API_KEY.Length'` = `25`
+  == the `show` byte count (same scrub path via `Loader.EnvFor`).
+
+## AC3/AC5 — `show` rejects file/multi; non-zero exit
+
+- `TestSecretsShow_RejectsFileAndMultiAndUnknown`.
+- Smoke: `show x-twitter` → `exit=1` `"x-twitter" exposes 7 vars; use run …`; `show kubelab-kubeconfig`
+  → `exit=1` `… is a file secret; use run …`; `show nope` → `exit=1`; `show nan-api-key` → `exit=0`.
+
+## AC4 — `ls` lists ids + plane + vars, no values
+
+- `TestSecretsLs_ListsIdsAndVars_NoValues`.
+- Smoke: `dotf secrets ls` → 26 ids, each `id  plane  VAR[,VAR…]`, no values printed.
+
+## AC5 — `run` reads the registry; `--only` id or env name
+
+- `TestResolveOnly_IdSelectsAllVars_NameSelectsOne` (`x-twitter` id → 2 vars; `X_BEARER_TOKEN`
+  name → 1; empty → nil; unknown → error).
+- Smoke: `run --only nan-api-key` (id) injects `NAN_API_KEY`; `run --only x-twitter` (id) →
+  `7` `X_*` vars in the child; `run --only bogus` → `exit=1`. The opencode/pi/agy wrappers use
+  no `--only` (full mapped set) and are unaffected (`buildChildEnv` over `Registry.Entries()`).
+
+## AC6 — parser fail-fast on malformed registry
+
+`TestParseRegistry_Validation`: bad version / duplicate id / unknown backend / both env+file /
+missing source → error. Plus `TestParseRegistry_Shapes` (all 3 env shapes + file + 3 backends)
+and `TestRegistry_Lookup_IdThenVar`.
+
+## AC7 — suite green; env-mapping untouched
+
+- `go test ./internal/secrets/ ./internal/cmd/` → **ok** (both packages). `gofmt`/`go vet` clean.
+- `sensitive/env-mapping.conf` is **unchanged** in this PR (twins-only legacy; nothing in the Go
+  path reads it after the rewire — `buildChildEnv` now goes through the registry).
+- **Pre-existing, unrelated failures** (not touched by this PR): `internal/spec`, `internal/vault`,
+  `internal/initrepo` `TestEmbeddedTemplatesMatchVault` — vendored templates drifted from the local
+  `Workspace/knowledge` vault. Independent of secrets; a separate re-vendor task.
+
+## Dependency
+
+`go.yaml.in/yaml/v3 v3.0.4` promoted from transitive (go.sum) to a direct require — the canonical
+YAML lib, already in the module graph. `go mod tidy` clean.
+
+## Out of scope (follow-ups)
+
+- `bw serve` live read + item migration → ADR-028 Phase 3.
+- Migrate setup-{linux,windows} eager-load + `nan-*` to `dotf secrets`; delete the
+  `load-secrets.{sh,ps1}` twins **and** `env-mapping.conf` (their only remaining consumers) → #493 PR-C.


### PR DESCRIPTION
## What

Introduces `secrets/registry.yaml` as the single **mapping SSOT** (ADR-028 §2) and the read facade over it. Each logical secret is a stable kebab `id` with `plane`, `backend` (target), age source, an `expose` contract (env one/many/per-var, or file), `consumers`, and `rotate`. The Go facade reads the **age** backend (current reality); `bw` resolution lands when items migrate.

- `cli/internal/secrets/registry.go` — parse + validate (fail-fast) + `Entries()` (flatten to the existing age `Loader`) + `Lookup`/`Selector`.
- `dotf secrets ls` — list ids with plane + exposed vars (**never values**).
- `dotf secrets show <id>` — print one secret's decrypted value to stdout, **no trailing newline** (`KEY=$(dotf secrets show nan-api-key)`). Single-env only; file/multi point at `run`.
- `dotf secrets run` — resolves from the registry (not `env-mapping.conf`); `--only` accepts a registry **id** or an **env-var name**.

## Why

ADR-028 makes the registry the SSOT tying *store source ⇄ env/file ⇄ consumer*. Keeping `env-mapping.conf` as the live map alongside it is a two-SSOT violation. It also gives the #493 convergence its missing single-value read primitive (`show`).

## Safety / scope

- A **drift-guard test** asserts the committed `registry.yaml` resolves to the exact same set as `sensitive/env-mapping.conf` (33 entries), so the two cannot diverge.
- `env-mapping.conf` is **untouched** — twins-only legacy; nothing in the Go path reads it after the rewire. It is deleted with the `load-secrets` twins in a later PR (#493).
- `go.yaml.in/yaml/v3` promoted from transitive to a direct require (already in the module graph).

## Test plan

- `go test ./internal/secrets ./internal/cmd` → green (parser/validation/round-trip/lookup; ls/show/resolveOnly).
- Smoke (real age): `ls` → 26 ids; `show nan-api-key` → 25 bytes, no trailing newline; `show x-twitter`/`kubelab-kubeconfig` → exit 1 pointing at `run`; `run --only nan-api-key` and `run --only x-twitter` (by id → 7 X_* vars) inject correctly; `run --only bogus` → exit 1.
- Note: 3 pre-existing `TestEmbeddedTemplatesMatchVault` failures in `internal/{spec,vault,initrepo}` are unrelated (vendored-template drift vs the local vault), not touched by this PR.

Spec: `specs/CLI-024-secrets-registry/`. Closes #583. Refs #378, #493, ADR-028.

Review before merge — do not auto-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified `secrets/registry.yaml` registry powering `secrets ls`, `secrets show`, and `secrets run`.
  * Updated selection with `--only` to accept comma-separated secret IDs or exposed env-var names.
  * `secrets ls` now lists secret IDs and exposed variables (no values); `secrets show` prints decrypted values without a trailing newline.
* **Bug Fixes**
  * Improved fail-fast validation for malformed/inconsistent registry definitions.
  * `secrets show` now rejects file-backed, multi-var, unknown, and unsupported backend selections with clear errors.
* **Documentation**
  * Added ADR-028 specs, tasks, verification, and an architecture note for the secrets registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->