### PR TITLE
fix(spec-gate): exclude Go *_test.go from the production-LOC count

### DIFF
--- a/scripts/check-spec-gate.sh
+++ b/scripts/check-spec-gate.sh
@@ -98,6 +98,7 @@ _excluded() {
         *generated*) return 0 ;;
     esac
     case "$base" in
+        *_test.go) return 0 ;;   # Go test files are tests, not production (#517)
         *.lock|*.lockb) return 0 ;;
         package-lock.json|pnpm-lock.yaml|go.sum) return 0 ;;
         .gitignore|CHANGELOG.md) return 0 ;;

--- a/tests/check-spec-gate.bats
+++ b/tests/check-spec-gate.bats
@@ -116,6 +116,15 @@ _commit() {
     [ "$status" -eq 0 ]
 }
 
+@test "excludes Go *_test.go from LOC count (#517)" {
+    mkdir -p cli/internal/foo
+    printf 'line %d\n' {1..200} > cli/internal/foo/foo_test.go
+    printf 'line %d\n' {1..10} > small.txt
+    _commit "go test file does not count as production"
+    run "$SCRIPTS_DIR/check-spec-gate.sh" --base-ref main --head-ref feature
+    [ "$status" -eq 0 ]
+}
+
 @test "excludes specs/archive/ from LOC count" {
     mkdir -p specs/archive/OLD-001-archived
     printf 'line %d\n' {1..200} > specs/archive/OLD-001-archived/proposal.md


### PR DESCRIPTION
`_excluded()` in `check-spec-gate.sh` skipped the `tests/` directory but not Go `*_test.go` files (which live next to source), so a test-only change counted as production diff — contradicting the documented "excluding tests" contract and forcing a `skip-sdd` workaround on #598.

- Add `*_test.go) return 0` to the `$base` exclusion case.
- bats: `excludes Go *_test.go from LOC count (#517)` (200-line test file outside `tests/` stays under threshold).

Closes #517.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the spec-gate check so Go test files are no longer counted as production code.
  * This prevents test-only changes from incorrectly affecting the LOC threshold and blocking the gate.
  
* **Tests**
  * Added coverage to verify that Go test files are excluded from production LOC counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->