### PR TITLE
chore: add env-mapping.conf, update copilot-instructions, refresh github token

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Copilot Custom Instructions
 
-> **First, read [`AGENTS.md`](../AGENTS.md) at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Copilot-specific extensions on top.
+> **First, read `AGENTS.md` at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Copilot-specific extensions on top.
 >
 > If `AGENTS.md` is missing from the current repo, default to the canonical version at `$DOTFILES_REPO_DIR/AGENTS.md` (resolved via `machine.json` per ADR-025; falls back to `~/Projects/Workspace/dotfiles/AGENTS.md`).
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,6 @@
-# Copilot Custom Instructions
+> **First, read [`AGENTS.md`](../AGENTS.md) at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Copilot-specific extensions on top.\n>\n> If `AGENTS.md` is missing from the current repo, default to the canonical version at `$DOTFILES_REPO_DIR/AGENTS.md` (resolved via `machine.json` per ADR-025; falls back to `~/Projects/Workspace/dotfiles/AGENTS.md`).\n\n# Copilot Custom Instructions
 
-> **First, read [`AGENTS.md`](../AGENTS.md) at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Copilot-specific extensions on top.
 >
-> If `AGENTS.md` is missing from the current repo, default to the canonical version at `$DOTFILES_REPO_DIR/AGENTS.md` (resolved via `machine.json` per ADR-025; falls back to `~/Projects/Workspace/dotfiles/AGENTS.md`).
 
 ## Role & Goal (Copilot framing)
 
@@ -48,4 +46,3 @@ between the markers.
 
 <!-- BEGIN HARNESS GENERATED -->
 <!-- END HARNESS GENERATED -->
-

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Copilot Custom Instructions
 
-> **First, read `AGENTS.md` at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Copilot-specific extensions on top.
+> **First, read [`AGENTS.md`](../AGENTS.md) at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Copilot-specific extensions on top.
 >
 > If `AGENTS.md` is missing from the current repo, default to the canonical version at `$DOTFILES_REPO_DIR/AGENTS.md` (resolved via `machine.json` per ADR-025; falls back to `~/Projects/Workspace/dotfiles/AGENTS.md`).
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,8 @@
-> **First, read [`AGENTS.md`](../AGENTS.md) at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Copilot-specific extensions on top.\n>\n> If `AGENTS.md` is missing from the current repo, default to the canonical version at `$DOTFILES_REPO_DIR/AGENTS.md` (resolved via `machine.json` per ADR-025; falls back to `~/Projects/Workspace/dotfiles/AGENTS.md`).\n\n# Copilot Custom Instructions
+# Copilot Custom Instructions
 
+> **First, read [`AGENTS.md`](../AGENTS.md) at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Copilot-specific extensions on top.
 >
+> If `AGENTS.md` is missing from the current repo, default to the canonical version at `$DOTFILES_REPO_DIR/AGENTS.md` (resolved via `machine.json` per ADR-025; falls back to `~/Projects/Workspace/dotfiles/AGENTS.md`).
 
 ## Role & Goal (Copilot framing)
 

--- a/ai/copilot/copilot-instructions.md
+++ b/ai/copilot/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Copilot Custom Instructions
 
-> **First, read [`AGENTS.md`](../AGENTS.md) at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Copilot-specific extensions on top.
+> **First, read `AGENTS.md` at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Copilot-specific extensions on top.
 >
 > If `AGENTS.md` is missing from the current repo, default to the canonical version at `$DOTFILES_REPO_DIR/AGENTS.md` (resolved via `machine.json` per ADR-025; falls back to `~/Projects/Workspace/dotfiles/AGENTS.md`).
 

--- a/ai/copilot/copilot-instructions.md
+++ b/ai/copilot/copilot-instructions.md
@@ -48,4 +48,3 @@ between the markers.
 
 <!-- BEGIN HARNESS GENERATED -->
 <!-- END HARNESS GENERATED -->
-

--- a/ai/copilot/copilot-instructions.md
+++ b/ai/copilot/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Copilot Custom Instructions
 
-> **First, read `AGENTS.md` at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Copilot-specific extensions on top.
+> **First, read [`AGENTS.md`](../AGENTS.md) at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Copilot-specific extensions on top.
 >
 > If `AGENTS.md` is missing from the current repo, default to the canonical version at `$DOTFILES_REPO_DIR/AGENTS.md` (resolved via `machine.json` per ADR-025; falls back to `~/Projects/Workspace/dotfiles/AGENTS.md`).
 

--- a/sensitive/env-mapping.conf
+++ b/sensitive/env-mapping.conf
@@ -1,0 +1,54 @@
+# Environment Variable Mapping
+# Format: ENV_VAR_NAME=filename (without .secret.age extension)
+#
+# Usage: secrets_add VAR_NAME filename
+# See: docs/SECRETS.md for full documentation
+
+# API Tokens
+# Same token, two variable names: GITHUB_PERSONAL_ACCESS_TOKEN for CLI/API use,
+# RELEASE_TOKEN for goreleaser and CI release workflows.
+GITHUB_PERSONAL_ACCESS_TOKEN=github.token
+RELEASE_TOKEN=github.token
+DOCKERHUB_TOKEN=dockerhub.token
+CLOUDFLARE_API_TOKEN=cloudflare.api-token
+HETZNER_API_TOKEN=hetzner.api-key
+OPENAI_API_KEY=chatgpt.api-key
+STRIPE_API_KEY=stripe.api-key
+YOUTUBE_API_KEY=youtube.api-key
+BEEHIIV_API_KEY=beehiiv.api-key
+PYPI_TOKEN=pypi.token
+TS_AUTHKEY=tailscale.auth-key
+POLLEX_API_KEY=pollex.api-key
+DOCKERHUB_USERNAME=dockerhub.username
+
+# X (Twitter) API
+X_API_KEY=x.api-key
+X_API_KEY_SECRET=x.api-key-secret
+X_ACCESS_TOKEN=x.access-token
+X_ACCESS_TOKEN_SECRET=x.access-token-secret
+X_BEARER_TOKEN=x.bearer-token
+X_CLIENT_ID=x.client-id
+X_CLIENT_SECRET=x.client-secret
+
+# Infrastructure
+HETZNER_SSH_KEY=hetzner.ssh
+BEEHIIV_DNS_RECORDS=beehiiv.dns-records
+ZOHO_APP_PASSWORDS=zoho.app-passwords
+OPENROUTER_API_KEY=openrouter.api.key
+
+# AI providers
+NAN_API_KEY=nan.api-key
+# Ollama at homelab (VPN-only). User encrypts when ready; commented until then.
+# OLLAMA_API_KEY=ollama.api-key
+
+# File secrets (deployed as files, not env values)
+@KUBECONFIG=kubelab.kubeconfig>~/.kube/kubelab.config
+@SSH_KEY=id_ed25519>~/.ssh/id_ed25519
+
+# Recovery & backup codes (file secrets — not loaded as env vars)
+@GMAIL_BACKUP_CODE=gmail.backup-code>~/.secrets/gmail-backup-code.txt
+@CHATGPT_BACKUP_CODE=chatgpt.backup-code>~/.secrets/chatgpt-backup-code.txt
+@CHATGPT_RECOVERY_CODE=chatgpt.recovery-code>~/.secrets/chatgpt-recovery-code.txt
+@STRIPE_BACKUP_CODE=stripe.backup-code>~/.secrets/stripe-backup-code.txt
+@ZOHO_RECOVERY_CODE=zoho.recovery-code>~/.secrets/zoho-recovery-code.txt
+BITACORA_PAT=github.bitacora

--- a/sensitive/github.token.secret.age
+++ b/sensitive/github.token.secret.age
@@ -1,6 +1,5 @@
 age-encryption.org/v1
--> X25519 M+tn7+vqkTx8BQqCawsXluNQJuAVBpwelufNmsrm+VM
-xJnJBBGMxFxpHLJYXbX+HL7NqUpMaH25IxH3cIFYiwY
---- /5jbOMj/EmsUrxcgnM+2zEGdXVpYjvGoOztPF9Y0OUQ
-¼¶ä/0o&³0ù€xb±w8kr@ÜH
-JÔâ±£Æõ;ÁÛVÜE4¿F¯ËO#³%9±êäa3£ÛHÑ¹»-ëøv ¦¬ÞÓ
+-> X25519 g1FwaqMZ4IyKigJ+zIEBLl64RvsVoAr5M9rjJVFdgTY
+cMweYDGhvfpcTr8tZHITCc6Xmg+VxhatppneO+Kmtrc
+--- faBrFnzRGYZpNl4N7BVA29j9lmaE8AN2polYuuGKIUE
+´kÅ3iDÕ‚	ú"kûçEJ²¥]99ÈÍ]Ý÷éZnäÁ÷’á¨Ò—ÈÆ¹µ}Ñaâ£Çnv#³VØ×™òçœž“êÎMÔ–M.ƒš·.0Í"µ*÷Ût’Nˆ»y}ÎMRUD.ûœƒÒT¡”Â0ƒm


### PR DESCRIPTION
## Changes

- **`sensitive/env-mapping.conf`** (new) — env-var to secret-file mapping. Tracked per user decision (no secret values, only `.secret.age` filenames)
- **`.github/copilot-instructions.md`** — formatting fix for the `AGENTS.md` reference block (collapsed superfluous quote lines)
- **`sensitive/github.token.secret.age`** — re-encrypted (updated token content)

## SDD skip rationale

Housekeeping PR: tracking a new mapping file (env-mapping.conf, 54 LOC), minor formatting in copilot-instructions.md (5 LOC), and re-encrypted secret (0 countable LOC). No structural change, no public API/CLI, no new dependency. The 54 LOC of env-mapping.conf are purely declarative data (env-var → filename pairs), not production logic.

## Notes

- Do not merge — review only.
- The 8 harness skill files that appeared modified were resolved by `git pull` (PR #657 already merged them). The `spec/SKILL.md` conflict was resolved by accepting the vault SSOT version (keeps `check`).
- Worktrees `dotfiles-wt-secrets` and `dotfiles-wt-spec-check` have been cleaned up.