### PR TITLE
feat(secrets): add BWWriter (bw write seam, read-modify-write)

### DIFF
--- a/cli/internal/secrets/bw.go
+++ b/cli/internal/secrets/bw.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -94,4 +95,122 @@ func fieldFromItem(data []byte, field string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("field %q not found on item", field)
+}
+
+// BWWriter writes a field value into a Bitwarden item. The write analog of BWReader:
+// the seam that keeps the write path unit-testable with no Bitwarden vault — tests
+// inject a fake; production is BWPut (a `bw edit` shell-out).
+type BWWriter interface {
+	SetField(item, field, value string) error
+}
+
+// setItemField returns itemJSON with field set to value, preserving EVERY other key
+// of the item (read-modify-write) so a sibling field — or the item's id/type/name —
+// is never clobbered. It works on a generic map (not the narrow bwItem struct) so
+// unknown keys survive. password/username set the typed login (created if absent);
+// notes sets the note; any other name updates the matching custom field or appends a
+// new hidden one (type 1).
+func setItemField(itemJSON []byte, field, value string) ([]byte, error) {
+	var m map[string]any
+	if err := json.Unmarshal(itemJSON, &m); err != nil {
+		return nil, fmt.Errorf("parse bw item JSON: %w", err)
+	}
+	switch field {
+	case "password", "username":
+		login, _ := m["login"].(map[string]any)
+		if login == nil {
+			login = map[string]any{}
+			m["login"] = login
+		}
+		login[field] = value
+	case "notes":
+		m["notes"] = value
+	default:
+		setCustomField(m, field, value)
+	}
+	return json.Marshal(m)
+}
+
+// setCustomField updates the custom field named field in m's fields[], or appends a
+// new hidden field (type 1) when none matches — never touching the other fields.
+func setCustomField(m map[string]any, field, value string) {
+	fields, _ := m["fields"].([]any)
+	for _, f := range fields {
+		if fm, ok := f.(map[string]any); ok {
+			if name, _ := fm["name"].(string); name == field {
+				fm["value"] = value
+				return
+			}
+		}
+	}
+	m["fields"] = append(fields, map[string]any{"name": field, "value": value, "type": 1})
+}
+
+// itemID extracts the Bitwarden item id from its JSON (the handle `bw edit item`
+// needs). An item with no id is a malformed payload.
+func itemID(itemJSON []byte) (string, error) {
+	var m struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(itemJSON, &m); err != nil {
+		return "", fmt.Errorf("parse bw item JSON: %w", err)
+	}
+	if m.ID == "" {
+		return "", fmt.Errorf("bw item has no id")
+	}
+	return m.ID, nil
+}
+
+// BWPut is the production BWWriter: it updates an existing item via read-modify-write
+// (`bw get item` → setItemField → base64 → `bw edit item <id>`). Thin I/O verified by
+// a live smoke with the operator's unlocked session, not in CI (the analog of BWGet).
+// The new value reaches `bw` through stdin (base64), never a temp file. Creating an
+// absent item is deferred to `dotf secrets set` — `SetField` errors clearly when the
+// item is missing rather than risk spawning a duplicate on a locked/transient failure.
+type BWPut struct {
+	Bin string // bw binary name/path; "" → "bw"
+}
+
+// SetField sets field on item to value, preserving the item's other fields.
+func (p BWPut) SetField(item, field, value string) error {
+	cur, err := p.run(nil, "get", "item", item)
+	if err != nil {
+		return fmt.Errorf("bw get item %q (it must already exist to edit): %w", item, err)
+	}
+	id, err := itemID(cur)
+	if err != nil {
+		return err
+	}
+	updated, err := setItemField(cur, field, value)
+	if err != nil {
+		return err
+	}
+	enc := base64.StdEncoding.EncodeToString(updated)
+	if _, err := p.run(strings.NewReader(enc), "edit", "item", id); err != nil {
+		return fmt.Errorf("bw edit item %q: %w", item, err)
+	}
+	return nil
+}
+
+// run executes `bw <args...> --nointeraction` with optional stdin, returning stdout
+// or an error carrying bw's stderr.
+func (p BWPut) run(stdin *strings.Reader, args ...string) ([]byte, error) {
+	bin := p.Bin
+	if bin == "" {
+		bin = "bw"
+	}
+	cmd := exec.Command(bin, append(args, "--nointeraction")...) //nolint:gosec // args are operator-controlled registry data
+	if stdin != nil {
+		cmd.Stdin = stdin
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("%s", msg)
+	}
+	return stdout.Bytes(), nil
 }

--- a/cli/internal/secrets/bw_writer_test.go
+++ b/cli/internal/secrets/bw_writer_test.go
@@ -1,0 +1,136 @@
+package secrets
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+const writerItem = `{
+  "id": "abc-123",
+  "type": 1,
+  "name": "x-twitter",
+  "notes": "old note",
+  "login": { "username": "example-user", "password": "example-old" },
+  "fields": [
+    { "name": "api-key", "value": "old-ak", "type": 1 },
+    { "name": "client-id", "value": "cid", "type": 1 }
+  ]
+}`
+
+// readBack reads a field from a setItemField result via the read path, proving the
+// write round-trips; preserved checks the untouched keys/fields.
+func assertPreserved(t *testing.T, out []byte) {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	if m["id"] != "abc-123" || m["name"] != "x-twitter" || m["type"] != float64(1) {
+		t.Errorf("top-level keys not preserved: id=%v name=%v type=%v", m["id"], m["name"], m["type"])
+	}
+}
+
+func TestSetItemField_TypedLogin_PreservesSiblings(t *testing.T) {
+	out, err := setItemField([]byte(writerItem), "password", "example-new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, _ := fieldFromItem(out, "password"); v != "example-new" {
+		t.Errorf("password = %q, want example-new", v)
+	}
+	for _, c := range []struct{ field, want string }{
+		{"username", "example-user"}, {"notes", "old note"}, {"api-key", "old-ak"}, {"client-id", "cid"},
+	} {
+		if v, _ := fieldFromItem(out, c.field); v != c.want {
+			t.Errorf("sibling %s clobbered = %q, want %q", c.field, v, c.want)
+		}
+	}
+	assertPreserved(t, out)
+}
+
+func TestSetItemField_CreatesLoginIfAbsent(t *testing.T) {
+	const note = `{"id":"n1","type":2,"name":"secure-note","notes":"hi"}`
+	out, err := setItemField([]byte(note), "password", "example-pass")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, _ := fieldFromItem(out, "password"); v != "example-pass" {
+		t.Errorf("password = %q, want example-pass (login created)", v)
+	}
+	if v, _ := fieldFromItem(out, "notes"); v != "hi" {
+		t.Errorf("notes clobbered = %q", v)
+	}
+}
+
+func TestSetItemField_Notes(t *testing.T) {
+	out, err := setItemField([]byte(writerItem), "notes", "new note")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, _ := fieldFromItem(out, "notes"); v != "new note" {
+		t.Errorf("notes = %q, want new note", v)
+	}
+	if v, _ := fieldFromItem(out, "password"); v != "example-old" {
+		t.Errorf("login clobbered by a notes write = %q", v)
+	}
+}
+
+func TestSetItemField_CustomFieldUpdate(t *testing.T) {
+	out, err := setItemField([]byte(writerItem), "api-key", "new-ak")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, _ := fieldFromItem(out, "api-key"); v != "new-ak" {
+		t.Errorf("api-key = %q, want new-ak", v)
+	}
+	if v, _ := fieldFromItem(out, "client-id"); v != "cid" {
+		t.Errorf("sibling custom field clobbered = %q", v)
+	}
+}
+
+func TestSetItemField_CustomFieldAppend(t *testing.T) {
+	out, err := setItemField([]byte(writerItem), "bearer-token", "bt-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, _ := fieldFromItem(out, "bearer-token"); v != "bt-1" {
+		t.Errorf("appended field bearer-token = %q, want bt-1", v)
+	}
+	// the existing custom fields survive the append
+	if v, _ := fieldFromItem(out, "api-key"); v != "old-ak" {
+		t.Errorf("existing field clobbered by append = %q", v)
+	}
+}
+
+func TestSetItemField_BadJSON(t *testing.T) {
+	if _, err := setItemField([]byte("not json"), "password", "x"); err == nil {
+		t.Error("malformed item JSON must error")
+	}
+}
+
+func TestItemID(t *testing.T) {
+	if id, err := itemID([]byte(writerItem)); err != nil || id != "abc-123" {
+		t.Errorf("itemID = %q (err %v), want abc-123", id, err)
+	}
+	if _, err := itemID([]byte(`{"name":"no-id"}`)); err == nil {
+		t.Error("an item with no id must error")
+	}
+}
+
+// fakeBWWriter records writes so command tests can assert without a real vault.
+type fakeBWWriter map[string]string // "item/field" -> value
+
+func (f fakeBWWriter) SetField(item, field, value string) error {
+	f[item+"/"+field] = value
+	return nil
+}
+
+func TestBWWriter_MockRoundTrip(t *testing.T) {
+	var w BWWriter = fakeBWWriter{}
+	if err := w.SetField("it", "password", "v"); err != nil {
+		t.Fatal(err)
+	}
+	if w.(fakeBWWriter)["it/password"] != "v" {
+		t.Error("fake BWWriter did not record the write")
+	}
+}

--- a/specs/CLI-024-secrets-bw-writer/features.json
+++ b/specs/CLI-024-secrets-bw-writer/features.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "CLI-024-secrets-bw-writer-f1",
+    "behavior": "setItemField sets login/notes/custom-update/custom-append, preserving every other key and sibling field; bad JSON errors",
+    "verification": "cd cli && go test ./internal/secrets/ -run 'SetItemField' -count=1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-bw-writer-f2",
+    "behavior": "itemID extracts the id (errors when absent); a BWWriter mock round-trips through the interface",
+    "verification": "cd cli && go test ./internal/secrets/ -run 'ItemID|BWWriter' -count=1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-bw-writer-f3",
+    "behavior": "secrets suite green, vet + fmt clean, module builds (BWPut compiles)",
+    "verification": "cd cli && go test ./internal/secrets/ -count=1 && go vet ./... && go build ./... && test -z \"$(gofmt -l internal/secrets)\"",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CLI-024-secrets-bw-writer/proposal.md
+++ b/specs/CLI-024-secrets-bw-writer/proposal.md
@@ -1,0 +1,83 @@
+---
+id: "CLI-024-secrets-bw-writer"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-26"
+issue: "mlorentedev/dotfiles#612"
+tags: [spec, proposal, secrets, cli, go, bitwarden]
+template_version: "1.0"
+---
+
+# CLI-024-secrets-bw-writer
+
+## Why
+
+The age→bw migration (#612) must be fully CLI-driven — no manual Bitwarden GUI
+clicks. The read seam (`BWReader`/`BWGet`) and the registry mutation (#617
+`SetBackendBW`) already exist; the missing half of #612 C2 is the **write** seam:
+put a value into a Bitwarden item field. It must be **read-modify-write** so a sibling
+field is never clobbered — critical once a multi-field item holds several values (the
+x-twitter 7-in-1, dockerhub 2-in-1 cases). This is what `dotf secrets set` / `migrate`
+(C3/C4) will call to write the secret into Bitwarden.
+
+## What
+
+1. **`BWWriter` interface** — `SetField(item, field, value string) error`, the write
+   analog of `BWReader`. Mock-testable; the command layer injects a fake (no real
+   Bitwarden in CI), exactly like `BWReader`/`bwReader`.
+2. **`setItemField(itemJSON, field, value)` — pure read-modify-write.** Returns the
+   item JSON with `field` set to `value`, **preserving every other key of the item**
+   (id, type, name, folderId, other fields…): `password`/`username` set the typed
+   login (created if the item has none); `notes` sets the note; any other name updates
+   the matching custom field or appends a new hidden one. This is the testable core,
+   unit-tested with no bw.
+3. **`BWPut` — the production `BWWriter`** (shell-out, the analog of `BWGet`): fetch
+   the item (`bw get item`), `setItemField`, base64-encode in Go, `bw edit item <id>`.
+   Thin I/O, `--nointeraction`, verified by a live smoke with the operator's session —
+   not CI (same coverage shape as `BWGet`/`AgeDecrypt`).
+
+Scope: **update an existing item.** Creating an absent item is deferred to `set`
+(C3) — distinguishing "item not found" from "vault locked" needs care, and creating on
+the wrong signal would spawn duplicate items; `SetField` therefore errors clearly when
+the item is absent, and the create path lands with the command that can prompt/confirm.
+
+## Out of scope
+
+- Creating a brand-new item (`set --create` / `EnsureItem`) — #612 C3.
+- The `set`/`migrate`/`rotate` commands that consume this seam — #612 C3/C4/C7.
+- `bw serve` write path (perf) — behind the same seam later.
+
+## Risks / open questions
+
+- **Read-modify-write preserves the whole item.** `setItemField` works on a generic
+  `map[string]any`, not the narrow `bwItem` struct, so unknown keys (id, type, name,
+  reprompt, …) survive the round-trip. Tested explicitly (assert an unrelated key is
+  unchanged + a sibling field is untouched).
+- **No accidental create.** `SetField` only edits; a missing item is a clear error, not
+  a silent create — the create-vs-locked ambiguity is handled by the command (C3).
+- **No plaintext to disk.** The value lives in memory + is passed to `bw` via stdin
+  (base64); never written to a temp file.
+- **Live-only verification of `BWPut`.** The shell orchestration is verified by a smoke
+  against the operator's unlocked vault (the canary, #612 C8); CI tests `setItemField`.
+
+## Acceptance criteria
+
+- [ ] **AC1** — `setItemField` sets a typed login field (creating `login` if absent),
+  a note, an existing custom field, and appends a new custom field — each preserving
+  all other item keys and sibling fields. *Verify:* table-driven Go test (assert the
+  target changed, an unrelated key + a sibling field unchanged, valid JSON out).
+- [ ] **AC2** — `setItemField` errors on malformed JSON; a `BWWriter` mock round-trips
+  through the interface. *Verify:* Go test.
+- [ ] **AC3** — `BWPut` is wired (compiles, update path: get→setItemField→encode→edit;
+  absent item → clear error). *Verify:* build + the structural shape; live smoke
+  deferred (documented).
+- [ ] **AC4** — `go test ./internal/secrets && go vet && gofmt && go build` clean;
+  additive (no existing behaviour changed).
+
+## References
+
+- Issue / backlog: `mlorentedev/dotfiles#612` (Phase C, C2 — write half).
+- Mirrors: `cli/internal/secrets/bw.go` (`BWReader`/`BWGet`/`fieldFromItem` — the read
+  seam this parallels).
+- Composes with: #617 `SetBackendBW` (registry mutation) — `migrate` (C4) calls both.
+- ADR: `docs/adr/adr-028-secrets-two-tier-bitwarden-age.md`.

--- a/specs/CLI-024-secrets-bw-writer/tasks.md
+++ b/specs/CLI-024-secrets-bw-writer/tasks.md
@@ -1,0 +1,33 @@
+---
+tags: [spec, tasks, secrets, cli, go, bitwarden]
+created: "2026-06-26"
+---
+
+# Tasks - CLI-024-secrets-bw-writer
+
+> TDD order. One task = one focused commit.
+
+## Setup
+
+- [x] Branch from main: `feat/secrets-bw-writer`
+- [x] `proposal.md` complete; acceptance criteria testable
+
+## Implementation
+
+- [x] `BWWriter` interface (`SetField`), the write analog of `BWReader`.
+- [x] `setItemField(itemJSON, field, value)` — pure read-modify-write over a generic
+  map: typed login (created if absent), notes, custom field update/append; preserves
+  every other key. `itemID` + `setCustomField` helpers.
+- [x] `BWPut` production writer (shell-out: `bw get item` → setItemField → base64 →
+  `bw edit item <id>`; absent item → clear error; value via stdin, never a temp file).
+- [x] Tests: `TestSetItemField_*` (typed login + siblings, login-created, notes,
+  custom update, custom append, bad JSON), `TestItemID`, `TestBWWriter_MockRoundTrip`.
+
+## Closing
+
+- [x] Every AC covered by ≥1 test (BWPut shell-out is live-smoke, like BWGet)
+- [x] `features.json` carries non-vacuous verification commands
+- [x] `go test ./internal/secrets` green; `go vet` + `gofmt` clean; `go build ./...` ok
+- [x] Additive (no existing behaviour changed); `registry.yaml` untouched
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec + #612 C2

--- a/specs/CLI-024-secrets-bw-writer/verification.md
+++ b/specs/CLI-024-secrets-bw-writer/verification.md
@@ -1,0 +1,56 @@
+---
+tags: [spec, verification, secrets, cli, go, bitwarden]
+created: "2026-06-26"
+---
+
+# Verification - CLI-024-secrets-bw-writer
+
+## Evidence
+
+- [x] **AC1** (`setItemField` sets each shape, preserves siblings + other keys) — PASS:
+  `TestSetItemField_TypedLogin_PreservesSiblings` (password set; username/notes/api-key/
+  client-id untouched; id/name/type preserved), `_CreatesLoginIfAbsent`, `_Notes`,
+  `_CustomFieldUpdate`, `_CustomFieldAppend`.
+- [x] **AC2** (bad JSON errors; mock round-trips) — PASS: `TestSetItemField_BadJSON`,
+  `TestItemID`, `TestBWWriter_MockRoundTrip`.
+- [x] **AC3** (`BWPut` wired, update path, absent→clear error) — compiles + `go build`;
+  shell orchestration (`bw get`→setItemField→base64→`bw edit`) verified by live smoke
+  with the operator's unlocked vault (deferred, documented — same as `BWGet`).
+- [x] **AC4** — see below.
+
+## Test status
+
+- `go test ./internal/secrets/ -count=1` → **ok**. Targeted `setItemField`/`ItemID`/
+  `BWWriter`: 8 tests PASS.
+- `go vet ./...` → clean. `go build ./...` → clean. `gofmt -l` on staged (LF) blobs →
+  clean.
+- Additive only: extended `bw.go` (the read seam's file) with the write seam + a new
+  test file; nothing else changed; no command wired; `registry.yaml` untouched.
+
+## Decisions made during implementation
+
+- **`setItemField` works on `map[string]any`, not the narrow `bwItem` struct** — so the
+  item's other keys (id, type, name, folderId, reprompt, …) and sibling fields survive
+  the read-modify-write. A struct round-trip would silently drop unknown keys; tested
+  that `id`/`name`/`type` + every sibling field are unchanged.
+- **Update-only, no accidental create.** `SetField` edits an existing item and errors
+  clearly when it is absent — distinguishing "not found" from "vault locked" needs care,
+  and creating on the wrong signal would spawn a duplicate. The create path lands with
+  `dotf secrets set` (C3), which can prompt/confirm.
+- **No plaintext to disk.** The modified item reaches `bw` as base64 over **stdin**,
+  never a temp file.
+- **base64 in Go, not `bw encode`** — one fewer shell hop; the payload is just base64.
+
+## Promotion candidates
+
+- [ ] Lesson for `docs/lessons.md`? **no** (the read-modify-write / preserve-unknown-keys
+  point is a standard JSON-patch practice).
+- [ ] ADR-worthy? **no** — implements #612 / ADR-028.
+- [ ] New cross-project pattern? **no**.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved to `specs/archive/CLI-024-secrets-bw-writer/`
+- [ ] #612 Phase C item C2 (write half) checked off; PR linked
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
## Why

The age→bw migration (#612) must be fully CLI-driven — no manual Bitwarden clicks. The read seam (`BWReader`/`BWGet`) and the registry mutation (#617 `SetBackendBW`) exist; this is the missing **write** half of #612 C2: put a value into a Bitwarden item field. It must be **read-modify-write** so a sibling field is never clobbered — vital once a multi-field item holds several values (x-twitter 7-in-1, dockerhub 2-in-1).

## What

- **`BWWriter` interface** — `SetField(item, field, value)`, the write analog of `BWReader`; mock-testable.
- **`setItemField(itemJSON, field, value)` — pure read-modify-write**, the testable core. Sets the typed login (`password`/`username`, creating `login` if absent), the `notes`, or a custom field (update existing / append a new hidden one), **preserving every other key of the item** (id, type, name, sibling fields) by working over a generic `map[string]any` so unknown keys survive.
- **`BWPut` — the production writer** (shell-out, analog of `BWGet`): `bw get item` → `setItemField` → base64 → `bw edit item <id>`. Thin I/O, value via **stdin** (no temp file), verified by a live smoke with the operator's session (not CI).

**Update-only by design:** `SetField` errors clearly when the item is absent rather than risk spawning a duplicate on a locked/transient failure; the create path lands with `dotf secrets set` (C3), which can prompt/confirm.

## Verification

- `go test ./internal/secrets/` → ok. 8 tests: `setItemField` (typed login + siblings preserved, login-created, notes, custom update, custom append, bad JSON), `itemID`, `BWWriter` mock round-trip. The "preserves other keys" test asserts `id`/`name`/`type` + every sibling field are unchanged.
- `go vet`, `go build ./...`, `gofmt` (staged LF blobs) → clean. Additive; `registry.yaml` untouched; no command wired.

Spec: `specs/CLI-024-secrets-bw-writer`. Refs #612 (Phase C, C2 — write half). Composes with #617 `SetBackendBW`; `migrate` (C4) calls both. Next: `dotf secrets set` (C3) wires both + the create path, then an early live smoke against a throwaway canary.