### PR TITLE
fix(secrets): deploy secrets/registry.yaml in setup so dotf secrets works

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -125,6 +125,14 @@ if [ "$CURRENT_DIR" != "$DOTFILES_DIR" ]; then
     cp -rf "$CURRENT_DIR/sensitive/"* "$DOTFILES_DIR/sensitive/" 2>/dev/null || true
 fi
 
+# Deploy the secrets registry (ADR-028 §2 mapping SSOT). dotf secrets reads it
+# from $DOTFILES_DIR/secrets/registry.yaml; without it `dotf secrets {ls,show,run}`
+# and the AI-CLI wrappers fail. Mirrors the sensitive/ deploy just above.
+ensure_directory "$DOTFILES_DIR/secrets"
+if [ "$CURRENT_DIR" != "$DOTFILES_DIR" ]; then
+    cp -rf "$CURRENT_DIR/secrets/"* "$DOTFILES_DIR/secrets/" 2>/dev/null || true
+fi
+
 # Eager-load secrets: source load-secrets.sh NOW (after sensitive/ deploy is in
 # place at $DOTFILES_DIR/sensitive) so every subsequent block in this setup
 # has $NAN_API_KEY / $OPENROUTER_API_KEY / $VAULT_PATH / $TS_AUTHKEY / etc.

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1619,6 +1619,18 @@ if (Test-Path $sensitiveSource) {
     Write-Warn "Sensitive directory not found at $sensitiveSource"
 }
 
+# Deploy the secrets registry (ADR-028 §2 mapping SSOT). dotf secrets reads it
+# from $DotfilesDest\secrets\registry.yaml; without it `dotf secrets {ls,show,run}`
+# and the AI-CLI wrappers fail. Mirrors the sensitive/ deploy above.
+$registrySource = "$DotfilesDir\secrets\registry.yaml"
+if (Test-Path -LiteralPath $registrySource) {
+    Ensure-Directory "$DotfilesDest\secrets"
+    Copy-Item $registrySource "$DotfilesDest\secrets\" -Force
+    Write-Success "Deployed secrets/registry.yaml"
+} else {
+    Write-Warn "secrets/registry.yaml not found at $registrySource"
+}
+
 # Eager-load secrets: dot-source load-secrets.ps1 NOW (after the .secret.age
 # files + env-mapping.conf are at $DotfilesDest\sensitive) so every subsequent
 # block in this setup has $env:NAN_API_KEY / OPENROUTER_API_KEY / VAULT_PATH /

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -48,6 +48,11 @@ setup() {
     grep -q 'jq-linux-amd64' "$DOTFILES_DIR/setup-linux.sh"
 }
 
+@test "setup-linux.sh deploys secrets/registry.yaml (dotf secrets mapping SSOT) [#587]" {
+    grep -qF 'DOTFILES_DIR/secrets' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF 'secrets/registry.yaml' "$DOTFILES_DIR/setup-linux.sh"
+}
+
 @test "setup-linux.sh installs gh if missing" {
     grep -q 'command -v gh' "$DOTFILES_DIR/setup-linux.sh"
     grep -q 'cli/cli/releases' "$DOTFILES_DIR/setup-linux.sh"

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -87,6 +87,16 @@ setup() {
     grep -qF 'Eager-load secrets' "$DOTFILES_DIR/setup-linux.sh"
 }
 
+@test "setup-windows.ps1 deploys secrets/registry.yaml (dotf secrets mapping SSOT) [#587]" {
+    grep -qF 'Deployed secrets/registry.yaml' "$PS1_SCRIPT"
+    grep -qF 'registry.yaml' "$PS1_SCRIPT"
+}
+
+@test "parity: both setups deploy the secrets registry [#587]" {
+    grep -qF 'registry.yaml' "$PS1_SCRIPT"
+    grep -qF 'registry.yaml' "$DOTFILES_DIR/setup-linux.sh"
+}
+
 @test "setup-windows.ps1 preflights the age identity key (warn, not fail)" {
     # Without ~/.config/age/key.txt, load-secrets.ps1 silently no-ops at
     # shell startup and opencode/agy 401 with no clue. Preflight WARNs (must

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -31,6 +31,10 @@ setup() {
     [ -d "$DOTFILES_DIR/sensitive" ]
 }
 
+@test "~/.dotfiles/secrets/registry.yaml exists (dotf secrets mapping SSOT) [#587]" {
+    [ -f "$DOTFILES_DIR/secrets/registry.yaml" ]
+}
+
 @test "~/.dotfiles/ssh directory exists" {
     [ -d "$DOTFILES_DIR/ssh" ]
 }


### PR DESCRIPTION
## What

Fixes a **0.19.0 regression**: `dotf secrets {ls,show,run}` resolve the mapping from
`$DOTFILES_DIR/secrets/registry.yaml`, but setup never deployed the `secrets/` dir
(only `sensitive/` + `scripts/`). On a freshly-deployed 0.19.0 machine, `dotf secrets
run` — and the opencode/pi/agy wrappers that call it — fail with `read registry: …
cannot find the path`.

`setup-{linux,windows}` now deploy `secrets/registry.yaml` to `$DOTFILES_DIR/secrets/`,
mirroring the `sensitive/` deploy.

## How it was found

Caught by the post-0.19.0-deploy smoke (#587): `dotf secrets ls` errored with the
missing-registry path. Stopgap-deployed on the current machine; this is the durable
cross-OS fix.

## Test

- `tests/setup-linux.bats` — asserts the registry deploy (structural).
- `tests/setup-windows.bats` — asserts the registry deploy + parity (structural).
- `tests/verify-setup.bats` — asserts `~/.dotfiles/secrets/registry.yaml` exists after a
  real setup run (the integration container / `integration` CI job).
- `bash -n` + `shellcheck -S error` clean.

## Scope

Registry deploy only. The eager `load-secrets`→`dotf secrets` migration is a follow-up
(#587 PR-B3): the Windows setup deploys secrets *after* the consumers (opencode/agy),
which needs careful reordering.

Refs #587; ADR-028.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secrets setup now includes the required registry file on both Linux and Windows, helping related tooling work after installation.
* **Bug Fixes**
  * Improved consistency between platforms by ensuring the same secrets registry is deployed during setup.
* **Tests**
  * Added coverage to verify the secrets registry is installed correctly and present after setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->