### PR TITLE
fix(mem): resolve a real bash, not the System32 WSL launcher, for vault-health

### DIFF
--- a/cli/internal/mem/session_start.go
+++ b/cli/internal/mem/session_start.go
@@ -116,7 +116,8 @@ func vaultHealth(vaultRoot, vaultName, scriptsDir string) string {
 	// `bash <script>` (no `-c`): the script path is a trusted env-contract location,
 	// not user input, and is passed as an argv element, so there is no shell-metachar
 	// injection surface. This is the faithful port of the shell's `bash "$vault_health"`.
-	cmd := exec.Command("bash", script)
+	// resolveBash, not a bare "bash", so Windows does not pick System32's WSL launcher.
+	cmd := exec.Command(resolveBash(), script)
 	cmd.Env = append(os.Environ(), "VAULT_DIR="+vaultRoot, "VAULT_NAME="+vaultName)
 	out, err := cmd.CombinedOutput()
 	healthExit := 0
@@ -294,4 +295,42 @@ func isExecutable(path string) bool {
 		return true
 	}
 	return info.Mode()&0o111 != 0
+}
+
+// resolveBash returns the bash interpreter used to run vault-health.sh. It deliberately
+// avoids Windows' System32\bash.exe — that path is the WSL launcher, which is a broken
+// stub when no distro is installed (it fails with "execvpe(/bin/bash) failed") and, even
+// when WSL works, cannot read a Windows-path script argument (WSL sees /mnt/c/...).
+// dotfiles installs Git Bash; that is the interpreter that can run a Windows-path script.
+//
+// Resolution order: $DOTF_BASH (explicit override) → the first bash on PATH that is not
+// the System32 WSL launcher → a bare "bash" fallback (PATH resolution — Linux/macOS have
+// no System32 ambiguity, so this matches the previous behaviour there).
+func resolveBash() string {
+	if b := os.Getenv("DOTF_BASH"); b != "" {
+		return b
+	}
+	exe := "bash"
+	if runtime.GOOS == "windows" {
+		exe = "bash.exe"
+	}
+	var wslLauncher string // lower-cased System32\bash.exe to skip; empty off Windows
+	if runtime.GOOS == "windows" {
+		if root := os.Getenv("SystemRoot"); root != "" {
+			wslLauncher = strings.ToLower(filepath.Join(root, "System32", exe))
+		}
+	}
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			continue
+		}
+		cand := filepath.Join(dir, exe)
+		if wslLauncher != "" && strings.ToLower(cand) == wslLauncher {
+			continue // the WSL launcher cannot run a Windows-path script
+		}
+		if isExecutable(cand) {
+			return cand
+		}
+	}
+	return "bash"
 }

--- a/cli/internal/mem/session_start_test.go
+++ b/cli/internal/mem/session_start_test.go
@@ -2,8 +2,8 @@ package mem
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -135,8 +135,10 @@ func TestVaultHealth(t *testing.T) {
 	})
 
 	t.Run("reports ALL CHECKS PASSED on a clean stub", func(t *testing.T) {
-		if _, err := exec.LookPath("bash"); err != nil {
-			t.Skip("bash required to run vault-health.sh stub")
+		// Gate on the interpreter vaultHealth actually uses (resolveBash), not a bare
+		// LookPath — on Windows that would find the System32 WSL launcher and not skip.
+		if !isExecutable(resolveBash()) {
+			t.Skip("a real bash is required to run the vault-health.sh stub")
 		}
 		sd := t.TempDir()
 		stub := filepath.Join(sd, "vault-health.sh")
@@ -147,6 +149,37 @@ func TestVaultHealth(t *testing.T) {
 		want := "\nVault health: ALL CHECKS PASSED"
 		if got := vaultHealth("/v", "v", sd); got != want {
 			t.Errorf("vaultHealth() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestResolveBash(t *testing.T) {
+	t.Run("DOTF_BASH override wins", func(t *testing.T) {
+		want := filepath.Join(t.TempDir(), "my-bash")
+		t.Setenv("DOTF_BASH", want)
+		if got := resolveBash(); got != want {
+			t.Errorf("resolveBash() = %q, want the DOTF_BASH override %q", got, want)
+		}
+	})
+
+	if runtime.GOOS != "windows" {
+		t.Skip("the System32 WSL-launcher skip is Windows-specific")
+	}
+	t.Run("skips the System32 WSL launcher and picks a real bash", func(t *testing.T) {
+		t.Setenv("DOTF_BASH", "") // force PATH resolution
+		root := t.TempDir()
+		t.Setenv("SystemRoot", root)
+		sys32 := filepath.Join(root, "System32")
+		real := filepath.Join(root, "tools")
+		mustMkdirAll(t, sys32)
+		mustMkdirAll(t, real)
+		mustWrite(t, filepath.Join(sys32, "bash.exe"), "") // the WSL launcher decoy
+		realBash := filepath.Join(real, "bash.exe")
+		mustWrite(t, realBash, "") // a Git-Bash-style real interpreter
+		// System32 first on PATH — the bug picked it; resolveBash must skip it.
+		t.Setenv("PATH", sys32+string(os.PathListSeparator)+real)
+		if got := resolveBash(); got != realBash {
+			t.Errorf("resolveBash() = %q, want the non-System32 bash %q", got, realBash)
 		}
 	})
 }


### PR DESCRIPTION
## Why

On Windows, Go's `exec.LookPath("bash")` resolves `C:\Windows\System32\bash.exe` — the **WSL launcher**. That path is:
- a broken stub when no WSL distro is installed (`WSL (4197 - Relay) ERROR: execvpe(/bin/bash) failed: No such file or directory`), and
- even when WSL works, unable to read a Windows-path script argument (WSL sees `/mnt/c/...`).

So `dotf` session-start vault-health shelled out via the wrong interpreter and silently reported `Vault health: \nIssues found:` on any machine where `System32` shadows Git Bash on `PATH`. Root-caused empirically: `exec.LookPath("bash")` returned `C:\Windows\system32\bash.exe`, and running a temp stub through it exited non-zero with the relay error.

## What

- Add `resolveBash()` in `cli/internal/mem/session_start.go`. Resolution order: `$DOTF_BASH` → the first `bash` on `PATH` that is **not** the System32 WSL launcher → bare `bash` fallback (Linux/macOS keep prior behaviour — no System32 ambiguity).
- `vaultHealth` now calls `resolveBash()` instead of a bare `"bash"`.
- Tests: new `TestResolveBash` (DOTF_BASH override + System32-skip with a synthetic PATH); the vault-health stub test now gates on the resolved interpreter rather than a bare `LookPath` (which would find the WSL launcher and fail to skip).

## Verification

- `go test ./...` is now fully green on Windows; previously `TestVaultHealth/reports_ALL_CHECKS_PASSED_on_a_clean_stub` failed only on this platform (passed on CI Linux).
- `go vet` clean; bugfix is ~28 production LOC (under the spec-gate threshold), with its regression guard in the same PR.