### PR TITLE
ci(pat-expiry): fail the job when a PAT-backed secret is invalid/expired

### DIFF
--- a/.github/workflows/pat-expiry.yml
+++ b/.github/workflows/pat-expiry.yml
@@ -9,8 +9,14 @@ name: PAT expiry preflight
 # github-authentication-token-expiration response header, and opens or UPDATES a
 # deduplicated `pat-expiry`-labelled issue (one per secret, stable title) when a
 # token is invalid/expired or within WARN_DAYS of expiry — so a rotation reminder
-# lands in the backlog BEFORE the next release run goes red. Detection only;
-# automatic rotation is HARNESS-022/#378. See specs/OPS-009-pat-expiry-preflight/.
+# lands in the backlog BEFORE the next release run goes red.
+#
+# A token that is ALREADY invalid/expired also FAILS the job (red), not just files
+# an issue: a backlog reminder was silently ignored once (BITACORA_PAT died, the
+# board automation 401'd for days) so the alarm must be unmissable. An expiring-soon
+# token (still valid, within WARN_DAYS) stays a soft heads-up — issue only, green job
+# — because the whole point is to warn while it still works. Automatic rotation is
+# HARNESS-022/#378. See specs/OPS-009-pat-expiry-preflight/.
 #
 # The issue calls use the default GITHUB_TOKEN (issues: write); each secret under
 # test is used ONLY as the probe's Authorization bearer, never to write.
@@ -101,7 +107,11 @@ jobs:
                 echo "::warning::${name}: api.github.com unreachable — liveness check skipped"
                 return 0
               fi
+              # Already-dead token: file the issue AND fail the job (red). INVALID is a
+              # job-level flag; we keep going so every secret is reported in one run.
               alert "${name}" "is invalid or expired (api.github.com returned HTTP ${status})"
+              echo "::error::${name} is invalid or expired (HTTP ${status}) — rotate it"
+              INVALID=1
               return 0
             fi
 
@@ -127,5 +137,13 @@ jobs:
             fi
           }
 
+          # INVALID flips to 1 inside check_token when a token is already dead. An
+          # expiring-soon (still-valid) token does not flip it — that stays a soft issue.
+          INVALID=0
           check_token "RELEASE_TOKEN" "${RELEASE_TOKEN}"
           check_token "BITACORA_PAT" "${BITACORA_PAT}"
+
+          if [ "${INVALID}" -ne 0 ]; then
+            echo "::error::one or more PAT-backed Actions secrets are invalid/expired — see the pat-expiry issue(s)"
+            exit 1
+          fi

--- a/.github/workflows/pat-expiry.yml
+++ b/.github/workflows/pat-expiry.yml
@@ -43,6 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # gh label/issue calls need a repo context; this job has no actions/checkout,
+      # so set GH_REPO (gh's default-repo env var) instead of a bare .git. Without it
+      # every gh call dies with "fatal: not a git repository" before any token is
+      # probed — the latent bug that silently broke this preflight since it shipped.
+      GH_REPO: ${{ github.repository }}
       WARN_DAYS: ${{ github.event.inputs.warn_days || '14' }}
       RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       BITACORA_PAT: ${{ secrets.BITACORA_PAT }}


### PR DESCRIPTION
**Tier 0** of the secret-liveness hardening (follow-up to the BITACORA_PAT incident in #636's CI).

## Problem

`pat-expiry.yml` was **detection-only**: on an invalid/expired token it filed a `pat-expiry` issue and stayed **green**. That backlog reminder was silently ignored once — `BITACORA_PAT` expired, `add-to-project`/`bitacora-status` 401'd for days, and a dead value was even re-uploaded to Actions. The one run that should have caught it (2026-06-22) went `failure` without ever filing the issue (no `pat-expiry` issue was ever created), so the signal was lost entirely.

## Change

- An **already invalid/expired** token now **fails the job** (`::error` + `exit 1`), in addition to filing the dedup issue — an unmissable red signal.
- Both tokens are still probed in one run (job-level `INVALID` flag, set inside `check_token`, checked after both calls) so a single run reports every dead secret.
- **Expiring-soon** (still valid, within `WARN_DAYS`) stays a **soft** issue-only heads-up, green job — the point is to warn while the token still works.

## Verification

- `python -c 'yaml.safe_load(...)'` parses; `bash -n` + `shellcheck -s bash -S warning` clean on the embedded script.
- Live: `workflow_dispatch` on this branch (tokens were just rotated → expect green).

## Scope

Small CI hardening (<50 LOC, archived OPS-009 feature). Part of a 3-tier follow-up: Tier 1 = opt-in `sync ci` token validation; Tier 2 = migrate the board automation off the PAT to a GitHub App (so it can't expire).