### PR TITLE
fix(secrets): parse-time guards — var uniqueness + name/path validation (#612 B1/B5)

### DIFF
--- a/cli/internal/secrets/registry.go
+++ b/cli/internal/secrets/registry.go
@@ -3,11 +3,21 @@ package secrets
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
 
 	yaml "go.yaml.in/yaml/v3"
+)
+
+// validVarName is the env-identifier grammar a var must satisfy to be injectable and
+// {env:VAR}-referenceable. validAgeBase guards an age source base name against path
+// traversal: it is joined into sensitive/<base>.secret.age, so a "/" or ".." could
+// read outside the store. Both are enforced at parse time (#612 B1/B5).
+var (
+	validVarName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	validAgeBase = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 )
 
 // Registry is secrets/registry.yaml — the mapping SSOT of ADR-028 §2: it ties each
@@ -123,6 +133,7 @@ func (r *Registry) validate() error {
 		return fmt.Errorf("registry version %d unsupported (want 1)", r.Version)
 	}
 	seen := make(map[string]bool, len(r.Secrets))
+	seenVar := make(map[string]string) // var name -> first secret id that exposed it
 	for i := range r.Secrets {
 		s := &r.Secrets[i]
 		if s.ID == "" {
@@ -163,6 +174,40 @@ func (r *Registry) validate() error {
 				return err
 			}
 		}
+
+		// Every exposed var must be a valid env identifier (B5) and unique across the
+		// whole registry (B1): a var mapped by two secrets has no single source, and
+		// render's dedup was age-only, so run/show would silently resolve last-write.
+		for _, v := range s.Vars() {
+			if !validVarName.MatchString(v) {
+				return fmt.Errorf("secret %q: invalid var name %q (want an env identifier [A-Za-z_][A-Za-z0-9_]*)", s.ID, v)
+			}
+			if first, dup := seenVar[v]; dup {
+				return fmt.Errorf("var %q is exposed by both %q and %q — each var must map to exactly one secret", v, first, s.ID)
+			}
+			seenVar[v] = s.ID
+		}
+	}
+	return nil
+}
+
+// checkAgeBase rejects an age source name that is not a bare base name — anything
+// with a path separator or ".." could escape sensitive/ when joined into
+// <base>.secret.age (read-traversal). The charset matches the registry's real names
+// (e.g. "openrouter.api.key", "id_ed25519").
+func checkAgeBase(id, base string) error {
+	if !validAgeBase.MatchString(base) || strings.Contains(base, "..") {
+		return fmt.Errorf("secret %q: unsafe age source name %q (want a bare base name, no path/..)", id, base)
+	}
+	return nil
+}
+
+// checkBwName rejects a control character in a Bitwarden item/field name (it is
+// passed to `bw get item` and echoed in errors). Spaces are allowed — bw item names
+// are freeform.
+func checkBwName(id, kind, name string) error {
+	if strings.ContainsAny(name, "\n\r\t\x00") {
+		return fmt.Errorf("secret %q: bw %s %q contains a control character", id, kind, name)
 	}
 	return nil
 }
@@ -176,11 +221,18 @@ func (s *Secret) checkAgeSources() error {
 		if s.Expose.File.Var == "" || s.Expose.File.Path == "" {
 			return fmt.Errorf("secret %q: file expose needs var+path", s.ID)
 		}
-		return nil
+		return checkAgeBase(s.ID, s.Age)
 	}
 	for _, v := range s.Expose.Env.Vars {
-		if v.Age == "" && s.Age == "" {
+		src := v.Age
+		if src == "" {
+			src = s.Age
+		}
+		if src == "" {
 			return fmt.Errorf("secret %q: env %q has no age source", s.ID, v.Name)
+		}
+		if err := checkAgeBase(s.ID, src); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -190,6 +242,12 @@ func (s *Secret) checkAgeSources() error {
 func (s *Secret) checkBwSources() error {
 	if s.BW == nil || s.BW.Item == "" {
 		return fmt.Errorf("secret %q: bw backend needs bw.item", s.ID)
+	}
+	if err := checkBwName(s.ID, "item", s.BW.Item); err != nil {
+		return err
+	}
+	if err := checkBwName(s.ID, "field", s.BW.Field); err != nil {
+		return err
 	}
 	if s.Expose.File != nil {
 		if s.BW.Field == "" {

--- a/cli/internal/secrets/registry_test.go
+++ b/cli/internal/secrets/registry_test.go
@@ -202,13 +202,16 @@ func TestParseRegistry_BwValidation(t *testing.T) {
 
 func TestParseRegistry_Validation(t *testing.T) {
 	cases := map[string]string{
-		"bad version":       "version: 2\nsecrets: []\n",
-		"duplicate id":      "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: f, expose: {env: A}}\n  - {id: a, plane: app, backend: age, age: g, expose: {env: B}}\n",
-		"unknown backend":   "version: 1\nsecrets:\n  - {id: a, plane: app, backend: vault, age: f, expose: {env: A}}\n",
-		"both env and file": "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: f, expose: {env: A, file: {var: V, path: /p}}}\n",
-		"missing source":    "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, expose: {env: A}}\n",
-		"invalid file mode": "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: f, expose: {file: {var: V, path: /p, mode: \"x\"}}}\n",
-		"non-octal digit":   "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: f, expose: {file: {var: V, path: /p, mode: \"99\"}}}\n",
+		"bad version":        "version: 2\nsecrets: []\n",
+		"duplicate id":       "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: f, expose: {env: A}}\n  - {id: a, plane: app, backend: age, age: g, expose: {env: B}}\n",
+		"unknown backend":    "version: 1\nsecrets:\n  - {id: a, plane: app, backend: vault, age: f, expose: {env: A}}\n",
+		"both env and file":  "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: f, expose: {env: A, file: {var: V, path: /p}}}\n",
+		"missing source":     "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, expose: {env: A}}\n",
+		"invalid file mode":  "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: f, expose: {file: {var: V, path: /p, mode: \"x\"}}}\n",
+		"non-octal digit":    "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: f, expose: {file: {var: V, path: /p, mode: \"99\"}}}\n",
+		"age path traversal": "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: ../../etc/passwd, expose: {env: A}}\n",
+		"age source slash":   "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: sub/dir, expose: {env: A}}\n",
+		"invalid var name":   "version: 1\nsecrets:\n  - {id: a, plane: app, backend: age, age: f, expose: {env: 1BAD}}\n",
 	}
 	for name, yml := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/cli/internal/secrets/render_test.go
+++ b/cli/internal/secrets/render_test.go
@@ -208,20 +208,19 @@ func TestRender_FileSecretVar_LeftIntactNotMaterialized(t *testing.T) {
 	}
 }
 
-// render needs a deterministic VAR→source map: if the registry exposes one var
-// from two distinct secrets, render fails fast (the shell twin silently took the
-// first mapping line; render refuses the ambiguity).
-func TestRender_DuplicateVar_FailsFast(t *testing.T) {
+// A var exposed by two secrets is now rejected at PARSE (#612 B1), centralizing for
+// all backends what render's envSourceMap caught age-only. render keeps that dedup as
+// defense-in-depth for a Registry hand-built past validate, but the normal path fails
+// earlier — at ParseRegistry — which this pins (the shell twin silently took the first
+// mapping line; we refuse the ambiguity up front).
+func TestParseRegistry_DuplicateVar_Rejected(t *testing.T) {
 	const dup = `
 version: 1
 secrets:
   - { id: a, plane: app, backend: age, age: a.src, expose: { env: SHARED } }
   - { id: b, plane: app, backend: age, age: b.src, expose: { env: SHARED } }
 `
-	reg := parseRenderReg(t, dup)
-	path := renderFixture(t, `v={env:SHARED}`)
-
-	if _, err := Render(path, reg, loaderFor(t), "/h"); err == nil {
-		t.Fatal("expected Render to fail when one var is exposed by two secrets")
+	if _, err := ParseRegistry([]byte(dup)); err == nil {
+		t.Fatal("expected ParseRegistry to reject a var exposed by two secrets")
 	}
 }


### PR DESCRIPTION
## Two parse-time hardening gaps (#612 audit)

### B1 — VAR uniqueness across the registry
A var exposed by two secrets has no single source. render's `envSourceMap` caught this but **age-only** (bw entries have `File==""`, so its `prev.File != e.File` guard never fired), and `validate()` checked only duplicate **ids**, never vars — so `run`/`show` would silently resolve last-write. `validate()` now rejects a var exposed by more than one secret, **for every backend**. render keeps its dedup as defense-in-depth for a hand-built `Registry` that bypasses validate.

### B5 — no charset/path validation at parse
An age source name is joined into `sensitive/<base>.secret.age`, so a `/` or `..` could read **outside** the store (read-traversal). `validate()` now requires:
- age source names match a bare-base charset and contain no `..` (anti-traversal)
- var names are env identifiers (`[A-Za-z_][A-Za-z0-9_]*`)
- bw item/field carry no control characters

Calibrated against the **real** registry (`openrouter.api.key`, `id_ed25519`, …) — **no false positives**; verified it still parses and `dotf secrets ls` works.

## Guards
- `TestParseRegistry_DuplicateVar_Rejected` (was `TestRender_DuplicateVar_FailsFast` — the check moved earlier and broadened to all backends).
- Validation cases: age path traversal (`../../etc/passwd`), age source with slash, invalid var name (`1BAD`).
- `gofmt`/`vet` clean; `internal/secrets` + `internal/cmd` green.

## Completes Phase B of #612
With #650 (B2/B4), this closes the Linux-doable Phase B items (B1/B2/B4/B5). B3 already shipped (#644); B6 are nits.

⚠️ Overlaps #650 in `validate()` + the validation test table — **rebase whichever merges second** (trivial: both append independent blocks).

## SDD skip rationale

Audit-driven hardening, not net-new feature design. Phase B of the #612 `dotf secrets` audit (B1: parse-time var-uniqueness; B5: name/path validation) — bug-fix-class additions to `validate()` in code already covered by the shipped `CLI-024-secrets-fail-loud` spec (Phase A). No public contract, no new dependency, no new command; the only behavioral change is rejecting previously-silent misconfigurations earlier. Fully test-covered (duplicate var, age path traversal, slash, invalid var name), calibrated against the real registry to avoid false positives. A fresh `specs/<id>/` for a bounded follow-up to an existing spec would be SDD theater.
