### PR TITLE
chore(cli): make template drift guard EOL-insensitive and re-vendor templates

### DIFF
--- a/cli/internal/initrepo/drift_test.go
+++ b/cli/internal/initrepo/drift_test.go
@@ -40,10 +40,18 @@ func TestEmbeddedTemplatesMatchVault(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read embedded %s: %v", embedded, err)
 		}
-		if !bytes.Equal(got, want) {
+		if !eqIgnoringEOL(got, want) {
 			t.Errorf("embedded templates/%s drifted from vault %s.\n"+
 				"Re-vendor: cp %s cli/internal/initrepo/templates/%s",
 				embedded, vaultName, filepath.Join(tmplDir, vaultName), embedded)
 		}
 	}
+}
+
+// eqIgnoringEOL compares ignoring CR, so CRLF and LF are equal. The embedded copy
+// is EOL-normalized to LF by .gitattributes; the vault is a separate repo this one
+// does not govern, so a byte-exact compare is line-ending-fragile across machines
+// (CRLF on a Windows checkout) and masks real content drift (#597).
+func eqIgnoringEOL(a, b []byte) bool {
+	return bytes.Equal(bytes.ReplaceAll(a, []byte("\r"), nil), bytes.ReplaceAll(b, []byte("\r"), nil))
 }

--- a/cli/internal/spec/drift_test.go
+++ b/cli/internal/spec/drift_test.go
@@ -40,10 +40,18 @@ func TestEmbeddedTemplatesMatchVault(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read embedded %s: %v", embedded, err)
 		}
-		if !bytes.Equal(got, want) {
+		if !eqIgnoringEOL(got, want) {
 			t.Errorf("embedded templates/%s drifted from vault %s.\n"+
 				"Re-vendor: cp %s cli/internal/spec/templates/%s",
 				embedded, vaultName, filepath.Join(tmplDir, vaultName), embedded)
 		}
 	}
+}
+
+// eqIgnoringEOL compares ignoring CR, so CRLF and LF are equal. The embedded copy
+// is EOL-normalized to LF by .gitattributes; the vault is a separate repo this one
+// does not govern, so a byte-exact compare is line-ending-fragile across machines
+// (CRLF on a Windows checkout) and masks real content drift (#597).
+func eqIgnoringEOL(a, b []byte) bool {
+	return bytes.Equal(bytes.ReplaceAll(a, []byte("\r"), nil), bytes.ReplaceAll(b, []byte("\r"), nil))
 }

--- a/cli/internal/spec/templates/proposal.md
+++ b/cli/internal/spec/templates/proposal.md
@@ -14,7 +14,7 @@ template_version: "1.0"
 
 ## Why
 
-Single paragraph. The user or business problem this feature solves. Link to the vault roadmap or `11-tasks.md` entry if applicable. If you cannot write this in 3 sentences, you do not understand the problem yet.
+Single paragraph. The user or business problem this feature solves. Link to the vault roadmap or the bitácora board issue if applicable. If you cannot write this in 3 sentences, you do not understand the problem yet.
 
 ## What
 
@@ -44,6 +44,6 @@ Observable outcomes. Each must be testable.
 
 ## References
 
-- Vault: `10_projects/<repo>/11-tasks.md` (backlog entry)
+- Bitácora board: the GitHub issue / Project item tracking this spec (see the `issue:` frontmatter field)
 - Related ADR: `<repo>/docs/adr/adr-XXX.md` (if any)
 - Related patterns: `00_meta/patterns/<pattern>.md` (if any)

--- a/cli/internal/spec/templates/verification.md
+++ b/cli/internal/spec/templates/verification.md
@@ -38,5 +38,5 @@ Before archiving, flag what (if anything) should be promoted to the vault. If al
 
 - [ ] `proposal.md` frontmatter set to `status: archived`
 - [ ] Folder moved: `specs/<feature-id>/` -> `specs/archive/<feature-id>/`
-- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
 - [ ] Promotions above executed (if any)

--- a/cli/internal/vault/drift_test.go
+++ b/cli/internal/vault/drift_test.go
@@ -42,10 +42,18 @@ func TestEmbeddedTemplatesMatchVault(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read embedded %s: %v", name, err)
 		}
-		if !bytes.Equal(got, want) {
+		if !eqIgnoringEOL(got, want) {
 			t.Errorf("embedded templates/%s drifted from vault %s.\n"+
 				"Re-vendor: cp %s cli/internal/vault/templates/%s",
 				name, name, filepath.Join(tmplDir, name), name)
 		}
 	}
+}
+
+// eqIgnoringEOL compares ignoring CR, so CRLF and LF are equal. The embedded copy
+// is EOL-normalized to LF by .gitattributes; the vault is a separate repo this one
+// does not govern, so a byte-exact compare is line-ending-fragile across machines
+// (CRLF on a Windows checkout) and masks real content drift (#597).
+func eqIgnoringEOL(a, b []byte) bool {
+	return bytes.Equal(bytes.ReplaceAll(a, []byte("\r"), nil), bytes.ReplaceAll(b, []byte("\r"), nil))
 }

--- a/cli/internal/vault/templates/work-sdk-context.md
+++ b/cli/internal/vault/templates/work-sdk-context.md
@@ -20,7 +20,7 @@ created: "{{date}}"
 - **Key Tools:**
 
 ## Repos in this Family
-See [[../00-context|{{family}} family context]] for all repos.
+See [[../context|{{family}} family context]] for all repos.
 
 ## Critical Links
 - **Real repo path:** Fill in source_path above with actual ${PROJECTS_PATH}/... path

--- a/cli/internal/vault/templates/work-sdk-family.md
+++ b/cli/internal/vault/templates/work-sdk-family.md
@@ -15,7 +15,7 @@ created: "{{date}}"
 
 | Component | Vault Path | Real Path |
 |-----------|-----------|-----------|
-| {{component}} | [[{{component}}/00-context]] | Fill in source_path |
+| {{component}} | [[{{component}}/context]] | Fill in source_path |
 
 ## Work Context
 - Product knowledge: [[../../20-products/{{family}}/00-overview|product overview]] (if exists)

--- a/cli/internal/vault/templates/work-sdk-memory.md
+++ b/cli/internal/vault/templates/work-sdk-memory.md
@@ -1,10 +1,19 @@
+---
+id: "{{component}}-memory"
+type: memory
+status: active
+owner: manu
+tags: [memory, work, sdk]
+updated: "{{date}}"
+---
+
 # {{component}} — Work SDK Session Memory
 
 ## Session Handoff
 > Updated: {{date}}
 **Last task:** Vault entry initialized
 **Decisions:** None
-**Open threads:** Fill source_path in 00-context.md with real repo path
+**Open threads:** Fill source_path in context.md with real repo path
 **Next action:** Open Claude in real repo; session hook will create symlink automatically
 
 ## User Preferences


### PR DESCRIPTION
## What

`TestEmbeddedTemplatesMatchVault` (in `cli/internal/{spec,vault,initrepo}/drift_test.go`)
compared go:embed'd templates against the vault SSOT with byte-exact `bytes.Equal`.

The embedded copy is EOL-normalized to LF by `.gitattributes`; the vault is a
separate repo this one does not govern, so the compare is **line-ending-fragile**:
on a Windows checkout it reports ~2x-line "drift" that is almost entirely CRLF vs
LF, masking the few genuine content changes.

It only fails locally (the test `t.Skip()`s when the vault is absent — CI per
ADR-013), but three red packages in `go test ./...` train developers to ignore red.

## Fix

1. Compare with a small `eqIgnoringEOL` helper (strip `\r`) in all three
   `drift_test.go` so CRLF and LF are equal — fixes the fragility at its root.
2. Re-vendor the genuinely-changed templates from the vault SSOT:
   - `11-tasks.md` references → bitácora board / GitHub issue wording (ADR-018)
   - `work-sdk-memory.md` gained a frontmatter block

## Verification

- The three drift packages went from FAIL → `ok` locally (vault present).
- `go build ./...` clean; the genuine content diff is 15 insertions / 6 deletions
  across 5 templates (the other 2 were pure-EOL, no content change).

Closes #597.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made template drift checks tolerant of line-ending differences, reducing false failures between CRLF and LF checkouts.

* **Documentation**
  * Updated template guidance and archive steps to reference the current board/roadmap flow.
  * Refreshed several internal template links and paths to point to the latest context pages.
  * Added template metadata to support clearer tracking and handoff details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## SDD skip rationale

Mechanical, no public contract / dependency / architecture change: an EOL-insensitivity
fix to an internal test helper plus a verbatim re-vendor of vault-SSOT templates. The
gate counted 51 LOC only because Go `*_test.go` files are not in its exclusion list
(`tests/*` dir is, but not `*_test.go`) — with tests excluded per the documented
contract ("production diff excluding tests") the real diff is ~21 LOC, under threshold.
Gate over-count tracked separately (see #517).