### PR TITLE
feat(secrets): strip backend unlock credentials from the run child env

### DIFF
--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -180,8 +180,10 @@ func newSecretsRunCmd() *cobra.Command {
 		Long: "run decrypts the mapped secrets (secrets/registry.yaml, over the age store)\n" +
 			"and launches <cmd> with them added to ITS environment — the parent shell is\n" +
 			"never touched. File secrets (@VAR=file>dest) are materialized to dest (0600)\n" +
-			"and VAR points at the path. --only scopes the injection to named vars. The\n" +
-			"child's exit code is propagated.\n\n" +
+			"and VAR points at the path. --only scopes the injection to named vars. Backend\n" +
+			"unlock credentials (e.g. BW_SESSION) are stripped from the child env, so <cmd>\n" +
+			"gets only the granted secrets, not the key to the whole vault. The child's exit\n" +
+			"code is propagated.\n\n" +
 			"Everything after -- is the command to run, e.g.:\n" +
 			"  dotf secrets run -- goreleaser release\n" +
 			"  dotf secrets run --only OPENAI_API_KEY -- python yt_metrics.py",
@@ -220,13 +222,40 @@ func newSecretsRunCmd() *cobra.Command {
 }
 
 // buildChildEnv flattens the registry to entries, resolves the selected secrets
-// (per-backend), and returns the parent environment with the KEY=VALUE pairs appended.
+// (per-backend), and returns the child environment: the parent env with the backend
+// unlock credentials stripped, plus the granted KEY=VALUE pairs. The child gets only
+// the secrets it was granted — never the master credential that opens the whole
+// vault (defense in depth; cf. 1Password's `op run` + `env -u OP_SERVICE_ACCOUNT_TOKEN`).
 func buildChildEnv(reg *secrets.Registry, only map[string]bool) ([]string, error) {
 	injected, err := secretLoader().EnvFor(reg.Entries(env.Home()), only)
 	if err != nil {
 		return nil, err
 	}
-	return append(os.Environ(), injected...), nil
+	return append(stripBackendAuth(os.Environ()), injected...), nil
+}
+
+// backendAuthVars are credentials that unlock a secret backend (the vault keys
+// themselves, not resolved secrets). dotf secrets run strips them from the child
+// environment so a launched tool cannot turn around and read the whole vault.
+var backendAuthVars = map[string]bool{
+	"BW_SESSION":               true, // Bitwarden unlock token (opens the whole vault)
+	"BW_PASSWORD":              true, // Bitwarden master password (API-key login)
+	"BW_CLIENTSECRET":          true, // Bitwarden API client secret
+	"OP_SERVICE_ACCOUNT_TOKEN": true, // 1Password service-account token
+}
+
+// stripBackendAuth returns environ without any backend-unlock credential (matched by
+// the KEY before '='). The input slice is not mutated.
+func stripBackendAuth(environ []string) []string {
+	out := make([]string, 0, len(environ))
+	for _, kv := range environ {
+		name, _, _ := strings.Cut(kv, "=")
+		if backendAuthVars[name] {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
 }
 
 // resolveOnly expands a comma-separated --only value into the set of env-var names

--- a/cli/internal/cmd/secrets_registry_test.go
+++ b/cli/internal/cmd/secrets_registry_test.go
@@ -164,6 +164,51 @@ func TestSecretsRun_ResolvesBwBackend(t *testing.T) {
 	}
 }
 
+func TestStripBackendAuth(t *testing.T) {
+	in := []string{"PATH=/bin", "BW_SESSION=tok", "FOO=bar", "OP_SERVICE_ACCOUNT_TOKEN=x", "BW_CLIENTSECRET=y", "EMPTY="}
+	got := strings.Join(stripBackendAuth(in), " ")
+	for _, banned := range []string{"BW_SESSION", "OP_SERVICE_ACCOUNT_TOKEN", "BW_CLIENTSECRET"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("%s must be stripped from the child env, got: %s", banned, got)
+		}
+	}
+	for _, kept := range []string{"PATH=/bin", "FOO=bar", "EMPTY="} {
+		if !strings.Contains(got, kept) {
+			t.Errorf("non-auth var %q must be kept, got: %s", kept, got)
+		}
+	}
+}
+
+// TestBuildChildEnv_StripsBackendAuth proves the resolved secret reaches the child
+// while the backend unlock token (BW_SESSION) does not — the child gets what it was
+// granted, never the key that opens the whole vault.
+func TestBuildChildEnv_StripsBackendAuth(t *testing.T) {
+	useTempRegistry(t, "version: 1\nsecrets:\n  - {id: bw-foo, plane: app, backend: bw, bw: {item: it, field: password}, expose: {env: FOO}}\n")
+	useBwReader(t, fakeBW{"it/password": "granted-value"})
+	t.Setenv("BW_SESSION", "unlock-token-must-not-leak")
+
+	reg, err := loadRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := buildChildEnv(reg, nil)
+	if err != nil {
+		t.Fatalf("buildChildEnv: %v", err)
+	}
+	var grantedFound bool
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "BW_SESSION=") {
+			t.Error("BW_SESSION must NOT be passed to the child environment")
+		}
+		if kv == "FOO=granted-value" {
+			grantedFound = true
+		}
+	}
+	if !grantedFound {
+		t.Error("the granted secret FOO=granted-value must still reach the child env")
+	}
+}
+
 func TestSecretsRender_SubstitutesInPlace(t *testing.T) {
 	useTempRegistry(t, testRegistry)
 	old := ageDecryptor


### PR DESCRIPTION
## Why

`dotf secrets run -- <cmd>` built the child environment as `os.Environ() + injected`, so the launched tool inherited the **entire** parent environment — including any backend **unlock credential** present (`BW_SESSION`, `BW_PASSWORD`/`BW_CLIENTSECRET`, `OP_SERVICE_ACCOUNT_TOKEN`). A granted tool could then read the **whole** vault, not just the secrets it was given.

## What

`stripBackendAuth` removes the backend unlock credentials from the child environment in `buildChildEnv`. The child gets only the granted `KEY=VALUE` secrets — never the master credential that opens the vault. Defense in depth, mirroring 1Password's `op run` + `env -u OP_SERVICE_ACCOUNT_TOKEN` pattern.

- Stripped: `BW_SESSION`, `BW_PASSWORD`, `BW_CLIENTSECRET`, `OP_SERVICE_ACCOUNT_TOKEN`.
- The granted registry secrets are still injected; `run --help` documents the guarantee.

## Verification

- `go test ./internal/cmd/ ./internal/secrets/` → ok. New: `TestStripBackendAuth` (unit), `TestBuildChildEnv_StripsBackendAuth` (BW_SESSION absent from child, granted secret present).
- `go vet ./...`, `go build ./...`, `gofmt` (staged LF blobs) → clean.
- Production diff ~29 LOC (secrets.go), under the spec-gate threshold — tracked by the issue.

Closes #609. Follow-up to the bw backend (#606); surfaced by the 1Password agent-runtime pattern.