### PR TITLE
feat(secrets): add `dotf secrets verify` health check

### DIFF
--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -25,7 +25,8 @@ func newSecretsCmd() *cobra.Command {
 		Long: "secrets reads the registry (secrets/registry.yaml) and exposes the mapped\n" +
 			"secrets on demand. `run` injects them into one child process only (never the\n" +
 			"ambient shell); `show` prints one value; `render` materializes {env:VAR}\n" +
-			"placeholders in a config file; `ls` lists ids (ADR-028 §2).",
+			"placeholders in a config file; `verify` health-checks resolution without\n" +
+			"printing values; `ls` lists ids (ADR-028 §2).",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
@@ -35,6 +36,7 @@ func newSecretsCmd() *cobra.Command {
 	cmd.AddCommand(newSecretsLsCmd())
 	cmd.AddCommand(newSecretsShowCmd())
 	cmd.AddCommand(newSecretsRenderCmd())
+	cmd.AddCommand(newSecretsVerifyCmd())
 	return cmd
 }
 
@@ -57,6 +59,70 @@ func secretLoader() *secrets.Loader {
 		Decrypt:    ageDecryptor,
 		BW:         bwReader,
 	}
+}
+
+// backendOf is the display label for an entry's backend ("age" when unset).
+func backendOf(e secrets.Entry) string {
+	if e.Backend == "" {
+		return "age"
+	}
+	return e.Backend
+}
+
+// newSecretsVerifyCmd resolves each selected registry secret and reports OK / MISSING
+// / FAILED per var — never the value (a read-only health check). No args verifies all
+// entries; ids/var-names scope it via the --only selector. Exit is non-zero when any
+// secret FAILED; --require-all also fails on a MISSING secret.
+func newSecretsVerifyCmd() *cobra.Command {
+	var requireAll bool
+	c := &cobra.Command{
+		Use:   "verify [id...]",
+		Short: "Resolve each registry secret and report OK/MISSING/FAILED (no values printed)",
+		Long: "verify resolves each registry secret through its backend and reports a per-var\n" +
+			"status without printing the value or materializing any file:\n" +
+			"  OK       resolved to a non-empty value\n" +
+			"  MISSING  not provisioned on this machine (age file absent) — tolerated\n" +
+			"  FAILED   a real failure (wrong key, locked Bitwarden, empty value, typo)\n" +
+			"No args verifies all; ids/var-names scope it. Exit is non-zero on any FAILED\n" +
+			"(--require-all also fails on MISSING).",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reg, err := loadRegistry()
+			if err != nil {
+				return err
+			}
+			only, err := resolveOnly(reg, strings.Join(args, ","))
+			if err != nil {
+				return err
+			}
+			loader := secretLoader()
+			w := cmd.OutOrStdout()
+			var ok, missing, failed int
+			for _, e := range reg.Entries(env.Home()) {
+				if only != nil && !only[e.Var] {
+					continue
+				}
+				switch err := loader.Verify(e); {
+				case err == nil:
+					ok++
+					_, _ = fmt.Fprintf(w, "OK       %-30s %s\n", e.Var, backendOf(e))
+				case errors.Is(err, secrets.ErrSecretAbsent):
+					missing++
+					_, _ = fmt.Fprintf(w, "MISSING  %-30s %s\n", e.Var, backendOf(e))
+				default:
+					failed++
+					_, _ = fmt.Fprintf(w, "FAILED   %-30s %s: %v\n", e.Var, backendOf(e), err)
+				}
+			}
+			_, _ = fmt.Fprintf(w, "\n%d ok, %d missing, %d failed\n", ok, missing, failed)
+			if failed > 0 || (requireAll && missing > 0) {
+				return fmt.Errorf("verify: %d failed, %d missing", failed, missing)
+			}
+			return nil
+		},
+	}
+	c.Flags().BoolVar(&requireAll, "require-all", false, "also fail when a secret is MISSING (not provisioned here)")
+	return c
 }
 
 func loadRegistry() (*secrets.Registry, error) {

--- a/cli/internal/cmd/secrets_registry_test.go
+++ b/cli/internal/cmd/secrets_registry_test.go
@@ -305,3 +305,74 @@ func TestResolveOnly_IdSelectsAllVars_NameSelectsOne(t *testing.T) {
 		t.Error("unknown --only token must error")
 	}
 }
+
+func TestSecretsVerify_ReportsStatuses_NoValues(t *testing.T) {
+	useTempRegistry(t, "version: 1\nsecrets:\n"+
+		"  - {id: age-ok, plane: app, backend: age, age: a.key, expose: {env: AGE_OK}}\n"+
+		"  - {id: age-missing, plane: app, backend: age, age: gone, expose: {env: AGE_MISSING}}\n"+
+		"  - {id: bw-fail, plane: app, backend: bw, bw: {item: nope, field: password}, expose: {env: BW_FAIL}}\n")
+	old := ageDecryptor
+	ageDecryptor = func(ageFile, _ string) ([]byte, error) {
+		if strings.Contains(ageFile, "gone") {
+			return nil, fmt.Errorf("%w: gone", secrets.ErrSecretAbsent)
+		}
+		return []byte("the-secret-value\n"), nil
+	}
+	t.Cleanup(func() { ageDecryptor = old })
+	useBwReader(t, fakeBW{}) // every bw lookup fails
+
+	var out bytes.Buffer
+	cmd := newSecretsVerifyCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+
+	got := out.String()
+	for _, want := range []string{"OK", "AGE_OK", "MISSING", "AGE_MISSING", "FAILED", "BW_FAIL"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("verify output missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "the-secret-value") {
+		t.Error("verify must NOT print secret values")
+	}
+	if err == nil {
+		t.Error("verify must exit non-zero when a secret FAILED")
+	}
+}
+
+func TestSecretsVerify_ScopesById(t *testing.T) {
+	useTempRegistry(t, "version: 1\nsecrets:\n"+
+		"  - {id: a, plane: app, backend: age, age: a, expose: {env: AAA}}\n"+
+		"  - {id: b, plane: app, backend: age, age: b, expose: {env: BBB}}\n")
+	old := ageDecryptor
+	ageDecryptor = func(string, string) ([]byte, error) { return []byte("v\n"), nil }
+	t.Cleanup(func() { ageDecryptor = old })
+
+	var out bytes.Buffer
+	cmd := newSecretsVerifyCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"a"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("verify a: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "AAA") {
+		t.Errorf("verify a must check AAA: %s", got)
+	}
+	if strings.Contains(got, "BBB") {
+		t.Errorf("verify a must NOT check BBB: %s", got)
+	}
+}
+
+func TestSecretsVerify_UnknownId_Errors(t *testing.T) {
+	useTempRegistry(t, testRegistry)
+	cmd := newSecretsVerifyCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"no-such-id"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("verify with an unknown id must error")
+	}
+}

--- a/cli/internal/secrets/resolve.go
+++ b/cli/internal/secrets/resolve.go
@@ -113,6 +113,33 @@ func (l *Loader) EnvFor(entries []Entry, only map[string]bool) ([]string, error)
 	return env, nil
 }
 
+// Verify resolves one entry through its backend resolver as a read-only health check:
+// it confirms the secret produces a non-empty value, applying run's empty-value
+// rejection, but it never materializes a file secret and never returns the value
+// (no leak, no side effect). It returns nil when the secret resolves, ErrSecretAbsent
+// (wrapped) when it is genuinely not provisioned here, or the specific failure
+// otherwise — so `dotf secrets verify` can classify OK / MISSING / FAILED.
+func (l *Loader) Verify(e Entry) error {
+	r, ok := l.resolvers()[e.Backend]
+	if !ok {
+		return fmt.Errorf("unknown backend %q", e.Backend)
+	}
+	plaintext, err := r.Resolve(e)
+	if err != nil {
+		return err
+	}
+	if e.IsFile {
+		if len(plaintext) == 0 {
+			return fmt.Errorf("resolved to empty content")
+		}
+		return nil
+	}
+	if stripNewlines(string(plaintext)) == "" {
+		return fmt.Errorf("resolved to an empty value")
+	}
+	return nil
+}
+
 // ageResolver decrypts the age file backing an entry. The Decryptor seam keeps
 // resolution testable with no age binary; AgeDecrypt is the production default.
 type ageResolver struct {

--- a/cli/internal/secrets/verify_test.go
+++ b/cli/internal/secrets/verify_test.go
@@ -1,0 +1,68 @@
+package secrets
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoader_Verify_Classification(t *testing.T) {
+	cases := []struct {
+		name       string
+		dec        Decryptor
+		wantErr    bool
+		wantAbsent bool
+	}{
+		{"ok", func(string, string) ([]byte, error) { return []byte("value\n"), nil }, false, false},
+		{"absent", func(string, string) ([]byte, error) { return nil, fmt.Errorf("%w: f", ErrSecretAbsent) }, true, true},
+		{"empty", func(string, string) ([]byte, error) { return []byte("\n"), nil }, true, false},
+		{"error", func(string, string) ([]byte, error) { return nil, fmt.Errorf("vault locked") }, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			l := &Loader{SecretsDir: t.TempDir(), Decrypt: c.dec}
+			err := l.Verify(Entry{Var: "X", Backend: "age", File: "x"})
+			if (err != nil) != c.wantErr {
+				t.Fatalf("err=%v, wantErr=%v", err, c.wantErr)
+			}
+			if c.wantAbsent && !errors.Is(err, ErrSecretAbsent) {
+				t.Errorf("expected ErrSecretAbsent, got %v", err)
+			}
+			if !c.wantAbsent && errors.Is(err, ErrSecretAbsent) {
+				t.Errorf("did not expect ErrSecretAbsent, got %v", err)
+			}
+		})
+	}
+}
+
+// Verify must resolve a file secret WITHOUT writing it to disk (no side effect).
+func TestLoader_Verify_FileSecret_NotMaterialized(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "sub", "kubeconfig")
+	l := &Loader{
+		SecretsDir: t.TempDir(),
+		Decrypt:    func(string, string) ([]byte, error) { return []byte("content\n"), nil },
+	}
+	if err := l.Verify(Entry{Var: "KUBECONFIG", Backend: "age", File: "k", IsFile: true, Dest: dest}); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if _, err := os.Stat(dest); err == nil {
+		t.Error("Verify must NOT materialize the file secret to disk")
+	}
+}
+
+func TestLoader_Verify_Bw(t *testing.T) {
+	if err := (&Loader{BW: fakeBW{"it/password": "v"}}).Verify(
+		Entry{Var: "X", Backend: "bw", Item: "it", Field: "password"}); err != nil {
+		t.Errorf("bw ok Verify: %v", err)
+	}
+	if err := (&Loader{BW: fakeBW{"it/password": ""}}).Verify(
+		Entry{Var: "X", Backend: "bw", Item: "it", Field: "password"}); err == nil {
+		t.Error("an empty bw value must fail Verify")
+	}
+	if err := (&Loader{BW: fakeBW{}}).Verify(
+		Entry{Var: "X", Backend: "bw", Item: "nope", Field: "password"}); err == nil {
+		t.Error("a missing bw item must fail Verify")
+	}
+}

--- a/specs/CLI-024-secrets-verify/features.json
+++ b/specs/CLI-024-secrets-verify/features.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "CLI-024-secrets-verify-f1",
+    "behavior": "Loader.Verify resolves without materializing/leaking; nil on ok, ErrSecretAbsent on absent, error otherwise",
+    "verification": "cd cli && go test ./internal/secrets/ -run 'Loader_Verify' -count=1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-verify-f2",
+    "behavior": "dotf secrets verify reports OK/MISSING/FAILED per var, prints no values, exits non-zero on any FAILED",
+    "verification": "cd cli && go test ./internal/cmd/ -run 'SecretsVerify_ReportsStatuses' -count=1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-verify-f3",
+    "behavior": "verify <id> scopes to the selected secret(s); unknown id errors",
+    "verification": "cd cli && go test ./internal/cmd/ -run 'SecretsVerify_ScopesById|SecretsVerify_UnknownId' -count=1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-verify-f4",
+    "behavior": "secrets + cmd suites green, vet + fmt clean",
+    "verification": "cd cli && go test ./internal/secrets/ ./internal/cmd/ -count=1 && go vet ./... && test -z \"$(gofmt -l internal/secrets internal/cmd)\"",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CLI-024-secrets-verify/proposal.md
+++ b/specs/CLI-024-secrets-verify/proposal.md
@@ -1,0 +1,88 @@
+---
+id: "CLI-024-secrets-verify"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-26"
+issue: "mlorentedev/dotfiles#612"
+tags: [spec, proposal, secrets, cli, go]
+template_version: "1.0"
+---
+
+# CLI-024-secrets-verify
+
+## Why
+
+The age→bw migration (#612) needs to be **reproducible and verifiable**: after
+flipping a secret to `backend: bw` you must be able to assert, from the CLI, that it
+still resolves — without printing the value or materializing a file. Today there is
+no such check. `dotf doctor` only verifies tool presence (bw/age installed), not that
+each registry secret actually resolves; `show` prints the value (leak, and single-env
+only); `run` needs a child command. `dotf secrets verify` is the read-only health
+check that makes the migration safe to drive incrementally and the registry's
+invariant ("every declared secret resolves") testable. It is the foundation of #612
+Phase C — zero write risk, and it exercises every backend and shape, so it doubles as
+the idempotency/repro gate before any write command lands.
+
+## What
+
+`dotf secrets verify [<id>...]` resolves each selected registry secret through the
+existing backend resolvers and reports a per-var status — **never the value**:
+
+- **OK** — resolved to a non-empty value.
+- **MISSING** — genuinely absent on this machine (`ErrSecretAbsent`: the age file
+  isn't provisioned here). Reported, non-fatal.
+- **FAILED** — a real failure (wrong age key, locked/missing Bitwarden session, empty
+  value, item/field typo, unknown backend), shown with its specific cause.
+
+No arguments → verify all entries. One or more ids/var-names → verify just those
+(reusing the `--only` selector semantics). Output is one aligned line per var
+(`STATUS  VAR  backend [: error]`) plus a summary (`N ok, M missing, K failed`). Exit
+code is non-zero when any secret **FAILED** (MISSING alone is tolerated — a machine
+need not hold every secret); `--require-all` also fails on MISSING.
+
+A new `Loader.Verify(entry)` resolves the bytes via the backend resolver **without
+materializing file secrets and without returning the value**, applying the same
+empty-value rejection as `run` — so verify has no side effects (no files written, no
+secret printed) and matches `run`'s resolution semantics exactly.
+
+## Out of scope
+
+- Any write/mutation (`set`/`migrate`/`rotate`/`retire`) — later in #612 Phase C.
+- A `doctor` integration / rotation-staleness check (`rotated_at`) — #612 M4.
+- Caching multi-field bw items into one fetch (#612 B-perf) — verify reuses the
+  current per-entry resolve; a multi-field item is fetched per var (acceptable for a
+  health check).
+
+## Risks / open questions
+
+- **No value leak.** `Verify` must discard the resolved bytes and never write them;
+  it returns only an error (or nil). File secrets are resolved but **not** materialized
+  (the resolver returns bytes; materialization lives in `EnvFor`, which verify does
+  not call).
+- **Locked Bitwarden → all bw secrets FAILED.** Correct (verify reports the real
+  state); the operator scopes with `verify <id>` or unlocks first. Document it.
+- **Exit semantics.** FAILED → non-zero (a health check that hides failures is
+  useless); MISSING → exit 0 by default (partial provisioning is legitimate),
+  `--require-all` to tighten.
+
+## Acceptance criteria
+
+- [ ] **AC1** — `Loader.Verify(entry)` returns nil for a resolvable non-empty secret,
+  `ErrSecretAbsent` (wrapped) for an absent one, and a real error otherwise; it
+  materializes **no** file and exposes **no** value. *Verify:* Go tests (fake
+  decryptor / fake BWReader: ok / empty / absent / error; assert no file written for a
+  file entry).
+- [ ] **AC2** — `dotf secrets verify` reports OK/MISSING/FAILED per var and a summary,
+  prints no secret values, and exits non-zero iff any FAILED. *Verify:* command Go
+  test (mixed registry; assert statuses, no value in output, exit code).
+- [ ] **AC3** — `dotf secrets verify <id>` scopes to the selected secret(s) via the
+  `--only` selector; an unknown id errors. *Verify:* Go test.
+- [ ] **AC4** — `go test ./... && go vet && gofmt` clean; no existing behaviour changed
+  (verify is additive).
+
+## References
+
+- Issue / backlog: `mlorentedev/dotfiles#612` (Phase C, C1).
+- Reuse: `cli/internal/secrets/resolve.go` (`Resolver`/`resolvers`, `ErrSecretAbsent`),
+  `cli/internal/cmd/secrets.go` (`secretLoader`, `resolveOnly`, `registryPath`).
+- ADR: `docs/adr/adr-028-secrets-two-tier-bitwarden-age.md`.

--- a/specs/CLI-024-secrets-verify/tasks.md
+++ b/specs/CLI-024-secrets-verify/tasks.md
@@ -1,0 +1,35 @@
+---
+tags: [spec, tasks, secrets, cli, go]
+created: "2026-06-26"
+---
+
+# Tasks - CLI-024-secrets-verify
+
+> TDD order. One task = one focused commit.
+
+## Setup
+
+- [x] Branch from main: `feat/secrets-verify`
+- [x] `proposal.md` complete; acceptance criteria testable
+
+## Implementation
+
+- [x] **AC1** — `Loader.Verify(entry)` resolves via the backend resolver without
+  materializing files or returning the value; nil on a non-empty secret,
+  `ErrSecretAbsent` (wrapped) on absent, a real error otherwise. Tests:
+  `TestLoader_Verify_Classification`, `TestLoader_Verify_FileSecret_NotMaterialized`,
+  `TestLoader_Verify_Bw`.
+- [x] **AC2/AC3** — `newSecretsVerifyCmd`: verify all or `[id...]` (via the `--only`
+  selector), report OK/MISSING/FAILED per var+backend, no values, exit non-zero on any
+  FAILED (`--require-all` also on MISSING). Registered in `newSecretsCmd`. Tests:
+  `TestSecretsVerify_ReportsStatuses_NoValues`, `TestSecretsVerify_ScopesById`,
+  `TestSecretsVerify_UnknownId_Errors`.
+
+## Closing
+
+- [x] Every AC covered by ≥1 test
+- [x] `features.json` carries non-vacuous verification commands
+- [x] `go test ./internal/secrets ./internal/cmd` green; `go vet` + `gofmt` clean
+- [x] No existing behaviour changed (verify is additive)
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec + #612 C1

--- a/specs/CLI-024-secrets-verify/verification.md
+++ b/specs/CLI-024-secrets-verify/verification.md
@@ -1,0 +1,57 @@
+---
+tags: [spec, verification, secrets, cli, go]
+created: "2026-06-26"
+---
+
+# Verification - CLI-024-secrets-verify
+
+## Evidence
+
+- [x] **AC1** (`Loader.Verify`: no materialize, no leak, correct classification) — PASS:
+  `TestLoader_Verify_Classification` (ok/absent/empty/error subtests),
+  `TestLoader_Verify_FileSecret_NotMaterialized` (asserts the Dest file is NOT written),
+  `TestLoader_Verify_Bw` (ok / empty / missing item).
+- [x] **AC2** (`verify` reports statuses, no values, exit non-zero on FAILED) — PASS:
+  `TestSecretsVerify_ReportsStatuses_NoValues` (OK/MISSING/FAILED all present, the
+  secret value absent from output, exit non-zero).
+- [x] **AC3** (`verify <id>` scopes; unknown id errors) — PASS:
+  `TestSecretsVerify_ScopesById`, `TestSecretsVerify_UnknownId_Errors`.
+- [x] **AC4** (suites green, vet/fmt clean, additive) — see below.
+
+## Test status
+
+- `go test ./internal/secrets/ ./internal/cmd/ -count=1` → **ok** (both). Targeted
+  `-run Verify`: all 6 cases PASS.
+- `go vet ./...` → clean. `go build ./...` → clean. `gofmt -l` on staged (LF) blobs →
+  clean for every changed file.
+- Additive only: no existing command/test changed (one new command + one new
+  `Loader.Verify` method + new test file).
+- Live smoke against the real registry deferred to the operator (it resolves real age/bw
+  secrets — needs the age key / an unlocked Bitwarden); the unit tests cover the logic
+  with fakes (the `Decryptor`/`BWReader` seams), no environment dependency.
+
+## Decisions made during implementation
+
+- **`Verify` reuses the resolver, not `EnvFor`** — so it gets identical resolution +
+  empty-value semantics as `run`, but skips materialization (the side effect lives in
+  `EnvFor`, not the resolver). No file written, value discarded → no leak.
+- **MISSING is tolerated by default** (a machine need not hold every secret); only
+  FAILED forces a non-zero exit. `--require-all` tightens MISSING into a failure for
+  callers that want full provisioning asserted.
+- **Scoping reuses `resolveOnly`** (the `--only` selector) so `verify <id>` and
+  `run --only <id>` agree on what an id/var selects; an unknown id errors there.
+- **bw errors are all FAILED** (a registry-declared bw secret absent from the vault is
+  a misconfiguration, not "absent on this machine" — only age files can be MISSING).
+
+## Promotion candidates
+
+- [ ] Lesson for `docs/lessons.md`? **no**.
+- [ ] ADR-worthy? **no** — implements ADR-028 / #612 Phase C.
+- [ ] New cross-project pattern? **no**.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved to `specs/archive/CLI-024-secrets-verify/`
+- [ ] #612 Phase C item C1 checked off; PR linked
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
## Why

The age→bw migration (#612) must be **reproducible and verifiable**: after flipping a secret to `backend: bw` you need to assert, from the CLI, that it still resolves — without printing the value or writing a file. Today there's no such check (`doctor` only verifies tool presence; `show` prints the value and is single-env; `run` needs a child). `verify` is the read-only foundation of #612 Phase C — zero write risk, exercises every backend/shape, and doubles as the idempotency/repro gate before any write command lands.

## What

`dotf secrets verify [<id>...]` resolves each selected registry secret and reports a per-var status — **never the value**:

- **OK** — resolved to a non-empty value.
- **MISSING** — genuinely absent on this machine (`ErrSecretAbsent`: age file not provisioned here). Tolerated.
- **FAILED** — a real failure (wrong age key, locked/missing Bitwarden session, empty value, item/field typo), shown with its cause.

No args → all; ids/var-names scope it (via the `--only` selector). One aligned line per var + a summary (`N ok, M missing, K failed`). Exit non-zero on any **FAILED**; `--require-all` also fails on MISSING.

A new `Loader.Verify(entry)` resolves the bytes via the backend resolver with `run`'s empty-value rejection, but **does not materialize file secrets and does not return the value** — no side effects, no leak.

## Verification

- `go test ./internal/secrets/ ./internal/cmd/` → ok. New: `TestLoader_Verify_Classification` (ok/absent/empty/error), `TestLoader_Verify_FileSecret_NotMaterialized` (no file written), `TestLoader_Verify_Bw`, `TestSecretsVerify_ReportsStatuses_NoValues` (statuses present, value absent from output, exit non-zero), `TestSecretsVerify_ScopesById`, `TestSecretsVerify_UnknownId_Errors`.
- `go vet ./...`, `go build ./...`, `gofmt` (staged LF blobs) → clean. Additive only; `registry.yaml` untouched.
- Live smoke against the real registry deferred to the operator (resolves real age/bw secrets); unit tests cover the logic via the `Decryptor`/`BWReader` seams.

Spec: `specs/CLI-024-secrets-verify`. Refs #612 (Phase C, C1). Next: `BWWriter` + idempotent registry mutation, then `set`/`migrate`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `dotf secrets verify` to check registered secrets and show per-item status without revealing secret values.
  * Added optional scoping to verify only selected secret IDs, plus support for requiring all selected secrets to be present.

* **Bug Fixes**
  * Improved handling of missing and failing secrets with clear `OK`, `MISSING`, and `FAILED` results.
  * Verification now avoids creating output files while checking file-based secrets.

* **Tests**
  * Added coverage for status reporting, scoped verification, unknown IDs, and backend-specific verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->