### PR TITLE
feat(secrets): reorganize registry — one entry per env var + bw: targets

### DIFF
--- a/docs/adr/adr-028-secrets-two-tier-bitwarden-age.md
+++ b/docs/adr/adr-028-secrets-two-tier-bitwarden-age.md
@@ -196,3 +196,58 @@ The registry is generated/seeded from `docs/secrets-inventory.md` and is the sin
 - `docs/secrets-inventory.md` (the 3-source inventory + critical actions).
 - Bitwarden CLI docs (studied 2026-06-25): `bw serve` for the facade; `bw export` is plaintext (→ `age -e`); full headless still needs the master password (the floor).
 - Tickets: #378, #493, #321, #518, #257, #454, #577.
+
+## Addendum (2026-06-26): bw mapping convention — ratified + reconciled with the implementation
+
+The `dotf secrets` lifecycle build-out (#612, the `set`/`migrate` work) exercised §6 and
+surfaced points to ratify and reconcile against the shipped code.
+
+### Item granularity — one item per *credential* (A1 base, A2 selective)
+
+Ratifies the §6 "Field-vs-item rule" as the operative model:
+
+- **A multi-part single credential → ONE item + named fields.** The X OAuth app (7
+  values, rotated together) is `x-twitter-api` with 7 kebab fields; a login pair
+  (DockerHub) is one item with typed `username` + `password`.
+- **Different-purpose credentials → SEPARATE items**, because they rotate / revoke /
+  are consumed independently (least-privilege). The GitHub tokens split per purpose
+  (`github-cli-pat`, `github-release-pat`, `github-bitacora-pat`) — #321.
+
+"Group by service" never overrides "separate by credential": same OAuth app groups,
+different-scope tokens split.
+
+### Value placement — named fields by default
+
+Refines §6's `field: null → password`. Prefer a **named custom field** (`api-key`,
+`api-token`, `auth-key`) even for a single-credential item — self-documenting and
+uniform with multi-field items. Reserve typed `username`/`password` for genuine login
+pairs (DockerHub); `notes` for multi-line blobs (kubeconfig, backup codes). SSH keys
+use `notes`/custom fields for now — the native SSH Key item type (5) needs a
+`fieldFromItem` reader extension (tracked follow-up), so it is **not** used yet.
+
+### The registry `bw:` block is the SSOT — declared up-front, read not guessed
+
+`set` and `migrate` resolve the Bitwarden target **only** from the entry's `bw: {item,
+field}` block. A secret declares its `bw:` target **at rewrite time, while still
+`backend: age`**, so the value can be written to bw and parity-checked before the
+backend flip. `migrate` never derives `item`/`field` from the `id`; a missing `bw:`
+block is an error (`--item`/`--field` exist only as a one-off override). At cutover,
+`SetBackendBW` flips `backend: age → bw` and re-emits the already-declared target.
+
+### Schema reconciliation — `folder` is not part of the mapping
+
+The shipped `BWSource` is `{ item, field }` — **no `folder` key** (the §"Registry
+schema" example showed one). Bitwarden resolves an item by **name or id**; the folder is
+organizational metadata, not a lookup key. Items are organized under
+`Dotfiles/{apps,infra,personal,floor}` separately (matching `plane`) — and the taxonomy
+gains **`Dotfiles/personal`** for the personal-plane recovery codes / app-passwords the
+registry manages (§"folder taxonomy" listed only apps/infra/floor). The implemented
+`expose.env` accepts scalar / list / `{age|field}`-map forms, matching §6's intent.
+
+### Floor stays age-only
+
+Floor secrets (`ssh-id-ed25519`, the age keys) carry **no `bw:` block** and are never
+migrated — they are needed before Bitwarden is reachable (circular dependency, §4).
+
+Implementation: `specs/CLI-024-secrets-set` (write primitive), `specs/CLI-024-secrets-migrate`
+(cutover). A draft A1 registry rewrite seeds the per-entry `bw:` targets.

--- a/docs/adr/adr-028-secrets-two-tier-bitwarden-age.md
+++ b/docs/adr/adr-028-secrets-two-tier-bitwarden-age.md
@@ -234,6 +234,17 @@ backend flip. `migrate` never derives `item`/`field` from the `id`; a missing `b
 block is an error (`--item`/`--field` exist only as a one-off override). At cutover,
 `SetBackendBW` flips `backend: age → bw` and re-emits the already-declared target.
 
+### Registry identity — the `id` is the env var; the `item` groups and is mutable
+
+One registry entry per **env var**, and the `id` **is** that env var name — the stable
+consumer contract apps depend on (`OPENAI_API_KEY`, `X_BEARER_TOKEN`). The Bitwarden
+`bw.item` is a **mutable pointer**: it GROUPS related vars (the 7 `X_*` entries share
+`item: x-twitter-api`, distinct `field`s) and can be renamed by editing only that line —
+consumers never reference it. A consequence: every entry is single-var, so
+`SetBackendBW`/`migrate` apply uniformly with **no multi-field special case** (the
+former M3/M6 blocker dissolves). Global env-var uniqueness falls out for free, since the
+`id` is the var and ids are unique (closes the B1 audit gap at the schema level).
+
 ### Schema reconciliation — `folder` is not part of the mapping
 
 The shipped `BWSource` is `{ item, field }` — **no `folder` key** (the §"Registry

--- a/secrets/registry.yaml
+++ b/secrets/registry.yaml
@@ -1,12 +1,17 @@
-# secrets/registry.yaml — the mapping SSOT (ADR-028 §2).
+# secrets/registry.yaml — the mapping SSOT (ADR-028 §2 + the 2026-06-26 addendum).
 #
-# Ties each logical secret (stable kebab `id`) to its store source, the env/file
-# it exposes, its consumers, and its rotation cadence. `dotf secrets {run,show,ls}`
-# read this file. Seeded from docs/secrets-inventory.md + sensitive/env-mapping.conf.
-#
-# backend: age (current reality) | age-offline (floor: offline-rooted) | bw (target,
-# resolved in ADR-028 Phase 3 once items migrate). `age:` is the base name under
-# sensitive/ without the .secret.age suffix.
+# ONE entry per env var. The `id` IS the env var name — the stable consumer contract
+# apps depend on. `dotf secrets {run,show,ls,set,migrate}` resolve by it.
+#   - backend: age (current) | age-offline (floor) | bw (target, ADR-028 Phase 3).
+#     `age:` is the base name under sensitive/ without the .secret.age suffix.
+#   - `bw: {item, field}` is the Bitwarden target (model A1). The `item` GROUPS related
+#     vars (the 7 X_* vars share `x-twitter-api`) and is a MUTABLE pointer — rename the
+#     Bitwarden item and only this line changes; consumers depend on the env var, never
+#     the item name. `field` is the named purpose (api-key, auth-token; notes for
+#     multi-line; username/password for a login pair).
+#   - `bw:` is declared up front but dormant while backend is age (validated once
+#     flipped). `migrate <VAR>` writes the age value to the target, parity-checks, then
+#     flips backend. floor secrets carry NO `bw:` (never live only in bw).
 #
 # This supersedes env-mapping.conf as the SSOT; env-mapping.conf remains only until
 # the load-secrets twins that still read it are deleted (#493 PR-C).
@@ -14,202 +19,297 @@
 version: 1
 secrets:
   # ── apps: service API keys/tokens the projects consume ────────────────────
-  - id: github-token            # one age file, two consumer names (#321 splits per-purpose in Phase 4)
+
+  # GitHub — github.token feeds two PURPOSES → split per-purpose (#321). Both entries
+  # read the SAME age file today; the real split issues DISTINCT tokens, so it needs C9
+  # `migrate --split` — plain `migrate` MUST refuse an entry sharing an age source.
+  - id: GITHUB_PERSONAL_ACCESS_TOKEN   # TODO C9: distinct token (shares github.token)
     plane: app
     backend: age
     age: github.token
-    expose: { env: [GITHUB_PERSONAL_ACCESS_TOKEN, RELEASE_TOKEN] }
-    consumers: [local, "ci:release"]
+    bw: { item: github-cli-pat, field: api-token }
+    expose: { env: GITHUB_PERSONAL_ACCESS_TOKEN }
+    consumers: [local]
     rotate: 90d
 
-  - id: github-bitacora-pat
+  - id: RELEASE_TOKEN                  # TODO C9: distinct token (shares github.token)
+    plane: app
+    backend: age
+    age: github.token
+    bw: { item: github-release-pat, field: api-token }
+    expose: { env: RELEASE_TOKEN }
+    consumers: ["ci:release"]
+    rotate: 90d
+
+  - id: BITACORA_PAT
     plane: app
     backend: age
     age: github.bitacora
+    bw: { item: github-bitacora-pat, field: api-token }
     expose: { env: BITACORA_PAT }
     consumers: ["ci:bitacora"]
     rotate: 90d
 
-  - id: dockerhub-token         # token + username collapse into one item (inventory)
+  # DockerHub — login pair, one bw item: token→password, username→username.
+  - id: DOCKERHUB_TOKEN
     plane: app
     backend: age
-    expose:
-      env:
-        DOCKERHUB_TOKEN:    { age: dockerhub.token }
-        DOCKERHUB_USERNAME: { age: dockerhub.username }
+    age: dockerhub.token
+    bw: { item: dockerhub, field: password }
+    expose: { env: DOCKERHUB_TOKEN }
     consumers: ["ci:image-push"]
     rotate: 180d
 
-  - id: openai-api-key          # naming drift: store says "chatgpt", service is OpenAI
+  - id: DOCKERHUB_USERNAME            # identifier, not a rotating secret
+    plane: app
+    backend: age
+    age: dockerhub.username
+    bw: { item: dockerhub, field: username }
+    expose: { env: DOCKERHUB_USERNAME }
+    consumers: ["ci:image-push"]
+
+  - id: OPENAI_API_KEY               # naming drift: store says "chatgpt", service is OpenAI
     plane: app
     backend: age
     age: chatgpt.api-key
+    bw: { item: openai-api-key, field: api-key }
     expose: { env: OPENAI_API_KEY }
     consumers: [local, "ci:yt-metrics"]
     rotate: 90d
 
-  - id: openrouter-api-key      # naming drift: double-dot .api.key
+  - id: OPENROUTER_API_KEY           # naming drift: double-dot .api.key
     plane: app
     backend: age
     age: openrouter.api.key
+    bw: { item: openrouter-api-key, field: api-key }
     expose: { env: OPENROUTER_API_KEY }
     consumers: ["agent:opencode"]
     rotate: 90d
 
-  - id: nan-api-key
+  - id: NAN_API_KEY
     plane: app
     backend: age
     age: nan.api-key
+    bw: { item: nan-api-key, field: api-key }
     expose: { env: NAN_API_KEY }
     consumers: ["agent:opencode", "agent:pi"]
     rotate: 90d
 
-  - id: pollex-api-key
+  - id: POLLEX_API_KEY
     plane: app
     backend: age
     age: pollex.api-key
+    bw: { item: pollex-api-key, field: api-key }
     expose: { env: POLLEX_API_KEY }
     consumers: ["agent:pollex"]
     rotate: 90d
 
-  - id: stripe-api-key
+  - id: STRIPE_API_KEY
     plane: app
     backend: age
     age: stripe.api-key
+    bw: { item: stripe-api-key, field: api-key }
     expose: { env: STRIPE_API_KEY }
     consumers: ["ci:payments"]
     rotate: 180d
 
-  - id: youtube-api-key
+  - id: YOUTUBE_API_KEY
     plane: app
     backend: age
     age: youtube.api-key
+    bw: { item: youtube-api-key, field: api-key }
     expose: { env: YOUTUBE_API_KEY }
     consumers: ["ci:yt-metrics"]
     rotate: 180d
 
-  - id: beehiiv-api-key
+  - id: BEEHIIV_API_KEY
     plane: app
     backend: age
     age: beehiiv.api-key
+    bw: { item: beehiiv-api-key, field: api-key }
     expose: { env: BEEHIIV_API_KEY }
     consumers: ["ci:newsletter"]
     rotate: 180d
 
-  - id: beehiiv-dns-records     # reference data, not a key
+  - id: BEEHIIV_DNS_RECORDS          # reference data, not a key → Secure Note
     plane: app
     backend: age
     age: beehiiv.dns-records
+    bw: { item: beehiiv-dns-records, field: notes }
     expose: { env: BEEHIIV_DNS_RECORDS }
     consumers: [local]
 
-  - id: pypi-token
+  - id: PYPI_TOKEN
     plane: app
     backend: age
     age: pypi.token
+    bw: { item: pypi-token, field: api-token }
     expose: { env: PYPI_TOKEN }
     consumers: ["ci:publish"]
     rotate: 180d
 
-  - id: x-twitter               # 7 age files today; collapses to 1 bw item w/ fields in Phase 4
+  # X/Twitter — one OAuth credential, 7 vars sharing the bw item `x-twitter-api`.
+  # Each var migrates independently (no multi-field special case).
+  - id: X_API_KEY
     plane: app
     backend: age
-    expose:
-      env:
-        X_API_KEY:             { age: x.api-key }
-        X_API_KEY_SECRET:      { age: x.api-key-secret }
-        X_ACCESS_TOKEN:        { age: x.access-token }
-        X_ACCESS_TOKEN_SECRET: { age: x.access-token-secret }
-        X_BEARER_TOKEN:        { age: x.bearer-token }
-        X_CLIENT_ID:           { age: x.client-id }
-        X_CLIENT_SECRET:       { age: x.client-secret }
+    age: x.api-key
+    bw: { item: x-twitter-api, field: api-key }
+    expose: { env: X_API_KEY }
+    consumers: ["ci:social"]
+    rotate: 180d
+
+  - id: X_API_KEY_SECRET
+    plane: app
+    backend: age
+    age: x.api-key-secret
+    bw: { item: x-twitter-api, field: api-key-secret }
+    expose: { env: X_API_KEY_SECRET }
+    consumers: ["ci:social"]
+    rotate: 180d
+
+  - id: X_ACCESS_TOKEN
+    plane: app
+    backend: age
+    age: x.access-token
+    bw: { item: x-twitter-api, field: access-token }
+    expose: { env: X_ACCESS_TOKEN }
+    consumers: ["ci:social"]
+    rotate: 180d
+
+  - id: X_ACCESS_TOKEN_SECRET
+    plane: app
+    backend: age
+    age: x.access-token-secret
+    bw: { item: x-twitter-api, field: access-token-secret }
+    expose: { env: X_ACCESS_TOKEN_SECRET }
+    consumers: ["ci:social"]
+    rotate: 180d
+
+  - id: X_BEARER_TOKEN
+    plane: app
+    backend: age
+    age: x.bearer-token
+    bw: { item: x-twitter-api, field: bearer-token }
+    expose: { env: X_BEARER_TOKEN }
+    consumers: ["ci:social"]
+    rotate: 180d
+
+  - id: X_CLIENT_ID
+    plane: app
+    backend: age
+    age: x.client-id
+    bw: { item: x-twitter-api, field: client-id }
+    expose: { env: X_CLIENT_ID }
+    consumers: ["ci:social"]
+    rotate: 180d
+
+  - id: X_CLIENT_SECRET
+    plane: app
+    backend: age
+    age: x.client-secret
+    bw: { item: x-twitter-api, field: client-secret }
+    expose: { env: X_CLIENT_SECRET }
     consumers: ["ci:social"]
     rotate: 180d
 
   # ── infra: infrastructure access ─────────────────────────────────────────
-  - id: cloudflare-api-token
+  - id: CLOUDFLARE_API_TOKEN
     plane: infra
     backend: age
     age: cloudflare.api-token
+    bw: { item: cloudflare-api-token, field: api-token }
     expose: { env: CLOUDFLARE_API_TOKEN }
     consumers: ["ci:dns", local]
     rotate: 180d
 
-  - id: hetzner-api-token
+  - id: HETZNER_API_TOKEN
     plane: infra
     backend: age
     age: hetzner.api-key
+    bw: { item: hetzner-api-token, field: api-token }
     expose: { env: HETZNER_API_TOKEN }
     consumers: [local]
     rotate: 180d
 
-  - id: hetzner-ssh
-    plane: infra
+  - id: HETZNER_SSH_KEY              # TODO: native SSH Key item type (5) needs a
+    plane: infra                     #       fieldFromItem reader extension; notes for now
     backend: age
     age: hetzner.ssh
+    bw: { item: hetzner-ssh, field: notes }
     expose: { env: HETZNER_SSH_KEY }
     consumers: [local]
 
-  - id: tailscale-auth-key      # short-lived by nature
+  - id: TS_AUTHKEY                   # short-lived by nature
     plane: infra
     backend: age
     age: tailscale.auth-key
+    bw: { item: tailscale-auth-key, field: auth-key }
     expose: { env: TS_AUTHKEY }
     consumers: [local, "ci:vpn"]
     rotate: 90d
 
-  - id: kubelab-kubeconfig
+  - id: KUBECONFIG                   # multi-line kubeconfig → Secure Note; file expose
     plane: infra
     backend: age
     age: kubelab.kubeconfig
+    bw: { item: kubelab-kubeconfig, field: notes }
     expose: { file: { var: KUBECONFIG, path: "~/.kube/kubelab.config", mode: "0600" } }
     consumers: [local]
 
-  # ── personal: recovery/backup codes, app passwords ───────────────────────
-  - id: zoho-app-passwords
+  # ── personal: recovery/backup codes, app passwords (Dotfiles/personal) ────
+  - id: ZOHO_APP_PASSWORDS           # shares the `zoho` item with ZOHO_RECOVERY_CODE
     plane: personal
     backend: age
     age: zoho.app-passwords
+    bw: { item: zoho, field: app-passwords }
     expose: { env: ZOHO_APP_PASSWORDS }
     consumers: [local]
 
-  - id: gmail-backup-code
-    plane: personal
-    backend: age
-    age: gmail.backup-code
-    expose: { file: { var: GMAIL_BACKUP_CODE, path: "~/.secrets/gmail-backup-code.txt", mode: "0600" } }
-    consumers: [local]
-
-  - id: chatgpt-backup-code
-    plane: personal
-    backend: age
-    age: chatgpt.backup-code
-    expose: { file: { var: CHATGPT_BACKUP_CODE, path: "~/.secrets/chatgpt-backup-code.txt", mode: "0600" } }
-    consumers: [local]
-
-  - id: chatgpt-recovery-code
-    plane: personal
-    backend: age
-    age: chatgpt.recovery-code
-    expose: { file: { var: CHATGPT_RECOVERY_CODE, path: "~/.secrets/chatgpt-recovery-code.txt", mode: "0600" } }
-    consumers: [local]
-
-  - id: stripe-backup-code
-    plane: personal
-    backend: age
-    age: stripe.backup-code
-    expose: { file: { var: STRIPE_BACKUP_CODE, path: "~/.secrets/stripe-backup-code.txt", mode: "0600" } }
-    consumers: [local]
-
-  - id: zoho-recovery-code
+  - id: ZOHO_RECOVERY_CODE           # shares the `zoho` item with ZOHO_APP_PASSWORDS
     plane: personal
     backend: age
     age: zoho.recovery-code
+    bw: { item: zoho, field: recovery-code }
     expose: { file: { var: ZOHO_RECOVERY_CODE, path: "~/.secrets/zoho-recovery-code.txt", mode: "0600" } }
     consumers: [local]
 
-  # ── floor: offline-rooted boot/DR roots ──────────────────────────────────
-  - id: ssh-id-ed25519          # boot dependency: needed before bw is reachable
+  - id: GMAIL_BACKUP_CODE
+    plane: personal
+    backend: age
+    age: gmail.backup-code
+    bw: { item: gmail-backup-code, field: notes }
+    expose: { file: { var: GMAIL_BACKUP_CODE, path: "~/.secrets/gmail-backup-code.txt", mode: "0600" } }
+    consumers: [local]
+
+  # The two ChatGPT account codes share `openai-account` — the OpenAI ACCOUNT
+  # (recovery), distinct from `openai-api-key` (the API credential).
+  - id: CHATGPT_BACKUP_CODE
+    plane: personal
+    backend: age
+    age: chatgpt.backup-code
+    bw: { item: openai-account, field: backup-code }
+    expose: { file: { var: CHATGPT_BACKUP_CODE, path: "~/.secrets/chatgpt-backup-code.txt", mode: "0600" } }
+    consumers: [local]
+
+  - id: CHATGPT_RECOVERY_CODE
+    plane: personal
+    backend: age
+    age: chatgpt.recovery-code
+    bw: { item: openai-account, field: recovery-code }
+    expose: { file: { var: CHATGPT_RECOVERY_CODE, path: "~/.secrets/chatgpt-recovery-code.txt", mode: "0600" } }
+    consumers: [local]
+
+  - id: STRIPE_BACKUP_CODE           # GROUP?: own item, or a field on stripe-api-key's item
+    plane: personal
+    backend: age
+    age: stripe.backup-code
+    bw: { item: stripe-backup-code, field: notes }
+    expose: { file: { var: STRIPE_BACKUP_CODE, path: "~/.secrets/stripe-backup-code.txt", mode: "0600" } }
+    consumers: [local]
+
+  # ── floor: offline-rooted boot/DR roots — NEVER migrated (no bw: block) ────
+  - id: SSH_KEY                      # boot dependency: needed before bw is reachable
     plane: floor
     backend: age-offline
     age: id_ed25519


### PR DESCRIPTION
## What

Reorganize `secrets/registry.yaml` to the A1 model and declare each secret's Bitwarden
target up front, plus an ADR-028 addendum documenting the convention. Prep for the
age→bw migration (#612); **no migration happens here** — `backend` stays `age`, so
resolution is unchanged.

## Model

- **One entry per env var; the `id` IS the env var name** — the stable consumer contract
  apps depend on (`OPENAI_API_KEY`, `X_BEARER_TOKEN`).
- **`bw.item` is a mutable pointer** that GROUPS related vars (the 7 `X_*` entries share
  `item: x-twitter-api`, distinct `field`s) and can be renamed without touching
  consumers. `field` is the named purpose (`api-key`, `auth-key`; `notes` for multi-line;
  `username`/`password` for the DockerHub login pair).
- **`bw:` is declared while `backend: age`** (dormant until `migrate` flips it).
- **floor** (`SSH_KEY`) carries no `bw:` — never lives only in bw.

## Why it's safe (additive)

- `backend` stays `age` for every entry → `run`/`show`/`render`/`verify` resolve exactly
  as before. Validated: `DOTFILES_DIR=<worktree> dotf secrets ls` parses all 33 entries.
- Env var names (the consumer contract) are unchanged; only the registry `id` handle
  changes (kebab → the env var). `--only <id>` now takes env-var-style ids.

## Consequences

- Every entry is single-var → `SetBackendBW`/`migrate` apply uniformly, **no multi-field
  special case** (the former M3/M6 blocker dissolves).
- Global env-var uniqueness is now structural (id == var, ids unique) — closes the B1
  audit gap at the schema level.
- `github.token` (one file, two purposes) is split per #321 into `github-cli-pat` +
  `github-release-pat`; both still read `github.token` today, so the real split needs C9
  `migrate --split` (marked TODO; plain `migrate` must refuse a shared age source).

## Open decisions (marked in-file, resolve in review)

- `STRIPE_BACKUP_CODE`: own `stripe-backup-code` item, or a field on the Stripe item?
- `HETZNER_SSH_KEY`: `notes` for now; native SSH Key item type needs a `fieldFromItem`
  reader extension (follow-up).
- `ZOHO_*` share one `zoho` item; the two `CHATGPT_*` codes share `openai-account`.

## Notes

- Convention is documented in the ADR-028 addendum included here.
- If spec-gate flags this (it counts YAML lines), it is a config/data rewrite whose
  design lives in the ADR-028 addendum + `specs/CLI-024-secrets-migrate` — label
  `skip-sdd` with that rationale.

Refs #612.

## SDD skip rationale

Config/data rewrite — no production logic changes (every `backend` stays `age`,
resolution validated unchanged via `dotf secrets ls`). The design this materializes is
specified in the ADR-028 addendum included in this PR and in `specs/CLI-024-secrets-migrate`.

<!-- spec-gate: re-evaluate with skip-sdd label + rationale -->
