### PR TITLE
fix(secrets): resolve the age store checkout-first too + fix ADR-029 collision

### DIFF
--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -59,10 +59,11 @@ var (
 )
 
 // secretLoader builds the resolution engine wired with both backend seams, over the
-// age store in <dotfiles>/sensitive and the operator's Bitwarden via bwReader.
+// age store in sensitive/ (checkout-first, ADR-030 — same source as the registry it
+// maps, so a repo-side rotation is seen without a redeploy) and Bitwarden via bwReader.
 func secretLoader() *secrets.Loader {
 	return &secrets.Loader{
-		SecretsDir: filepath.Join(env.DotfilesDir(env.Home()), "sensitive"),
+		SecretsDir: env.ResolveSensitiveDir(),
 		KeyPath:    ageKeyPath(),
 		Decrypt:    ageDecryptor,
 		BW:         bwReader,

--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -45,7 +45,7 @@ func newSecretsCmd() *cobra.Command {
 }
 
 // registryPath resolves secrets/registry.yaml for READS — repo checkout first, then
-// the deployed copy (ADR-029). registryWritePath is the WRITE seam: it resolves the
+// the deployed copy (ADR-030). registryWritePath is the WRITE seam: it resolves the
 // checkout's registry and fails loud if none is found, so a mutation lands in the
 // version-controlled SSOT and not the throwaway deployed copy (#635). Both are vars so
 // tests can point them at a fixture. ageDecryptor is the age decrypt seam (nil →

--- a/cli/internal/env/env.go
+++ b/cli/internal/env/env.go
@@ -169,6 +169,21 @@ func ResolveRegistryPath() string {
 	return filepath.Join(DotfilesDir(Home()), "secrets", "registry.yaml")
 }
 
+// ResolveSensitiveDir locates the age secret store (sensitive/) for READS. Like
+// ResolveRegistryPath (ADR-030), it prefers the dotfiles checkout — the version-
+// controlled SSOT where rotations land — falling back to the deployed copy under
+// DOTFILES_DIR when no checkout is found or the dir is absent there. Keeping the
+// registry and the values it maps on the same source avoids the split-brain where a
+// repo-side rotation stays invisible until a redeploy (the #635 class, for secret files).
+func ResolveSensitiveDir() string {
+	if root := RepoDir(); root != "" {
+		if p := filepath.Join(root, "sensitive"); isDir(p) {
+			return p
+		}
+	}
+	return filepath.Join(DotfilesDir(Home()), "sensitive")
+}
+
 // RepoRegistryPath returns secrets/registry.yaml inside the dotfiles checkout, or an
 // error when no checkout is found. WRITERS (dotf secrets migrate) MUST use this: the
 // registry is a version-controlled SSOT, so a mutation has to land in the checkout to

--- a/cli/internal/env/env.go
+++ b/cli/internal/env/env.go
@@ -142,7 +142,7 @@ func ResolveContractPath() string {
 // a real directory, else walking up from the working directory for a .git entry (a
 // file in a worktree, a directory in a normal clone — os.Stat matches both). Returns
 // "" when neither locates a checkout. This is the shared "where is the checkout"
-// seam the registry resolvers (ADR-029) build on.
+// seam the registry resolvers (ADR-030) build on.
 func RepoDir() string {
 	if r := os.Getenv("DOTFILES_REPO_DIR"); r != "" && isDir(r) {
 		return r
@@ -159,7 +159,7 @@ func RepoDir() string {
 // dotfiles checkout (the version-controlled SSOT, and fresher than the deployed
 // copy on a dev machine), falling back to the deployed copy under DOTFILES_DIR when
 // no checkout is found or the file is absent there. Mirrors ResolveContractPath and
-// implements the read side of the registry source model (ADR-029, #635).
+// implements the read side of the registry source model (ADR-030, #635).
 func ResolveRegistryPath() string {
 	if root := RepoDir(); root != "" {
 		if p := filepath.Join(root, "secrets", "registry.yaml"); fileExists(p) {

--- a/cli/internal/env/env_test.go
+++ b/cli/internal/env/env_test.go
@@ -246,3 +246,31 @@ func TestRepoRegistryPathFailsLoudWithoutCheckout(t *testing.T) {
 		t.Fatal("RepoRegistryPath() = nil error, want fail-loud when no checkout is found")
 	}
 }
+
+func TestResolveSensitiveDirPrefersRepoCheckout(t *testing.T) {
+	// The checkout's sensitive/ (where a rotation lands) wins over the deployed copy, so
+	// the values track the same source as the registry that maps them (ADR-030).
+	repo := t.TempDir()
+	want := filepath.Join(repo, "sensitive")
+	if err := os.Mkdir(want, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DOTFILES_REPO_DIR", repo)
+
+	if got := ResolveSensitiveDir(); got != want {
+		t.Errorf("ResolveSensitiveDir() = %q, want repo copy %q", got, want)
+	}
+}
+
+func TestResolveSensitiveDirFallsBackToDeployed(t *testing.T) {
+	// Checkout present but with no sensitive/ dir → fall through to the deployed store
+	// under DOTFILES_DIR rather than returning a non-existent repo path.
+	t.Setenv("DOTFILES_REPO_DIR", t.TempDir()) // empty: no sensitive/
+	deployed := t.TempDir()
+	t.Setenv("DOTFILES_DIR", deployed)
+	want := filepath.Join(deployed, "sensitive")
+
+	if got := ResolveSensitiveDir(); got != want {
+		t.Errorf("ResolveSensitiveDir() = %q, want deployed copy %q", got, want)
+	}
+}

--- a/cli/internal/env/env_test.go
+++ b/cli/internal/env/env_test.go
@@ -196,7 +196,7 @@ func TestRepoDirNoneFound(t *testing.T) {
 
 func TestResolveRegistryPathPrefersRepoCheckout(t *testing.T) {
 	// The checkout's registry (the version-controlled SSOT) wins over the deployed
-	// copy — the read side of ADR-029 / #635.
+	// copy — the read side of ADR-030 / #635.
 	repo := t.TempDir()
 	want := filepath.Join(repo, "secrets", "registry.yaml")
 	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {

--- a/docs/adr/adr-030-secrets-registry-source-model.md
+++ b/docs/adr/adr-030-secrets-registry-source-model.md
@@ -1,7 +1,7 @@
 ---
-id: "dotfiles-adr-029-secrets-registry-source-model"
+id: "dotfiles-adr-030-secrets-registry-source-model"
 type: adr
-adr: "029"
+adr: "030"
 title: "Secrets registry source model — checkout-first reads, fail-loud checkout-only writes"
 tags: [adr, dotfiles, secrets, registry, cli, go]
 status: accepted
@@ -10,7 +10,7 @@ owner: manu
 relates_to: "adr-025 (cross-machine paths), adr-028 (two-tier secrets)"
 ---
 
-# ADR-029: Secrets registry source model
+# ADR-030: Secrets registry source model
 
 ## Context
 

--- a/docs/adr/adr-030-secrets-registry-source-model.md
+++ b/docs/adr/adr-030-secrets-registry-source-model.md
@@ -99,10 +99,25 @@ stale read is recoverable, unlike the silent write loss in the deployed-copy mod
 - Tests now cover repo-vs-deployed resolution for both seams, including the
   fail-loud-without-checkout path that the prior path-mocking tests could not catch.
 
+## Addendum (the values follow the mapping)
+
+The first cut applied the checkout-first read model to the registry *path* but left the
+age value store (`sensitive/`) resolving deployed-only. That re-created the split-brain
+for the secret *files*: a rotation re-encrypted in the checkout was invisible to
+`dotf secrets` until a redeploy, and a value freshened only in the deployed copy never
+reached the committed SSOT (surfaced live during the 2026-06-26 RELEASE_TOKEN rotation).
+
+The model therefore extends to the value store: `env.ResolveSensitiveDir()` resolves
+`sensitive/` checkout-first with the same deployed fallback, and `secretLoader` uses it.
+The registry and the values it maps now resolve from one source, so a repo-side rotation
+is `re-encrypt → dotf secrets sync ci` with no `DOTFILES_DIR` override and no redeploy.
+The age *private key* (`~/.config/age/key.txt`) is a machine secret, not in the repo, and
+is intentionally unaffected.
+
 ## References
 
 - Issue: #635. Epic: #612 (Phase C). Migration: #585.
-- Code: `cli/internal/env/env.go` (`RepoDir`, `ResolveRegistryPath`, `RepoRegistryPath`),
-  `cli/internal/cmd/secrets.go` (`registryPath`, `registryWritePath`),
-  `cli/internal/cmd/secrets_migrate.go`.
+- Code: `cli/internal/env/env.go` (`RepoDir`, `ResolveRegistryPath`, `RepoRegistryPath`,
+  `ResolveSensitiveDir`), `cli/internal/cmd/secrets.go` (`registryPath`,
+  `registryWritePath`, `secretLoader`), `cli/internal/cmd/secrets_migrate.go`.
 - Prior art: ADR-025 (`ResolveContractPath`, the stale-deployed-copy drift fix).

--- a/specs/CLI-024-secrets-registry-ssot/proposal.md
+++ b/specs/CLI-024-secrets-registry-ssot/proposal.md
@@ -28,7 +28,7 @@ This is the same failure `env.ResolveContractPath` (ADR-025) already solved for
 
 ## What
 
-Per **ADR-029**, an asymmetric source model over a shared checkout resolver:
+Per **ADR-030**, an asymmetric source model over a shared checkout resolver:
 
 - `env.RepoDir()` — `DOTFILES_REPO_DIR` (when a real dir) else walk up cwd for `.git`
   (file or dir); `""` when neither.

--- a/specs/CLI-024-secrets-registry-ssot/tasks.md
+++ b/specs/CLI-024-secrets-registry-ssot/tasks.md
@@ -22,6 +22,13 @@ created: "2026-06-26"
 - [x] `secrets_migrate.go` — flip via `registryWritePath()`, error before the mutation.
 - [x] `useTempRegistry` test helper — override both seams at the fixture.
 
+## Follow-up (ADR-030 addendum — the values follow the mapping)
+
+- [x] `env.ResolveSensitiveDir()` — age store resolves checkout-first too (same model as
+  the registry), so a repo-side rotation is seen without a redeploy; `secretLoader` uses it.
+- [x] Renumber the ADR 029→030 (a post-merge collision: 029 was already taken by
+  `secrets-sync-headless-materialization`).
+
 ## Tests
 
 - [x] `TestRepoDir*` — env, `.git` walk-up, none-found.

--- a/specs/CLI-024-secrets-registry-ssot/tasks.md
+++ b/specs/CLI-024-secrets-registry-ssot/tasks.md
@@ -11,7 +11,7 @@ created: "2026-06-26"
 
 - [x] Branch from main: `fix/secrets-registry-ssot` (worktree)
 - [x] `proposal.md` complete; acceptance criteria testable
-- [x] ADR-029 written (registry source model: checkout-first reads, fail-loud writes)
+- [x] ADR-030 written (registry source model: checkout-first reads, fail-loud writes)
 
 ## Implementation
 


### PR DESCRIPTION
Follow-up to #636 (ADR-030), surfaced live while rotating RELEASE_TOKEN.

## Two fixes

### 1. `SecretsDir` checkout-first (the values follow the mapping)

#636 made the **registry** resolve checkout-first but left the **age value store** (`sensitive/`) deployed-only. That re-created the exact split-brain #635 fixed, one level down — for the secret *files*:

- A rotation re-encrypted in the checkout was invisible to `dotf secrets` until a redeploy.
- A value freshened only in the deployed copy never reached the committed SSOT.

Both happened live during the RELEASE_TOKEN rotation: `dotf secrets sync ci` read the dead deployed token and only worked with a `DOTFILES_DIR=` override (a hardcode that shouldn't be needed). `env.ResolveSensitiveDir()` now resolves `sensitive/` checkout-first with the same deployed fallback as the registry, and `secretLoader` uses it. The rotation flow becomes `re-encrypt → dotf secrets sync ci` — no override, no redeploy. The age **private key** (`~/.config/age/key.txt`, a machine secret not in the repo) is intentionally unaffected.

### 2. ADR-029 collision (post-merge correctness)

#636's ADR was renumbered 029→030 in a commit pushed **after** #636 had already merged, so it never reached main — leaving **two `adr-029-*.md`** files and code comments pointing at the wrong ADR. This renames the registry-source-model ADR to **030** (029 stays `secrets-sync-headless-materialization`) and fixes the stale `ADR-029` references in `env.go` / `secrets.go` / `env_test.go` / the spec. The sync-headless references are left untouched.

## Verification

- 2 new tests (`ResolveSensitiveDir` repo-first + deployed fallback); full suite (12 pkgs) green; vet · build · `gofmt -l` clean.
- ADR-030 carries an addendum documenting the value-store extension.
- Only 1 `adr-029` remains; `grep` confirms registry-source refs are now `ADR-030`, sync-headless stays `ADR-029`.

## No debt left

This closes the gap that forced the `DOTFILES_DIR=` workaround during the live rotation; the rotation runbook is now hardcode-free.