### PR TITLE
fix(secrets): make resolution fail loud instead of silently empty

### DIFF
--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -138,17 +138,21 @@ func newSecretsShowCmd() *cobra.Command {
 // {env:VAR} placeholder whose VAR is a registry-exposed env secret with that
 // secret's decrypted value (ADR-028 / SDD-009). It is the Go replacement for the
 // substitute_env_placeholders / Substitute-EnvPlaceholders shell twins, wired
-// into setup for opencode.jsonc and pi's models.json. Unmapped/undecryptable
-// placeholders are left intact for the runtime resolver (never fatal).
+// into setup for opencode.jsonc and pi's models.json. Unmapped placeholders and
+// genuinely-absent secrets are left intact for the runtime resolver; a real
+// resolution failure is surfaced with its specific cause (and fatal under --strict).
 func newSecretsRenderCmd() *cobra.Command {
-	return &cobra.Command{
+	var strict bool
+	c := &cobra.Command{
 		Use:   "render <file>",
 		Short: "Substitute {env:VAR} placeholders in <file> with decrypted secret values (in place)",
 		Long: "render rewrites <file> in place, replacing each {env:VAR} placeholder whose\n" +
-			"VAR is a registry-mapped env secret (secrets/registry.yaml, over the age\n" +
-			"store) with the decrypted value. Placeholders with no registry mapping, or\n" +
-			"whose secret cannot be decrypted, are left intact for the runtime resolver —\n" +
-			"setup must complete even when some secrets are absent. Atomic write, 0600.",
+			"VAR is a registry-mapped env secret (secrets/registry.yaml) with the resolved\n" +
+			"value. Placeholders with no registry mapping, or whose secret is genuinely\n" +
+			"absent on this machine, are left intact for the runtime resolver — setup\n" +
+			"completes. A real failure (wrong age key, locked vault, empty value, bw\n" +
+			"item/field typo) is reported with its specific cause and leaves the placeholder\n" +
+			"intact; --strict turns any such failure into a non-zero exit. Atomic write, 0600.",
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -164,12 +168,20 @@ func newSecretsRenderCmd() *cobra.Command {
 			if len(res.Unmapped) > 0 {
 				_, _ = fmt.Fprintf(errOut, "render: unmapped placeholders left for runtime resolution: %s\n", strings.Join(res.Unmapped, " "))
 			}
-			if len(res.Unresolved) > 0 {
-				_, _ = fmt.Fprintf(errOut, "warning: render: mapped but undecryptable, left intact (check age key/secret files): %s\n", strings.Join(res.Unresolved, " "))
+			if len(res.Missing) > 0 {
+				_, _ = fmt.Fprintf(errOut, "render: secrets not provisioned here, left intact: %s\n", strings.Join(res.Missing, " "))
+			}
+			for _, u := range res.Unresolved {
+				_, _ = fmt.Fprintf(errOut, "warning: render: %s could not be resolved: %v\n", u.Var, u.Err)
+			}
+			if strict && len(res.Unresolved) > 0 {
+				return fmt.Errorf("render: %d placeholder(s) failed to resolve (--strict)", len(res.Unresolved))
 			}
 			return nil
 		},
 	}
+	c.Flags().BoolVar(&strict, "strict", false, "exit non-zero if any mapped secret fails to resolve (absent secrets still tolerated)")
+	return c
 }
 
 func newSecretsRunCmd() *cobra.Command {
@@ -277,6 +289,11 @@ func resolveOnly(reg *secrets.Registry, s string) (map[string]bool, error) {
 		for _, v := range vars {
 			set[v] = true
 		}
+	}
+	// An explicit --only that resolves to nothing (e.g. "," or "  ,  ") must never
+	// silently inject zero secrets — that runs the child unauthenticated (#612 A3).
+	if len(set) == 0 {
+		return nil, fmt.Errorf("--only %q selected no secrets", s)
 	}
 	return set, nil
 }

--- a/cli/internal/cmd/secrets_registry_test.go
+++ b/cli/internal/cmd/secrets_registry_test.go
@@ -233,6 +233,58 @@ func TestSecretsRender_SubstitutesInPlace(t *testing.T) {
 	}
 }
 
+func TestSecretsShow_EmptyValue_Errors(t *testing.T) {
+	useTempRegistry(t, "version: 1\nsecrets:\n  - {id: bw-empty, plane: app, backend: bw, bw: {item: it, field: password}, expose: {env: E_KEY}}\n")
+	useBwReader(t, fakeBW{"it/password": ""})
+	cmd := newSecretsShowCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"bw-empty"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("show must error when the secret resolves to an empty value")
+	}
+}
+
+// render default stays non-fatal on one failing secret (placeholder left, exit 0);
+// --strict turns the same real failure into a non-zero exit (#612 A2).
+func TestSecretsRender_Strict_NonZeroOnFailure(t *testing.T) {
+	old := ageDecryptor
+	ageDecryptor = func(_, _ string) ([]byte, error) { return nil, fmt.Errorf("age: vault locked") }
+	t.Cleanup(func() { ageDecryptor = old })
+
+	render := func(args ...string) error {
+		useTempRegistry(t, testRegistry)
+		cfg := filepath.Join(t.TempDir(), "c.jsonc")
+		if err := os.WriteFile(cfg, []byte(`{"k":"{env:NAN_API_KEY}"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		c := newSecretsRenderCmd()
+		c.SetOut(io.Discard)
+		c.SetErr(io.Discard)
+		c.SetArgs(append(args, cfg))
+		return c.Execute()
+	}
+	if err := render(); err != nil {
+		t.Fatalf("render default must not fail on one unresolved secret: %v", err)
+	}
+	if err := render("--strict"); err == nil {
+		t.Error("render --strict must exit non-zero when a mapped secret fails to resolve")
+	}
+}
+
+func TestResolveOnly_EmptyTokens_Errors(t *testing.T) {
+	reg, err := secrets.ParseRegistry([]byte(testRegistry))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveOnly(reg, ","); err == nil {
+		t.Error("--only with only-empty tokens must error (it selects nothing)")
+	}
+	if _, err := resolveOnly(reg, "  ,  "); err == nil {
+		t.Error("--only with whitespace-only tokens must error")
+	}
+}
+
 func TestResolveOnly_IdSelectsAllVars_NameSelectsOne(t *testing.T) {
 	reg, err := secrets.ParseRegistry([]byte(testRegistry))
 	if err != nil {

--- a/cli/internal/secrets/bw.go
+++ b/cli/internal/secrets/bw.go
@@ -54,7 +54,7 @@ func (g BWGet) Field(item, field string) (string, error) {
 
 // bwItem is the subset of `bw get item` JSON that BWGet reads.
 type bwItem struct {
-	Login struct {
+	Login *struct {
 		Username string `json:"username"`
 		Password string `json:"password"`
 	} `json:"login"`
@@ -67,17 +67,23 @@ type bwItem struct {
 
 // fieldFromItem extracts field from a `bw get item` JSON payload. The typed login
 // fields and the note are first-class names; any other name is matched against the
-// item's custom fields[] — an unknown name is an error (catches a registry typo),
-// while an empty typed field is returned as-is (parity with an empty age secret).
+// item's custom fields[] — an unknown name is an error (catches a registry typo).
+// Requesting a login field on an item with no login block (e.g. field: password on
+// a secure note) is an error too, not a silent empty value (#612 A1). An empty but
+// present value is left to EnvFor's empty-value guard.
 func fieldFromItem(data []byte, field string) (string, error) {
 	var it bwItem
 	if err := json.Unmarshal(data, &it); err != nil {
 		return "", fmt.Errorf("parse bw item JSON: %w", err)
 	}
 	switch field {
-	case "password":
-		return it.Login.Password, nil
-	case "username":
+	case "password", "username":
+		if it.Login == nil {
+			return "", fmt.Errorf("field %q requested but item has no login block", field)
+		}
+		if field == "password" {
+			return it.Login.Password, nil
+		}
 		return it.Login.Username, nil
 	case "notes":
 		return it.Notes, nil

--- a/cli/internal/secrets/bw_test.go
+++ b/cli/internal/secrets/bw_test.go
@@ -118,3 +118,28 @@ func TestFieldFromItem(t *testing.T) {
 		t.Error("invalid JSON must error")
 	}
 }
+
+// A typed login field requested against an item with no login block (e.g. a secure
+// note) must error, not return a silent empty value (#612 A1).
+func TestFieldFromItem_NonLoginItem_Errors(t *testing.T) {
+	const noteJSON = `{"notes":"some note","fields":[{"name":"api-key","value":"ak-1"}]}`
+	if _, err := fieldFromItem([]byte(noteJSON), "password"); err == nil {
+		t.Error("field: password against a non-login item must error")
+	}
+	if v, err := fieldFromItem([]byte(noteJSON), "notes"); err != nil || v != "some note" {
+		t.Errorf("notes = %q (err %v)", v, err)
+	}
+	if v, err := fieldFromItem([]byte(noteJSON), "api-key"); err != nil || v != "ak-1" {
+		t.Errorf("custom field = %q (err %v)", v, err)
+	}
+}
+
+// A bw field that resolves to an empty value must fail fast in EnvFor — never inject
+// VAR= into the child (#612 A1).
+func TestEnvFor_BwEmptyValue_FailsFast(t *testing.T) {
+	l := &Loader{BW: fakeBW{"it/password": ""}}
+	_, err := l.EnvFor([]Entry{{Var: "X", Backend: "bw", Item: "it", Field: "password"}}, nil)
+	if err == nil || !strings.Contains(err.Error(), "empty value") {
+		t.Fatalf("empty bw value must fail fast, got err=%v", err)
+	}
+}

--- a/cli/internal/secrets/render.go
+++ b/cli/internal/secrets/render.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,13 +14,24 @@ import (
 // identifier. Same grammar the shell twin (substitute_env_placeholders) used.
 var envToken = regexp.MustCompile(`\{env:([A-Z_][A-Z0-9_]*)\}`)
 
-// Result reports what Render did, so the caller can surface the shell twin's
-// operator diagnostics: which placeholders were substituted, left for the
-// runtime resolver (Unmapped), or mapped-but-undecryptable (Unresolved).
+// Result reports what Render did, so the caller can surface precise operator
+// diagnostics and decide whether to fail. A mapped placeholder that didn't resolve
+// is split two ways (#612 A2): Missing (the secret is genuinely absent on this
+// machine — expected during partial setup, quiet/info) vs Unresolved (a real
+// failure — wrong key, locked vault, empty value, bw item/field typo — surfaced
+// loudly with the specific error, and fatal under --strict).
 type Result struct {
 	Substituted int
-	Unmapped    []string // {env:VAR} with no registry entry — left intact (info)
-	Unresolved  []string // mapped but decrypt failed/empty — left intact (warning)
+	Unmapped    []string        // {env:VAR} with no registry entry — left intact (info)
+	Missing     []string        // mapped but the secret is absent (age file missing) — left intact (info)
+	Unresolved  []UnresolvedVar // mapped but a real failure — left intact, surfaced with its error
+}
+
+// UnresolvedVar pairs a placeholder var with the specific error that blocked it, so
+// render no longer collapses every distinct failure into one opaque bucket.
+type UnresolvedVar struct {
+	Var string
+	Err error
 }
 
 // Render rewrites the config at path in place, substituting every {env:VAR}
@@ -64,9 +76,15 @@ func Render(path string, reg *Registry, loader *Loader, home string) (Result, er
 			res.Unmapped = append(res.Unmapped, name)
 			continue
 		}
-		value, ok := resolve(loader, entry)
-		if !ok {
-			res.Unresolved = append(res.Unresolved, name)
+		value, err := resolve(loader, entry)
+		if err != nil {
+			// Absent (secret not provisioned here) stays quiet/non-fatal; any other
+			// error is a real failure surfaced with its specific cause (#612 A2).
+			if errors.Is(err, ErrSecretAbsent) {
+				res.Missing = append(res.Missing, name)
+			} else {
+				res.Unresolved = append(res.Unresolved, UnresolvedVar{Var: name, Err: err})
+			}
 			continue
 		}
 		out = strings.ReplaceAll(out, "{env:"+name+"}", value)
@@ -116,19 +134,21 @@ func envSourceMap(reg *Registry, home string) (map[string]Entry, error) {
 	return bySource, nil
 }
 
-// resolve decrypts a single env entry by reusing EnvFor (the one decrypt+strip
-// path shared with run/show). EnvFor fails fast; here a failure is non-fatal —
-// it maps to "unresolved, leave the placeholder intact" (twin parity).
-func resolve(loader *Loader, e Entry) (string, bool) {
+// resolve decrypts a single env entry by reusing EnvFor (the one resolve+strip path
+// shared with run/show). It returns the underlying error verbatim (no longer
+// swallowed) so Render can classify absent vs misconfigured and surface the specific
+// cause. EnvFor already rejects an empty value, so an empty secret arrives here as a
+// real error, not a silent "".
+func resolve(loader *Loader, e Entry) (string, error) {
 	kv, err := loader.EnvFor([]Entry{e}, nil)
-	if err != nil || len(kv) == 0 {
-		return "", false
+	if err != nil {
+		return "", err
+	}
+	if len(kv) == 0 {
+		return "", fmt.Errorf("no value produced for %q", e.Var)
 	}
 	_, value, _ := strings.Cut(kv[0], "=")
-	if value == "" {
-		return "", false
-	}
-	return value, true
+	return value, nil
 }
 
 // atomicWrite stages content to a temp file in the target's directory, sets 0600,

--- a/cli/internal/secrets/render_test.go
+++ b/cli/internal/secrets/render_test.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -111,25 +112,77 @@ func TestRender_NoPlaceholders_NoOp(t *testing.T) {
 	}
 }
 
-// Parity with the shell twin: a mapped var whose secret cannot be decrypted is
-// left intact and reported as unresolved — render must NOT fail-fast (setup must
-// still complete; the placeholder falls through to the runtime resolver).
-func TestRender_UnresolvedDecryptError_LeftIntact(t *testing.T) {
+// A mapped var whose secret hits a real decrypt error is left intact (render is
+// non-fatal by default) but reported as Unresolved WITH its specific error (no
+// longer swallowed) — the placeholder falls through to the runtime resolver.
+func TestRender_UnresolvedDecryptError_LeftIntactWithError(t *testing.T) {
 	reg := parseRenderReg(t, renderRegistry)
 	path := renderFixture(t, `x={env:NAN_API_KEY}`)
 	l := loaderFor(t)
-	l.Decrypt = func(string, string) ([]byte, error) { return nil, os.ErrNotExist }
+	l.Decrypt = func(string, string) ([]byte, error) { return nil, fmt.Errorf("age: no identity matched") }
 
 	res, err := Render(path, reg, l, "/h")
 	if err != nil {
-		t.Fatalf("Render must not fail on an undecryptable secret: %v", err)
+		t.Fatalf("Render must not fail on a single undecryptable secret: %v", err)
 	}
 	got, _ := os.ReadFile(path)
 	if string(got) != `x={env:NAN_API_KEY}` {
 		t.Errorf("undecryptable placeholder should be left intact, got %q", got)
 	}
-	if len(res.Unresolved) != 1 || res.Unresolved[0] != "NAN_API_KEY" {
-		t.Errorf("Unresolved = %v, want [NAN_API_KEY]", res.Unresolved)
+	if len(res.Unresolved) != 1 || res.Unresolved[0].Var != "NAN_API_KEY" {
+		t.Fatalf("Unresolved = %v, want one entry for NAN_API_KEY", res.Unresolved)
+	}
+	if res.Unresolved[0].Err == nil || !strings.Contains(res.Unresolved[0].Err.Error(), "no identity matched") {
+		t.Errorf("Unresolved error not surfaced: %v", res.Unresolved[0].Err)
+	}
+	if len(res.Missing) != 0 {
+		t.Errorf("a decrypt error is not 'absent'; Missing = %v", res.Missing)
+	}
+}
+
+// A genuinely-absent secret (ErrSecretAbsent) is the quiet, non-fatal case: left
+// intact, classified Missing (not Unresolved), no error.
+func TestRender_AbsentSecret_QuietMissing(t *testing.T) {
+	reg := parseRenderReg(t, renderRegistry)
+	path := renderFixture(t, `x={env:NAN_API_KEY}`)
+	l := loaderFor(t)
+	l.Decrypt = func(string, string) ([]byte, error) { return nil, fmt.Errorf("%w: nan.api-key", ErrSecretAbsent) }
+
+	res, err := Render(path, reg, l, "/h")
+	if err != nil {
+		t.Fatalf("Render must not fail on an absent secret: %v", err)
+	}
+	if got, _ := os.ReadFile(path); string(got) != `x={env:NAN_API_KEY}` {
+		t.Errorf("absent placeholder should be left intact, got %q", got)
+	}
+	if len(res.Missing) != 1 || res.Missing[0] != "NAN_API_KEY" {
+		t.Errorf("Missing = %v, want [NAN_API_KEY]", res.Missing)
+	}
+	if len(res.Unresolved) != 0 {
+		t.Errorf("absent must not be Unresolved; Unresolved = %v", res.Unresolved)
+	}
+}
+
+// An empty resolved value is a real failure now (EnvFor rejects it) → Unresolved,
+// not a silent substitution of "".
+func TestRender_EmptyValue_Unresolved(t *testing.T) {
+	reg := parseRenderReg(t, renderRegistry)
+	path := renderFixture(t, `x={env:NAN_API_KEY}`)
+	l := loaderFor(t)
+	l.Decrypt = func(string, string) ([]byte, error) { return []byte("\n"), nil } // strips to ""
+
+	res, err := Render(path, reg, l, "/h")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if got, _ := os.ReadFile(path); string(got) != `x={env:NAN_API_KEY}` {
+		t.Errorf("empty-valued placeholder should be left intact, got %q", got)
+	}
+	if len(res.Unresolved) != 1 || res.Unresolved[0].Var != "NAN_API_KEY" {
+		t.Fatalf("Unresolved = %v, want NAN_API_KEY (empty value)", res.Unresolved)
+	}
+	if !strings.Contains(res.Unresolved[0].Err.Error(), "empty value") {
+		t.Errorf("expected an empty-value error, got %v", res.Unresolved[0].Err)
 	}
 }
 

--- a/cli/internal/secrets/resolve.go
+++ b/cli/internal/secrets/resolve.go
@@ -1,12 +1,20 @@
 package secrets
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 )
+
+// ErrSecretAbsent marks a secret that is genuinely not provisioned on this machine
+// (its age file does not exist), as opposed to a real failure (wrong key, locked
+// vault, decrypt error). render treats absent as a quiet, non-fatal case; everything
+// else is surfaced loudly (#612 A2).
+var ErrSecretAbsent = errors.New("secret not provisioned")
 
 // Decryptor decrypts the age file at ageFile using the identity at keyPath,
 // returning the plaintext. The seam that keeps EnvFor unit-testable with no age
@@ -15,8 +23,13 @@ type Decryptor func(ageFile, keyPath string) ([]byte, error)
 
 // AgeDecrypt shells out to `age --decrypt --identity <key> <file>` — the same
 // tool and key load-secrets.sh uses (Phase 0 provisions age). Plaintext is
-// returned in memory; it is never written to disk for env secrets.
+// returned in memory; it is never written to disk for env secrets. A missing age
+// file is reported as ErrSecretAbsent (not provisioned here) so render can keep it
+// quiet; a present-but-undecryptable file surfaces age's error.
 func AgeDecrypt(ageFile, keyPath string) ([]byte, error) {
+	if _, err := os.Stat(ageFile); errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("%w: %s", ErrSecretAbsent, filepath.Base(ageFile))
+	}
 	out, err := exec.Command("age", "--decrypt", "--identity", keyPath, ageFile).Output()
 	if err != nil {
 		return nil, fmt.Errorf("age decrypt %s: %w", filepath.Base(ageFile), err)
@@ -80,13 +93,22 @@ func (l *Loader) EnvFor(entries []Entry, only map[string]bool) ([]string, error)
 		}
 
 		if e.IsFile {
+			if len(plaintext) == 0 {
+				return nil, fmt.Errorf("secret %q resolved to empty content (backend %q) — refusing to materialize", e.Var, e.Backend)
+			}
 			if err := materialize(e.Dest, plaintext); err != nil {
 				return nil, err
 			}
 			env = append(env, e.Var+"="+e.Dest)
 			continue
 		}
-		env = append(env, e.Var+"="+stripNewlines(string(plaintext)))
+		value := stripNewlines(string(plaintext))
+		if value == "" {
+			// A blank secret would launch the child unauthenticated with no signal —
+			// the silent-empty incident class. Fail loud instead (#612 A1).
+			return nil, fmt.Errorf("secret %q resolved to an empty value (backend %q) — refusing to inject", e.Var, e.Backend)
+		}
+		env = append(env, e.Var+"="+value)
 	}
 	return env, nil
 }

--- a/specs/CLI-024-secrets-fail-loud/features.json
+++ b/specs/CLI-024-secrets-fail-loud/features.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "CLI-024-secrets-fail-loud-f1",
+    "behavior": "run/show fail fast on an empty resolved value; field:password on a non-login bw item errors",
+    "verification": "cd cli && go test ./internal/secrets/ ./internal/cmd/ -run 'EmptyValue|BwEmptyValue|NonLogin' -count=1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-fail-loud-f2",
+    "behavior": "render surfaces the specific error per misconfigured var; absent stays quiet/non-fatal; --strict exits non-zero on a real failure",
+    "verification": "cd cli && go test ./internal/secrets/ ./internal/cmd/ -run 'Render_Absent|Render_Unresolved|Render_Empty|Render_Strict' -count=1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-fail-loud-f3",
+    "behavior": "an explicit --only resolving to zero secrets is an error",
+    "verification": "cd cli && go test ./internal/cmd/ -run 'ResolveOnly_EmptyTokens' -count=1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-fail-loud-f4",
+    "behavior": "secrets + cmd suites green, vet + fmt clean",
+    "verification": "cd cli && go test ./internal/secrets/ ./internal/cmd/ -count=1 && go vet ./... && test -z \"$(gofmt -l internal/secrets internal/cmd)\"",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CLI-024-secrets-fail-loud/proposal.md
+++ b/specs/CLI-024-secrets-fail-loud/proposal.md
@@ -1,0 +1,101 @@
+---
+id: "CLI-024-secrets-fail-loud"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-26"
+issue: "mlorentedev/dotfiles#612"
+tags: [spec, proposal, secrets, cli, go, hardening]
+template_version: "1.0"
+---
+
+# CLI-024-secrets-fail-loud
+
+## Why
+
+A 3-agent audit (#612, Phase A) found that `dotf secrets` resolution can fail
+**silently** — the worst failure mode for a secrets path:
+
+1. **Empty value injected/printed without error.** A bw field (or age secret)
+   that resolves to `""` is injected by `run` as `VAR=` and printed by `show`
+   (exit 0). The launched process runs **unauthenticated**; `KEY=$(dotf secrets
+   show x)` yields an empty key — both with no signal. `render` already rejects
+   empty, so the same input is "a failure" in one path and "success" in another.
+2. **`render` swallows the real error and exits 0.** `resolve()` discards the
+   underlying error, collapsing *locked vault*, *wrong age key*, *registry typo*,
+   and *genuinely-absent secret* into one indistinguishable "unresolved" bucket,
+   and the command returns 0 regardless. Under `set -e` setup, a wrong age key or
+   a locked vault ships a config with literal `{env:VAR}` placeholders on a green
+   exit.
+3. **`--only ","` (all-empty tokens) selects nothing silently** — the child runs
+   with zero secrets, exit 0, no error.
+
+Silent failure in a secrets path means unauthenticated processes and green builds
+on broken config. This PR makes resolution **fail loud**.
+
+## What
+
+1. **A1 — empty resolved value is a hard error.** `EnvFor` (run) and `show` reject
+   an empty resolved value (env or file) fail-fast. `fieldFromItem` errors when a
+   typed field (`password`/`username`/`notes`) is requested but the Bitwarden item
+   has **no such block** (e.g. `field: password` against a secure-note item),
+   instead of returning `""`.
+2. **A2 — `render` surfaces the specific error and distinguishes absence from
+   misconfiguration.**
+   - **Absent** (the `sensitive/<x>.secret.age` file does not exist) stays
+     non-fatal and quiet — the expected partial-setup case. The age resolver
+     signals this with a sentinel `ErrSecretAbsent` (checked via `errors.Is`).
+   - **Misconfiguration** (wrong key, locked vault, decrypt error, empty value,
+     bw item/field typo) is **never swallowed**: the *specific* underlying error
+     is printed to stderr per var.
+   - A new **`--strict`** flag makes any real failure (not mere absence) exit
+     non-zero, so setup/CI can abort. Default stays non-fatal (setup completes)
+     but now **loud** about real errors.
+3. **A3 — an explicit `--only` that resolves to zero secrets is an error**
+   (`resolveOnly` rejects an all-empty/garbage selection). `--only` omitted = all
+   (unchanged).
+
+## Out of scope
+
+- The lifecycle commands (`verify`/`set`/`migrate`/`rotate`/`sync`/`retire`) — #612
+  Phase C.
+- Validation hardening (global VAR uniqueness, `FileExpose.Mode`, atomic
+  materialize, path-traversal, age stderr) — #612 Phase B.
+- `stripBackendAuth` (the `run` child-env credential leak) — the separate open PR.
+
+## Risks / open questions
+
+- **Backward compatibility of "empty = error".** None of the registry secrets are
+  legitimately empty; if one ever is, the fix is an explicit per-entry `allowEmpty`
+  flag — never a silent default. Documented, not built now.
+- **Absent vs misconfig classification.** age = `os.Stat` the `.secret.age` before
+  decrypt → missing file = `ErrSecretAbsent`; a present-but-undecryptable file is a
+  real error. bw errors are all treated as real (a registry-declared bw secret that
+  is not in the vault *is* a misconfiguration). This keeps classification robust (no
+  stderr string-parsing).
+- **`render` default must stay non-fatal** so setup completes when a secret is
+  genuinely absent on this machine — only `--strict` is fatal; misconfig is always
+  loud regardless.
+- **Existing tests change behaviour** — render/run tests that relied on silent-empty
+  must be updated to expect the new errors.
+
+## Acceptance criteria
+
+- [ ] **AC1** — `run` and `show` exit non-zero with a clear message when a secret
+  resolves empty (env or file); `field: password` against a non-login bw item errors
+  clearly. *Verify:* Go tests (fake BWReader returning empty / non-login JSON).
+- [ ] **AC2** — `render` prints the *specific* underlying error per misconfigured var
+  (no swallow); a genuinely-absent age secret stays non-fatal + quiet (placeholder
+  intact, exit 0); `--strict` makes a real failure exit non-zero. *Verify:* Go tests
+  (absent → exit 0 + placeholder; locked/empty → stderr has the real error; `--strict`
+  → non-zero).
+- [ ] **AC3** — an explicit `--only` resolving to zero secrets returns an error.
+  *Verify:* Go test (`--only ","`).
+- [ ] **AC4** — `go test ./... && go vet ./... && gofmt` clean; existing secrets tests
+  updated to the fail-loud contract; no scope creep.
+
+## References
+
+- Issue / backlog: `mlorentedev/dotfiles#612` (Phase A items A1–A3).
+- Audit: parallel code-reviewer + silent-failure-hunter + design, 2026-06-26.
+- Code: `cli/internal/secrets/{resolve,bw,render}.go`, `cli/internal/cmd/secrets.go`.
+- ADR: `docs/adr/adr-028-secrets-two-tier-bitwarden-age.md`.

--- a/specs/CLI-024-secrets-fail-loud/tasks.md
+++ b/specs/CLI-024-secrets-fail-loud/tasks.md
@@ -1,0 +1,39 @@
+---
+tags: [spec, tasks, secrets, cli, go, hardening]
+created: "2026-06-26"
+---
+
+# Tasks - CLI-024-secrets-fail-loud
+
+> TDD order. One task = one focused commit. Tick as you go.
+
+## Setup
+
+- [x] Branch from main: `fix/secrets-fail-loud-resolution`
+- [x] `proposal.md` complete; acceptance criteria testable
+
+## Implementation
+
+- [x] **A1** — `EnvFor` rejects an empty resolved value (env or file) fail-fast;
+  `show` inherits it. `fieldFromItem` errors on a typed field against a non-login
+  item (`bwItem.Login` → pointer). Tests: `TestEnvFor_BwEmptyValue_FailsFast`,
+  `TestFieldFromItem_NonLoginItem_Errors`, `TestSecretsShow_EmptyValue_Errors`.
+- [x] **A2** — `ErrSecretAbsent` sentinel; `AgeDecrypt` reports a missing file as
+  absent. `render.Result` splits `Missing` (quiet) from `Unresolved []UnresolvedVar`
+  (loud, carries the error); `resolve` returns the error (no swallow); the command
+  prints the specific error per var and adds `--strict` (non-zero on real failure).
+  Tests: `TestRender_AbsentSecret_QuietMissing`,
+  `TestRender_UnresolvedDecryptError_LeftIntactWithError`,
+  `TestRender_EmptyValue_Unresolved`, `TestSecretsRender_Strict_NonZeroOnFailure`.
+- [x] **A3** — `resolveOnly` errors when an explicit `--only` resolves to zero
+  secrets. Test: `TestResolveOnly_EmptyTokens_Errors`.
+- [x] **A4** — #610 (`stripBackendAuth`) merged independently; the child-env leak is
+  closed on main.
+
+## Closing
+
+- [x] Every AC covered by ≥1 test; existing render test updated to the new contract
+- [x] `features.json` carries non-vacuous verification commands
+- [x] `go test ./internal/secrets ./internal/cmd` green; `go vet` + `gofmt` clean
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec + #612

--- a/specs/CLI-024-secrets-fail-loud/verification.md
+++ b/specs/CLI-024-secrets-fail-loud/verification.md
@@ -1,0 +1,62 @@
+---
+tags: [spec, verification, secrets, cli, go, hardening]
+created: "2026-06-26"
+---
+
+# Verification - CLI-024-secrets-fail-loud
+
+## Evidence
+
+- [x] **AC1** (empty → fail fast; non-login item → error) — PASS:
+  `TestEnvFor_BwEmptyValue_FailsFast`, `TestFieldFromItem_NonLoginItem_Errors`,
+  `TestSecretsShow_EmptyValue_Errors`.
+- [x] **AC2** (render surfaces the specific error; absent quiet; `--strict` non-zero)
+  — PASS: `TestRender_AbsentSecret_QuietMissing` (Missing, exit 0, intact),
+  `TestRender_UnresolvedDecryptError_LeftIntactWithError` (Unresolved carries the
+  real "no identity matched" error), `TestRender_EmptyValue_Unresolved`,
+  `TestSecretsRender_Strict_NonZeroOnFailure` (default exit 0, `--strict` errors).
+- [x] **AC3** (explicit `--only` → zero = error) — PASS:
+  `TestResolveOnly_EmptyTokens_Errors` (`,` and `  ,  `).
+- [x] **AC4** (suites green, vet/fmt clean, existing tests updated) — see below.
+
+## Test status
+
+- `go test ./internal/secrets/ ./internal/cmd/ -count=1` → **ok** (both). Targeted
+  fail-loud run: all 11 new/updated cases PASS.
+- `go vet ./...` → clean. `go build ./...` → clean. `gofmt -l` on staged (LF) blobs
+  → clean for every changed file.
+- Updated existing test: `TestRender_UnresolvedDecryptError_LeftIntact` →
+  `...WithError` (asserts the surfaced error + `[]UnresolvedVar` shape).
+- No regressions: full `go test ./...` green **except** `internal/mem`
+  `TestVaultHealth/...clean_stub`, which **fails identically on clean main**
+  (environment-dependent vault-health stub on this Windows box) — untouched here.
+
+## Decisions made during implementation
+
+- **Absent vs misconfig is classified at the resolver, not by parsing stderr.**
+  `AgeDecrypt` `os.Stat`s the file and returns `ErrSecretAbsent` when missing; the
+  injected fake decryptor can simulate either case. bw errors are all "real" (a
+  registry-declared bw secret absent from the vault *is* a misconfiguration).
+- **Empty is a hard error for both shapes** (env and file). None of the registry
+  secrets are legitimately empty; an explicit `allowEmpty` flag is the future path if
+  one ever is — never a silent default.
+- **render default stays non-fatal** (setup completes when a secret is genuinely
+  absent); only `--strict` is fatal, and only on real failures (not absence).
+  Misconfig is always loud on stderr regardless of `--strict`.
+- **`bwItem.Login` became a pointer** so "no login block" is distinguishable from "empty
+  password" — the former errors here, the latter is caught by the empty-value guard.
+- A4 (`stripBackendAuth`, #610) merged independently while this was in flight.
+
+## Promotion candidates
+
+- [ ] Lesson for `docs/lessons.md`? **no** — the "secrets must fail loud" principle is
+  captured in the audit issue #612 + this spec.
+- [ ] ADR-worthy? **no** — implements ADR-028; no new architectural decision.
+- [ ] New cross-project pattern? **no** — repo-specific.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved to `specs/archive/CLI-024-secrets-fail-loud/`
+- [ ] #612 Phase A items A1–A3 checked off; PR linked
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
## Why

A 3-agent audit (#612 Phase A) found `dotf secrets` resolution could fail **silently** — the worst failure mode for a secrets path: an empty value injected into a process, a swallowed error shipping a broken config on a green exit, an `--only` that selects nothing.

## What (the three worst cases, fixed)

1. **Empty resolved value → fail fast.** `run` no longer injects `VAR=` and `show` no longer prints `""` (exit 0) when a secret resolves empty — both error. `fieldFromItem` errors when a typed field (`password`/`username`) is requested against an item with **no login block** (e.g. `field: password` on a secure note), instead of returning `""` (`bwItem.Login` is now a pointer).
2. **`render` no longer swallows the error / always exits 0.** It now classifies:
   - **absent** (the `.secret.age` file doesn't exist → `ErrSecretAbsent`) — quiet, non-fatal, placeholder left for the runtime resolver (setup still completes);
   - **misconfigured** (wrong age key, locked vault, empty value, bw item/field typo) — the **specific** error is printed per var (no longer collapsed into one opaque bucket).
   - New **`--strict`** flag makes any real failure exit non-zero, so setup/CI can abort. A wrong key / locked vault no longer ships `{env:VAR}` placeholder configs on a green build.
3. **`--only ","` (all-empty tokens) → error** instead of silently injecting zero secrets.

`registry.yaml` is untouched — pure behaviour hardening, no secret changed.

## Verification

- `go test ./internal/secrets/ ./internal/cmd/` → ok. 11 new/updated fail-loud tests pass (empty env+file, non-login item, absent→Missing, misconfig→Unresolved-with-error, `--strict` non-zero, `--only` empty).
- `go vet ./...`, `go build ./...`, `gofmt` (staged LF blobs) → clean.
- Existing `TestRender_UnresolvedDecryptError_LeftIntact` updated to assert the surfaced error + new `[]UnresolvedVar` shape.
- No regressions (the unrelated `internal/mem` `TestVaultHealth` stub fails identically on clean main — environment-dependent, untouched here).

Spec: `specs/CLI-024-secrets-fail-loud`. Refs #612 (Phase A: A1–A3; A4/#610 already merged). First of the audit-backlog hardening before the age→bw migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secret rendering now provides clearer status for missing vs. unresolved secrets, and supports a `--strict` option to fail on real resolution errors.
  * Secret selection with `--only` now errors when it matches nothing, preventing accidental runs with no injected secrets.

* **Bug Fixes**
  * Empty secret values are now treated as errors instead of being injected silently.
  * Secret resolution now distinguishes truly unprovisioned secrets from other failures, improving command output and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->