### PR TITLE
feat(secrets): resolve nan-* scripts' NAN_API_KEY via dotf secrets show

### DIFF
--- a/scripts/nan-bench.sh
+++ b/scripts/nan-bench.sh
@@ -8,16 +8,15 @@
 
 set -euo pipefail
 
-# Load secrets if not already exported
-if [ -z "${NAN_API_KEY:-}" ]; then
-    if [ -f scripts/load-secrets.sh ]; then
-        . scripts/load-secrets.sh
-        secrets_refresh >/dev/null 2>&1
-    fi
+# NAN_API_KEY: injected by `dotf secrets run -- <this script>`, or self-fetched
+# on demand via `dotf secrets show` (ADR-028 — never the ambient shell env).
+if [ -z "${NAN_API_KEY:-}" ] && command -v dotf >/dev/null 2>&1; then
+    NAN_API_KEY="$(dotf secrets show nan-api-key 2>/dev/null || true)"
+    export NAN_API_KEY
 fi
 
 if [ -z "${NAN_API_KEY:-}" ]; then
-    echo "ERROR: NAN_API_KEY not set. Run: . scripts/load-secrets.sh && secrets_refresh" >&2
+    echo "ERROR: NAN_API_KEY not set. Run: dotf secrets run -- $0" >&2
     exit 1
 fi
 

--- a/scripts/nan-debug.sh
+++ b/scripts/nan-debug.sh
@@ -34,10 +34,13 @@ else
     exit 1
 fi
 
-if [ -z "${NAN_API_KEY:-}" ]; then
-    [ -f scripts/load-secrets.sh ] && . scripts/load-secrets.sh && secrets_refresh >/dev/null 2>&1
+# NAN_API_KEY: injected by `dotf secrets run`, or self-fetched via `dotf secrets
+# show` on demand (ADR-028 — never the ambient shell env).
+if [ -z "${NAN_API_KEY:-}" ] && command -v dotf >/dev/null 2>&1; then
+    NAN_API_KEY="$(dotf secrets show nan-api-key 2>/dev/null || true)"
+    export NAN_API_KEY
 fi
-[ -z "${NAN_API_KEY:-}" ] && { echo "ERROR: NAN_API_KEY not set" >&2; exit 1; }
+[ -z "${NAN_API_KEY:-}" ] && { echo "ERROR: NAN_API_KEY not set. Run: dotf secrets run -- $0" >&2; exit 1; }
 
 BASE_URL="${NAN_BASE_URL:-https://api.nan.builders/v1}"
 

--- a/scripts/nan-quality-bench.sh
+++ b/scripts/nan-quality-bench.sh
@@ -8,11 +8,13 @@
 
 set -euo pipefail
 
-# Load secrets
-if [ -z "${NAN_API_KEY:-}" ]; then
-    [ -f scripts/load-secrets.sh ] && . scripts/load-secrets.sh && secrets_refresh >/dev/null 2>&1
+# NAN_API_KEY: injected by `dotf secrets run`, or self-fetched via `dotf secrets
+# show` on demand (ADR-028 — never the ambient shell env).
+if [ -z "${NAN_API_KEY:-}" ] && command -v dotf >/dev/null 2>&1; then
+    NAN_API_KEY="$(dotf secrets show nan-api-key 2>/dev/null || true)"
+    export NAN_API_KEY
 fi
-[ -z "${NAN_API_KEY:-}" ] && { echo "ERROR: NAN_API_KEY not set" >&2; exit 1; }
+[ -z "${NAN_API_KEY:-}" ] && { echo "ERROR: NAN_API_KEY not set. Run: dotf secrets run -- $0" >&2; exit 1; }
 
 OUT="${1:-/tmp/nan-bench-$(date +%Y%m%d-%H%M%S)}"
 mkdir -p "$OUT"

--- a/specs/CLI-024-secrets-retire-loadsecrets/features.json
+++ b/specs/CLI-024-secrets-retire-loadsecrets/features.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "CLI-024-secrets-retire-loadsecrets-f1",
+    "behavior": "nan-bench/nan-debug/nan-quality-bench resolve NAN_API_KEY via `dotf secrets show nan-api-key`; none source load-secrets or call secrets_refresh",
+    "verification": "bats tests/nan-scripts-secrets.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-retire-loadsecrets-f2",
+    "behavior": "setup-{linux,windows} resolve mid-setup secrets via `dotf secrets show`; neither eager-sources load-secrets",
+    "verification": "bats tests/setup-windows.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-retire-loadsecrets-f3",
+    "behavior": "load-secrets.{sh,ps1} + sensitive/env-mapping.conf are deleted; no runtime reference remains",
+    "verification": "! grep -rln --include='*.sh' --include='*.ps1' -e 'load-secrets' -e 'env-mapping.conf' scripts setup-linux.sh setup-windows.ps1",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CLI-024-secrets-retire-loadsecrets/proposal.md
+++ b/specs/CLI-024-secrets-retire-loadsecrets/proposal.md
@@ -1,0 +1,85 @@
+---
+id: "CLI-024-secrets-retire-loadsecrets"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-06-25"
+issue: "mlorentedev/dotfiles#587"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, secrets, shell]
+template_version: "1.0"
+---
+
+# CLI-024-secrets-retire-loadsecrets
+
+## Why
+
+ADR-028 Phase 1 killed the ambient `load-secrets` shell export (#581) and shipped
+the `secrets/registry.yaml` mapping SSOT with `dotf secrets run/ls/show` (#579,
+#584). But the **non-shell** consumers of the old `load-secrets.{sh,ps1}` twins and
+`sensitive/env-mapping.conf` are still live — three `nan-*` scripts and both
+`setup-*` bootstrappers source them directly. Until those are migrated, the twins
+and `env-mapping.conf` cannot be deleted, so the two-SSOT (registry vs
+env-mapping.conf) and the "decrypt-at-startup" code path both persist. The original
+tracker (#493) is closed and its design — a Linux superset + `eval "$(dotf secrets
+env)"` that mutated the parent shell — was explicitly rejected by ADR-028 (inject
+into the child only). This spec is the ADR-028-aligned retirement.
+
+## What
+
+After this feature no runtime path sources `load-secrets.{sh,ps1}` or reads
+`env-mapping.conf`. Secrets are resolved on demand through the `dotf secrets`
+facade:
+
+- The three `nan-*` scripts fetch `NAN_API_KEY` via `dotf secrets show nan-api-key`
+  (and stay invocable under `dotf secrets run -- <script>` with no double-fetch).
+- `setup-{linux,windows}` resolve each mid-setup secret (`OPENROUTER_API_KEY`, …)
+  via scoped `dotf secrets show <id>` instead of a blanket eager source.
+- The `load-secrets.{sh,ps1}` twins and `sensitive/env-mapping.conf` are deleted,
+  along with their tests and the setup chmod/deploy blocks.
+
+Delivered as three atomic PRs against this one spec/issue:
+
+| PR | Scope | Risk |
+|----|-------|------|
+| **B1** (this branch) | migrate the 3 `nan-*` scripts to `dotf secrets show` | low |
+| **B2** | migrate the `setup-{linux,windows}` eager-load | high (critical path, cross-OS) |
+| **C** | `git rm` the twins + `env-mapping.conf` + tests; archive the PAT lesson | low (gated on a clean consumer sweep) |
+
+## Out of scope
+
+- The Bitwarden (`bw serve`) backend and the age→bw migration — Phase 3, **#585**.
+- Curation: Bitwarden folders, per-purpose token split (#321), offline age key —
+  Phase 4, **#586**.
+- How agents materialize MCP configs (placeholder `{env:…}` injection stays as-is).
+- Secret rotation.
+
+## Risks / open questions
+
+- **B1 depends on a deployed `dotf secrets show`** (ships in 0.19.0). Until the
+  redeploy, a direct `nan-*` invocation degrades gracefully: empty key → a clear
+  error pointing at `dotf secrets run`. Resolved: graceful degradation, no hard dep.
+- **B2 is critical-path, cross-OS.** A missed mid-setup consumer silently receives
+  an empty value. Mitigation: enumerate every consumer of the eager-loaded vars
+  before editing; the existing age-key preflight warning still fires.
+- **PR-C deletion must be gated on a clean consumer sweep** (grep over scripts +
+  setup + rc files shows zero live readers of the twins / `env-mapping.conf`).
+
+## Acceptance criteria
+
+- [ ] **AC1 (B1)** — `nan-bench.sh`, `nan-debug.sh`, `nan-quality-bench.sh` resolve
+  `NAN_API_KEY` via `dotf secrets show nan-api-key`; none source `load-secrets` or
+  call `secrets_refresh`. *Verify:* `bats tests/nan-scripts-secrets.bats`.
+- [ ] **AC2 (B2)** — `setup-linux.sh` / `setup-windows.ps1` resolve mid-setup
+  secrets via `dotf secrets show`; neither eager-sources `load-secrets`. *Verify:*
+  `bats tests/setup-windows.bats` + `setup-linux` grep.
+- [ ] **AC3 (C)** — `load-secrets.{sh,ps1}` + `sensitive/env-mapping.conf` deleted;
+  a repo-wide grep finds no runtime reference. *Verify:* grep sweep is clean.
+- [ ] **AC4** — all bats suites green cross-OS after each PR.
+- [ ] **AC5 (C)** — fine-grained-PAT lesson archived in
+  `docs/runbooks/guide-bitacora-setup.md`.
+
+## References
+
+- ADR: `docs/adr/adr-028-secrets-two-tier-bitwarden-age.md`
+- Issue: `mlorentedev/dotfiles#587` (supersedes the closed #493)
+- Registry: `secrets/registry.yaml` (id `nan-api-key` → `NAN_API_KEY`)
+- Related patterns: `00_meta/patterns/secrets-security.md`, `shell-standards.md`

--- a/specs/CLI-024-secrets-retire-loadsecrets/tasks.md
+++ b/specs/CLI-024-secrets-retire-loadsecrets/tasks.md
@@ -1,0 +1,44 @@
+---
+tags: [spec, tasks, secrets, shell]
+created: "2026-06-25"
+---
+
+# Tasks - CLI-024-secrets-retire-loadsecrets
+
+> TDD order. One task = one focused commit. Three PRs (B1/B2/C) against this spec.
+
+## Setup
+
+- [x] Branch created from main: `feat/nan-scripts-via-dotf-secrets` (B1)
+- [x] `proposal.md` complete; acceptance criteria testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## PR-B1 — nan-* scripts → dotf secrets show (this branch)
+
+- [ ] **RED**: `tests/nan-scripts-secrets.bats` — assert the 3 scripts do NOT
+  source `load-secrets` / call `secrets_refresh`, and DO self-fetch via
+  `dotf secrets show nan-api-key` guarded by `command -v dotf`.
+- [ ] **GREEN**: edit `scripts/nan-bench.sh`, `nan-debug.sh`, `nan-quality-bench.sh`
+  — replace the `load-secrets` fallback with the `dotf secrets show` idiom; update
+  the error hint to `dotf secrets run -- <script>`.
+- [ ] **Verify**: `bats tests/nan-scripts-secrets.bats` green; `bash -n` clean.
+- [ ] `verification.md` + `features.json` (`f1` = AC1) filled with evidence.
+- [ ] PR-B1 opened referencing #587 (title `feat(secrets): …` → triggers 0.19.0).
+
+## PR-B2 — setup eager-load → dotf secrets show (later branch)
+
+- [ ] Enumerate every mid-setup consumer of the eager-loaded vars.
+- [ ] Replace the eager source with scoped `dotf secrets show <id>`; update
+  `tests/setup-windows.bats` parity assertions.
+
+## PR-C — delete twins + env-mapping.conf (later branch)
+
+- [ ] Consumer sweep clean → `git rm` twins + `env-mapping.conf` + `load-secrets.bats`.
+- [ ] Drop setup chmod (`setup-linux:101`) + deploy block (`setup-windows:1565-1574`).
+- [ ] Archive the fine-grained-PAT lesson in `docs/runbooks/guide-bitacora-setup.md`.
+- [ ] Close #587.
+
+## Machine-readable features
+
+See sibling `features.json`. `f1` (AC1, B1) is verifiable now; `f2`/`f3` (B2/C)
+land with their PRs.

--- a/specs/CLI-024-secrets-retire-loadsecrets/verification.md
+++ b/specs/CLI-024-secrets-retire-loadsecrets/verification.md
@@ -1,0 +1,80 @@
+---
+tags: [spec, verification, secrets, shell]
+created: "2026-06-25"
+---
+
+# Verification - CLI-024-secrets-retire-loadsecrets
+
+> PR-B1 only. Branch `feat/nan-scripts-via-dotf-secrets` (off main). B2/C verified
+> with their own PRs.
+
+## Evidence
+
+- [x] **AC1** — nan-* resolve `NAN_API_KEY` via `dotf secrets show nan-api-key`
+  → test `tests/nan-scripts-secrets.bats` (7/7), edits to
+  `scripts/nan-{bench,debug,quality-bench}.sh`.
+- [ ] **AC2/AC3** — setup migration + twin deletion → PR-B2 / PR-C.
+- [x] **AC4** — neighbouring suites green; no regressions.
+- [ ] **AC5** — PAT lesson archived → PR-C.
+
+## TDD log — AC1
+
+`tests/nan-scripts-secrets.bats` is structural (grep-based), matching the other
+RC/script contract tests in this suite.
+
+- **RED** (before edit): 5/7 failing —
+  `not ok 2 … do not source the retired load-secrets twin`,
+  `not ok 3 … do not call secrets_refresh`,
+  `not ok 4 … self-fetch via dotf secrets show`,
+  `not ok 5 … guard with command -v dotf`,
+  `not ok 6 … hint 'dotf secrets run'`.
+- **GREEN** (after editing the 3 scripts): **7/7 ok**.
+
+The fallback in each script is now:
+
+```sh
+if [ -z "${NAN_API_KEY:-}" ] && command -v dotf >/dev/null 2>&1; then
+    NAN_API_KEY="$(dotf secrets show nan-api-key 2>/dev/null || true)"
+    export NAN_API_KEY
+fi
+```
+
+`|| true` sits inside the substitution so `set -euo pipefail` never trips. The
+`[ -z … ] && command -v dotf` guard means a `dotf secrets run -- <script>`
+invocation (key already injected) skips the block — no double-fetch.
+
+## Test status
+
+- `bats tests/nan-scripts-secrets.bats` → **7/7**.
+- `bats tests/shell-wrapper-dedup.bats` → **13/13** (asserts the `dbg`→nan-debug
+  alias dedup; unaffected by the scripts' internal secret resolution).
+- `bats tests/powershell-profile.bats` → **14/14**.
+- `bash -n` on all three scripts → clean. `shellcheck` → clean.
+- **Live fetch deferred:** deployed `dotf` is 0.18.0 (no `secrets show` yet — this
+  PR is the `feat(secrets):` commit that lets release-please cut 0.19.0). The
+  end-to-end `dotf secrets show nan-api-key` is exercised at the post-deploy smoke
+  (issue #587 / spec task #3). Until then a direct run degrades gracefully:
+  `show` fails → `2>/dev/null || true` → empty key → the `dotf secrets run` hint.
+
+## Decisions made during implementation
+
+- **`show` (self-fetch), not a shell wrapper.** nan-* read a single var, so the
+  in-script `dotf secrets show nan-api-key` keeps them directly runnable AND
+  wrappable under `dotf secrets run` — no new alias/function surface, aliases
+  (`dbg`, …) keep calling the script on PATH untouched.
+- **Split out of the user's "PR-B".** The setup eager-load is a high-risk
+  critical-path refactor; bundling it with this trivial swap would violate the
+  atomic-PR rule. → PR-B2.
+
+## Promotion candidates
+
+- [ ] Lesson for `docs/lessons.md`? no (mechanical migration; the pattern is the
+  ADR-028 idiom, already documented).
+- [ ] ADR-worthy? no (executes ADR-028).
+- [ ] New cross-project pattern? no.
+
+## Archive checklist (deferred to PR-C, which closes #587)
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved to `specs/archive/CLI-024-secrets-retire-loadsecrets/`
+- [ ] Promotions above executed (if any)

--- a/tests/nan-scripts-secrets.bats
+++ b/tests/nan-scripts-secrets.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# Secret-resolution contract for the nan-* helper scripts (ADR-028 Phase 1,
+# spec CLI-024-secrets-retire-loadsecrets / #587).
+#
+# The nan-* scripts must resolve NAN_API_KEY through the `dotf secrets` facade
+# (`dotf secrets show nan-api-key`, or injected by `dotf secrets run`), never by
+# sourcing the retired `load-secrets` twin. Structural (grep-based) like the
+# other RC/script contract tests in this suite.
+
+setup() {
+    export SCRIPTS_DIR="$BATS_TEST_DIRNAME/../scripts"
+    NAN_SCRIPTS=(nan-bench.sh nan-debug.sh nan-quality-bench.sh)
+}
+
+@test "nan-* scripts exist" {
+    for s in "${NAN_SCRIPTS[@]}"; do
+        [[ -f "$SCRIPTS_DIR/$s" ]] || { echo "missing: $s"; return 1; }
+    done
+}
+
+@test "nan-* scripts do not source the retired load-secrets twin" {
+    for s in "${NAN_SCRIPTS[@]}"; do
+        ! grep -qE 'load-secrets' "$SCRIPTS_DIR/$s" || { echo "still references load-secrets: $s"; return 1; }
+    done
+}
+
+@test "nan-* scripts do not call secrets_refresh (the old twin API)" {
+    for s in "${NAN_SCRIPTS[@]}"; do
+        ! grep -q 'secrets_refresh' "$SCRIPTS_DIR/$s" || { echo "still calls secrets_refresh: $s"; return 1; }
+    done
+}
+
+@test "nan-* scripts self-fetch NAN_API_KEY via dotf secrets show" {
+    for s in "${NAN_SCRIPTS[@]}"; do
+        grep -qF 'dotf secrets show nan-api-key' "$SCRIPTS_DIR/$s" || { echo "no 'dotf secrets show': $s"; return 1; }
+    done
+}
+
+@test "nan-* scripts guard the dotf fetch with command -v dotf" {
+    for s in "${NAN_SCRIPTS[@]}"; do
+        grep -qE 'command -v dotf' "$SCRIPTS_DIR/$s" || { echo "no 'command -v dotf' guard: $s"; return 1; }
+    done
+}
+
+@test "nan-* scripts hint 'dotf secrets run' when the key is missing" {
+    for s in "${NAN_SCRIPTS[@]}"; do
+        grep -qF 'dotf secrets run' "$SCRIPTS_DIR/$s" || { echo "no run hint: $s"; return 1; }
+    done
+}
+
+@test "nan-* scripts parse cleanly (bash -n)" {
+    for s in "${NAN_SCRIPTS[@]}"; do
+        bash -n "$SCRIPTS_DIR/$s" || { echo "syntax error: $s"; return 1; }
+    done
+}


### PR DESCRIPTION
## What

Migrates the three `nan-*` helper scripts off the retired `load-secrets` twin.
Each now resolves `NAN_API_KEY` via `dotf secrets show nan-api-key` (guarded by
`command -v dotf`), staying directly runnable and wrappable under `dotf secrets
run -- <script>` with no double-fetch.

First slice of the load-secrets retirement — spec
`specs/CLI-024-secrets-retire-loadsecrets/`, issue #587 (supersedes the closed
#493, whose `eval "$(dotf secrets env)"` parent-shell design ADR-028 rejected).

## Why this PR also unblocks 0.19.0

#584 (registry + `dotf secrets ls/show`) merged with a **non-conventional squash
subject**, so release-please parsed 0 commits and never opened a release PR —
`dotf secrets ls/show` are on `main` but unreleased (deployed `dotf` is 0.18.0).
This PR's `feat(secrets):` subject is the trigger: on merge, release-please opens
the **0.19.0** PR sweeping in #584 + this. Redeploy then makes `show`/`ls`/
run-via-registry live (and these nan-* scripts functional).

## Test

- `tests/nan-scripts-secrets.bats` — new structural contract: no `load-secrets`
  sourcing / `secrets_refresh`; self-fetch via `dotf secrets show`; `command -v
  dotf` guard; `dotf secrets run` hint. **RED → GREEN 7/7.**
- Neighbours unaffected: `shell-wrapper-dedup` 13/13, `powershell-profile` 14/14.
- `bash -n` + `shellcheck` clean.
- Live `dotf secrets show` fetch validated at the post-deploy 0.19.0 smoke (#587).

## Follow-ups (this spec / #587)

- **PR-B2** — migrate the `setup-{linux,windows}` eager-load (high risk).
- **PR-C** — delete `load-secrets.{sh,ps1}` + `env-mapping.conf` + archive the PAT lesson.

Refs #587; ADR-028.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `nan-*` helper scripts now load `NAN_API_KEY` more reliably when available, and show clearer guidance if the key is missing.
  * Updated fallback behavior to avoid legacy secret-loading steps.

* **Tests**
  * Added automated checks for secret resolution, missing-key messaging, and script syntax.
  * Added verification coverage for the updated secret-loading flow.

* **Documentation**
  * Added release planning and verification notes for the secret-loading changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->