### PR TITLE
feat(secrets): add dotf secrets render and wire setups off the shell twins

### DIFF
--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -24,7 +24,8 @@ func newSecretsCmd() *cobra.Command {
 		Short: "On-demand secrets — inject into a child process, never the shell (ADR-028)",
 		Long: "secrets reads the registry (secrets/registry.yaml) and exposes the mapped\n" +
 			"secrets on demand. `run` injects them into one child process only (never the\n" +
-			"ambient shell); `show` prints one value; `ls` lists ids (ADR-028 §2).",
+			"ambient shell); `show` prints one value; `render` materializes {env:VAR}\n" +
+			"placeholders in a config file; `ls` lists ids (ADR-028 §2).",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
@@ -33,6 +34,7 @@ func newSecretsCmd() *cobra.Command {
 	cmd.AddCommand(newSecretsRunCmd())
 	cmd.AddCommand(newSecretsLsCmd())
 	cmd.AddCommand(newSecretsShowCmd())
+	cmd.AddCommand(newSecretsRenderCmd())
 	return cmd
 }
 
@@ -99,6 +101,46 @@ func newSecretsShowCmd() *cobra.Command {
 			}
 			_, val, _ := strings.Cut(kv[0], "=") // EnvFor scrubs newlines → capture-friendly
 			_, _ = fmt.Fprint(cmd.OutOrStdout(), val)
+			return nil
+		},
+	}
+}
+
+// newSecretsRenderCmd materializes a config file in place: it substitutes every
+// {env:VAR} placeholder whose VAR is a registry-exposed env secret with that
+// secret's decrypted value (ADR-028 / SDD-009). It is the Go replacement for the
+// substitute_env_placeholders / Substitute-EnvPlaceholders shell twins, wired
+// into setup for opencode.jsonc and pi's models.json. Unmapped/undecryptable
+// placeholders are left intact for the runtime resolver (never fatal).
+func newSecretsRenderCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "render <file>",
+		Short: "Substitute {env:VAR} placeholders in <file> with decrypted secret values (in place)",
+		Long: "render rewrites <file> in place, replacing each {env:VAR} placeholder whose\n" +
+			"VAR is a registry-mapped env secret (secrets/registry.yaml, over the age\n" +
+			"store) with the decrypted value. Placeholders with no registry mapping, or\n" +
+			"whose secret cannot be decrypted, are left intact for the runtime resolver —\n" +
+			"setup must complete even when some secrets are absent. Atomic write, 0600.",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reg, err := loadRegistry()
+			if err != nil {
+				return err
+			}
+			secretsDir := filepath.Join(env.DotfilesDir(env.Home()), "sensitive")
+			loader := &secrets.Loader{SecretsDir: secretsDir, KeyPath: ageKeyPath(), Decrypt: ageDecryptor}
+			res, err := secrets.Render(args[0], reg, loader, env.Home())
+			if err != nil {
+				return err
+			}
+			errOut := cmd.ErrOrStderr()
+			if len(res.Unmapped) > 0 {
+				_, _ = fmt.Fprintf(errOut, "render: unmapped placeholders left for runtime resolution: %s\n", strings.Join(res.Unmapped, " "))
+			}
+			if len(res.Unresolved) > 0 {
+				_, _ = fmt.Fprintf(errOut, "warning: render: mapped but undecryptable, left intact (check age key/secret files): %s\n", strings.Join(res.Unresolved, " "))
+			}
 			return nil
 		},
 	}

--- a/cli/internal/cmd/secrets_registry_test.go
+++ b/cli/internal/cmd/secrets_registry_test.go
@@ -89,6 +89,30 @@ func TestSecretsShow_RejectsBwBackend(t *testing.T) {
 	}
 }
 
+func TestSecretsRender_SubstitutesInPlace(t *testing.T) {
+	useTempRegistry(t, testRegistry)
+	old := ageDecryptor
+	ageDecryptor = func(_, _ string) ([]byte, error) { return []byte("rendered-value\n"), nil }
+	t.Cleanup(func() { ageDecryptor = old })
+
+	cfg := filepath.Join(t.TempDir(), "opencode.jsonc")
+	if err := os.WriteFile(cfg, []byte(`{"k":"{env:NAN_API_KEY}","h":"{env:HOME}"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newSecretsRenderCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{cfg})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(cfg)
+	// NAN_API_KEY is registry-mapped → substituted; HOME is not → left for runtime.
+	if want := `{"k":"rendered-value","h":"{env:HOME}"}`; string(got) != want {
+		t.Errorf("render = %q, want %q", got, want)
+	}
+}
+
 func TestResolveOnly_IdSelectsAllVars_NameSelectsOne(t *testing.T) {
 	reg, err := secrets.ParseRegistry([]byte(testRegistry))
 	if err != nil {

--- a/cli/internal/secrets/render.go
+++ b/cli/internal/secrets/render.go
@@ -1,0 +1,159 @@
+package secrets
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// envToken matches a {env:NAME} placeholder, NAME being an upper-snake env-var
+// identifier. Same grammar the shell twin (substitute_env_placeholders) used.
+var envToken = regexp.MustCompile(`\{env:([A-Z_][A-Z0-9_]*)\}`)
+
+// Result reports what Render did, so the caller can surface the shell twin's
+// operator diagnostics: which placeholders were substituted, left for the
+// runtime resolver (Unmapped), or mapped-but-undecryptable (Unresolved).
+type Result struct {
+	Substituted int
+	Unmapped    []string // {env:VAR} with no registry entry — left intact (info)
+	Unresolved  []string // mapped but decrypt failed/empty — left intact (warning)
+}
+
+// Render rewrites the config at path in place, substituting every {env:VAR}
+// placeholder whose VAR is a registry-exposed env secret with that secret's
+// decrypted value. It is the Go port of the substitute_env_placeholders /
+// Substitute-EnvPlaceholders twins (ADR-020 convergence over the registry SSOT).
+//
+// Behaviour parity with the twins:
+//   - unmapped VAR (no registry entry, e.g. {env:HOME})  -> left intact (Unmapped)
+//   - mapped VAR but the secret won't decrypt/is empty   -> left intact (Unresolved)
+//   - resolved                                           -> substituted in place
+//
+// Setup must complete even when some secrets are absent, so an undecryptable
+// secret is NOT fatal (unlike run's EnvFor, which fails fast): the placeholder
+// falls through to opencode/pi's runtime resolver. The one fatal case render
+// adds — which the twins lacked — is a non-deterministic registry: a VAR exposed
+// by two distinct secrets has no single source, so render refuses it.
+//
+// The write is atomic (temp file in the same dir, then rename) at 0600, with no
+// trailing-newline drift. A file with no placeholders is left untouched.
+func Render(path string, reg *Registry, loader *Loader, home string) (Result, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return Result{}, fmt.Errorf("render: read %s: %w", path, err)
+	}
+
+	refs := referencedVars(content)
+	if len(refs) == 0 {
+		return Result{}, nil // nothing to substitute — leave the file as-is
+	}
+
+	bySource, err := envSourceMap(reg, home)
+	if err != nil {
+		return Result{}, err
+	}
+
+	out := string(content)
+	res := Result{}
+	for _, name := range refs {
+		entry, mapped := bySource[name]
+		if !mapped {
+			res.Unmapped = append(res.Unmapped, name)
+			continue
+		}
+		value, ok := resolve(loader, entry)
+		if !ok {
+			res.Unresolved = append(res.Unresolved, name)
+			continue
+		}
+		out = strings.ReplaceAll(out, "{env:"+name+"}", value)
+		res.Substituted++
+	}
+
+	if res.Substituted == 0 {
+		return res, nil // every placeholder unmapped/unresolved — no rewrite needed
+	}
+	if err := atomicWrite(path, []byte(out)); err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+// referencedVars returns the sorted, de-duplicated set of VAR names appearing as
+// {env:VAR} in content. Sorted so Render's behaviour (and its diagnostics) is
+// deterministic regardless of placeholder order in the file.
+func referencedVars(content []byte) []string {
+	seen := map[string]bool{}
+	for _, m := range envToken.FindAllSubmatch(content, -1) {
+		seen[string(m[1])] = true
+	}
+	names := make([]string, 0, len(seen))
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// envSourceMap flattens the registry to a VAR -> age entry map over env secrets
+// only (file secrets are materialized by `run`, never substituted into configs).
+// A VAR exposed by two distinct secrets is a non-deterministic registry and is
+// rejected fail-fast — render needs exactly one source per var.
+func envSourceMap(reg *Registry, home string) (map[string]Entry, error) {
+	bySource := map[string]Entry{}
+	for _, e := range reg.Entries(home) {
+		if e.IsFile {
+			continue
+		}
+		if prev, dup := bySource[e.Var]; dup && prev.File != e.File {
+			return nil, fmt.Errorf("render: registry exposes %q from two sources (%s, %s); the registry must map each var to one secret", e.Var, prev.File, e.File)
+		}
+		bySource[e.Var] = e
+	}
+	return bySource, nil
+}
+
+// resolve decrypts a single env entry by reusing EnvFor (the one decrypt+strip
+// path shared with run/show). EnvFor fails fast; here a failure is non-fatal —
+// it maps to "unresolved, leave the placeholder intact" (twin parity).
+func resolve(loader *Loader, e Entry) (string, bool) {
+	kv, err := loader.EnvFor([]Entry{e}, nil)
+	if err != nil || len(kv) == 0 {
+		return "", false
+	}
+	_, value, _ := strings.Cut(kv[0], "=")
+	if value == "" {
+		return "", false
+	}
+	return value, true
+}
+
+// atomicWrite stages content to a temp file in the target's directory, sets 0600,
+// and renames it over the target. Same-dir keeps the rename on one filesystem;
+// os.Rename replaces an existing file on both POSIX and Windows (MoveFileEx).
+func atomicWrite(path string, content []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".render-*.tmp")
+	if err != nil {
+		return fmt.Errorf("render: create temp for %s: %w", path, err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op once the rename succeeds
+
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		return fmt.Errorf("render: write temp for %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("render: close temp for %s: %w", path, err)
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		return fmt.Errorf("render: chmod temp for %s: %w", path, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("render: replace %s: %w", path, err)
+	}
+	return nil
+}

--- a/cli/internal/secrets/render.go
+++ b/cli/internal/secrets/render.go
@@ -140,10 +140,10 @@ func atomicWrite(path string, content []byte) error {
 		return fmt.Errorf("render: create temp for %s: %w", path, err)
 	}
 	tmpName := tmp.Name()
-	defer os.Remove(tmpName) // no-op once the rename succeeds
+	defer func() { _ = os.Remove(tmpName) }() // no-op once the rename succeeds
 
 	if _, err := tmp.Write(content); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return fmt.Errorf("render: write temp for %s: %w", path, err)
 	}
 	if err := tmp.Close(); err != nil {

--- a/cli/internal/secrets/render_test.go
+++ b/cli/internal/secrets/render_test.go
@@ -1,0 +1,174 @@
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// renderRegistry exposes one single-var env secret plus a file secret, so render
+// can prove it (a) substitutes the env placeholder and (b) never treats the file
+// secret's var as a substitution target nor materializes it as a side effect.
+const renderRegistry = `
+version: 1
+secrets:
+  - id: nan-api-key
+    plane: app
+    backend: age
+    age: nan.api-key
+    expose: { env: NAN_API_KEY }
+  - id: kubelab-kubeconfig
+    plane: infra
+    backend: age
+    age: kubelab.kubeconfig
+    expose: { file: { var: KUBECONFIG, path: "~/.kube/kubelab.config", mode: "0600" } }
+`
+
+func renderFixture(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "opencode.jsonc")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("seed fixture: %v", err)
+	}
+	return p
+}
+
+func parseRenderReg(t *testing.T, yml string) *Registry {
+	t.Helper()
+	reg, err := ParseRegistry([]byte(yml))
+	if err != nil {
+		t.Fatalf("ParseRegistry: %v", err)
+	}
+	return reg
+}
+
+// AC1 — a registry-mapped {env:VAR} is replaced with its decrypted value; an
+// unmapped placeholder ({env:HOME}) is left intact for the runtime resolver.
+func TestRender_SubstitutesMapped_LeavesUnmappedIntact(t *testing.T) {
+	reg := parseRenderReg(t, renderRegistry)
+	path := renderFixture(t, `{"key":"{env:NAN_API_KEY}","home":"{env:HOME}"}`)
+
+	res, err := Render(path, reg, loaderFor(t), "/h")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	// fakeDecryptor yields "secret-of-<age-basename>\n"; EnvFor strips the newline.
+	want := `{"key":"secret-of-nan.api-key.secret.age","home":"{env:HOME}"}`
+	if string(got) != want {
+		t.Errorf("rendered = %q, want %q", got, want)
+	}
+	if res.Substituted != 1 {
+		t.Errorf("Substituted = %d, want 1", res.Substituted)
+	}
+	if len(res.Unmapped) != 1 || res.Unmapped[0] != "HOME" {
+		t.Errorf("Unmapped = %v, want [HOME]", res.Unmapped)
+	}
+}
+
+// AC2 — atomic write at 0600 with byte parity: render must NOT append a trailing
+// newline the source file did not have.
+func TestRender_Mode0600_NoTrailingNewlineDrift(t *testing.T) {
+	reg := parseRenderReg(t, renderRegistry)
+	path := renderFixture(t, `x={env:NAN_API_KEY}`) // no trailing newline
+
+	if _, err := Render(path, reg, loaderFor(t), "/h"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if strings.HasSuffix(string(got), "\n") {
+		t.Errorf("render added a trailing newline: %q", got)
+	}
+	if string(got) != "x=secret-of-nan.api-key.secret.age" {
+		t.Errorf("rendered = %q", got)
+	}
+	if runtime.GOOS != "windows" { // NTFS drops POSIX mode bits
+		info, err := os.Stat(path)
+		if err != nil || info.Mode().Perm() != 0o600 {
+			t.Errorf("mode = %v (want 0600)", info.Mode().Perm())
+		}
+	}
+}
+
+// A file with no placeholders is left byte-for-byte untouched (and not rewritten).
+func TestRender_NoPlaceholders_NoOp(t *testing.T) {
+	reg := parseRenderReg(t, renderRegistry)
+	const body = `{"plain":"config","n":1}`
+	path := renderFixture(t, body)
+
+	res, err := Render(path, reg, loaderFor(t), "/h")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != body {
+		t.Errorf("no-op render changed content: %q", got)
+	}
+	if res.Substituted != 0 {
+		t.Errorf("Substituted = %d, want 0", res.Substituted)
+	}
+}
+
+// Parity with the shell twin: a mapped var whose secret cannot be decrypted is
+// left intact and reported as unresolved — render must NOT fail-fast (setup must
+// still complete; the placeholder falls through to the runtime resolver).
+func TestRender_UnresolvedDecryptError_LeftIntact(t *testing.T) {
+	reg := parseRenderReg(t, renderRegistry)
+	path := renderFixture(t, `x={env:NAN_API_KEY}`)
+	l := loaderFor(t)
+	l.Decrypt = func(string, string) ([]byte, error) { return nil, os.ErrNotExist }
+
+	res, err := Render(path, reg, l, "/h")
+	if err != nil {
+		t.Fatalf("Render must not fail on an undecryptable secret: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != `x={env:NAN_API_KEY}` {
+		t.Errorf("undecryptable placeholder should be left intact, got %q", got)
+	}
+	if len(res.Unresolved) != 1 || res.Unresolved[0] != "NAN_API_KEY" {
+		t.Errorf("Unresolved = %v, want [NAN_API_KEY]", res.Unresolved)
+	}
+}
+
+// A file secret's var is NOT an env-substitution target: {env:KUBECONFIG} is left
+// intact and the kube config is NOT materialized to disk as a side effect.
+func TestRender_FileSecretVar_LeftIntactNotMaterialized(t *testing.T) {
+	reg := parseRenderReg(t, renderRegistry)
+	path := renderFixture(t, `k={env:KUBECONFIG}`)
+
+	res, err := Render(path, reg, loaderFor(t), "/h")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != `k={env:KUBECONFIG}` {
+		t.Errorf("file-secret var should be left intact, got %q", got)
+	}
+	if len(res.Unmapped) != 1 || res.Unmapped[0] != "KUBECONFIG" {
+		t.Errorf("Unmapped = %v, want [KUBECONFIG]", res.Unmapped)
+	}
+	if _, err := os.Stat(filepath.Join("/h", ".kube", "kubelab.config")); err == nil {
+		t.Error("render materialized a file secret as a side effect")
+	}
+}
+
+// render needs a deterministic VAR→source map: if the registry exposes one var
+// from two distinct secrets, render fails fast (the shell twin silently took the
+// first mapping line; render refuses the ambiguity).
+func TestRender_DuplicateVar_FailsFast(t *testing.T) {
+	const dup = `
+version: 1
+secrets:
+  - { id: a, plane: app, backend: age, age: a.src, expose: { env: SHARED } }
+  - { id: b, plane: app, backend: age, age: b.src, expose: { env: SHARED } }
+`
+	reg := parseRenderReg(t, dup)
+	path := renderFixture(t, `v={env:SHARED}`)
+
+	if _, err := Render(path, reg, loaderFor(t), "/h"); err == nil {
+		t.Fatal("expected Render to fail when one var is exposed by two secrets")
+	}
+}

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -699,7 +699,14 @@ OPENCODE_CONFIG_DST="$HOME/.config/opencode/opencode.jsonc"
 if [ -f "$OPENCODE_CONFIG_SRC" ]; then
     OPENCODE_CONFIG_TMP=$(mktemp)
     cp "$OPENCODE_CONFIG_SRC" "$OPENCODE_CONFIG_TMP"
-    substitute_env_placeholders "$OPENCODE_CONFIG_TMP"
+    # Deploy-time {env:VAR} materialization via the dotf CLI (over secrets/registry.yaml,
+    # ADR-020 convergence); the shell twin stays as the bootstrap fallback until dotf
+    # is guaranteed on PATH (its deletion lands with #587).
+    if command -v dotf >/dev/null 2>&1; then
+        dotf secrets render "$OPENCODE_CONFIG_TMP"
+    else
+        substitute_env_placeholders "$OPENCODE_CONFIG_TMP"
+    fi
     mv "$OPENCODE_CONFIG_TMP" "$OPENCODE_CONFIG_DST"
     log_success "Deployed opencode.jsonc (deploy-time secrets) to $OPENCODE_CONFIG_DST"
 else
@@ -802,7 +809,11 @@ PI_MODELS_DST="$PI_AGENT_DIR/models.json"
 if [ -f "$PI_MODELS_SRC" ]; then
     PI_MODELS_TMP=$(mktemp)
     cp "$PI_MODELS_SRC" "$PI_MODELS_TMP"
-    substitute_env_placeholders "$PI_MODELS_TMP"
+    if command -v dotf >/dev/null 2>&1; then
+        dotf secrets render "$PI_MODELS_TMP"
+    else
+        substitute_env_placeholders "$PI_MODELS_TMP"
+    fi
     if [ -f "$PI_MODELS_DST" ] && cmp -s "$PI_MODELS_TMP" "$PI_MODELS_DST"; then
         log_info "pi models.json already in sync"
         rm -f "$PI_MODELS_TMP"

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -700,10 +700,13 @@ if [ -f "$OPENCODE_CONFIG_SRC" ]; then
     OPENCODE_CONFIG_TMP=$(mktemp)
     cp "$OPENCODE_CONFIG_SRC" "$OPENCODE_CONFIG_TMP"
     # Deploy-time {env:VAR} materialization via the dotf CLI (over secrets/registry.yaml,
-    # ADR-020 convergence); the shell twin stays as the bootstrap fallback until dotf
-    # is guaranteed on PATH (its deletion lands with #587).
-    if command -v dotf >/dev/null 2>&1; then
-        dotf secrets render "$OPENCODE_CONFIG_TMP"
+    # ADR-020 convergence). Gate on the subcommand SUCCEEDING, not just dotf's presence:
+    # a stale dotf passes `command -v` but fails `secrets render`, and under set -e that
+    # would abort setup instead of falling back. Running it in the `if` condition exempts
+    # it from set -e, so any failure drops to the twin (kept until dotf is guaranteed
+    # current; its deletion lands with #587).
+    if command -v dotf >/dev/null 2>&1 && dotf secrets render "$OPENCODE_CONFIG_TMP"; then
+        : # materialized via dotf secrets render
     else
         substitute_env_placeholders "$OPENCODE_CONFIG_TMP"
     fi
@@ -809,8 +812,9 @@ PI_MODELS_DST="$PI_AGENT_DIR/models.json"
 if [ -f "$PI_MODELS_SRC" ]; then
     PI_MODELS_TMP=$(mktemp)
     cp "$PI_MODELS_SRC" "$PI_MODELS_TMP"
-    if command -v dotf >/dev/null 2>&1; then
-        dotf secrets render "$PI_MODELS_TMP"
+    # Gate on `secrets render` succeeding, not just dotf presence (see opencode block).
+    if command -v dotf >/dev/null 2>&1 && dotf secrets render "$PI_MODELS_TMP"; then
+        : # materialized via dotf secrets render
     else
         substitute_env_placeholders "$PI_MODELS_TMP"
     fi

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1033,14 +1033,21 @@ if (Test-Path -LiteralPath $opencodeConfigSrc -PathType Leaf) {
     $opencodeConfigTmp = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "opencode-$PID.jsonc")
     Copy-Item -LiteralPath $opencodeConfigSrc -Destination $opencodeConfigTmp -Force
     # Deploy-time {env:VAR} materialization via the dotf CLI (over secrets/registry.yaml,
-    # ADR-020 convergence); the PowerShell twin stays as the bootstrap fallback until
-    # dotf is guaranteed on PATH (its deletion lands with #587).
+    # ADR-020 convergence). dotf presence is not success: a stale binary runs but exits
+    # non-zero, so check $LASTEXITCODE and fall back to the twin / literal placeholders
+    # rather than deploying a half-rendered file (the twin stays until dotf is guaranteed
+    # current; its deletion lands with #587).
+    $opencodeRendered = $false
     if (Get-Command dotf -ErrorAction SilentlyContinue) {
         & dotf secrets render $opencodeConfigTmp
-    } elseif (Get-Command Substitute-EnvPlaceholders -ErrorAction SilentlyContinue) {
-        [void](Substitute-EnvPlaceholders -Path $opencodeConfigTmp)
-    } else {
-        Write-Warn "neither dotf nor Substitute-EnvPlaceholders available; deploying opencode.jsonc with literal {env:VAR} placeholders intact"
+        $opencodeRendered = ($LASTEXITCODE -eq 0)
+    }
+    if (-not $opencodeRendered) {
+        if (Get-Command Substitute-EnvPlaceholders -ErrorAction SilentlyContinue) {
+            [void](Substitute-EnvPlaceholders -Path $opencodeConfigTmp)
+        } else {
+            Write-Warn "dotf secrets render unavailable/failed and Substitute-EnvPlaceholders missing; deploying opencode.jsonc with literal {env:VAR} placeholders intact"
+        }
     }
     if (Get-Command Deploy-File -ErrorAction SilentlyContinue) {
         [void](Deploy-File -Source $opencodeConfigTmp -Destination $opencodeConfigDst)
@@ -1164,12 +1171,18 @@ $piModelsDst = Join-Path $piAgentDir 'models.json'
 if (Test-Path -LiteralPath $piModelsSrc -PathType Leaf) {
     $piModelsTmp = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "pi-models-$PID.json")
     Copy-Item -LiteralPath $piModelsSrc -Destination $piModelsTmp -Force
+    # Gate on $LASTEXITCODE, not just dotf presence (see opencode block).
+    $piRendered = $false
     if (Get-Command dotf -ErrorAction SilentlyContinue) {
         & dotf secrets render $piModelsTmp
-    } elseif (Get-Command Substitute-EnvPlaceholders -ErrorAction SilentlyContinue) {
-        [void](Substitute-EnvPlaceholders -Path $piModelsTmp)
-    } else {
-        Write-Warn "neither dotf nor Substitute-EnvPlaceholders available; deploying pi models.json with literal {env:VAR} placeholders intact"
+        $piRendered = ($LASTEXITCODE -eq 0)
+    }
+    if (-not $piRendered) {
+        if (Get-Command Substitute-EnvPlaceholders -ErrorAction SilentlyContinue) {
+            [void](Substitute-EnvPlaceholders -Path $piModelsTmp)
+        } else {
+            Write-Warn "dotf secrets render unavailable/failed and Substitute-EnvPlaceholders missing; deploying pi models.json with literal {env:VAR} placeholders intact"
+        }
     }
     if (Get-Command Deploy-File -ErrorAction SilentlyContinue) {
         [void](Deploy-File -Source $piModelsTmp -Destination $piModelsDst)

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1032,10 +1032,15 @@ if (Test-Path -LiteralPath $opencodeConfigSrc -PathType Leaf) {
     # still works after substitution.
     $opencodeConfigTmp = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "opencode-$PID.jsonc")
     Copy-Item -LiteralPath $opencodeConfigSrc -Destination $opencodeConfigTmp -Force
-    if (Get-Command Substitute-EnvPlaceholders -ErrorAction SilentlyContinue) {
+    # Deploy-time {env:VAR} materialization via the dotf CLI (over secrets/registry.yaml,
+    # ADR-020 convergence); the PowerShell twin stays as the bootstrap fallback until
+    # dotf is guaranteed on PATH (its deletion lands with #587).
+    if (Get-Command dotf -ErrorAction SilentlyContinue) {
+        & dotf secrets render $opencodeConfigTmp
+    } elseif (Get-Command Substitute-EnvPlaceholders -ErrorAction SilentlyContinue) {
         [void](Substitute-EnvPlaceholders -Path $opencodeConfigTmp)
     } else {
-        Write-Warn "Substitute-EnvPlaceholders missing; deploying opencode.jsonc with literal {env:VAR} placeholders intact"
+        Write-Warn "neither dotf nor Substitute-EnvPlaceholders available; deploying opencode.jsonc with literal {env:VAR} placeholders intact"
     }
     if (Get-Command Deploy-File -ErrorAction SilentlyContinue) {
         [void](Deploy-File -Source $opencodeConfigTmp -Destination $opencodeConfigDst)
@@ -1159,10 +1164,12 @@ $piModelsDst = Join-Path $piAgentDir 'models.json'
 if (Test-Path -LiteralPath $piModelsSrc -PathType Leaf) {
     $piModelsTmp = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "pi-models-$PID.json")
     Copy-Item -LiteralPath $piModelsSrc -Destination $piModelsTmp -Force
-    if (Get-Command Substitute-EnvPlaceholders -ErrorAction SilentlyContinue) {
+    if (Get-Command dotf -ErrorAction SilentlyContinue) {
+        & dotf secrets render $piModelsTmp
+    } elseif (Get-Command Substitute-EnvPlaceholders -ErrorAction SilentlyContinue) {
         [void](Substitute-EnvPlaceholders -Path $piModelsTmp)
     } else {
-        Write-Warn "Substitute-EnvPlaceholders missing; deploying pi models.json with literal {env:VAR} placeholders intact"
+        Write-Warn "neither dotf nor Substitute-EnvPlaceholders available; deploying pi models.json with literal {env:VAR} placeholders intact"
     }
     if (Get-Command Deploy-File -ErrorAction SilentlyContinue) {
         [void](Deploy-File -Source $piModelsTmp -Destination $piModelsDst)

--- a/specs/CLI-025-secrets-render/proposal.md
+++ b/specs/CLI-025-secrets-render/proposal.md
@@ -1,7 +1,7 @@
 ---
 id: "CLI-025-secrets-render"
 type: spec
-status: draft # draft | implementing | verifying | archived
+status: implementing # draft | implementing | verifying | archived
 created: "2026-06-25"
 issue: "mlorentedev/dotfiles#587"
 tags: [spec, proposal, secrets, cli, go]

--- a/specs/CLI-025-secrets-render/proposal.md
+++ b/specs/CLI-025-secrets-render/proposal.md
@@ -1,0 +1,82 @@
+---
+id: "CLI-025-secrets-render"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-25"
+issue: "mlorentedev/dotfiles#587"
+tags: [spec, proposal, secrets, cli, go]
+template_version: "1.0"
+---
+
+# CLI-025-secrets-render
+
+## Why
+
+Deploy-time config materialization (SDD-009) — substituting `{env:VAR}` placeholders
+in `opencode.jsonc` / pi `models.json` with the decrypted secret at setup time — is
+done today by a **twin pair**: `substitute_env_placeholders` (`scripts/utils.sh`) and
+`Substitute-EnvPlaceholders` (`scripts/utils.ps1`). Both age-decrypt `{env:VAR}` by
+reading **`sensitive/env-mapping.conf`** directly. They are:
+
+1. **The last live consumers of `env-mapping.conf`** — it cannot be deleted (closing
+   #587) until they stop reading it.
+2. **An ADR-020 twin pair** — the same logic in two OS dialects, which already drifted
+   once (their default `SecretsDir` resolution differs).
+
+A `dotf secrets render` subcommand collapses both into one Go implementation over the
+`secrets/registry.yaml` SSOT, deletes the twins + `env-mapping.conf`, and closes #587.
+
+## What
+
+`dotf secrets render <file>` rewrites `<file>` in place, substituting every
+`{env:VAR}` placeholder whose `VAR` is a registry-exposed env secret with that
+secret's decrypted value; placeholders with no registry mapping are **left intact**
+(opencode/pi resolve those at runtime). Atomic write, `0600`.
+
+`setup-{linux,windows}` call `dotf secrets render <config>` for `opencode.jsonc` and
+pi `models.json` instead of the shell twins. The `substitute_env_placeholders` /
+`Substitute-EnvPlaceholders` functions + their tests are deleted, `env-mapping.conf`
+is removed, and the registry↔env-mapping drift-guard test is retired.
+
+## Out of scope
+
+- The Bitwarden (`bw`) backend — Phase 3 / #585. `render` reads the age backend only,
+  via `Secret.AgeBacked()` (same gate as `show`/`run`).
+- Non-secret placeholders (`{env:HOME}`, `{env:OLLAMA_API_KEY}`) — left intact.
+- The agy `mcp_config.json` materialization (a jq-merge, not a `{env:VAR}`
+  substitution; already on `dotf secrets show` since B3) — untouched.
+
+## Risks / open questions
+
+- **VAR → value resolution.** The registry maps `id → expose.env` (a var, a list, or a
+  per-var map). Reuse `secrets.Registry.Entries()` (already flattens to `{Var, age}`
+  entries for `run`) to build a `VAR → ageSource` map; decrypt via the existing
+  `ageDecryptor` seam. If two secrets expose the same `VAR`, the registry validation
+  should already reject it — confirm, else fail-fast in `render`.
+- **Atomic + mode parity.** Match the twins: stage to a temp file, `0600`, rename over
+  the target; preserve byte parity (no trailing newline added).
+- **Unmapped placeholders must NOT error** — leave `{env:VAR}` intact and continue, so
+  `{env:HOME}` etc. survive for the runtime resolver (matches the twins).
+- **Cross-OS verification gap.** setup-windows isn't run at runtime in CI — unit-test
+  the render core in Go (table-driven) so correctness doesn't depend on a setup run.
+
+## Acceptance criteria
+
+- [ ] **AC1** — `dotf secrets render <file>` substitutes `{env:VAR}` for each registry
+  env secret whose exposed var is `VAR` (decrypted value), and leaves unmapped
+  placeholders intact. *Verify:* table-driven Go test on the render core + a fixture.
+- [ ] **AC2** — atomic write, `0600`, no trailing-newline drift. *Verify:* Go test.
+- [ ] **AC3** — `setup-{linux,windows}` materialize `opencode.jsonc` / pi `models.json`
+  via `dotf secrets render`; the `substitute_env_placeholders` twins + their tests are
+  gone. *Verify:* grep clean + bats.
+- [ ] **AC4** — `sensitive/env-mapping.conf` deleted; the registry↔env-mapping
+  drift-guard test removed; no runtime reference remains. *Verify:* grep + `go test`.
+- [ ] **AC5** — bats + integration green cross-OS; **#587 closes**.
+
+## References
+
+- ADR: `docs/adr/adr-028-secrets-two-tier-bitwarden-age.md`; ADR-020 (twin convergence).
+- Issue: `mlorentedev/dotfiles#587` (this is its final, env-mapping-deleting step).
+- Reuse: `cli/internal/secrets/registry.go` (`Entries()`), `cli/internal/cmd/secrets.go`
+  (`ageDecryptor` seam, `registryPath()`), `scripts/utils.{sh,ps1}` (twin behaviour to match).
+- Prior: spec `CLI-024-secrets-retire-loadsecrets` (B1/B2/B3/PR-C, all merged).

--- a/specs/CLI-025-secrets-render/proposal.md
+++ b/specs/CLI-025-secrets-render/proposal.md
@@ -42,7 +42,8 @@ is removed, and the registry↔env-mapping drift-guard test is retired.
 
 - The Bitwarden (`bw`) backend — Phase 3 / #585. `render` reads the age backend only,
   via `Secret.AgeBacked()` (same gate as `show`/`run`).
-- Non-secret placeholders (`{env:HOME}`, `{env:OLLAMA_API_KEY}`) — left intact.
+- Unmapped placeholders (no registry entry — e.g. `{env:HOME}`, `{env:OLLAMA_API_KEY}`)
+  — left intact, even if the name looks secret: the decision is registry-based, not value-based.
 - The agy `mcp_config.json` materialization (a jq-merge, not a `{env:VAR}`
   substitution; already on `dotf secrets show` since B3) — untouched.
 

--- a/specs/CLI-025-secrets-render/tasks.md
+++ b/specs/CLI-025-secrets-render/tasks.md
@@ -23,7 +23,10 @@ created: "2026-06-25"
   `registryPath()` + `ageDecryptor` into `Render`. (No `--dry-run`; not needed.)
 - [x] Wire `setup-linux.sh` + `setup-windows.ps1`: replace the
   `substitute_env_placeholders` / `Substitute-EnvPlaceholders` calls (opencode.jsonc,
-  pi models.json) with `dotf secrets render <config>`, guarded by `command -v dotf`.
+  pi models.json) with `dotf secrets render <config>`, gated on the subcommand
+  *succeeding* (Linux: `command -v dotf && dotf secrets render` in the `if` condition,
+  which exempts it from `set -e`; Windows: `Get-Command dotf` + `$LASTEXITCODE` check),
+  with the twin as fallback so a stale dotf never aborts setup.
 - [ ] Bump `versions.conf` is automatic (release-please). Use a `feat(secrets):` title.
 
 ## PR-B — delete the twins + env-mapping.conf (closes #587)

--- a/specs/CLI-025-secrets-render/tasks.md
+++ b/specs/CLI-025-secrets-render/tasks.md
@@ -11,16 +11,17 @@ created: "2026-06-25"
 
 ## PR-A — `dotf secrets render` + wire setups
 
-- [ ] **RED**: `cli/internal/secrets/render_test.go` — table-driven: (1) a mapped
+- [x] **RED**: `cli/internal/secrets/render_test.go` — table-driven: (1) a mapped
   `{env:VAR}` is replaced with the decrypted value, (2) an unmapped `{env:HOME}` is
   left intact, (3) atomic write + `0600`, (4) no trailing-newline drift. Inject a fake
   decryptor + a fixture registry (reuse the `registry_seed_test.go` pattern).
-- [ ] **GREEN**: `cli/internal/secrets/render.go` — `Render(path, reg, decryptor)`:
-  build `VAR → ageSource` from `reg.Entries()`, regex `\{env:([A-Z_][A-Z0-9_]*)\}`,
-  decrypt mapped vars (skip `bw`/unmapped), atomic temp-file rewrite at `0600`.
-- [ ] **GREEN**: `cli/internal/cmd/secrets.go` — `dotf secrets render <file>` wires
-  `registryPath()` + `ageDecryptor` into `Render`. `--dry-run` optional.
-- [ ] Wire `setup-linux.sh` + `setup-windows.ps1`: replace the
+- [x] **GREEN**: `cli/internal/secrets/render.go` — `Render(path, reg, loader, home)`:
+  builds `VAR → entry` from `reg.Entries()` (env only), regex `\{env:([A-Z_][A-Z0-9_]*)\}`,
+  decrypts mapped vars via `Loader.EnvFor` (skip `bw`/unmapped), atomic temp-file rewrite
+  at `0600`. Lenient on undecryptable (leave intact), fail-fast on a duplicate var.
+- [x] **GREEN**: `cli/internal/cmd/secrets.go` — `dotf secrets render <file>` wires
+  `registryPath()` + `ageDecryptor` into `Render`. (No `--dry-run`; not needed.)
+- [x] Wire `setup-linux.sh` + `setup-windows.ps1`: replace the
   `substitute_env_placeholders` / `Substitute-EnvPlaceholders` calls (opencode.jsonc,
   pi models.json) with `dotf secrets render <config>`, guarded by `command -v dotf`.
 - [ ] Bump `versions.conf` is automatic (release-please). Use a `feat(secrets):` title.

--- a/specs/CLI-025-secrets-render/tasks.md
+++ b/specs/CLI-025-secrets-render/tasks.md
@@ -1,0 +1,48 @@
+---
+tags: [spec, tasks, secrets, cli, go]
+created: "2026-06-25"
+---
+
+# Tasks - CLI-025-secrets-render
+
+> TDD order. Likely 2 PRs: (A) add `dotf secrets render` + wire setups off the shell
+> twins; (B) delete the twins + `env-mapping.conf` + the drift-guard test (closes #587).
+> Could be one PR if the diff stays < ~300 LOC.
+
+## PR-A — `dotf secrets render` + wire setups
+
+- [ ] **RED**: `cli/internal/secrets/render_test.go` — table-driven: (1) a mapped
+  `{env:VAR}` is replaced with the decrypted value, (2) an unmapped `{env:HOME}` is
+  left intact, (3) atomic write + `0600`, (4) no trailing-newline drift. Inject a fake
+  decryptor + a fixture registry (reuse the `registry_seed_test.go` pattern).
+- [ ] **GREEN**: `cli/internal/secrets/render.go` — `Render(path, reg, decryptor)`:
+  build `VAR → ageSource` from `reg.Entries()`, regex `\{env:([A-Z_][A-Z0-9_]*)\}`,
+  decrypt mapped vars (skip `bw`/unmapped), atomic temp-file rewrite at `0600`.
+- [ ] **GREEN**: `cli/internal/cmd/secrets.go` — `dotf secrets render <file>` wires
+  `registryPath()` + `ageDecryptor` into `Render`. `--dry-run` optional.
+- [ ] Wire `setup-linux.sh` + `setup-windows.ps1`: replace the
+  `substitute_env_placeholders` / `Substitute-EnvPlaceholders` calls (opencode.jsonc,
+  pi models.json) with `dotf secrets render <config>`, guarded by `command -v dotf`.
+- [ ] Bump `versions.conf` is automatic (release-please). Use a `feat(secrets):` title.
+
+## PR-B — delete the twins + env-mapping.conf (closes #587)
+
+- [ ] Remove `substitute_env_placeholders` (`scripts/utils.sh`) +
+  `Substitute-EnvPlaceholders` (`scripts/utils.ps1`) + their tests
+  (`tests/sdd-009-deploy-time-secrets.bats`, `*.Tests.ps1`).
+- [ ] `git rm sensitive/env-mapping.conf`; remove the registry↔env-mapping drift-guard
+  test (`cli/internal/secrets/registry_seed_test.go` — or repoint it to a static fixture).
+- [ ] Grep sweep: no runtime reference to `env-mapping.conf` / the twins remains.
+- [ ] `gh issue close 587` (or let the closing PR's `Closes #587` do it).
+
+## Closing
+
+- [ ] Every AC in `proposal.md` covered by a test; `features.json` updated.
+- [ ] `go test ./...`, bats, integration green; `dotf spec archive CLI-025-secrets-render`.
+
+## Pre-flight notes (read before coding)
+
+- `dotf secrets show` is already deployed (0.19.x) — `render` is a sibling subcommand.
+- Confirm the registry rejects two secrets exposing the same env var (validation in
+  `registry.go`); if not, fail-fast in `Render`.
+- Match the twins' byte parity: `Set-Content -NoNewline` / `printf '%s'` (no trailing \n).

--- a/specs/CLI-025-secrets-render/verification.md
+++ b/specs/CLI-025-secrets-render/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-06-25"
+---
+
+# Verification - CLI-025-secrets-render
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/CLI-025-secrets-render/` -> `specs/archive/CLI-025-secrets-render/`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)

--- a/specs/CLI-025-secrets-render/verification.md
+++ b/specs/CLI-025-secrets-render/verification.md
@@ -5,26 +5,50 @@ created: "2026-06-25"
 
 # Verification - CLI-025-secrets-render
 
+Delivered across 2 PRs (see `tasks.md`). PR-A adds `dotf secrets render` + wires
+the setups; PR-B deletes the twins + `env-mapping.conf` and closes #587.
+
 ## Evidence
 
-Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+- [x] **AC1** (substitute mapped, leave unmapped intact) -> `secrets/render_test.go`
+  `TestRender_SubstitutesMapped_LeavesUnmappedIntact`, `TestRender_NoPlaceholders_NoOp`,
+  `TestRender_FileSecretVar_LeftIntactNotMaterialized`; cmd `TestSecretsRender_SubstitutesInPlace`;
+  real smoke: rendered a fixture against the live registry+age store -> `{env:NAN_API_KEY}`
+  substituted (0 remaining), `{env:HOME}` + an unmapped var left intact (1 each).
+- [x] **AC2** (atomic write, 0600, no trailing-newline drift) -> `secrets/render_test.go`
+  `TestRender_Mode0600_NoTrailingNewlineDrift`; smoke confirmed last byte is `}` (no newline added).
+- [~] **AC3** (setups materialize via `dotf secrets render`; twins gone) -> PR-A wires
+  `setup-linux.sh` (opencode, pi) + `setup-windows.ps1` (opencode, pi) to `dotf secrets render`,
+  guarded by `command -v dotf` / `Get-Command dotf` with the twin as bootstrap fallback. The
+  twins' *deletion* is PR-B.
+- [ ] **AC4** (`env-mapping.conf` deleted; drift-guard test removed) -> PR-B.
+- [ ] **AC5** (bats + integration green cross-OS; #587 closes) -> PR-B.
 
-- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+Parity bonus added beyond the twins: a var exposed by two distinct secrets is a
+non-deterministic registry and is rejected fail-fast (`TestRender_DuplicateVar_FailsFast`);
+a mapped-but-undecryptable secret is left intact (not fatal), matching twin behaviour
+(`TestRender_UnresolvedDecryptError_LeftIntact`).
 
 ## Test status
 
-- Test suite: `<command> -> <output / coverage %>`
-- Manual smoke test: what was exercised, what was observed
-- No regressions in existing test suite: yes / no (if no, document)
+- `go test ./internal/secrets/ ./internal/cmd/` -> ok (render unit + cmd-wiring tests green).
+- Pre-existing, unrelated: `TestEmbeddedTemplatesMatchVault` fails in `internal/{spec,vault,initrepo}`
+  on this machine (local vault ahead of vendored templates) -> confirmed identical on untouched
+  `main`, i.e. not introduced here; passes in CI.
+- `go vet ./...` clean; `gofmt -l` clean on changed Go files; `bash -n setup-linux.sh` OK.
+- Manual smoke: `dotf secrets render <fixture>` end-to-end over the real age store (above).
 
 ## Decisions made during implementation
 
 Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
 
--
--
+- **Reuse `EnvFor` per-var, not in batch.** `Render` decrypts by calling the existing
+  `Loader.EnvFor` (one decrypt+strip path shared with run/show) one entry at a time, so a
+  decrypt failure degrades to "unresolved, leave placeholder intact" instead of `EnvFor`'s
+  fail-fast (correct for `run`, wrong for setup which must complete). It also filters to env
+  entries so file secrets are never materialized to disk as a render side effect.
+- **Two-PR split kept.** PR-A leaves the twins in place as a bootstrap fallback so the new
+  path can be validated by a real setup/integration run before PR-B removes the safety net.
 
 ## Promotion candidates
 


### PR DESCRIPTION
## What

Adds `dotf secrets render <file>` — the Go port of the deploy-time `{env:VAR}`
materialization done by the `substitute_env_placeholders` (`scripts/utils.sh`) /
`Substitute-EnvPlaceholders` (`scripts/utils.ps1`) shell twins — over the
`secrets/registry.yaml` SSOT (ADR-020 convergence, ADR-028).

`render` rewrites a config file in place, substituting each `{env:VAR}`
placeholder whose `VAR` is a registry-mapped env secret with its decrypted
value. `setup-linux.sh` and `setup-windows.ps1` now materialize `opencode.jsonc`
and pi `models.json` via `dotf secrets render`, guarded by `command -v dotf`,
with the shell twin kept as the bootstrap fallback.

## Behaviour parity with the twins

- unmapped `{env:VAR}` (e.g. `{env:HOME}`) → left intact (runtime resolves it)
- mapped but undecryptable → left intact, **not fatal** (setup must complete)
- resolved → substituted; atomic write at `0600`, no trailing-newline drift

Beyond the twins: a var exposed by two distinct secrets is a non-deterministic
registry and is rejected fail-fast — `render` needs one source per var.

## Why this shape

Decryption reuses `Loader.EnvFor` (the single decrypt+strip path shared with
`run`/`show`), called per-var so a failure degrades to "unresolved, leave
intact" instead of `EnvFor`'s fail-fast (correct for `run`, wrong for setup),
and so file secrets are never materialized as a render side effect.

## Tests

- `cli/internal/secrets/render_test.go` — 7 table-driven cases (substitute/leave,
  0600 + no-newline-drift, undecryptable-left-intact, duplicate-var fail-fast,
  file-secret-not-materialized, no-op).
- `cli/internal/cmd/secrets_registry_test.go` — end-to-end command wiring.
- Manual smoke over the live age store: `{env:NAN_API_KEY}` substituted, unmapped
  vars left intact, last byte `}` (no newline added).

## Scope

Part of #587. This is PR 1 of 2: it adds `render` and wires the setups but keeps
the twins as a fallback. The follow-up PR deletes the twins + `env-mapping.conf`
+ the registry↔mapping drift-guard test and **closes #587**.

Spec: `specs/CLI-025-secrets-render/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `dotf secrets render <file>` to rewrite configuration files in place by substituting `{env:VAR}` with decrypted, registry-backed secret values.
  * Updated Linux and Windows setup flows to prefer `dotf secrets render` for `opencode` and `pi` configuration artifacts, with automatic fallback to legacy placeholder substitution when needed.
* **Bug Fixes**
  * Unmapped or unresolved placeholders remain intact; results are reported clearly.
  * Safer updates via atomic file replacement with `0600` permissions and no trailing-newline drift; fail fast on duplicate env-var mappings.
* **Tests**
  * Added unit and CLI command coverage for substitution, no-op behavior, permissions/parity, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->