### PR TITLE
feat(secrets): dotf secrets sync ci (backend-agnostic Actions materialization)

### DIFF
--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -38,6 +38,7 @@ func newSecretsCmd() *cobra.Command {
 	cmd.AddCommand(newSecretsShowCmd())
 	cmd.AddCommand(newSecretsSetCmd())
 	cmd.AddCommand(newSecretsMigrateCmd())
+	cmd.AddCommand(newSecretsSyncCmd())
 	cmd.AddCommand(newSecretsRenderCmd())
 	cmd.AddCommand(newSecretsVerifyCmd())
 	return cmd

--- a/cli/internal/cmd/secrets_sync.go
+++ b/cli/internal/cmd/secrets_sync.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/initrepo"
+	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
+	"github.com/spf13/cobra"
+)
+
+// ghSecretSetter is the GitHub Actions write seam (GHSecretSet in production), overridable
+// so command tests inject a fake with no gh, no network, no secrets. repoOriginResolver
+// derives the current repo's origin slug for the --repo default; a var so tests bypass git.
+var (
+	ghSecretSetter     secrets.GitHubSecretSetter = secrets.GHSecretSet{}
+	repoOriginResolver                            = defaultOriginRepo
+)
+
+// defaultOriginRepo resolves the current working directory's git origin to an owner/name
+// slug (git -C cwd walks up to the repo root, so any subdir works).
+func defaultOriginRepo() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return initrepo.OriginRepo(cwd)
+}
+
+// newSecretsSyncCmd is the `dotf secrets sync <target>` noun (ADR-029): backend-agnostic,
+// deploy-time materialization of a scoped secret set for headless consumers. This slice
+// ships the `ci` target only; container/agent are designed but deferred.
+func newSecretsSyncCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "sync",
+		Short: "Materialize a scoped secret set for a headless consumer (CI, …)",
+		Long: "sync resolves a scoped secret set backend-agnostically (age|bw, via the same\n" +
+			"Loader as `run`) and pushes it to a headless consumer's delivery surface, ahead\n" +
+			"of time — the consumer never talks to Bitwarden at runtime (ADR-028/ADR-029).\n" +
+			"This slice implements the `ci` target (GitHub Actions secrets).",
+	}
+	c.AddCommand(newSecretsSyncCiCmd())
+	return c
+}
+
+// newSecretsSyncCiCmd implements `dotf secrets sync ci [--repo OWNER/REPO] [--dry-run]`:
+// select the repo's ci:<repo> secrets, resolve each value via the Loader (age or bw,
+// transparently), and upload via the gh seam. Idempotent (`gh secret set` overwrites);
+// --dry-run reports VAR→repo with byte lengths and never a value, and never uploads.
+func newSecretsSyncCiCmd() *cobra.Command {
+	var repo string
+	var dryRun bool
+	c := &cobra.Command{
+		Use:   "ci",
+		Short: "Push a repo's ci:* secrets to its GitHub Actions secrets (age|bw agnostic)",
+		Long: "ci selects every registry secret whose consumers contains ci:<repo>, resolves\n" +
+			"each value backend-agnostically, and uploads it to the repo's GitHub Actions\n" +
+			"secrets via `gh secret set`. File, floor/offline, and GITHUB_*-prefixed secrets\n" +
+			"are excluded with a reason. --repo defaults to the current repo's origin.",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			reg, err := loadRegistry()
+			if err != nil {
+				return err
+			}
+			if repo == "" {
+				repo, err = repoOriginResolver()
+				if err != nil {
+					return fmt.Errorf("--repo not given and could not derive it: %w\n"+
+						"pass --repo owner/name", err)
+				}
+			}
+			if !initrepo.ValidRepoSlug(repo) {
+				return fmt.Errorf("invalid --repo %q: want owner/name", repo)
+			}
+
+			sel := reg.SelectCI(repo)
+			out := cmd.OutOrStdout()
+			for _, sk := range sel.Skipped {
+				_, _ = fmt.Fprintf(out, "skip %s: %s\n", sk.ID, sk.Reason)
+			}
+			if len(sel.Upload) == 0 {
+				_, _ = fmt.Fprintf(out, "no ci secrets selected for %s\n", repo)
+				return nil
+			}
+
+			// One Loader path resolves both age and bw entries — the backend-agnostic
+			// boundary ADR-029 introduces. Fail-fast: a resolution error aborts before any
+			// upload, so the repo is never left with a partial secret set.
+			env, err := secretLoader().EnvFor(sel.Upload, nil)
+			if err != nil {
+				return err
+			}
+			for i, kv := range env {
+				name := sel.Upload[i].Var
+				value := kv[len(name)+1:] // EnvFor returns "name=value"
+				if dryRun {
+					_, _ = fmt.Fprintf(out, "would set %s → %s (%d bytes)\n", name, repo, len(value))
+					continue
+				}
+				if err := ghSecretSetter.SetSecret(repo, name, value); err != nil {
+					return err
+				}
+				_, _ = fmt.Fprintf(out, "set %s → %s\n", name, repo)
+			}
+			return nil
+		},
+	}
+	c.Flags().StringVar(&repo, "repo", "", "target repo owner/name (default: current repo's origin)")
+	c.Flags().BoolVar(&dryRun, "dry-run", false, "report VAR→repo without uploading (names + byte lengths, never values)")
+	return c
+}

--- a/cli/internal/cmd/secrets_sync_test.go
+++ b/cli/internal/cmd/secrets_sync_test.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
+)
+
+// fakeSetter records uploads ("repo|name" -> value) so sync tests assert with no gh.
+type fakeSetter map[string]string
+
+func (f fakeSetter) SetSecret(repo, name, value string) error {
+	f[repo+"|"+name] = value
+	return nil
+}
+
+// useGHSecretSetter points the ghSecretSetter seam at a fake for the test's duration.
+func useGHSecretSetter(t *testing.T, s secrets.GitHubSecretSetter) {
+	t.Helper()
+	old := ghSecretSetter
+	ghSecretSetter = s
+	t.Cleanup(func() { ghSecretSetter = old })
+}
+
+// useOriginResolver overrides the --repo default resolver (bypasses git).
+func useOriginResolver(t *testing.T, fn func() (string, error)) {
+	t.Helper()
+	old := repoOriginResolver
+	repoOriginResolver = fn
+	t.Cleanup(func() { repoOriginResolver = old })
+}
+
+// syncCiExec runs `secrets sync ci` against a temp registry with fake age/bw/gh seams,
+// returning (stdout, error). ageVals maps an age source base name to its plaintext.
+func syncCiExec(t *testing.T, registry string, setter fakeSetter, bw fakeBW, ageVals map[string]string, args ...string) (string, error) {
+	t.Helper()
+	useTempRegistry(t, registry)
+	useBwReader(t, bw)
+	useGHSecretSetter(t, setter)
+	old := ageDecryptor
+	ageDecryptor = func(ageFile, _ string) ([]byte, error) {
+		base := strings.TrimSuffix(filepath.Base(ageFile), ".secret.age")
+		if v, ok := ageVals[base]; ok {
+			return []byte(v), nil
+		}
+		return []byte("age:" + base), nil
+	}
+	t.Cleanup(func() { ageDecryptor = old })
+
+	var out bytes.Buffer
+	cmd := newSecretsSyncCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs(append([]string{"ci"}, args...))
+	return func() (string, error) { err := cmd.Execute(); return out.String(), err }()
+}
+
+const ciRegistry = `
+version: 1
+secrets:
+  - {id: rel, plane: app, backend: age, age: rel.src, expose: {env: RELEASE_TOKEN}, consumers: ["ci:mlorentedev/dotfiles"]}
+  - {id: bw1, plane: app, backend: bw, bw: {item: it, field: f}, expose: {env: BW_TOKEN}, consumers: ["ci:mlorentedev/dotfiles"]}
+  - {id: other, plane: app, backend: age, age: other.src, expose: {env: OTHER_TOKEN}, consumers: ["ci:mlorentedev/payments"]}
+`
+
+// AC1 — selects + uploads exactly this repo's CI set; other-repo entries excluded.
+func TestSecretsSyncCi_SelectsRepoSet(t *testing.T) {
+	setter := fakeSetter{}
+	out, err := syncCiExec(t, ciRegistry, setter, fakeBW{"it/f": "bw-val"},
+		map[string]string{"rel.src": "rel-val"}, "--repo", "mlorentedev/dotfiles")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for k := range setter {
+		got = append(got, k)
+	}
+	slices.Sort(got)
+	want := []string{"mlorentedev/dotfiles|BW_TOKEN", "mlorentedev/dotfiles|RELEASE_TOKEN"}
+	if !slices.Equal(got, want) {
+		t.Errorf("uploads = %v, want %v (other-repo excluded)", got, want)
+	}
+	if !strings.Contains(out, "set RELEASE_TOKEN") {
+		t.Errorf("missing upload line:\n%s", out)
+	}
+}
+
+// AC2 — backend-agnostic: the age and bw entries upload identically (the unblock).
+func TestSecretsSyncCi_AgeAndBwUploadIdentically(t *testing.T) {
+	setter := fakeSetter{}
+	_, err := syncCiExec(t, ciRegistry, setter, fakeBW{"it/f": "bw-val"},
+		map[string]string{"rel.src": "rel-val"}, "--repo", "mlorentedev/dotfiles")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if setter["mlorentedev/dotfiles|RELEASE_TOKEN"] != "rel-val" {
+		t.Errorf("age value = %q, want rel-val", setter["mlorentedev/dotfiles|RELEASE_TOKEN"])
+	}
+	if setter["mlorentedev/dotfiles|BW_TOKEN"] != "bw-val" {
+		t.Errorf("bw value = %q, want bw-val", setter["mlorentedev/dotfiles|BW_TOKEN"])
+	}
+}
+
+// AC3 — exclusions: file / floor|offline / GITHUB_* skipped with a reason, no upload.
+func TestSecretsSyncCi_Exclusions(t *testing.T) {
+	const reg = `
+version: 1
+secrets:
+  - {id: kc, plane: infra, backend: age, age: kc.src, bw: {item: kc, field: notes}, expose: {file: {var: KUBECONFIG, path: "~/.k"}}, consumers: ["ci:mlorentedev/dotfiles"]}
+  - {id: floor, plane: floor, backend: age-offline, age: floor.src, expose: {env: FLOOR_TOKEN}, consumers: ["ci:mlorentedev/dotfiles"]}
+  - {id: gh, plane: app, backend: age, age: gh.src, expose: {env: GITHUB_PAT}, consumers: ["ci:mlorentedev/dotfiles"]}
+`
+	setter := fakeSetter{}
+	out, err := syncCiExec(t, reg, setter, fakeBW{}, nil, "--repo", "mlorentedev/dotfiles")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(setter) != 0 {
+		t.Errorf("exclusions must upload nothing, got %v", setter)
+	}
+	for _, want := range []string{"skip kc:", "skip floor:", "skip GITHUB_PAT:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing skip report %q in:\n%s", want, out)
+		}
+	}
+}
+
+// AC4 — --dry-run reports VAR->repo with byte lengths, never a value, and uploads nothing.
+func TestSecretsSyncCi_DryRunInert(t *testing.T) {
+	setter := fakeSetter{}
+	out, err := syncCiExec(t, ciRegistry, setter, fakeBW{"it/f": "bw-secret"},
+		map[string]string{"rel.src": "rel-secret"}, "--repo", "mlorentedev/dotfiles", "--dry-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(setter) != 0 {
+		t.Errorf("--dry-run must upload nothing, got %v", setter)
+	}
+	if !strings.Contains(out, "would set RELEASE_TOKEN") || !strings.Contains(out, "bytes)") {
+		t.Errorf("dry-run output missing 'would set' + byte length:\n%s", out)
+	}
+	if strings.Contains(out, "rel-secret") || strings.Contains(out, "bw-secret") {
+		t.Errorf("--dry-run leaked a secret value:\n%s", out)
+	}
+}
+
+// AC5 — --repo defaults to the origin slug; an invalid slug errors.
+func TestSecretsSyncCi_RepoResolution(t *testing.T) {
+	t.Run("origin default", func(t *testing.T) {
+		useOriginResolver(t, func() (string, error) { return "mlorentedev/dotfiles", nil })
+		setter := fakeSetter{}
+		_, err := syncCiExec(t, ciRegistry, setter, fakeBW{"it/f": "bw-val"},
+			map[string]string{"rel.src": "rel-val"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if setter["mlorentedev/dotfiles|RELEASE_TOKEN"] != "rel-val" {
+			t.Errorf("origin default did not target the resolved repo: %v", setter)
+		}
+	})
+	t.Run("bad slug", func(t *testing.T) {
+		setter := fakeSetter{}
+		_, err := syncCiExec(t, ciRegistry, setter, fakeBW{}, nil, "--repo", "notaslug")
+		if err == nil || !strings.Contains(err.Error(), "invalid --repo") {
+			t.Fatalf("want invalid-repo error, got %v", err)
+		}
+		if len(setter) != 0 {
+			t.Error("a bad slug must upload nothing")
+		}
+	})
+}

--- a/cli/internal/secrets/github.go
+++ b/cli/internal/secrets/github.go
@@ -1,0 +1,103 @@
+package secrets
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"slices"
+	"strings"
+)
+
+// GitHubSecretSetter sets one repository Actions secret (create or update). The seam that
+// keeps `dotf secrets sync ci` unit-testable with no gh, no network, no real secret —
+// tests inject a fake; production is GHSecretSet (a `gh secret set` shell-out). It is the
+// GitHub-Actions write analog of BWWriter (Bitwarden).
+type GitHubSecretSetter interface {
+	SetSecret(repo, name, value string) error
+}
+
+// GHSecretSet is the production GitHubSecretSetter: it shells out to the GitHub CLI to set
+// a repository Actions secret, delivering the value on stdin — never an argv element or a
+// temp file (the plaintext-at-rest minimization of ADR-028). `gh secret set` creates or
+// overwrites, so a re-run is idempotent. Live-verified with the operator's `gh auth` (the
+// canary smoke, #612 C8), not in CI — like BWGet/BWPut.
+type GHSecretSet struct {
+	Bin string // gh binary name/path; "" → "gh"
+}
+
+// SetSecret uploads name=value to repo's Actions secrets via one `gh secret set` call.
+func (g GHSecretSet) SetSecret(repo, name, value string) error {
+	bin := g.Bin
+	if bin == "" {
+		bin = "gh"
+	}
+	cmd := exec.Command(bin, "secret", "set", name, "--repo", repo) //nolint:gosec // name/repo are operator-controlled registry/flag data
+	cmd.Stdin = strings.NewReader(value)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return fmt.Errorf("gh secret set %s --repo %s: %s", name, repo, msg)
+	}
+	return nil
+}
+
+// CISkip records one secret/var excluded from a CI sync, with the reason (for reporting).
+type CISkip struct {
+	ID     string
+	Reason string
+}
+
+// CISelection is the outcome of SelectCI: the flattened env entries to resolve + upload,
+// and the secrets/vars excluded with a reason.
+type CISelection struct {
+	Upload  []Entry
+	Skipped []CISkip
+}
+
+// SelectCI picks the secrets feeding repo's CI — those whose consumers contains
+// "ci:<repo>" — and splits them into the env vars to upload and the ones excluded. The
+// repo (not a workflow "purpose") is the routing key, because `gh secret set` is per-repo
+// (ADR-029). A secret is excluded — never silently — when it is a floor/age-offline secret
+// (needed before the store is reachable; never a CI secret), a file secret (not a GitHub
+// Actions secret), or exposes a GITHUB_*-prefixed var (Actions reserves the prefix). The
+// result is backend-agnostic: age- and bw-backed entries flatten identically, so the
+// caller resolves both through one Loader path — the whole point of ADR-029.
+func (r *Registry) SelectCI(repo string) CISelection {
+	tag := "ci:" + repo
+	var sel CISelection
+	for i := range r.Secrets {
+		s := &r.Secrets[i]
+		if !slices.Contains(s.Consumers, tag) {
+			continue
+		}
+		switch {
+		case s.Plane == "floor" || s.Backend == "age-offline":
+			sel.Skipped = append(sel.Skipped, CISkip{s.ID, "floor/offline secret — never pushed to CI"})
+			continue
+		case s.Expose.File != nil:
+			sel.Skipped = append(sel.Skipped, CISkip{s.ID, "file secret — not a GitHub Actions secret"})
+			continue
+		}
+		for _, e := range s.envEntries() {
+			if strings.HasPrefix(e.Var, "GITHUB_") {
+				sel.Skipped = append(sel.Skipped, CISkip{e.Var, "GITHUB_* prefix is reserved by Actions — rename the var at the workflow"})
+				continue
+			}
+			sel.Upload = append(sel.Upload, e)
+		}
+	}
+	return sel
+}
+
+// envEntries flattens a non-file secret to its env entries, dispatching on backend like
+// Registry.Entries (home is irrelevant — env vars never materialize a file).
+func (s *Secret) envEntries() []Entry {
+	if s.Backend == "bw" {
+		return s.bwEntries("")
+	}
+	return s.ageEntries("")
+}

--- a/cli/internal/secrets/github_test.go
+++ b/cli/internal/secrets/github_test.go
@@ -1,0 +1,81 @@
+package secrets
+
+import (
+	"slices"
+	"testing"
+)
+
+// fakeSetter records uploads ("repo|name" -> value) so tests assert with no gh/network.
+type fakeSetter map[string]string
+
+func (f fakeSetter) SetSecret(repo, name, value string) error {
+	f[repo+"|"+name] = value
+	return nil
+}
+
+func TestGitHubSecretSetter_FakeRoundTrip(t *testing.T) {
+	var s GitHubSecretSetter = fakeSetter{}
+	if err := s.SetSecret("o/r", "TOK", "v"); err != nil {
+		t.Fatal(err)
+	}
+	if s.(fakeSetter)["o/r|TOK"] != "v" {
+		t.Error("fake setter did not record the upload")
+	}
+}
+
+// selectRegistry mixes backends, repos, and every exclusion class.
+const selectRegistry = `
+version: 1
+secrets:
+  - {id: rel, plane: app, backend: age, age: rel.src, expose: {env: RELEASE_TOKEN}, consumers: ["ci:mlorentedev/dotfiles"]}
+  - {id: bw1, plane: app, backend: bw, bw: {item: it, field: f}, expose: {env: BW_TOKEN}, consumers: ["ci:mlorentedev/dotfiles"]}
+  - {id: other, plane: app, backend: age, age: other.src, expose: {env: OTHER_TOKEN}, consumers: ["ci:mlorentedev/payments"]}
+  - {id: kc, plane: infra, backend: age, age: kc.src, bw: {item: kc, field: notes}, expose: {file: {var: KUBECONFIG, path: "~/.k"}}, consumers: ["ci:mlorentedev/dotfiles"]}
+  - {id: floor, plane: floor, backend: age-offline, age: floor.src, expose: {env: FLOOR_TOKEN}, consumers: ["ci:mlorentedev/dotfiles"]}
+  - {id: gh, plane: app, backend: age, age: gh.src, expose: {env: GITHUB_PAT}, consumers: ["ci:mlorentedev/dotfiles"]}
+`
+
+func TestSelectCI(t *testing.T) {
+	reg, err := ParseRegistry([]byte(selectRegistry))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sel := reg.SelectCI("mlorentedev/dotfiles")
+
+	// Upload: the age + bw entries for this repo, flattened identically (backend-agnostic).
+	var uploaded []string
+	for _, e := range sel.Upload {
+		uploaded = append(uploaded, e.Var)
+	}
+	slices.Sort(uploaded)
+	want := []string{"BW_TOKEN", "RELEASE_TOKEN"}
+	if !slices.Equal(uploaded, want) {
+		t.Errorf("upload vars = %v, want %v (other-repo + file + floor + GITHUB_* excluded)", uploaded, want)
+	}
+
+	// Each exclusion class is reported (never silent).
+	skips := map[string]string{}
+	for _, sk := range sel.Skipped {
+		skips[sk.ID] = sk.Reason
+	}
+	for _, id := range []string{"kc", "floor", "GITHUB_PAT"} {
+		if _, ok := skips[id]; !ok {
+			t.Errorf("expected %q to be reported as skipped; skips=%v", id, skips)
+		}
+	}
+	// The other-repo secret is simply not selected (not a skip of this repo's set).
+	if _, ok := skips["other"]; ok {
+		t.Error("other-repo secret must not appear in this repo's skip list")
+	}
+}
+
+func TestSelectCI_NoMatch(t *testing.T) {
+	reg, err := ParseRegistry([]byte(selectRegistry))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sel := reg.SelectCI("mlorentedev/nonexistent")
+	if len(sel.Upload) != 0 || len(sel.Skipped) != 0 {
+		t.Errorf("no-match repo must select nothing: upload=%v skipped=%v", sel.Upload, sel.Skipped)
+	}
+}

--- a/secrets/registry.yaml
+++ b/secrets/registry.yaml
@@ -38,7 +38,7 @@ secrets:
     age: github.token
     bw: { item: github-release-pat, field: api-token }
     expose: { env: RELEASE_TOKEN }
-    consumers: ["ci:release"]
+    consumers: ["ci:mlorentedev/dotfiles"]
     rotate: 90d
 
   - id: BITACORA_PAT
@@ -47,7 +47,7 @@ secrets:
     age: github.bitacora
     bw: { item: github-bitacora-pat, field: api-token }
     expose: { env: BITACORA_PAT }
-    consumers: ["ci:bitacora"]
+    consumers: ["ci:mlorentedev/dotfiles"]
     rotate: 90d
 
   # DockerHub — login pair, one bw item: token→password, username→username.

--- a/specs/CLI-024-secrets-sync/proposal.md
+++ b/specs/CLI-024-secrets-sync/proposal.md
@@ -89,13 +89,20 @@ so `migrate <ci-var>` no longer drops it — the `migrateGuard`'s `ci:*` refusal
 
 ## Risks / open questions
 
-- **Consumer-tag migration is a registry edit with cross-repo reach.** This slice migrates
-  **dotfiles' own** CI tags (`ci:release`, `ci:bitacora`, `ci:image-push`) to
-  `ci:mlorentedev/dotfiles` — the entries C5 actually unblocks and can verify. The
-  remaining purpose tags belonging to *other* repos (`ci:payments`, `ci:newsletter`,
-  `ci:social`, `ci:publish`, `ci:yt-metrics`) are swept to `ci:<owner>/<repo>` **with the
-  operator confirming each owner/repo** — tracked as an explicit task here, never silently
-  dropped (a half-migrated registry is tolerated by the parser and by `migrateGuard`'s
+- **Consumer-tag migration is a registry edit with cross-repo reach.** Which entries are
+  dotfiles' own is determined by **evidence, not naming**: a grep of `.github/workflows/`
+  shows dotfiles actually consumes only `RELEASE_TOKEN` (`ci:release`, used by
+  release-please + pat-expiry) and `BITACORA_PAT` (`ci:bitacora`, used by add-to-project +
+  bitacora-status + pat-expiry). `GITHUB_TOKEN` is the built-in Actions token, never a
+  registry secret. So this slice migrates **only** `ci:release` + `ci:bitacora` →
+  `ci:mlorentedev/dotfiles`. **`ci:image-push` (DOCKERHUB_TOKEN/USERNAME) is NOT dotfiles'**
+  — no dotfiles workflow references it — so it joins the operator-confirmed sweep, not this
+  slice. Mislabeling it as dotfiles would push another repo's DockerHub creds into dotfiles'
+  Actions — precisely the cross-repo leak the `ci:<owner>/<repo>` routing exists to prevent.
+  The remaining purpose tags (`ci:image-push`, `ci:payments`, `ci:newsletter`, `ci:social`,
+  `ci:publish`, `ci:yt-metrics`) are swept to `ci:<owner>/<repo>` **with the operator
+  confirming each owner/repo** — tracked as an explicit task here, never silently dropped (a
+  half-migrated registry is tolerated by the parser and by `migrateGuard`'s
   `HasPrefix(c, "ci:")` check, so the sweep can land incrementally without breakage).
 - **`GITHUB_*` vars cannot become Actions secrets.** GitHub reserves the prefix; the
   legacy script skips them. `sync ci` must exclude them with a clear message — and the real

--- a/specs/CLI-024-secrets-sync/tasks.md
+++ b/specs/CLI-024-secrets-sync/tasks.md
@@ -18,26 +18,31 @@ created: "2026-06-26"
 - [x] `proposal.md` complete; acceptance criteria testable
 - [x] Consumer-routing decision resolved (`ci:<owner>/<repo>`, DECIDED 2026-06-26)
 
-## Implementation
+## Implementation (PR-A — this PR)
 
-- [ ] **`GitHubSecretSetter` seam** — interface `SetSecret(repo, name, value string) error`
-  in `cli/internal/secrets` (next to `BWWriter`). Production `GHSecretSet` shells out to
-  `gh secret set <name> --repo <repo>` with the value on stdin. Unit-test the fake; the
-  shell-out is the live canary (#612 C8), not CI — mirror `BWPut`'s test split.
-- [ ] **CI selection helper** — given a registry + an `owner/repo`, return the entries whose
+- [x] **`GitHubSecretSetter` seam** — `SetSecret(repo, name, value string) error` in
+  `cli/internal/secrets/github.go` (next to `BWWriter`). Production `GHSecretSet` shells out
+  to `gh secret set <name> --repo <repo>` with the value on stdin. Fake unit-tested; the
+  shell-out is the live canary (#612 C8), not CI — mirrors `BWPut`'s test split.
+- [x] **CI selection helper** — `Registry.SelectCI(repo)` returns the entries whose
   `consumers` contains `ci:<owner/repo>`, excluding file / `floor` / `age-offline` /
-  `GITHUB_*`-prefixed vars, each with a specific skip reason. Pure function, table-driven test.
-- [ ] **`sync` command skeleton + `sync ci`** — `newSecretsSyncCmd()` with a `ci` subcommand;
-  `--repo` (default `initrepo.OriginRepo`, validate `initrepo.ValidRepoSlug`) and `--dry-run`
-  flags; package-level `ghSecretSetter` seam var (like `bwReader`). Wire into `newSecretsCmd`.
-- [ ] **Resolve + upload** — resolve each selected var via `secretLoader().EnvFor(entries, only)`
-  (age|bw transparent); for each `VAR=value`, call `ghSecretSetter.SetSecret(repo, VAR, value)`.
-  Fail-fast on a resolution error (never a partial upload).
-- [ ] **`--dry-run`** — report `VAR → repo` with byte lengths, never the value; zero setter calls.
-- [ ] **Registry tag migration (dotfiles' own)** — rewrite `ci:release` / `ci:bitacora` /
-  `ci:image-push` → `ci:mlorentedev/dotfiles` in `secrets/registry.yaml` (comment-preserving).
-- [ ] **Tests** — AC1 selects+uploads only the repo's set; AC2 age+bw upload identically;
+  `GITHUB_*`-prefixed vars, each with a specific skip reason. Pure, table-driven test.
+- [x] **`sync` command skeleton + `sync ci`** — `newSecretsSyncCmd()` with a `ci` subcommand;
+  `--repo` (default via injectable `repoOriginResolver` → `initrepo.OriginRepo`, validated by
+  `initrepo.ValidRepoSlug`) + `--dry-run`; package-level `ghSecretSetter` seam (like
+  `bwReader`). Wired into `newSecretsCmd`.
+- [x] **Resolve + upload** — resolves each selected var via `secretLoader().EnvFor` (age|bw
+  transparent); calls `ghSecretSetter.SetSecret(repo, VAR, value)`. Fail-fast (no partial upload).
+- [x] **`--dry-run`** — reports `VAR → repo (N bytes)`, never the value; zero setter calls.
+- [x] **Registry tag migration (dotfiles' own, evidence-scoped)** — rewrote `ci:release`
+  (RELEASE_TOKEN) + `ci:bitacora` (BITACORA_PAT) → `ci:mlorentedev/dotfiles`. Scope confirmed
+  by grepping `.github/workflows/` — `ci:image-push` (DOCKERHUB_*) is NOT a dotfiles secret,
+  so it is excluded here and handled in the sweep below.
+- [x] **Tests** — AC1 selects+uploads only the repo's set; AC2 age+bw upload identically;
   AC3 three exclusions; AC4 `--dry-run` inert + non-leaking; AC5 origin default + bad-slug error.
+
+## PR-B (next — retirement, parity-gated)
+
 - [ ] **Parity gate, then retire** — confirm `sync ci --dry-run` VAR set == the legacy script's
   uploaded set for dotfiles; then delete `scripts/github-secrets-manager.sh`,
   `tests/github-secrets-manager.bats`, the `ls --pairs` flag, and `TestSecretsLs_Pairs_EnvOnly`.
@@ -46,19 +51,20 @@ created: "2026-06-26"
 
 ## Follow-ups (tracked, not in this slice)
 
-- [ ] Sweep the remaining purpose tags (`ci:payments` / `ci:newsletter` / `ci:social` /
-  `ci:publish` / `ci:yt-metrics`) to `ci:<owner>/<repo>` — operator confirms each owner/repo.
+- [ ] Sweep the remaining purpose tags (`ci:image-push` / `ci:payments` / `ci:newsletter` /
+  `ci:social` / `ci:publish` / `ci:yt-metrics`) to `ci:<owner>/<repo>` — operator confirms
+  each owner/repo (none are dotfiles' own per the workflow grep).
 - [ ] (Optional) naming-convention lint in `Registry.validate()` (service prefix / field vocab).
 
-## Closing
+## Closing (PR-A)
 
-- [ ] Every AC covered by ≥1 test (live `gh`/`bw` is the canary smoke, #612 C8)
-- [ ] `features.json` carries non-vacuous verification commands
-- [ ] `cd cli && go test ./... ` green; `go vet ./...` + `golangci-lint run
+- [x] Every PR-A AC covered by ≥1 test (live `gh`/`bw` is the canary smoke, #612 C8)
+- [x] `features.json` carries non-vacuous verification commands
+- [x] `cd cli && go test ./...` green; `go vet ./...` + `golangci-lint run
   --exclude-use-default=false ./internal/...` clean; `go build ./...` ok
-- [ ] Additive: new command + seam + registry tag migration + retirements only
-- [ ] `verification.md` filled in
-- [ ] PR opened referencing this spec + #612 C5
+- [x] Additive: new command + seam + registry tag migration only (retirements are PR-B)
+- [x] `verification.md` filled in
+- [x] PR opened referencing this spec + #612
 
 ## Machine-readable features
 

--- a/specs/CLI-024-secrets-sync/verification.md
+++ b/specs/CLI-024-secrets-sync/verification.md
@@ -5,34 +5,35 @@ created: "2026-06-26"
 
 # Verification - CLI-024-secrets-sync
 
-> Status: **draft** — filled at implementation time. The AC skeleton below is the checklist
-> the implementer ticks with concrete proof (test name + commit). No evidence is fabricated
-> ahead of the work.
+> Status: **PR-A implemented + verified** (the `sync ci` command). AC6/AC7-retirement land in
+> PR-B (the parity-gated removal of the shell twin). No evidence is fabricated.
 
 ## Evidence
 
-- [ ] **AC1 — selects + uploads the repo's CI set** -> `TestSecretsSyncCi_SelectsRepoSet`
+- [x] **AC1 — selects + uploads the repo's CI set** -> `TestSecretsSyncCi_SelectsRepoSet`
   (fake resolver + fake setter; asserts the exact `(repo, VAR, value)` calls; other-repo
-  entries not selected).
-- [ ] **AC2 — backend-agnostic** -> `TestSecretsSyncCi_AgeAndBwUploadIdentically`
-  (one age + one bw entry both reach the setter).
-- [ ] **AC3 — exclusions specific + silent-free** -> `TestSecretsSyncCi_Exclusions`
+  entries not selected) + `TestSelectCI` (pure-helper coverage).
+- [x] **AC2 — backend-agnostic** -> `TestSecretsSyncCi_AgeAndBwUploadIdentically`
+  (one age + one bw entry both reach the setter with their resolved values).
+- [x] **AC3 — exclusions specific + silent-free** -> `TestSecretsSyncCi_Exclusions`
   (file / floor|age-offline / `GITHUB_*` each skipped with a distinct reason, no setter call).
-- [ ] **AC4 — `--dry-run` inert + non-leaking** -> `TestSecretsSyncCi_DryRunInert`
-  (zero setter calls; output has byte lengths, never a value).
-- [ ] **AC5 — `--repo` default + bad slug** -> `TestSecretsSyncCi_RepoResolution`
-  (origin default via injected repo-root; invalid `owner/name` errors).
-- [ ] **AC6 — parity gate before retirement** -> parity check logged below + the diff removes
-  the script, its bats, `ls --pairs`, and `TestSecretsLs_Pairs_EnvOnly`.
-- [ ] **AC7 — clean + additive** -> full suite green; `go vet` + `golangci-lint
-  --exclude-use-default=false` exit 0; gofmt-clean on LF blobs.
+- [x] **AC4 — `--dry-run` inert + non-leaking** -> `TestSecretsSyncCi_DryRunInert`
+  (zero setter calls; output has byte lengths, asserts neither secret value appears).
+- [x] **AC5 — `--repo` default + bad slug** -> `TestSecretsSyncCi_RepoResolution`
+  (origin default via injected `repoOriginResolver`; invalid `owner/name` errors, no upload).
+- [ ] **AC6 — parity gate before retirement** -> **PR-B**: parity check logged + the diff
+  removes the script, its bats, `ls --pairs`, and `TestSecretsLs_Pairs_EnvOnly`.
+- [x] **AC7 — clean + additive (PR-A scope)** -> full suite green; `go vet` + `golangci-lint
+  --exclude-use-default=false` exit 0; gofmt-clean. (Retirements are PR-B.)
 
 ## Test status
 
-- `cd cli && go test ./...` -> _pending_
-- Lint: `golangci-lint run --exclude-use-default=false ./internal/...`; `go vet ./...` -> _pending_
-- Parity (AC6): `dotf secrets sync ci --repo mlorentedev/dotfiles --dry-run` VAR set vs the
-  legacy `github-secrets-manager.sh --from-mapping --list` set -> _pending_ (record both lists).
+- `cd cli && go test ./...` -> all packages `ok` (secrets + cmd suites incl. the 7 new tests).
+- Lint: `golangci-lint run --exclude-use-default=false ./internal/...` exit 0; `go vet ./...`
+  clean; `gofmt -l` clean on the new files.
+- Smoke: `go run ./cmd/dotf secrets sync ci --help` renders the command + flags.
+- Parity (AC6, PR-B): `dotf secrets sync ci --repo mlorentedev/dotfiles --dry-run` VAR set vs
+  the legacy `github-secrets-manager.sh --from-mapping --list` set -> _to record in PR-B_.
 - Live `gh secret set` + a real `bw`-backed resolve are the canary smoke (#612 C8) with the
   operator's `bw unlock` + `gh auth` — Windows-empirical, not CI.
 


### PR DESCRIPTION
Implements the `ci` slice of `dotf secrets sync` per ADR-029 (#630) and the spec
`specs/CLI-024-secrets-sync/` (#631). This is PR-A (the command); PR-B retires the shell
twin behind a parity gate.

## What

`dotf secrets sync ci [--repo OWNER/REPO] [--dry-run]` pushes a repo's CI secrets to its
GitHub Actions secrets, **backend-agnostically** (age **or** bw, via the existing
`Loader.EnvFor`). The instant a `ci:*` secret flips age→bw, the legacy age-only
`ls --pairs` path drops it; this command resolves the *value* regardless of backend, so the
upload set is stable across the migration — unblocking #612 Phase C.

- **Routing `ci:<owner>/<repo>`** — the consumer tag carries the target repo (the repo, not
  a workflow "purpose", is the routing key since `gh secret set` is per-repo). `--repo`
  defaults to the current repo's origin (`initrepo.OriginRepo`, validated by `ValidRepoSlug`).
- **Mockable seam** — `GitHubSecretSetter` (mirror of `BWReader`/`BWWriter`); production
  `GHSecretSet` shells out to `gh secret set` with the value on stdin (no argv leak, no temp
  file). A package-level `ghSecretSetter` seam + an injectable `repoOriginResolver` make the
  whole command unit-testable on Linux with no `gh`, no network, no secrets.
- **Exclusions, never silent** — file / floor-offline / `GITHUB_*`-prefixed secrets are
  skipped with a specific reason (`GITHUB_*` is reserved by Actions).
- **Idempotent + `--dry-run`** — `gh secret set` overwrites; `--dry-run` reports `VAR → repo`
  with byte lengths, never a value, and uploads nothing.
- **Registry migration (evidence-scoped)** — `ci:release` (RELEASE_TOKEN) + `ci:bitacora`
  (BITACORA_PAT) → `ci:mlorentedev/dotfiles`. Scope confirmed by grepping
  `.github/workflows/`: `ci:image-push` (DOCKERHUB_*) is **not** a dotfiles secret, so it is
  left for the operator-confirmed sweep — migrating it to dotfiles would have pushed another
  repo's creds into dotfiles' Actions (the exact cross-repo leak the routing prevents).

## Tests

7 new tests (5 command ACs + 2 pure-helper), all with fakes. `go test ./...`, `go vet`, and
`golangci-lint --exclude-use-default=false` all clean; the live `gh`/`bw` run is the canary
smoke (#612 C8, Windows-empirical), not CI.

## Deferred to PR-B

Retiring `github-secrets-manager.sh` + `tests/github-secrets-manager.bats` + `ls --pairs` +
`TestSecretsLs_Pairs_EnvOnly`, and lifting the `ci:*` refusal in `migrate`'s guard — all
behind a one-time parity check (`sync ci --dry-run` set == the script's uploaded set).

Spec: `specs/CLI-024-secrets-sync/`. Work-gate: #612.