### PR TITLE
feat(secrets): add the Bitwarden backend resolver to dotf secrets

### DIFF
--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -39,11 +39,25 @@ func newSecretsCmd() *cobra.Command {
 }
 
 // registryPath resolves secrets/registry.yaml (the mapping SSOT); a var so tests
-// can point it at a fixture. ageDecryptor is the decrypt seam (nil → AgeDecrypt).
+// can point it at a fixture. ageDecryptor is the age decrypt seam (nil → AgeDecrypt);
+// bwReader is the Bitwarden read seam (BWGet in production), both overridable so
+// command tests inject fakes with no age key and no unlocked Bitwarden.
 var (
 	registryPath = func() string { return filepath.Join(env.DotfilesDir(env.Home()), "secrets", "registry.yaml") }
 	ageDecryptor secrets.Decryptor
+	bwReader     secrets.BWReader = secrets.BWGet{}
 )
+
+// secretLoader builds the resolution engine wired with both backend seams, over the
+// age store in <dotfiles>/sensitive and the operator's Bitwarden via bwReader.
+func secretLoader() *secrets.Loader {
+	return &secrets.Loader{
+		SecretsDir: filepath.Join(env.DotfilesDir(env.Home()), "sensitive"),
+		KeyPath:    ageKeyPath(),
+		Decrypt:    ageDecryptor,
+		BW:         bwReader,
+	}
+}
 
 func loadRegistry() (*secrets.Registry, error) {
 	data, err := os.ReadFile(registryPath())
@@ -54,9 +68,10 @@ func loadRegistry() (*secrets.Registry, error) {
 }
 
 // newSecretsLsCmd lists registry ids with plane + exposed vars — never values.
-// With --pairs it instead prints one "VAR\t<age-source>" line per env secret
-// (file secrets excluded), the machine-readable form github-secrets-manager.sh
-// consumes in place of the retired env-mapping.conf.
+// With --pairs it instead prints one "VAR\t<age-source>" line per age env secret
+// (file and bw secrets excluded), the machine-readable form github-secrets-manager.sh
+// consumes in place of the retired env-mapping.conf. bw secrets carry no age source,
+// so the age-based CI-push path skips them (rethought in the migration follow-up).
 func newSecretsLsCmd() *cobra.Command {
 	var pairs bool
 	c := &cobra.Command{
@@ -72,8 +87,8 @@ func newSecretsLsCmd() *cobra.Command {
 			w := cmd.OutOrStdout()
 			if pairs {
 				for _, e := range reg.Entries(env.Home()) {
-					if e.IsFile {
-						continue // file secrets are not GitHub Actions secrets
+					if e.IsFile || e.Backend == "bw" {
+						continue // file secrets aren't GitHub Actions secrets; bw has no age source
 					}
 					_, _ = fmt.Fprintf(w, "%s\t%s\n", e.Var, e.File)
 				}
@@ -104,13 +119,11 @@ func newSecretsShowCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			name, src, err := showSource(reg, args[0])
+			entry, err := reg.ShowEntry(args[0])
 			if err != nil {
 				return err
 			}
-			secretsDir := filepath.Join(env.DotfilesDir(env.Home()), "sensitive")
-			loader := &secrets.Loader{SecretsDir: secretsDir, KeyPath: ageKeyPath(), Decrypt: ageDecryptor}
-			kv, err := loader.EnvFor([]secrets.Entry{{Var: name, File: src}}, nil)
+			kv, err := secretLoader().EnvFor([]secrets.Entry{entry}, nil)
 			if err != nil {
 				return err
 			}
@@ -143,9 +156,7 @@ func newSecretsRenderCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			secretsDir := filepath.Join(env.DotfilesDir(env.Home()), "sensitive")
-			loader := &secrets.Loader{SecretsDir: secretsDir, KeyPath: ageKeyPath(), Decrypt: ageDecryptor}
-			res, err := secrets.Render(args[0], reg, loader, env.Home())
+			res, err := secrets.Render(args[0], reg, secretLoader(), env.Home())
 			if err != nil {
 				return err
 			}
@@ -159,29 +170,6 @@ func newSecretsRenderCmd() *cobra.Command {
 			return nil
 		},
 	}
-}
-
-// showSource picks the single env var + age source `show` will decrypt, rejecting
-// file and multi-var secrets with guidance to use `run`.
-func showSource(reg *secrets.Registry, idOrVar string) (name, src string, err error) {
-	s := reg.Lookup(idOrVar)
-	if s == nil {
-		return "", "", fmt.Errorf("unknown secret %q (try `dotf secrets ls`)", idOrVar)
-	}
-	if !s.AgeBacked() {
-		return "", "", fmt.Errorf("%q uses the %s backend, not yet supported (ADR-028 Phase 3)", s.ID, s.Backend)
-	}
-	if s.Expose.File != nil {
-		return "", "", fmt.Errorf("%q is a file secret; use `dotf secrets run --only %s -- <cmd>`", s.ID, s.ID)
-	}
-	if len(s.Expose.Env.Vars) != 1 {
-		return "", "", fmt.Errorf("%q exposes %d vars; use `dotf secrets run --only %s -- <cmd>`", s.ID, len(s.Expose.Env.Vars), s.ID)
-	}
-	v := s.Expose.Env.Vars[0]
-	if src = v.Age; src == "" {
-		src = s.Age
-	}
-	return v.Name, src, nil
 }
 
 func newSecretsRunCmd() *cobra.Command {
@@ -213,8 +201,7 @@ func newSecretsRunCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			secretsDir := filepath.Join(env.DotfilesDir(env.Home()), "sensitive")
-			childEnv, err := buildChildEnv(reg, secretsDir, ageKeyPath(), sel)
+			childEnv, err := buildChildEnv(reg, sel)
 			if err != nil {
 				return err
 			}
@@ -232,12 +219,10 @@ func newSecretsRunCmd() *cobra.Command {
 	return c
 }
 
-// buildChildEnv flattens the registry to entries, decrypts the selected secrets,
-// and returns the parent environment with the decrypted KEY=VALUE pairs appended.
-func buildChildEnv(reg *secrets.Registry, secretsDir, keyPath string, only map[string]bool) ([]string, error) {
-	entries := reg.Entries(env.Home())
-	loader := &secrets.Loader{SecretsDir: secretsDir, KeyPath: keyPath, Decrypt: ageDecryptor}
-	injected, err := loader.EnvFor(entries, only)
+// buildChildEnv flattens the registry to entries, resolves the selected secrets
+// (per-backend), and returns the parent environment with the KEY=VALUE pairs appended.
+func buildChildEnv(reg *secrets.Registry, only map[string]bool) ([]string, error) {
+	injected, err := secretLoader().EnvFor(reg.Entries(env.Home()), only)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/cmd/secrets_registry_test.go
+++ b/cli/internal/cmd/secrets_registry_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -10,6 +11,25 @@ import (
 
 	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
 )
+
+// fakeBW is a map-backed secrets.BWReader ("item/field" → value) so command tests
+// resolve bw secrets with no unlocked Bitwarden.
+type fakeBW map[string]string
+
+func (f fakeBW) Field(item, field string) (string, error) {
+	if v, ok := f[item+"/"+field]; ok {
+		return v, nil
+	}
+	return "", fmt.Errorf("fake bw: no %s/%s", item, field)
+}
+
+// useBwReader points the bwReader seam at a fake for the duration of a test.
+func useBwReader(t *testing.T, r secrets.BWReader) {
+	t.Helper()
+	old := bwReader
+	bwReader = r
+	t.Cleanup(func() { bwReader = old })
+}
 
 const testRegistry = `
 version: 1
@@ -99,14 +119,48 @@ func TestSecretsShow_RejectsFileAndMultiAndUnknown(t *testing.T) {
 	}
 }
 
-func TestSecretsShow_RejectsBwBackend(t *testing.T) {
-	useTempRegistry(t, "version: 1\nsecrets:\n  - {id: bw-one, plane: app, backend: bw, expose: {env: B_KEY}}\n")
+func TestSecretsShow_ResolvesBwBackend(t *testing.T) {
+	useTempRegistry(t, "version: 1\nsecrets:\n  - {id: bw-one, plane: app, backend: bw, bw: {item: bw-item, field: password}, expose: {env: B_KEY}}\n")
+	useBwReader(t, fakeBW{"bw-item/password": "bw-secret"})
+	var out bytes.Buffer
 	cmd := newSecretsShowCmd()
-	cmd.SetOut(io.Discard)
+	cmd.SetOut(&out)
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"bw-one"})
-	if err := cmd.Execute(); err == nil {
-		t.Error("show on a bw-backed secret must error (bw not supported until Phase 3)")
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("show bw-one: %v", err)
+	}
+	if out.String() != "bw-secret" {
+		t.Errorf("show bw = %q, want %q (resolved from Bitwarden, no trailing newline)", out.String(), "bw-secret")
+	}
+}
+
+// TestSecretsRun_ResolvesBwBackend exercises run's wiring: registry → secretLoader →
+// EnvFor → bwResolver → the bw reader. --only selects the bw secret by id.
+func TestSecretsRun_ResolvesBwBackend(t *testing.T) {
+	useTempRegistry(t, "version: 1\nsecrets:\n  - {id: bw-foo, plane: app, backend: bw, bw: {item: it, field: password}, expose: {env: FOO}}\n")
+	useBwReader(t, fakeBW{"it/password": "bw-secret-value"})
+
+	reg, err := loadRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sel, err := resolveOnly(reg, "bw-foo") // --only by id → the secret's vars
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := buildChildEnv(reg, sel)
+	if err != nil {
+		t.Fatalf("buildChildEnv: %v", err)
+	}
+	found := false
+	for _, kv := range env {
+		if kv == "FOO=bw-secret-value" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("run did not inject the bw secret FOO=bw-secret-value into the child env")
 	}
 }
 

--- a/cli/internal/secrets/bw.go
+++ b/cli/internal/secrets/bw.go
@@ -1,0 +1,91 @@
+package secrets
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// BWReader fetches a single field value from a Bitwarden item. The seam that keeps
+// the bw backend unit-testable with no Bitwarden vault and no unlock — tests inject
+// a map-backed fake; production is BWGet (a `bw get` shell-out).
+type BWReader interface {
+	Field(item, field string) (string, error)
+}
+
+// BWGet is the production BWReader: it shells out to the Bitwarden CLI to read a
+// field from an item. It is the bw analog of AgeDecrypt (age --decrypt) — thin I/O,
+// verified by a live smoke with the operator's unlocked session, not in CI.
+//
+// One `bw get item <item>` call returns the item JSON; fieldFromItem then picks the
+// field from the typed login (password/username), the note (notes), or a custom
+// field by name. `--nointeraction` guarantees it never blocks on a prompt: a locked
+// vault or missing BW_SESSION fails fast with the CLI's stderr surfaced. The item is
+// keyed by its unique name or id (the Bitwarden folder is not part of the lookup).
+//
+// bw serve — a local REST daemon holding the unlocked vault, faster for batch reads
+// (one unlock, many millisecond GETs) — is a drop-in replacement behind this same
+// BWReader seam, deferred as a perf upgrade (ADR-028). It must stay localhost-only:
+// the serve API is unauthenticated by design and exposes the whole unlocked vault.
+type BWGet struct {
+	Bin string // bw binary name/path; "" → "bw" (a field for tests/overrides)
+}
+
+// Field reads field from the Bitwarden item via one `bw get item` shell-out.
+func (g BWGet) Field(item, field string) (string, error) {
+	bin := g.Bin
+	if bin == "" {
+		bin = "bw"
+	}
+	cmd := exec.Command(bin, "get", "item", item, "--nointeraction") //nolint:gosec // item is operator-controlled registry data
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("bw get item %q: %s", item, msg)
+	}
+	return fieldFromItem(stdout.Bytes(), field)
+}
+
+// bwItem is the subset of `bw get item` JSON that BWGet reads.
+type bwItem struct {
+	Login struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	} `json:"login"`
+	Notes  string `json:"notes"`
+	Fields []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	} `json:"fields"`
+}
+
+// fieldFromItem extracts field from a `bw get item` JSON payload. The typed login
+// fields and the note are first-class names; any other name is matched against the
+// item's custom fields[] — an unknown name is an error (catches a registry typo),
+// while an empty typed field is returned as-is (parity with an empty age secret).
+func fieldFromItem(data []byte, field string) (string, error) {
+	var it bwItem
+	if err := json.Unmarshal(data, &it); err != nil {
+		return "", fmt.Errorf("parse bw item JSON: %w", err)
+	}
+	switch field {
+	case "password":
+		return it.Login.Password, nil
+	case "username":
+		return it.Login.Username, nil
+	case "notes":
+		return it.Notes, nil
+	}
+	for _, f := range it.Fields {
+		if f.Name == field {
+			return f.Value, nil
+		}
+	}
+	return "", fmt.Errorf("field %q not found on item", field)
+}

--- a/cli/internal/secrets/bw_test.go
+++ b/cli/internal/secrets/bw_test.go
@@ -1,0 +1,120 @@
+package secrets
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeBW is a map-backed BWReader keyed "item/field" → value. The seam that proves
+// the bw backend resolves with no Bitwarden vault and no unlock.
+type fakeBW map[string]string
+
+func (f fakeBW) Field(item, field string) (string, error) {
+	if v, ok := f[item+"/"+field]; ok {
+		return v, nil
+	}
+	return "", fmt.Errorf("fake bw: no %s/%s", item, field)
+}
+
+func TestEnvFor_BwEnvSecret(t *testing.T) {
+	// Fixture values are deliberately plain words, not shaped like real provider
+	// keys/tokens, so the secret scanner never flags the test data as a credential.
+	l := &Loader{BW: fakeBW{"openai-item/password": "openai-test-value"}}
+	entries := []Entry{{Var: "OPENAI_API_KEY", Backend: "bw", Item: "openai-item", Field: "password"}}
+	env, err := l.EnvFor(entries, nil)
+	if err != nil {
+		t.Fatalf("EnvFor: %v", err)
+	}
+	if len(env) != 1 || env[0] != "OPENAI_API_KEY=openai-test-value" {
+		t.Fatalf("env = %v, want [OPENAI_API_KEY=openai-test-value]", env)
+	}
+}
+
+func TestEnvFor_BwFileSecret_Materialized(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "sub", "kubeconfig")
+	l := &Loader{BW: fakeBW{"kube-item/notes": "apiVersion: v1\n"}}
+	entries := []Entry{{Var: "KUBECONFIG", Backend: "bw", Item: "kube-item", Field: "notes", IsFile: true, Dest: dest}}
+	env, err := l.EnvFor(entries, nil)
+	if err != nil {
+		t.Fatalf("EnvFor: %v", err)
+	}
+	if want := "KUBECONFIG=" + dest; len(env) != 1 || env[0] != want {
+		t.Fatalf("env = %v, want [%q]", env, want)
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil || string(data) != "apiVersion: v1\n" {
+		t.Errorf("materialized = %q (err %v), want content verbatim", data, err)
+	}
+}
+
+// TestEnvFor_MixedBackends_OnlyFilter proves one EnvFor call dispatches age and bw
+// entries to their own resolvers, and --only scopes across both.
+func TestEnvFor_MixedBackends_OnlyFilter(t *testing.T) {
+	l := &Loader{
+		SecretsDir: t.TempDir(),
+		Decrypt:    func(_, _ string) ([]byte, error) { return []byte("age-val\n"), nil },
+		BW:         fakeBW{"it/password": "bw-val"},
+	}
+	entries := []Entry{
+		{Var: "AGE_VAR", Backend: "age", File: "a"},
+		{Var: "BW_VAR", Backend: "bw", Item: "it", Field: "password"},
+	}
+	env, err := l.EnvFor(entries, map[string]bool{"BW_VAR": true})
+	if err != nil {
+		t.Fatalf("EnvFor: %v", err)
+	}
+	if len(env) != 1 || env[0] != "BW_VAR=bw-val" {
+		t.Fatalf("--only BW_VAR = %v, want [BW_VAR=bw-val]", env)
+	}
+}
+
+func TestEnvFor_BwReaderError_FailsFast(t *testing.T) {
+	l := &Loader{BW: fakeBW{}} // empty → Field errors
+	if _, err := l.EnvFor([]Entry{{Var: "X", Backend: "bw", Item: "missing", Field: "password"}}, nil); err == nil {
+		t.Fatal("expected EnvFor to fail fast when the bw reader errors")
+	}
+}
+
+func TestEnvFor_BwNilReader_ClearError(t *testing.T) {
+	l := &Loader{} // BW nil — Bitwarden locked / not wired
+	_, err := l.EnvFor([]Entry{{Var: "X", Backend: "bw", Item: "it", Field: "password"}}, nil)
+	if err == nil || !strings.Contains(err.Error(), "bw backend unavailable") {
+		t.Fatalf("nil reader err = %v, want a clear 'bw backend unavailable' message", err)
+	}
+}
+
+func TestEnvFor_UnknownBackend_Errors(t *testing.T) {
+	l := &Loader{}
+	if _, err := l.EnvFor([]Entry{{Var: "X", Backend: "vault", File: "x"}}, nil); err == nil {
+		t.Fatal("expected an error for an unknown backend")
+	}
+}
+
+func TestFieldFromItem(t *testing.T) {
+	const itemJSON = `{
+		"login": {"username": "alice", "password": "login-test-value"},
+		"notes": "multi\nline",
+		"fields": [{"name": "api-key", "value": "ak-1"}, {"name": "client-id", "value": "cid-2"}]
+	}`
+	for _, c := range []struct{ field, want string }{
+		{"password", "login-test-value"},
+		{"username", "alice"},
+		{"notes", "multi\nline"},
+		{"api-key", "ak-1"},
+		{"client-id", "cid-2"},
+	} {
+		got, err := fieldFromItem([]byte(itemJSON), c.field)
+		if err != nil || got != c.want {
+			t.Errorf("field %q = %q (err %v), want %q", c.field, got, err, c.want)
+		}
+	}
+	if _, err := fieldFromItem([]byte(itemJSON), "nonexistent"); err == nil {
+		t.Error("unknown custom field must error (catches a registry typo)")
+	}
+	if _, err := fieldFromItem([]byte("not json"), "password"); err == nil {
+		t.Error("invalid JSON must error")
+	}
+}

--- a/cli/internal/secrets/registry.go
+++ b/cli/internal/secrets/registry.go
@@ -9,8 +9,8 @@ import (
 
 // Registry is secrets/registry.yaml — the mapping SSOT of ADR-028 §2: it ties each
 // logical secret (a stable kebab id) to its store source, the env/file it exposes,
-// and its consumers/rotation. This package reads the age backend (current reality);
-// `backend: bw` resolution lands when items migrate (ADR-028 Phase 3).
+// and its consumers/rotation. Both the age backend (the local age store) and the bw
+// backend (Bitwarden, ADR-028 Phase 3) resolve here; the Loader dispatches per entry.
 type Registry struct {
 	Version int      `yaml:"version"`
 	Secrets []Secret `yaml:"secrets"`
@@ -18,15 +18,27 @@ type Registry struct {
 
 // Secret is one registry entry. Age is the base name under sensitive/ (no
 // .secret.age) used as the source for age/age-offline backends, unless an
-// expose.env var overrides it per-var.
+// expose.env var overrides it per-var. BW is the Bitwarden source for the bw
+// backend, unless an expose.env var overrides the field per-var.
 type Secret struct {
-	ID        string   `yaml:"id"`
-	Plane     string   `yaml:"plane"`   // app | infra | personal | floor
-	Backend   string   `yaml:"backend"` // age | age-offline | bw
-	Age       string   `yaml:"age"`
-	Expose    Expose   `yaml:"expose"`
-	Consumers []string `yaml:"consumers"`
-	Rotate    string   `yaml:"rotate"`
+	ID        string    `yaml:"id"`
+	Plane     string    `yaml:"plane"`   // app | infra | personal | floor
+	Backend   string    `yaml:"backend"` // age | age-offline | bw
+	Age       string    `yaml:"age"`
+	BW        *BWSource `yaml:"bw"`
+	Expose    Expose    `yaml:"expose"`
+	Consumers []string  `yaml:"consumers"`
+	Rotate    string    `yaml:"rotate"`
+}
+
+// BWSource is a bw backend source: the Bitwarden item (its unique name or id) and,
+// for a single-var or file secret, the field within it. Multi-var secrets share
+// the item and set the field per-var (expose.env: { VAR: { field: ... } }). The
+// Bitwarden folder is org metadata, not a lookup key — `bw get` resolves by item
+// name/id (ADR-028 §2; folder taxonomy is the curation issue).
+type BWSource struct {
+	Item  string `yaml:"item"`
+	Field string `yaml:"field"`
 }
 
 // Expose is the consumer contract: exactly one of env (one or many vars) or file.
@@ -43,17 +55,20 @@ type FileExpose struct {
 	Mode string `yaml:"mode"`
 }
 
-// EnvVar is one exposed env var with an optional per-var age source override.
+// EnvVar is one exposed env var with optional per-var source overrides: Age for
+// age backends, Field for the bw backend.
 type EnvVar struct {
-	Name string
-	Age  string // "" → use the secret's top-level Age
+	Name  string
+	Age   string // "" → use the secret's top-level Age
+	Field string // "" → use the secret's top-level BW.Field
 }
 
 // EnvExpose normalizes the three YAML shapes of expose.env:
 //
-//	env: VAR                    → one var (source = secret.age)
-//	env: [VAR1, VAR2]           → many vars, same source
-//	env: { VAR: {age: file} }   → per-var sources
+//	env: VAR                     → one var (source = secret.age / secret.bw)
+//	env: [VAR1, VAR2]            → many vars, same source
+//	env: { VAR: {age: file} }    → per-var age source
+//	env: { VAR: {field: name} }  → per-var bw field
 type EnvExpose struct {
 	Vars []EnvVar
 }
@@ -72,12 +87,13 @@ func (e *EnvExpose) UnmarshalYAML(node *yaml.Node) error {
 		// Content is a flat [key, value, key, value, ...] list.
 		for i := 0; i+1 < len(node.Content); i += 2 {
 			var src struct {
-				Age string `yaml:"age"`
+				Age   string `yaml:"age"`
+				Field string `yaml:"field"`
 			}
 			if err := node.Content[i+1].Decode(&src); err != nil {
 				return err
 			}
-			e.Vars = append(e.Vars, EnvVar{Name: node.Content[i].Value, Age: src.Age})
+			e.Vars = append(e.Vars, EnvVar{Name: node.Content[i].Value, Age: src.Age, Field: src.Field})
 		}
 	default:
 		return fmt.Errorf("expose.env: unsupported YAML node (kind %d)", node.Kind)
@@ -124,10 +140,14 @@ func (r *Registry) validate() error {
 			return fmt.Errorf("secret %q: expose must have exactly one of env|file", s.ID)
 		}
 
-		// age/age-offline must resolve a source for everything they expose; bw
-		// sources are validated when the bw backend lands (Phase 3).
-		if s.Backend == "age" || s.Backend == "age-offline" {
+		// Each backend must resolve a source for everything it exposes.
+		switch s.Backend {
+		case "age", "age-offline":
 			if err := s.checkAgeSources(); err != nil {
+				return err
+			}
+		case "bw":
+			if err := s.checkBwSources(); err != nil {
 				return err
 			}
 		}
@@ -154,41 +174,95 @@ func (s *Secret) checkAgeSources() error {
 	return nil
 }
 
-// Entries flattens the registry into the same []Entry the age Loader consumes, so
-// `run` resolves through the existing decrypt path. File exposes become IsFile
-// entries (Dest = ~-expanded path); env exposes become one entry per var, each
-// pointing at its per-var or the secret's top-level age source.
+// checkBwSources verifies every exposed var/file has a Bitwarden item + field.
+func (s *Secret) checkBwSources() error {
+	if s.BW == nil || s.BW.Item == "" {
+		return fmt.Errorf("secret %q: bw backend needs bw.item", s.ID)
+	}
+	if s.Expose.File != nil {
+		if s.BW.Field == "" {
+			return fmt.Errorf("secret %q: bw file expose needs bw.field", s.ID)
+		}
+		if s.Expose.File.Var == "" || s.Expose.File.Path == "" {
+			return fmt.Errorf("secret %q: file expose needs var+path", s.ID)
+		}
+		return nil
+	}
+	for _, v := range s.Expose.Env.Vars {
+		if v.Field == "" && s.BW.Field == "" {
+			return fmt.Errorf("secret %q: bw env %q has no field source", s.ID, v.Name)
+		}
+	}
+	return nil
+}
+
+// Entries flattens the registry into the []Entry the Loader consumes, so run/show/
+// render resolve through one path. Each entry is tagged with its Backend; the Loader
+// dispatches to the matching Resolver. File exposes become IsFile entries (Dest =
+// ~-expanded path); env exposes become one entry per var, each carrying its per-var
+// (or the secret's top-level) source — an age base name, or a bw item+field.
 func (r *Registry) Entries(home string) []Entry {
 	var es []Entry
 	for i := range r.Secrets {
 		s := &r.Secrets[i]
-		if !s.AgeBacked() {
-			continue // bw secrets carry no age source; resolved in ADR-028 Phase 3
-		}
-		if s.Expose.File != nil {
-			es = append(es, Entry{
-				Var:    s.Expose.File.Var,
-				File:   s.Age,
-				IsFile: true,
-				Dest:   expandHome(s.Expose.File.Path, home),
-			})
+		if s.Backend == "bw" {
+			es = append(es, s.bwEntries(home)...)
 			continue
 		}
-		for _, v := range s.Expose.Env.Vars {
-			src := v.Age
-			if src == "" {
-				src = s.Age
-			}
-			es = append(es, Entry{Var: v.Name, File: src})
-		}
+		es = append(es, s.ageEntries(home)...)
 	}
 	return es
 }
 
-// AgeBacked reports whether the secret is resolvable by the age reader. The bw
-// backend is declared in the schema (a target) but only resolved in ADR-028 Phase 3.
-func (s *Secret) AgeBacked() bool {
-	return s.Backend == "age" || s.Backend == "age-offline"
+// ageEntries flattens an age/age-offline secret. The per-var age override falls
+// back to the secret's top-level Age source.
+func (s *Secret) ageEntries(home string) []Entry {
+	if s.Expose.File != nil {
+		return []Entry{{
+			Var:     s.Expose.File.Var,
+			Backend: s.Backend,
+			File:    s.Age,
+			IsFile:  true,
+			Dest:    expandHome(s.Expose.File.Path, home),
+		}}
+	}
+	es := make([]Entry, 0, len(s.Expose.Env.Vars))
+	for _, v := range s.Expose.Env.Vars {
+		src := v.Age
+		if src == "" {
+			src = s.Age
+		}
+		es = append(es, Entry{Var: v.Name, Backend: s.Backend, File: src})
+	}
+	return es
+}
+
+// bwEntries flattens a bw secret. All vars share the item; the per-var field
+// override falls back to the secret's top-level BW.Field.
+func (s *Secret) bwEntries(home string) []Entry {
+	var item, topField string
+	if s.BW != nil {
+		item, topField = s.BW.Item, s.BW.Field
+	}
+	if s.Expose.File != nil {
+		return []Entry{{
+			Var:     s.Expose.File.Var,
+			Backend: "bw",
+			Item:    item,
+			Field:   topField,
+			IsFile:  true,
+			Dest:    expandHome(s.Expose.File.Path, home),
+		}}
+	}
+	es := make([]Entry, 0, len(s.Expose.Env.Vars))
+	for _, v := range s.Expose.Env.Vars {
+		field := v.Field
+		if field == "" {
+			field = topField
+		}
+		es = append(es, Entry{Var: v.Name, Backend: "bw", Item: item, Field: field})
+	}
+	return es
 }
 
 // Vars lists the env-var names a secret exposes (the file var for a file secret).
@@ -218,6 +292,28 @@ func (r *Registry) Selector(token string) ([]string, bool) {
 		}
 	}
 	return nil, false
+}
+
+// ShowEntry resolves a single-env-var secret to its Entry for `show` (one value to
+// stdout). File and multi-var secrets are rejected — a single value to stdout is
+// ambiguous for them; use `run`. The returned Entry is backend-tagged (age or bw),
+// reusing the same flattening as Entries (home is irrelevant: env vars never
+// materialize a file).
+func (r *Registry) ShowEntry(idOrVar string) (Entry, error) {
+	s := r.Lookup(idOrVar)
+	if s == nil {
+		return Entry{}, fmt.Errorf("unknown secret %q (try `dotf secrets ls`)", idOrVar)
+	}
+	if s.Expose.File != nil {
+		return Entry{}, fmt.Errorf("%q is a file secret; use `dotf secrets run --only %s -- <cmd>`", s.ID, s.ID)
+	}
+	if len(s.Expose.Env.Vars) != 1 {
+		return Entry{}, fmt.Errorf("%q exposes %d vars; use `dotf secrets run --only %s -- <cmd>`", s.ID, len(s.Expose.Env.Vars), s.ID)
+	}
+	if s.Backend == "bw" {
+		return s.bwEntries("")[0], nil
+	}
+	return s.ageEntries("")[0], nil
 }
 
 // Lookup resolves a token to its secret: id first (the stable handle), then an

--- a/cli/internal/secrets/registry_test.go
+++ b/cli/internal/secrets/registry_test.go
@@ -122,17 +122,81 @@ func TestRegistry_Lookup_IdThenVar(t *testing.T) {
 	}
 }
 
-func TestRegistry_Entries_SkipsBwBackend(t *testing.T) {
+func TestRegistry_Entries_IncludesBwBackend(t *testing.T) {
 	const yml = "version: 1\nsecrets:\n" +
 		"  - {id: age-one, plane: app, backend: age, age: a.key, expose: {env: A_KEY}}\n" +
-		"  - {id: bw-one, plane: app, backend: bw, expose: {env: B_KEY}}\n"
+		"  - {id: bw-one, plane: app, backend: bw, bw: {item: bw-item, field: password}, expose: {env: B_KEY}}\n"
 	reg, err := ParseRegistry([]byte(yml))
 	if err != nil {
 		t.Fatalf("ParseRegistry: %v", err)
 	}
-	es := reg.Entries("/h")
-	if len(es) != 1 || es[0].Var != "A_KEY" {
-		t.Errorf("Entries = %+v, want only A_KEY (bw not age-readable yet)", es)
+	got := entriesByVar(reg.Entries("/h"))
+	if len(got) != 2 {
+		t.Fatalf("Entries = %+v, want both age + bw entries", got)
+	}
+	if a := got["A_KEY"]; a.Backend != "age" || a.File != "a.key" {
+		t.Errorf("A_KEY = %+v, want backend=age file=a.key", a)
+	}
+	if b := got["B_KEY"]; b.Backend != "bw" || b.Item != "bw-item" || b.Field != "password" {
+		t.Errorf("B_KEY = %+v, want backend=bw item=bw-item field=password", b)
+	}
+}
+
+func TestParseRegistry_BwShapes(t *testing.T) {
+	const yml = `
+version: 1
+secrets:
+  - id: single
+    plane: app
+    backend: bw
+    bw: { item: single-item, field: password }
+    expose: { env: SINGLE }
+  - id: multi
+    plane: app
+    backend: bw
+    bw: { item: multi-item }
+    expose:
+      env:
+        A_KEY: { field: a-field }
+        B_KEY: { field: b-field }
+  - id: bwfile
+    plane: infra
+    backend: bw
+    bw: { item: kube-item, field: notes }
+    expose: { file: { var: KUBECONFIG, path: "~/.kube/c", mode: "0600" } }
+`
+	reg, err := ParseRegistry([]byte(yml))
+	if err != nil {
+		t.Fatalf("ParseRegistry: %v", err)
+	}
+	got := entriesByVar(reg.Entries("/home/u"))
+	if e := got["SINGLE"]; e.Backend != "bw" || e.Item != "single-item" || e.Field != "password" {
+		t.Errorf("SINGLE = %+v (single var inherits top-level field)", e)
+	}
+	if e := got["A_KEY"]; e.Item != "multi-item" || e.Field != "a-field" {
+		t.Errorf("A_KEY = %+v (shared item, per-var field)", e)
+	}
+	if e := got["B_KEY"]; e.Item != "multi-item" || e.Field != "b-field" {
+		t.Errorf("B_KEY = %+v", e)
+	}
+	if e := got["KUBECONFIG"]; !e.IsFile || e.Item != "kube-item" || e.Field != "notes" || e.Dest != "/home/u/.kube/c" {
+		t.Errorf("KUBECONFIG = %+v (bw file secret, ~-expanded dest)", e)
+	}
+}
+
+func TestParseRegistry_BwValidation(t *testing.T) {
+	cases := map[string]string{
+		"bw missing bw block":   "version: 1\nsecrets:\n  - {id: a, plane: app, backend: bw, expose: {env: A}}\n",
+		"bw missing item":       "version: 1\nsecrets:\n  - {id: a, plane: app, backend: bw, bw: {field: password}, expose: {env: A}}\n",
+		"bw env missing field":  "version: 1\nsecrets:\n  - {id: a, plane: app, backend: bw, bw: {item: it}, expose: {env: A}}\n",
+		"bw file missing field": "version: 1\nsecrets:\n  - {id: a, plane: app, backend: bw, bw: {item: it}, expose: {file: {var: V, path: /p}}}\n",
+	}
+	for name, yml := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseRegistry([]byte(yml)); err == nil {
+				t.Errorf("expected error for %q, got nil", name)
+			}
+		})
 	}
 }
 

--- a/cli/internal/secrets/resolve.go
+++ b/cli/internal/secrets/resolve.go
@@ -24,34 +24,57 @@ func AgeDecrypt(ageFile, keyPath string) ([]byte, error) {
 	return out, nil
 }
 
-// Loader resolves entries to child-process environment, decrypting on demand.
+// Resolver turns one Entry into its plaintext secret bytes. One implementation per
+// backend; EnvFor dispatches on Entry.Backend through a resolver map, so adding a
+// backend (bws, Vault) is a new Resolver + one map entry — no edit to the resolution
+// loop, no change to run/show/render (Open/Closed). ADR-028 §2.
+type Resolver interface {
+	Resolve(e Entry) ([]byte, error)
+}
+
+// Loader resolves entries to child-process environment, fetching on demand. It holds
+// the per-backend seams — Decrypt (age) and BW (Bitwarden) — both injectable so
+// EnvFor is unit-testable with no age binary, no age key, and no Bitwarden vault.
 type Loader struct {
 	SecretsDir string    // dir holding <file>.secret.age (…/sensitive)
 	KeyPath    string    // age identity key path
 	Decrypt    Decryptor // nil → AgeDecrypt
+	BW         BWReader  // bw field reader; nil → bw entries fail with a clear error
 }
 
-// EnvFor decrypts the selected entries and returns "KEY=VALUE" strings for the
-// child environment. When only is non-nil, only entries whose Var is in it are
-// resolved (smaller blast radius). Env secrets are returned as VAR=<value> with
-// newlines stripped (parity with load-secrets' `tr -d '\n'`); file secrets are
-// written to Dest (0600, parent dirs created) and returned as VAR=<dest>.
+// resolvers maps a backend name to its Resolver. "" maps to age so a hand-built
+// Entry{Var, File} (no Backend set) still resolves — back-compat with pre-bw callers.
+func (l *Loader) resolvers() map[string]Resolver {
+	age := ageResolver{secretsDir: l.SecretsDir, keyPath: l.KeyPath, decrypt: l.Decrypt}
+	return map[string]Resolver{
+		"":            age,
+		"age":         age,
+		"age-offline": age,
+		"bw":          bwResolver{reader: l.BW},
+	}
+}
+
+// EnvFor resolves the selected entries and returns "KEY=VALUE" strings for the child
+// environment. When only is non-nil, only entries whose Var is in it are resolved
+// (smaller blast radius). Env secrets are returned as VAR=<value> with newlines
+// stripped (parity with load-secrets' `tr -d '\n'`); file secrets are written to
+// Dest (0600, parent dirs created) and returned as VAR=<dest>.
 //
-// A decryption failure is returned immediately (fail-fast) so the child is never
+// A resolution failure is returned immediately (fail-fast) so the child is never
 // launched with a partially-populated secret set.
 func (l *Loader) EnvFor(entries []Entry, only map[string]bool) ([]string, error) {
-	decrypt := l.Decrypt
-	if decrypt == nil {
-		decrypt = AgeDecrypt
-	}
+	resolvers := l.resolvers()
 
 	var env []string
 	for _, e := range entries {
 		if only != nil && !only[e.Var] {
 			continue
 		}
-		ageFile := filepath.Join(l.SecretsDir, e.File+".secret.age")
-		plaintext, err := decrypt(ageFile, l.KeyPath)
+		r, ok := resolvers[e.Backend]
+		if !ok {
+			return nil, fmt.Errorf("secret %q: unknown backend %q", e.Var, e.Backend)
+		}
+		plaintext, err := r.Resolve(e)
 		if err != nil {
 			return nil, err
 		}
@@ -66,6 +89,38 @@ func (l *Loader) EnvFor(entries []Entry, only map[string]bool) ([]string, error)
 		env = append(env, e.Var+"="+stripNewlines(string(plaintext)))
 	}
 	return env, nil
+}
+
+// ageResolver decrypts the age file backing an entry. The Decryptor seam keeps
+// resolution testable with no age binary; AgeDecrypt is the production default.
+type ageResolver struct {
+	secretsDir string
+	keyPath    string
+	decrypt    Decryptor
+}
+
+func (r ageResolver) Resolve(e Entry) ([]byte, error) {
+	decrypt := r.decrypt
+	if decrypt == nil {
+		decrypt = AgeDecrypt
+	}
+	return decrypt(filepath.Join(r.secretsDir, e.File+".secret.age"), r.keyPath)
+}
+
+// bwResolver reads a Bitwarden item field through the BWReader seam. A nil reader
+// (Bitwarden locked, bw missing, or not wired) is a clear, actionable error — never
+// a panic, never a hang.
+type bwResolver struct{ reader BWReader }
+
+func (r bwResolver) Resolve(e Entry) ([]byte, error) {
+	if r.reader == nil {
+		return nil, fmt.Errorf("secret %q: bw backend unavailable (Bitwarden locked or `bw` missing — run `bw unlock` and export BW_SESSION)", e.Var)
+	}
+	val, err := r.reader.Field(e.Item, e.Field)
+	if err != nil {
+		return nil, fmt.Errorf("bw resolve %s/%s: %w", e.Item, e.Field, err)
+	}
+	return []byte(val), nil
 }
 
 // materialize writes a file secret to dest with 0600, creating parent dirs.

--- a/cli/internal/secrets/secrets.go
+++ b/cli/internal/secrets/secrets.go
@@ -1,8 +1,9 @@
-// Package secrets implements the on-demand (JIT) secrets path of ADR-028: decrypt
-// the age-mapped secrets and inject them into a single child process, never the
-// ambient shell. It ports the resolution logic of scripts/load-secrets.sh into Go
-// behind the `dotf secrets run` facade (#493), over the existing age store with
-// no migration.
+// Package secrets implements the on-demand (JIT) secrets path of ADR-028: resolve
+// the registry-mapped secrets and inject them into a single child process, never
+// the ambient shell. It ports the resolution logic of scripts/load-secrets.sh into
+// Go behind the `dotf secrets run` facade (#493). The age backend reads the local
+// age store; the bw backend reads Bitwarden (ADR-028 Phase 3), dispatched per
+// Entry.Backend through the Resolver seam.
 package secrets
 
 import (
@@ -10,14 +11,18 @@ import (
 )
 
 // Entry is one flattened registry secret — the form Registry.Entries produces and
-// the age Loader consumes. Two shapes:
-//   - env secret:  decrypt sensitive/<File>.secret.age into $Var.
-//   - file secret: IsFile, decrypt to Dest (0600) and set $Var=Dest.
+// the Loader resolves. Backend selects the Resolver; the source fields are
+// backend-specific (File for age, Item+Field for bw). Two exposure shapes:
+//   - env secret:  resolve the source into $Var.
+//   - file secret: IsFile, resolve to Dest (0600) and set $Var=Dest.
 type Entry struct {
-	Var    string // env var name
-	File   string // base name under sensitive/, without the .secret.age suffix
-	IsFile bool   // true for a file secret
-	Dest   string // materialization path (~ expanded); only when IsFile
+	Var     string // env var name
+	Backend string // age | age-offline | bw; "" resolves as age (back-compat)
+	File    string // age source: base name under sensitive/, without .secret.age
+	Item    string // bw source: Bitwarden item name/id
+	Field   string // bw source: field within the item
+	IsFile  bool   // true for a file secret
+	Dest    string // materialization path (~ expanded); only when IsFile
 }
 
 // expandHome rewrites a leading ~ (or ~/...) to home, leaving other paths intact.

--- a/specs/CLI-024-secrets-bw-backend/features.json
+++ b/specs/CLI-024-secrets-bw-backend/features.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "CLI-024-secrets-bw-backend-f1",
+    "behavior": "Registry parses + validates bw {item, field} and per-var field; a bw secret with no item/field source is rejected fail-fast",
+    "verification": "cd cli && go test ./internal/secrets/ -run 'TestParseRegistry|TestRegistry' -count=1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-bw-backend-f2",
+    "behavior": "Entries() emits bw entries tagged Backend/Item/Field (no longer skipped) and EnvFor resolves them via the injected BWReader",
+    "verification": "cd cli && go test ./internal/secrets/ -run 'TestEnvFor|TestRegistry_Entries' -count=1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-bw-backend-f3",
+    "behavior": "dotf secrets show <bw-id> and run --only <bw-id> resolve from Bitwarden via the bw resolver; showSource no longer rejects bw",
+    "verification": "cd cli && go test ./internal/cmd/ -run 'Secrets' -count=1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-bw-backend-f4",
+    "behavior": "A locked/unreachable Bitwarden yields a clear, actionable error (no hang, no plaintext to disk)",
+    "verification": "cd cli && go test ./internal/secrets/ -run 'TestEnvFor_BwError|TestBwResolver' -count=1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-bw-backend-f5",
+    "behavior": "Full suite + vet + fmt clean; registry.yaml unchanged (no secret flipped)",
+    "verification": "cd cli && go test ./... -count=1 && go vet ./... && test -z \"$(gofmt -l internal/secrets internal/cmd)\"",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CLI-024-secrets-bw-backend/proposal.md
+++ b/specs/CLI-024-secrets-bw-backend/proposal.md
@@ -1,0 +1,124 @@
+---
+id: "CLI-024-secrets-bw-backend"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-26"
+issue: "mlorentedev/dotfiles#585"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, secrets, cli, go, bitwarden]
+template_version: "1.0"
+---
+
+# CLI-024-secrets-bw-backend
+
+## Why
+
+The registry (`secrets/registry.yaml`) already declares `backend: bw` as a target
+(ADR-028 §2), but it is a **no-op today**: `Secret.AgeBacked()` gates bw out of
+`Registry.Entries()`, and `showSource` rejects it ("not yet supported, ADR-028
+Phase 3"). No secret can resolve from Bitwarden, so the age→bw migration that makes
+Bitwarden the SSOT cannot begin.
+
+This spec makes the **bw backend live** — the resolver core that turns a registry
+`backend: bw` entry into a decrypted value via the Bitwarden CLI. It is the Go piece
+of #585 and is **fully unit-testable without a real Bitwarden vault or an unlock**
+(a `BWReader` seam, mirroring the existing `Decryptor` seam). It deliberately
+migrates **zero** secrets: flipping the ~20 dev/infra entries `age → bw` + rotating
++ retiring their age files needs the operator's unlocked `bw` session and is a
+separate, non-blocking follow-up (#585 AC2–4).
+
+## What
+
+Concrete, observable changes after this PR:
+
+1. **Registry schema — a `bw` source.** A bw secret declares `bw: { item, field }`
+   (single var) or a shared `bw: { item }` plus a per-var `field` override (the
+   multi-field item case, e.g. x-twitter's 7 values collapsed into one Bitwarden
+   item). Mirrors the age `{ age: file }` / per-var `{ age: file }` shapes.
+   Validation requires an `item` + a `field` for every bw-exposed var (parallel to
+   `checkAgeSources`), fail-fast.
+2. **A per-backend `Resolver` interface** (Open/Closed). `EnvFor` dispatches on
+   `Entry.Backend` through a resolver map: the **age resolver** wraps the existing
+   `Decryptor`; the **bw resolver** sits behind a `BWReader` seam. Adding a future
+   backend (`bws`, Vault) is a new `Resolver` + one map entry — no edit to the
+   resolution loop, no change to consumers.
+3. **`Registry.Entries()` stops skipping bw** — it emits bw entries tagged
+   `Backend: "bw", Item, Field`; the whole `--only` / file-materialization /
+   fail-fast / newline-strip machinery is reused unchanged.
+4. **`dotf secrets show <bw-id>` and `run --only <bw-id>` resolve from Bitwarden**
+   when `bw` is unlocked; `showSource` no longer rejects bw. A **locked or
+   unreachable** Bitwarden produces a clear, actionable error (never a hang, never
+   plaintext to disk).
+5. **Production `BWReader` = a `bw get` shell-out** (`BWGet`), the bw analog of
+   `AgeDecrypt`'s `age --decrypt`. `bw serve` (a local REST daemon holding the
+   unlocked vault, faster for batch reads) is a **drop-in perf upgrade behind the
+   same seam**, documented in ADR-028 — not implemented here.
+
+`registry.yaml` itself is **not** edited to flip any secret: the bw path is exercised
+only by test fixtures, so this PR adds the *capability* with **zero live behaviour
+change** until the migration follow-up flips the first entry.
+
+## Out of scope
+
+- **The migration itself** (#585 AC2–4): adding the ~20 secrets to Bitwarden,
+  flipping `backend: age → bw`, rotating, retiring `sensitive/<file>.secret.age`.
+  Needs the operator's unlocked `bw` session — separate, non-blocking follow-up.
+- **`bw serve` daemon lifecycle** (auto-start / health-check / shutdown) — a perf
+  optimisation behind the `BWReader` seam, not correctness. Follow-up.
+- **Bitwarden Secrets Manager (`bws`) / HashiCorp Vault** — the infra-grade,
+  identity-based path. Documented as the upgrade route the facade keeps open; **not**
+  adopted (would reopen ADR-028 and add a second store; over-scaled for personal use).
+- **Folder taxonomy / item-naming curation, the GitHub token split (#321), the
+  offline age key + DR escrow** — the curation issue. `item` here is the **unique
+  item name (or ID)**; the Bitwarden folder is org metadata, not a lookup key.
+
+## Risks / open questions
+
+- **Item + field resolution.** `bw get item <name-or-id>` keys on the item **name or
+  ID**, not the folder — so the registry keys on `item` (unique within the vault) and
+  `field`. `BWGet` fetches the item JSON once and picks the field: `password` /
+  `username` / `notes` from the typed login object, anything else from custom
+  `fields[]` by name. An **ambiguous** item name → `bw` errors clearly (the curated
+  `Dotfiles/*` namespace keeps names unique); resolved → done.
+- **Locked / non-interactive bw must never hang.** `BWGet` runs `bw --nointeraction`
+  and relies on `BW_SESSION` in the environment for the unlock token; a locked vault,
+  missing session, or unknown item maps to a clear error ("Bitwarden locked — run
+  `bw unlock` / export `BW_SESSION`"), surfaced fail-fast like an age decrypt failure.
+- **No plaintext to disk.** Env secrets stay in memory (same as age); bw **file**
+  secrets materialise `0600` through the existing `materialize()` path. No new at-rest
+  copy.
+- **Testability boundary.** The `BWReader` seam unit-tests the resolver core with a
+  map-backed fake — **no Bitwarden in CI**, exactly as `fakeDecryptor` does for age.
+  `BWGet` itself (thin I/O to the `bw` binary) is verified by a **live smoke** with
+  the operator's unlocked session, not in CI — the same coverage shape `AgeDecrypt`
+  already has (untested real impl, tested fake).
+- **Determinism invariant.** A var exposed by two secrets is already rejected by
+  validation; keep that for bw (render needs one source per var).
+
+## Acceptance criteria
+
+- [ ] **AC1** — The registry parses + validates `bw: { item, field }` and the per-var
+  `field` override; a bw secret missing an item/field source is rejected fail-fast.
+  *Verify:* table-driven Go test (valid shapes + the missing-source error case).
+- [ ] **AC2** — `Registry.Entries()` emits bw entries tagged `Backend: "bw", Item,
+  Field` (no longer skipped), and `EnvFor` resolves them through the injected
+  `BWReader`. *Verify:* Go test with a fake `BWReader` covering env + file + `--only`.
+- [ ] **AC3** — `dotf secrets show <bw-id>` and `run --only <bw-id>` resolve from
+  Bitwarden via the bw resolver; `showSource` no longer rejects bw. *Verify:*
+  command-layer Go test with a fake `BWReader`.
+- [ ] **AC4** — A locked / unreachable Bitwarden yields a clear, actionable error
+  (no hang, no plaintext to disk). *Verify:* Go test where the fake `BWReader`
+  returns an error → `EnvFor`/`show` fail fast with a wrapped message.
+- [ ] **AC5** — `go test ./... && go vet ./... && gofmt -l` clean; `registry.yaml`
+  unchanged (no secret flipped); the migration remains a documented follow-up.
+
+## References
+
+- ADR: `docs/adr/adr-028-secrets-two-tier-bitwarden-age.md` (§2 backends, Phased plan
+  step 3; the upgrade path: bw serve / bws / Vault behind the facade).
+- Issue: `mlorentedev/dotfiles#585` (this PR delivers AC1; AC2–4 = the migration
+  follow-up).
+- Reuse: `cli/internal/secrets/{registry,resolve,secrets}.go`,
+  `cli/internal/cmd/secrets.go` (the `ageDecryptor` seam, `registryPath()`,
+  `showSource`); test style: `secrets_test.go` (`fakeDecryptor`), `registry_test.go`.
+- Prior: specs `CLI-024-secrets-run-jit`, `CLI-024-secrets-registry`,
+  `CLI-025-secrets-render` (all merged) — the resolution path this extends.

--- a/specs/CLI-024-secrets-bw-backend/tasks.md
+++ b/specs/CLI-024-secrets-bw-backend/tasks.md
@@ -1,0 +1,51 @@
+---
+tags: [spec, tasks, secrets, cli, go, bitwarden]
+created: "2026-06-26"
+---
+
+# Tasks - CLI-024-secrets-bw-backend
+
+> TDD order. One task = one focused commit. Tick as you go.
+
+## Setup
+
+- [x] Branch created from main: `feat/secrets-bw-backend`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+- [x] **AC1** — Registry schema: `BW *BWSource{Item, Field}` on `Secret`, `Field` on
+  `EnvVar`, per-var `field` parsed in `EnvExpose.UnmarshalYAML`, `checkBwSources`
+  wired into `validate()`. Tests: `TestParseRegistry_BwShapes`,
+  `TestParseRegistry_BwValidation`.
+- [x] **AC2a** — `Entry` gained `Backend`/`Item`/`Field`; `Entries()` emits bw entries
+  via `bwEntries`/`ageEntries`, tagged. `AgeBacked()` removed (dead). Test:
+  `TestRegistry_Entries_IncludesBwBackend`.
+- [x] **AC2b** — `Resolver` interface + `ageResolver` + `bwResolver` (behind
+  `BWReader`); `Loader.BW` seam; `EnvFor` dispatches via a resolver map (`""` → age).
+  Tests: `TestEnvFor_BwEnvSecret`, `TestEnvFor_BwFileSecret_Materialized`,
+  `TestEnvFor_MixedBackends_OnlyFilter`.
+- [x] **AC4** — nil reader → "bw backend unavailable"; reader error → wrapped fail-fast.
+  Tests: `TestEnvFor_BwNilReader_ClearError`, `TestEnvFor_BwReaderError_FailsFast`,
+  `TestEnvFor_UnknownBackend_Errors`.
+- [x] **AC3** — `bwReader` seam + `secretLoader()` helper in `secrets.go`;
+  `reg.ShowEntry` replaces `showSource` (bw allowed); `ls --pairs` skips bw. Tests:
+  `TestSecretsShow_ResolvesBwBackend`, `TestSecretsRun_ResolvesBwBackend`.
+- [x] **AC5** — `BWGet` (`bw --nointeraction get item` → JSON → field) in `bw.go`;
+  `fieldFromItem` unit-tested (`TestFieldFromItem`); `bw serve` perf upgrade documented.
+
+## Closing
+
+- [x] Every acceptance criterion is covered by ≥1 test (AC5's `BWGet` shell-out excepted — live smoke)
+- [x] `features.json` carries non-vacuous verification commands (state left `pending` for the harness)
+- [x] `go vet ./...` + `gofmt -l` (staged LF blobs) clean; `go build ./...` clean
+- [x] `registry.yaml` unchanged (no secret flipped — confirmed with `git diff`)
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+See `features.json` (sibling). Each acceptance criterion maps to ≥1 feature with an
+executable `verification`. The agent may not set `"state": "passing"` — only the
+harness, after capturing exit 0, may.

--- a/specs/CLI-024-secrets-bw-backend/verification.md
+++ b/specs/CLI-024-secrets-bw-backend/verification.md
@@ -1,0 +1,82 @@
+---
+tags: [spec, verification, secrets, cli, go, bitwarden]
+created: "2026-06-26"
+---
+
+# Verification - CLI-024-secrets-bw-backend
+
+## Evidence
+
+All AC verified by table-driven Go tests (no Bitwarden vault, no unlock — the
+`BWReader`/`Decryptor` seams inject fakes). Run from `cli/`.
+
+- [x] **AC1** (bw schema parses + validates; missing source rejected) ->
+  `TestParseRegistry_BwShapes` (single / multi-field / file shapes),
+  `TestParseRegistry_BwValidation` (missing bw block / item / env field / file field).
+- [x] **AC2** (`Entries()` emits bw entries tagged Backend/Item/Field; `EnvFor`
+  resolves via the injected `BWReader`) -> `TestRegistry_Entries_IncludesBwBackend`,
+  `TestEnvFor_BwEnvSecret`, `TestEnvFor_BwFileSecret_Materialized`,
+  `TestEnvFor_MixedBackends_OnlyFilter`.
+- [x] **AC3** (`show`/`run --only` resolve bw; `showSource` no longer rejects bw) ->
+  `TestSecretsShow_ResolvesBwBackend`, `TestSecretsRun_ResolvesBwBackend` (cmd pkg).
+- [x] **AC4** (locked/unreachable Bitwarden → clear, actionable error; no hang, no
+  plaintext to disk) -> `TestEnvFor_BwNilReader_ClearError` (asserts the "bw backend
+  unavailable" message), `TestEnvFor_BwReaderError_FailsFast`,
+  `TestEnvFor_UnknownBackend_Errors`. `BWGet` runs `bw --nointeraction` (cannot block).
+- [x] **AC5** (suite + vet + fmt clean; registry.yaml unchanged) -> see Test status;
+  `git diff` touches no `secrets/registry.yaml` (no secret flipped).
+- [x] Bonus: `fieldFromItem` JSON extraction (login / notes / custom fields / unknown
+  / bad JSON) -> `TestFieldFromItem`.
+
+## Test status
+
+- `go test ./internal/secrets/ ./internal/cmd/ -count=1` -> **ok** (both packages).
+  bw-focused run: 12 secrets-pkg tests + `TestSecretsShow_ResolvesBwBackend` +
+  `TestSecretsRun_ResolvesBwBackend` all PASS.
+- `go vet ./...` -> clean. `go build ./...` -> clean.
+- `gofmt -l` on the staged (LF) blobs -> clean for every changed file
+  (`git show :<file> | gofmt -l` empty). Windows working-tree shows CRLF, but
+  `git ls-files --eol` reports `i/lf` — git stores LF, so CI's Linux gofmt passes.
+- No regressions: the full `go test ./...` is green **except** `internal/mem`
+  `TestVaultHealth/...clean_stub`, which **fails identically on a clean `main`
+  checkout** (environment-dependent vault-health stub on this Windows box) — not
+  touched by this change.
+- Live smoke against a real unlocked Bitwarden: **deferred to the migration
+  follow-up** (needs the operator's `bw unlock` session). `BWGet` is thin I/O,
+  untested in CI exactly as `AgeDecrypt` is; `fieldFromItem` (the parsing logic) is
+  unit-tested.
+
+## Decisions made during implementation
+
+- **`item` keys on the Bitwarden item name/id, not a folder path.** `bw get item`
+  resolves by name/id; the folder is org metadata (curation issue). Refined the
+  issue's `bw: {folder, item, field}` sketch to `bw: {item, field}`.
+- **Resolver interface over a `switch`** — the user asked for the scalable/maintainable
+  shape. A per-backend `Resolver` registered in a map makes a future `bws`/Vault
+  backend a new impl + one map entry (Open/Closed), with no edit to the resolution
+  loop. `""` backend maps to age for caller back-compat.
+- **`BWGet` = `bw get` shell-out**, the boring/correct mirror of `AgeDecrypt`'s
+  `age --decrypt`. `bw serve` (local REST, faster batch reads) is a drop-in upgrade
+  behind the same seam, deferred (ADR-028). Documented that serve must stay
+  localhost-only (unauthenticated by design).
+- **`ls --pairs` skips bw entries** (no age source to emit) so the age-based
+  github-secrets-manager push path never emits a malformed `VAR\t` line; the CI-push
+  path for bw secrets is rethought in the migration follow-up.
+- **Zero migration in this PR** — `registry.yaml` is untouched; the bw path is
+  exercised only by fixtures, so the capability lands with no live behaviour change.
+
+## Promotion candidates
+
+- [ ] Lesson for the repo's `docs/lessons.md`? **no** — the design follows ADR-028; no
+  new project-level gotcha beyond what the ADR records.
+- [ ] ADR-worthy decision? **no** — ADR-028 already decided bw-as-SSOT; this is its
+  implementation. (The `bw serve` localhost-only / `bw`-vs-`bws` notes are captured in
+  the ADR upgrade-path section and the runbook, not a new ADR.)
+- [ ] New pattern candidate for `00_meta/patterns/`? **no** — repo-specific.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/CLI-024-secrets-bw-backend/` -> `specs/archive/CLI-024-secrets-bw-backend/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
## Why

The registry already declares `backend: bw` as a target (ADR-028 §2), but it's a no-op: `AgeBacked()` gated bw out of resolution and `show`/`run` rejected it ("not yet supported, Phase 3"). No secret could resolve from Bitwarden, so the age→bw migration couldn't begin.

This PR makes the **bw backend live** — the resolver core. It's the Go piece of #585, fully unit-tested with **no Bitwarden vault and no unlock** (a `BWReader` seam, mirroring the existing `Decryptor` seam). It migrates **zero** secrets.

## What

- **Registry schema** — `bw: {item, field}` source + per-var `field` override (the multi-field item case, e.g. x-twitter's 7 values → 1 item). Validated fail-fast (`checkBwSources`).
- **Per-backend `Resolver` interface** (Open/Closed) — `ageResolver` wraps the `Decryptor`; `bwResolver` sits behind a `BWReader` seam. `EnvFor` dispatches on `Entry.Backend` via a resolver map (`""` → age, back-compat). A future `bws`/Vault backend is a new impl + one map entry.
- **`Entries()` no longer skips bw** — emits entries tagged `Backend/Item/Field`; reuses the `--only`/materialization/fail-fast/newline-strip machinery.
- **`show <bw-id>` / `run --only <bw-id>` resolve from Bitwarden**; `showSource` → `reg.ShowEntry` allows bw. A locked/unreachable vault fails fast with a clear, actionable error (no hang, no plaintext to disk).
- **Production `BWGet`** = `bw --nointeraction get item` shell-out (the bw analog of `AgeDecrypt`); `fieldFromItem` picks `password`/`username`/`notes` or a custom field by name. `bw serve` (local REST, faster batch reads) is a drop-in upgrade behind the same seam — must stay localhost-only (unauthenticated by design).

`registry.yaml` is **unchanged** — the bw path is exercised only by fixtures, so this adds the capability with **zero live behaviour change** until the migration flips the first entry.

## Design notes

- `item` keys on the Bitwarden item **name/id**, not a folder path (`bw get` resolves by name/id; folder = curation metadata). Refines the issue's `{folder, item, field}` sketch to `{item, field}`.
- Follows ADR-028 (bw password-manager as SSOT). `bws`/Vault stay documented future swaps behind the facade — not adopted (over-scaled for personal use).

## Out of scope (follow-ups)

- **The migration** (#585 AC2–4): add ~20 secrets to Bitwarden, flip `backend: age→bw`, rotate, retire `*.secret.age`. Needs an unlocked `bw` session.
- `bw serve` daemon lifecycle (perf, behind the seam).

## Verification

- `go test ./internal/secrets/ ./internal/cmd/` → **ok**. bw-focused tests (schema/validation, `Entries`, `EnvFor` env+file+`--only`+error paths, `fieldFromItem`, `show`/`run` bw) all pass.
- `go vet ./...`, `go build ./...`, `gofmt` on the staged (LF) blobs → clean.
- Live smoke against a real unlocked Bitwarden is deferred to the migration follow-up (`BWGet` is thin I/O, untested in CI exactly as `AgeDecrypt`; `fieldFromItem` is unit-tested).

Spec: `specs/CLI-024-secrets-bw-backend`. Refs ADR-028, #378, #493, #583.

Closes nothing — #585 stays open for the migration (this delivers AC1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bitwarden (“bw”) backend support for `dotf secrets`, including `show` and `run`.
  * `secrets run --only` now resolves and injects `bw`-backed secret values into the child environment.
  * Secret registry parsing and entry resolution now support `bw`-defined item/field sources.
* **Bug Fixes**
  * `ls --pairs` consistently omits non-applicable entries, including `bw`-backed ones.
  * Clear errors are shown when Bitwarden access is unavailable.
* **Tests**
  * Expanded coverage for `bw` resolution, `--only` behavior, and parsing/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->