### PR TITLE
fix(secrets): resolve registry from the checkout SSOT, not the deployed copy

### DIFF
--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -44,14 +44,18 @@ func newSecretsCmd() *cobra.Command {
 	return cmd
 }
 
-// registryPath resolves secrets/registry.yaml (the mapping SSOT); a var so tests
-// can point it at a fixture. ageDecryptor is the age decrypt seam (nil → AgeDecrypt);
-// bwReader is the Bitwarden read seam (BWGet in production), both overridable so
-// command tests inject fakes with no age key and no unlocked Bitwarden.
+// registryPath resolves secrets/registry.yaml for READS — repo checkout first, then
+// the deployed copy (ADR-029). registryWritePath is the WRITE seam: it resolves the
+// checkout's registry and fails loud if none is found, so a mutation lands in the
+// version-controlled SSOT and not the throwaway deployed copy (#635). Both are vars so
+// tests can point them at a fixture. ageDecryptor is the age decrypt seam (nil →
+// AgeDecrypt); bwReader is the Bitwarden read seam (BWGet in production), all
+// overridable so command tests inject fakes with no age key and no unlocked Bitwarden.
 var (
-	registryPath = func() string { return filepath.Join(env.DotfilesDir(env.Home()), "secrets", "registry.yaml") }
-	ageDecryptor secrets.Decryptor
-	bwReader     secrets.BWReader = secrets.BWGet{}
+	registryPath      = env.ResolveRegistryPath
+	registryWritePath = env.RepoRegistryPath
+	ageDecryptor      secrets.Decryptor
+	bwReader          secrets.BWReader = secrets.BWGet{}
 )
 
 // secretLoader builds the resolution engine wired with both backend seams, over the

--- a/cli/internal/cmd/secrets_migrate.go
+++ b/cli/internal/cmd/secrets_migrate.go
@@ -90,7 +90,14 @@ func newSecretsMigrateCmd() *cobra.Command {
 			// Flip the registry — the last mutation. The target is the entry's
 			// pre-declared bw: block (the same item/field parity verified above), so the
 			// flip only toggles backend + drops age; it needs no item/field of its own.
-			if err := secrets.FlipRegistryToBW(registryPath(), id); err != nil {
+			// Write to the checkout's registry (the version-controlled SSOT), failing
+			// loud if no checkout is found: writing the deployed copy would be silently
+			// reverted on the next redeploy and never reach git (#635).
+			wp, err := registryWritePath()
+			if err != nil {
+				return err
+			}
+			if err := secrets.FlipRegistryToBW(wp, id); err != nil {
 				return err
 			}
 			if err := loader.Verify(secrets.Entry{Var: id, Backend: "bw", Item: item, Field: field}); err != nil {

--- a/cli/internal/cmd/secrets_registry_test.go
+++ b/cli/internal/cmd/secrets_registry_test.go
@@ -39,16 +39,19 @@ secrets:
   - {id: kubelab-kubeconfig, plane: infra, backend: age, age: kubelab.kubeconfig, expose: {file: {var: KUBECONFIG, path: "~/.kube/c", mode: "0600"}}}
 `
 
-// useTempRegistry points registryPath at a fixture for the duration of a test.
+// useTempRegistry points both the read seam (registryPath) and the write seam
+// (registryWritePath) at one fixture for the duration of a test, so command tests
+// exercise migrate's flip without needing a real checkout.
 func useTempRegistry(t *testing.T, body string) {
 	t.Helper()
 	p := filepath.Join(t.TempDir(), "registry.yaml")
 	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	old := registryPath
+	oldRead, oldWrite := registryPath, registryWritePath
 	registryPath = func() string { return p }
-	t.Cleanup(func() { registryPath = old })
+	registryWritePath = func() (string, error) { return p, nil }
+	t.Cleanup(func() { registryPath, registryWritePath = oldRead, oldWrite })
 }
 
 func TestSecretsLs_ListsIdsAndVars_NoValues(t *testing.T) {

--- a/cli/internal/env/env.go
+++ b/cli/internal/env/env.go
@@ -138,6 +138,57 @@ func ResolveContractPath() string {
 	return ""
 }
 
+// RepoDir resolves the dotfiles checkout root: DOTFILES_REPO_DIR when it points at
+// a real directory, else walking up from the working directory for a .git entry (a
+// file in a worktree, a directory in a normal clone — os.Stat matches both). Returns
+// "" when neither locates a checkout. This is the shared "where is the checkout"
+// seam the registry resolvers (ADR-029) build on.
+func RepoDir() string {
+	if r := os.Getenv("DOTFILES_REPO_DIR"); r != "" && isDir(r) {
+		return r
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		if git := walkUpFor(cwd, ".git"); git != "" {
+			return filepath.Dir(git)
+		}
+	}
+	return ""
+}
+
+// ResolveRegistryPath locates secrets/registry.yaml for READS. It prefers the
+// dotfiles checkout (the version-controlled SSOT, and fresher than the deployed
+// copy on a dev machine), falling back to the deployed copy under DOTFILES_DIR when
+// no checkout is found or the file is absent there. Mirrors ResolveContractPath and
+// implements the read side of the registry source model (ADR-029, #635).
+func ResolveRegistryPath() string {
+	if root := RepoDir(); root != "" {
+		if p := filepath.Join(root, "secrets", "registry.yaml"); fileExists(p) {
+			return p
+		}
+	}
+	return filepath.Join(DotfilesDir(Home()), "secrets", "registry.yaml")
+}
+
+// RepoRegistryPath returns secrets/registry.yaml inside the dotfiles checkout, or an
+// error when no checkout is found. WRITERS (dotf secrets migrate) MUST use this: the
+// registry is a version-controlled SSOT, so a mutation has to land in the checkout to
+// be committed. Writing the deployed copy under ~/.dotfiles is silently reverted on
+// the next redeploy and never reaches git — the durability bug behind #635. This
+// fails loud rather than write a throwaway copy.
+func RepoRegistryPath() (string, error) {
+	root := RepoDir()
+	if root == "" {
+		return "", fmt.Errorf("no dotfiles checkout found (set DOTFILES_REPO_DIR or run from inside the repo) — refusing to write the registry SSOT to the deployed copy")
+	}
+	return filepath.Join(root, "secrets", "registry.yaml"), nil
+}
+
+// isDir reports whether p exists and is a directory.
+func isDir(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && fi.IsDir()
+}
+
 // walkUpFor walks up from start looking for a file named name, returning its
 // full path or "".
 func walkUpFor(start, name string) string {

--- a/cli/internal/env/env_test.go
+++ b/cli/internal/env/env_test.go
@@ -151,3 +151,98 @@ func TestResolveContractPathRepoMissingFallsThrough(t *testing.T) {
 		t.Errorf("ResolveContractPath() = %q, want deployed copy %q", got, want)
 	}
 }
+
+func TestRepoDirPrefersDotfilesRepoDir(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("DOTFILES_REPO_DIR", repo)
+	if got := RepoDir(); got != repo {
+		t.Errorf("RepoDir() = %q, want %q", got, repo)
+	}
+}
+
+func TestRepoDirWalksUpForGitWhenNoEnv(t *testing.T) {
+	// No DOTFILES_REPO_DIR → RepoDir walks up from cwd for a .git entry.
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(repo, "cli", "internal")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DOTFILES_REPO_DIR", "") // force the walk-up branch
+	t.Chdir(sub)
+
+	got, err := filepath.EvalSymlinks(RepoDir()) // tmp dirs may be symlinked (macOS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("RepoDir() = %q, want repo root %q", got, want)
+	}
+}
+
+func TestRepoDirNoneFound(t *testing.T) {
+	t.Setenv("DOTFILES_REPO_DIR", "")
+	t.Chdir(t.TempDir()) // a bare tmp dir has no .git ancestor
+	if got := RepoDir(); got != "" {
+		t.Errorf("RepoDir() = %q, want empty (no checkout)", got)
+	}
+}
+
+func TestResolveRegistryPathPrefersRepoCheckout(t *testing.T) {
+	// The checkout's registry (the version-controlled SSOT) wins over the deployed
+	// copy — the read side of ADR-029 / #635.
+	repo := t.TempDir()
+	want := filepath.Join(repo, "secrets", "registry.yaml")
+	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(want, []byte("version: 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DOTFILES_REPO_DIR", repo)
+
+	if got := ResolveRegistryPath(); got != want {
+		t.Errorf("ResolveRegistryPath() = %q, want repo copy %q", got, want)
+	}
+}
+
+func TestResolveRegistryPathFallsBackToDeployed(t *testing.T) {
+	// Checkout present but carrying no registry → fall through to the deployed copy
+	// under DOTFILES_DIR rather than returning a non-existent repo path.
+	t.Setenv("DOTFILES_REPO_DIR", t.TempDir()) // empty: no secrets/registry.yaml
+	deployed := t.TempDir()
+	t.Setenv("DOTFILES_DIR", deployed)
+	want := filepath.Join(deployed, "secrets", "registry.yaml")
+
+	if got := ResolveRegistryPath(); got != want {
+		t.Errorf("ResolveRegistryPath() = %q, want deployed copy %q", got, want)
+	}
+}
+
+func TestRepoRegistryPathReturnsCheckoutPath(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("DOTFILES_REPO_DIR", repo)
+	got, err := RepoRegistryPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := filepath.Join(repo, "secrets", "registry.yaml"); got != want {
+		t.Errorf("RepoRegistryPath() = %q, want %q", got, want)
+	}
+}
+
+func TestRepoRegistryPathFailsLoudWithoutCheckout(t *testing.T) {
+	// The write seam must refuse to fall back to the deployed copy: a migrate written
+	// there is reverted on the next redeploy and never reaches git (#635).
+	t.Setenv("DOTFILES_REPO_DIR", "")
+	t.Chdir(t.TempDir())
+	if _, err := RepoRegistryPath(); err == nil {
+		t.Fatal("RepoRegistryPath() = nil error, want fail-loud when no checkout is found")
+	}
+}

--- a/docs/adr/adr-029-secrets-registry-source-model.md
+++ b/docs/adr/adr-029-secrets-registry-source-model.md
@@ -1,0 +1,108 @@
+---
+id: "dotfiles-adr-029-secrets-registry-source-model"
+type: adr
+adr: "029"
+title: "Secrets registry source model — checkout-first reads, fail-loud checkout-only writes"
+tags: [adr, dotfiles, secrets, registry, cli, go]
+status: accepted
+created: "2026-06-26"
+owner: manu
+relates_to: "adr-025 (cross-machine paths), adr-028 (two-tier secrets)"
+---
+
+# ADR-029: Secrets registry source model
+
+## Context
+
+`secrets/registry.yaml` is the mapping SSOT for `dotf secrets` (ADR-028): it declares
+every secret's id, backend (`age` / `bw`), exposure, and — for migratable entries —
+a dormant `bw: { item, field }` target. It is **version-controlled** and lives in the
+dotfiles checkout. Setup deploys a copy to `~/.dotfiles/secrets/registry.yaml`, which
+is the runtime location the shell and the CLI read from on a non-dev machine.
+
+`dotf secrets` resolved that path through one helper:
+
+```go
+registryPath = filepath.Join(env.DotfilesDir(home), "secrets", "registry.yaml")
+```
+
+`env.DotfilesDir` returns `$DOTFILES_DIR` or `~/.dotfiles` — **always the deployed
+copy, never the checkout**. Both the read path (`run`/`show`/`render`/`verify`/`sync`/
+`ls`) and the single write path (`migrate`, via `FlipRegistryToBW`) used it. This was
+discovered during the `dotf secrets sync ci` smoke on 2026-06-26 (#635):
+
+- **Read drift (annoying, recoverable):** a `sync ci --dry-run` selected 0 because the
+  deployed copy still carried pre-migration consumer tags while the committed checkout
+  had the migrated tags. A redeploy fixed it.
+- **Write durability bug (silent data loss):** `migrate` flips `backend: age→bw` in the
+  **deployed** copy. The checkout SSOT stays at `age`. On the next `git pull` + setup
+  redeploy, the checkout's `age` version **overwrites the deployed `bw` flip — the
+  migration is silently reverted and never lands in git**. `migrate` has not run for
+  real yet (everything is still `age`), so C8 (the first real migrate, #585/#612) would
+  be the first to hit this.
+
+This is the same "version-controlled SSOT written to / read from a throwaway deployed
+copy" failure `env.ResolveContractPath` (ADR-025) already solved for `env-contract.json`.
+
+## Decision
+
+Adopt an **asymmetric-source model with a shared checkout resolver**, mirroring
+`ResolveContractPath`:
+
+1. **`env.RepoDir()`** — the shared "where is the checkout" seam: `DOTFILES_REPO_DIR`
+   when it is a real directory, else walking up from cwd for a `.git` entry (a file in
+   a worktree, a dir in a clone — `os.Stat` matches both). Returns `""` when neither.
+
+2. **Reads → checkout-first, fall back to deployed** (`env.ResolveRegistryPath`). When
+   a checkout is found and carries the registry, read it; else read the deployed copy
+   under `DOTFILES_DIR`. On a dev machine the checkout is the fresher, authoritative
+   copy, so registry edits go live on `git pull` with no redeploy footgun. On a
+   non-dev machine (no checkout) it transparently falls back to the deployed copy.
+
+3. **Writes → checkout-only, fail loud** (`env.RepoRegistryPath`). The one registry
+   mutation (`migrate`'s `FlipRegistryToBW`) resolves the checkout's registry and
+   **errors if no checkout is found**, rather than writing the deployed copy. A
+   migration is therefore durable and committable; it can never be silently reverted
+   by a redeploy.
+
+`set` writes to **Bitwarden**, not the registry, so it is not a registry writer — the
+write seam has exactly one consumer today (`migrate`), keeping the blast radius small.
+
+### Read-side trade-off (accepted)
+
+Checkout-first reads mean secrets resolution **follows the active git branch**: a
+feature branch that edits `registry.yaml` changes what `dotf secrets run` resolves at
+shell startup (since `DOTFILES_REPO_DIR` is exported in the login shell). This is the
+deliberate cost of "edits go live on pull without a redeploy." It is acceptable
+because (a) the registry is a mapping, not the secret values — a wrong branch resolves
+to a different *declared* target, caught by `verify`, not a corrupted secret; and (b) a
+stale read is recoverable, unlike the silent write loss in the deployed-copy model.
+
+## Alternatives considered
+
+- **Deployed-only (status quo, reads + writes):** rejected — it *is* the durability
+  bug; a real `migrate` is non-reproducible.
+- **Checkout-only reads (no deployed fallback):** rejected — breaks a non-dev machine
+  that legitimately has only the deployed copy.
+- **Asymmetric the other way (repo writes, deployed reads):** rejected — every
+  registry edit would then require a redeploy before it is visible, re-introducing the
+  exact footgun the smoke hit; the user chose live-on-pull reads.
+
+## Consequences
+
+- `migrate` is durable: the flip lands in the checkout, ready to commit; a redeploy
+  cannot revert it. With no checkout it fails loud instead of writing a dead copy.
+- Registry edits are live-on-pull for reads; resolution tracks the active branch
+  (the accepted trade-off above).
+- New shared seam `env.RepoDir()` is available for future callers that need the
+  checkout root (converging with `spec.RepoRoot` / `doctor.findRepoRoot`).
+- Tests now cover repo-vs-deployed resolution for both seams, including the
+  fail-loud-without-checkout path that the prior path-mocking tests could not catch.
+
+## References
+
+- Issue: #635. Epic: #612 (Phase C). Migration: #585.
+- Code: `cli/internal/env/env.go` (`RepoDir`, `ResolveRegistryPath`, `RepoRegistryPath`),
+  `cli/internal/cmd/secrets.go` (`registryPath`, `registryWritePath`),
+  `cli/internal/cmd/secrets_migrate.go`.
+- Prior art: ADR-025 (`ResolveContractPath`, the stale-deployed-copy drift fix).

--- a/specs/CLI-024-secrets-registry-ssot/features.json
+++ b/specs/CLI-024-secrets-registry-ssot/features.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "CLI-024-secrets-registry-ssot-f1",
+    "behavior": "ResolveRegistryPath reads the checkout registry when present, falls back to the deployed copy under DOTFILES_DIR otherwise",
+    "verification": "cd cli && go test ./internal/env/ -run 'ResolveRegistryPath' -count=1",
+    "state": "passing",
+    "evidence": "TestResolveRegistryPathPrefersRepoCheckout, TestResolveRegistryPathFallsBackToDeployed PASS"
+  },
+  {
+    "id": "CLI-024-secrets-registry-ssot-f2",
+    "behavior": "RepoRegistryPath returns the checkout registry path and fails loud when no checkout is found; RepoDir resolves via DOTFILES_REPO_DIR and .git walk-up",
+    "verification": "cd cli && go test ./internal/env/ -run 'RepoRegistryPath|RepoDir' -count=1",
+    "state": "passing",
+    "evidence": "TestRepoRegistryPathReturnsCheckoutPath, TestRepoRegistryPathFailsLoudWithoutCheckout, TestRepoDir{PrefersDotfilesRepoDir,WalksUpForGitWhenNoEnv,NoneFound} PASS"
+  },
+  {
+    "id": "CLI-024-secrets-registry-ssot-f3",
+    "behavior": "secrets command suite still green with the split read/write seams; module builds, vet + fmt clean",
+    "verification": "cd cli && go test ./internal/env/ ./internal/cmd/ ./internal/secrets/ -count=1 && go vet ./... && go build ./... && test -z \"$(gofmt -l internal/env internal/cmd)\"",
+    "state": "passing",
+    "evidence": "all three packages ok; vet/build clean; gofmt -l empty"
+  }
+]

--- a/specs/CLI-024-secrets-registry-ssot/proposal.md
+++ b/specs/CLI-024-secrets-registry-ssot/proposal.md
@@ -1,0 +1,59 @@
+---
+id: "CLI-024-secrets-registry-ssot"
+type: spec
+status: verifying # draft | implementing | verifying | archived
+created: "2026-06-26"
+issue: "mlorentedev/dotfiles#635"
+tags: [spec, proposal, secrets, registry, cli, go]
+template_version: "1.0"
+---
+
+# CLI-024-secrets-registry-ssot
+
+## Why
+
+`dotf secrets` resolved `secrets/registry.yaml` through `env.DotfilesDir` — always the
+**deployed** copy under `~/.dotfiles`, never the version-controlled checkout. Both the
+read path and the one write path (`migrate` → `FlipRegistryToBW`) used it. The smoke of
+`dotf secrets sync ci` (#635) surfaced two failures:
+
+- **Write durability bug:** `migrate` flips `backend: age→bw` in the deployed copy; the
+  checkout SSOT stays `age`; the next redeploy silently reverts the flip and it never
+  reaches git. C8 (the first real migrate) would hit this.
+- **Read drift:** resolution read a stale deployed copy that diverged from the committed
+  checkout (a `--dry-run` selected 0).
+
+This is the same failure `env.ResolveContractPath` (ADR-025) already solved for
+`env-contract.json`.
+
+## What
+
+Per **ADR-029**, an asymmetric source model over a shared checkout resolver:
+
+- `env.RepoDir()` — `DOTFILES_REPO_DIR` (when a real dir) else walk up cwd for `.git`
+  (file or dir); `""` when neither.
+- `env.ResolveRegistryPath()` — **reads** checkout-first, fall back to the deployed copy.
+- `env.RepoRegistryPath()` — **writes** resolve the checkout's registry and **fail loud**
+  if no checkout is found (never write the deployed copy).
+- `secrets.go`: read seam `registryPath = env.ResolveRegistryPath`; new write seam
+  `registryWritePath = env.RepoRegistryPath`.
+- `secrets_migrate.go`: flip via `registryWritePath()`, erroring before the mutation when
+  no checkout exists.
+
+`set` writes Bitwarden, not the registry, so it is not a registry writer — one write
+consumer (`migrate`).
+
+## Acceptance criteria
+
+- **AC1** — Reads prefer the checkout registry, fall back to the deployed copy when no
+  checkout / no file there.
+- **AC2** — `migrate` writes the checkout SSOT and fails loud when no checkout is found.
+- **AC3** — `RepoDir` resolves via `DOTFILES_REPO_DIR` and via `.git` walk-up, and is
+  empty when neither.
+- **AC4** — Tests cover repo-vs-deployed resolution for both seams (the prior path-mock
+  tests could not catch this); suite green, vet + fmt clean, module builds.
+
+## Out of scope
+
+- The `sync ci` "0 selected" clearer message + lessons (separate follow-up per #635).
+- C8 (the first real age→bw migrate) — needs Windows/bw; validated after this lands.

--- a/specs/CLI-024-secrets-registry-ssot/tasks.md
+++ b/specs/CLI-024-secrets-registry-ssot/tasks.md
@@ -1,0 +1,37 @@
+---
+tags: [spec, tasks, secrets, registry, cli, go]
+created: "2026-06-26"
+---
+
+# Tasks - CLI-024-secrets-registry-ssot
+
+> TDD order. One task = one focused commit.
+
+## Setup
+
+- [x] Branch from main: `fix/secrets-registry-ssot` (worktree)
+- [x] `proposal.md` complete; acceptance criteria testable
+- [x] ADR-029 written (registry source model: checkout-first reads, fail-loud writes)
+
+## Implementation
+
+- [x] `env.RepoDir()` — shared checkout resolver (DOTFILES_REPO_DIR → `.git` walk-up).
+- [x] `env.ResolveRegistryPath()` — read seam, checkout-first then deployed fallback.
+- [x] `env.RepoRegistryPath()` — write seam, checkout-only, fail loud (no deployed write).
+- [x] `secrets.go` — split seams: `registryPath` → read; `registryWritePath` → write.
+- [x] `secrets_migrate.go` — flip via `registryWritePath()`, error before the mutation.
+- [x] `useTempRegistry` test helper — override both seams at the fixture.
+
+## Tests
+
+- [x] `TestRepoDir*` — env, `.git` walk-up, none-found.
+- [x] `TestResolveRegistryPath*` — repo-first, deployed fallback.
+- [x] `TestRepoRegistryPath*` — checkout path, fail-loud without checkout.
+
+## Closing
+
+- [x] Every AC covered by ≥1 test
+- [x] `features.json` carries non-vacuous verification commands
+- [x] `go test ./...` green; `go vet` + `gofmt` clean; `go build ./...` ok
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec + #635

--- a/specs/CLI-024-secrets-registry-ssot/verification.md
+++ b/specs/CLI-024-secrets-registry-ssot/verification.md
@@ -1,0 +1,41 @@
+---
+tags: [spec, verification, secrets, registry, cli, go]
+created: "2026-06-26"
+---
+
+# Verification - CLI-024-secrets-registry-ssot
+
+## Evidence
+
+- [x] **AC1** (checkout-first reads, deployed fallback) — PASS:
+  `TestResolveRegistryPathPrefersRepoCheckout` (a checkout registry wins over the
+  deployed copy) and `TestResolveRegistryPathFallsBackToDeployed` (no registry in the
+  checkout → the deployed path under `DOTFILES_DIR`).
+- [x] **AC2** (checkout-only writes, fail loud) — PASS:
+  `TestRepoRegistryPathReturnsCheckoutPath` (returns `<checkout>/secrets/registry.yaml`)
+  and `TestRepoRegistryPathFailsLoudWithoutCheckout` (errors with no checkout — the write
+  never falls back to the deployed copy). `migrate` consumes `registryWritePath()` and
+  returns that error before the flip.
+- [x] **AC3** (RepoDir resolution) — PASS: `TestRepoDirPrefersDotfilesRepoDir`,
+  `TestRepoDirWalksUpForGitWhenNoEnv`, `TestRepoDirNoneFound`.
+- [x] **AC4** (repo-vs-deployed coverage + suite green) — PASS: the 7 env tests above
+  exercise the path the prior `useTempRegistry` path-mock could not; the existing
+  `cmd` + `secrets` suites stay green with the split seams.
+
+## Test status
+
+- `cd cli && go test ./internal/env/ ./internal/cmd/ ./internal/secrets/ -count=1` → **ok**
+  (3/3 packages).
+- `go vet ./...` → clean. `go build ./...` → clean. `gofmt -l internal/env internal/cmd` → empty.
+
+## Decisions made during implementation
+
+- **Only `migrate` writes the registry.** `set` writes Bitwarden (an item/field), not
+  `registry.yaml`, so the write seam has a single consumer — smaller blast radius than
+  the issue's "migrate/set" framing implied.
+- **`.git` marker (not a sentinel filename) for `RepoDir`.** It detects both a normal
+  clone (`.git` dir) and a worktree (`.git` file) via `os.Stat`, so the fix works in the
+  isolated worktree this change was developed in.
+- **Fail-loud at the env seam, not just the command.** `RepoRegistryPath` returns the
+  error; `migrate` propagates it. The env-level test pins the behavior independent of the
+  command wiring.


### PR DESCRIPTION
Closes #635.

## Problem

`dotf secrets` resolved `secrets/registry.yaml` via `env.DotfilesDir` — always the **deployed** copy under `~/.dotfiles`, never the version-controlled checkout. Both reads and the one write path (`migrate` → `FlipRegistryToBW`) used it.

Surfaced by the `dotf secrets sync ci` smoke (2026-06-26):
- **Write durability bug (silent loss):** `migrate` flips `backend: age→bw` in the deployed copy; the checkout SSOT stays `age`; the next `git pull` + redeploy **silently reverts the flip and it never reaches git**. C8 (first real migrate) would hit this.
- **Read drift:** a `--dry-run` read a stale deployed copy that diverged from the committed checkout (selected 0).

Same failure `env.ResolveContractPath` (ADR-025) already solved for `env-contract.json`.

## Fix — ADR-029 (asymmetric source model over a shared resolver)

| Seam | New func | Behavior |
|---|---|---|
| Checkout root | `env.RepoDir()` | `DOTFILES_REPO_DIR` (real dir) → walk up cwd for `.git` (file or dir → worktree-safe); `""` when neither |
| **Read** | `env.ResolveRegistryPath()` | checkout-first, fall back to the deployed copy (edits go live on `git pull`) |
| **Write** | `env.RepoRegistryPath()` | checkout-only, **fail loud** when no checkout (never write a throwaway copy) |

- `secrets.go`: split `registryPath` (read) / `registryWritePath` (write).
- `secrets_migrate.go`: flip via the write seam, erroring before the mutation.
- Note: only `migrate` writes the registry — `set` writes Bitwarden, not the file. One write consumer.

### Read-side trade-off (accepted, by request)

Checkout-first reads mean resolution follows the active git branch (a branch that edits the registry changes what `dotf secrets run` resolves). Accepted: the registry is a mapping (not secret values, and `verify` catches a wrong target), and a stale read is recoverable — unlike the silent write loss it replaces.

## Verification

- 7 new env tests cover repo-vs-deployed for both seams, incl. fail-loud-without-checkout (the prior path-mock tests could not catch this — AC4).
- `go test ./...` (12 pkgs) green · `go vet` · `go build` · `gofmt -l` clean.
- ADR-029 + spec `CLI-024-secrets-registry-ssot` (spec-gate).

## Out of scope (ticketed)

- C8 (first real age→bw migrate, needs Windows/bw) — validates the end-to-end flow after this lands.
- `sync ci` "0 selected" clearer message + lessons — separate follow-up per #635.