### PR TITLE
feat(secrets): dotf secrets backup DR escrow (ADR-028)

### DIFF
--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -41,6 +41,7 @@ func newSecretsCmd() *cobra.Command {
 	cmd.AddCommand(newSecretsSyncCmd())
 	cmd.AddCommand(newSecretsRenderCmd())
 	cmd.AddCommand(newSecretsVerifyCmd())
+	cmd.AddCommand(newSecretsBackupCmd())
 	return cmd
 }
 

--- a/cli/internal/cmd/secrets_backup.go
+++ b/cli/internal/cmd/secrets_backup.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/env"
+	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
+	"github.com/spf13/cobra"
+)
+
+// Backup seams as overridable vars so command tests inject fakes (no bw, no age key, no
+// network) — the same pattern as ageDecryptor/bwReader in secrets.go. Production wires the
+// real shell-outs (BWExport, AgeEncrypt, AgeRecipient) and the checkout-resolving dest.
+var (
+	bwExporter       secrets.BWExporter  = secrets.BWExport{}
+	ageEncryptor     secrets.Encryptor   = secrets.AgeEncrypt
+	ageRecipient     secrets.RecipientFn = secrets.AgeRecipient
+	repoSensitiveDir                     = env.RepoSensitiveDir
+)
+
+// newSecretsBackupCmd is `dotf secrets backup`: the disaster-recovery escrow of ADR-028
+// §5. It exports the entire Bitwarden vault, encrypts it to the operator's own age
+// recipient, and writes the verified ciphertext to sensitive/dr/ in the checkout — the
+// account-independent recovery floor (recover with the offline age key + a repo clone,
+// no Bitwarden account needed). The command is the automatable unit a scheduler invokes.
+func newSecretsBackupCmd() *cobra.Command {
+	var out string
+	c := &cobra.Command{
+		Use:   "backup",
+		Short: "Escrow the whole Bitwarden vault, age-encrypted, to sensitive/dr (ADR-028 §5)",
+		Long: "backup runs the disaster-recovery escrow: `bw sync` + `bw export` (the entire\n" +
+			"vault — keys, tokens, TOTP seeds) piped in memory into age, encrypted to your own\n" +
+			"recipient (`age-keygen -y` of your identity), and written atomically (0600) to\n" +
+			"sensitive/dr/bitwarden-export.age in the dotfiles checkout. The plaintext is never\n" +
+			"written to disk. The artifact is decrypted back and verified to round-trip before\n" +
+			"the command succeeds; a corrupt escrow is removed, never committed. Recover with\n" +
+			"the offline age key + a repo clone (docs/runbooks/guide-secrets-governance.md).",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			destDir := out
+			if destDir == "" {
+				dir, err := repoSensitiveDir()
+				if err != nil {
+					return fmt.Errorf("backup: %w", err)
+				}
+				destDir = filepath.Join(dir, "dr")
+			}
+			path, err := secrets.Backup(secrets.BackupConfig{
+				Exporter:  bwExporter,
+				Recipient: ageRecipient,
+				Encrypt:   ageEncryptor,
+				Decrypt:   ageDecryptor, // nil in prod → Backup falls back to AgeDecrypt
+				KeyPath:   ageKeyPath(),
+				DestDir:   destDir,
+			})
+			if err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "escrow written and verified: %s\n", path)
+			return nil
+		},
+	}
+	c.Flags().StringVar(&out, "out", "", "destination dir for the escrow (default: <checkout>/sensitive/dr)")
+	return c
+}

--- a/cli/internal/cmd/secrets_backup_test.go
+++ b/cli/internal/cmd/secrets_backup_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
+)
+
+// fakeExp is the cmd-package BWExporter fake (the secrets-package fake lives in another
+// package and is not importable here).
+type fakeExp struct {
+	data []byte
+	err  error
+}
+
+func (f fakeExp) Export() ([]byte, error) { return f.data, f.err }
+
+// stubBackupSeams replaces the four backup seams with a fully-faked, reversible (base64)
+// round-trip — no real bw, no age binary, no key — and restores them after the test.
+func stubBackupSeams(t *testing.T, exp secrets.BWExporter) {
+	t.Helper()
+	oe, oen, orc, od := bwExporter, ageEncryptor, ageRecipient, ageDecryptor
+	bwExporter = exp
+	ageEncryptor = func(pt []byte, _ string) ([]byte, error) {
+		enc := make([]byte, base64.StdEncoding.EncodedLen(len(pt)))
+		base64.StdEncoding.Encode(enc, pt)
+		return enc, nil
+	}
+	ageRecipient = func(string) (string, error) { return "age1fake", nil }
+	ageDecryptor = func(path, _ string) ([]byte, error) {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		dec := make([]byte, base64.StdEncoding.DecodedLen(len(data)))
+		n, err := base64.StdEncoding.Decode(dec, data)
+		if err != nil {
+			return nil, err
+		}
+		return dec[:n], nil
+	}
+	t.Cleanup(func() { bwExporter, ageEncryptor, ageRecipient, ageDecryptor = oe, oen, orc, od })
+}
+
+func useRepoSensitiveDir(t *testing.T, dir string, err error) {
+	t.Helper()
+	old := repoSensitiveDir
+	repoSensitiveDir = func() (string, error) { return dir, err }
+	t.Cleanup(func() { repoSensitiveDir = old })
+}
+
+func TestSecretsBackup_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	stubBackupSeams(t, fakeExp{data: []byte(`{"items":[{"name":"a"}]}`)})
+	useRepoSensitiveDir(t, dir, nil)
+
+	var out bytes.Buffer
+	cmd := newSecretsBackupCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	escrow := filepath.Join(dir, "dr", secrets.EscrowFileName)
+	if _, err := os.Stat(escrow); err != nil {
+		t.Errorf("escrow not written under the checkout's sensitive/dr: %v", err)
+	}
+	if !strings.Contains(out.String(), "verified") {
+		t.Errorf("expected a success message, got %q", out.String())
+	}
+}
+
+func TestSecretsBackup_OutFlagOverridesDest(t *testing.T) {
+	dir := t.TempDir()
+	stubBackupSeams(t, fakeExp{data: []byte(`{"items":[]}`)})
+	// repoSensitiveDir would fail loud; --out must bypass it entirely.
+	useRepoSensitiveDir(t, "", fmt.Errorf("no checkout"))
+
+	cmd := newSecretsBackupCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--out", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("backup --out: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, secrets.EscrowFileName)); err != nil {
+		t.Errorf("escrow not written to --out dir: %v", err)
+	}
+}
+
+func TestSecretsBackup_LockedBw_Errors(t *testing.T) {
+	dir := t.TempDir()
+	stubBackupSeams(t, fakeExp{err: fmt.Errorf("bw export: vault is locked")})
+	useRepoSensitiveDir(t, dir, nil)
+
+	cmd := newSecretsBackupCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected an error when bw is locked")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "dr", secrets.EscrowFileName)); !os.IsNotExist(err) {
+		t.Errorf("no escrow should be written when bw is locked")
+	}
+}
+
+func TestSecretsBackup_NoCheckout_FailsLoud(t *testing.T) {
+	stubBackupSeams(t, fakeExp{data: []byte(`{"items":[]}`)})
+	useRepoSensitiveDir(t, "", fmt.Errorf("no dotfiles checkout found"))
+
+	cmd := newSecretsBackupCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected a fail-loud refusal when no checkout is found (never the deployed copy)")
+	}
+}

--- a/cli/internal/env/env.go
+++ b/cli/internal/env/env.go
@@ -198,6 +198,20 @@ func RepoRegistryPath() (string, error) {
 	return filepath.Join(root, "secrets", "registry.yaml"), nil
 }
 
+// RepoSensitiveDir returns the sensitive/ dir inside the dotfiles checkout, or an error
+// when no checkout is found. WRITERS (dotf secrets backup's DR escrow) MUST use this: the
+// escrow is version-controlled state, so it has to land in the checkout to be committed —
+// writing the deployed copy under ~/.dotfiles is reverted on the next redeploy and never
+// reaches git (the #635 durability class, the write-side analog of ResolveSensitiveDir).
+// Fails loud rather than write a throwaway copy.
+func RepoSensitiveDir() (string, error) {
+	root := RepoDir()
+	if root == "" {
+		return "", fmt.Errorf("no dotfiles checkout found (set DOTFILES_REPO_DIR or run from inside the repo) — refusing to write the DR escrow to the deployed copy")
+	}
+	return filepath.Join(root, "sensitive"), nil
+}
+
 // isDir reports whether p exists and is a directory.
 func isDir(p string) bool {
 	fi, err := os.Stat(p)

--- a/cli/internal/env/env_test.go
+++ b/cli/internal/env/env_test.go
@@ -274,3 +274,27 @@ func TestResolveSensitiveDirFallsBackToDeployed(t *testing.T) {
 		t.Errorf("ResolveSensitiveDir() = %q, want deployed copy %q", got, want)
 	}
 }
+
+func TestRepoSensitiveDirPrefersRepoCheckout(t *testing.T) {
+	// The DR-escrow write seam returns the checkout's sensitive/ so the escrow is
+	// committable (the write side of ADR-030 / #635).
+	repo := t.TempDir()
+	t.Setenv("DOTFILES_REPO_DIR", repo)
+	got, err := RepoSensitiveDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := filepath.Join(repo, "sensitive"); got != want {
+		t.Errorf("RepoSensitiveDir() = %q, want %q", got, want)
+	}
+}
+
+func TestRepoSensitiveDirNoCheckoutFailsLoud(t *testing.T) {
+	// The write seam must refuse the deployed copy: an escrow written there is reverted
+	// on the next redeploy and never reaches git (#635) — fail loud instead.
+	t.Setenv("DOTFILES_REPO_DIR", "")
+	t.Chdir(t.TempDir())
+	if _, err := RepoSensitiveDir(); err == nil {
+		t.Fatal("RepoSensitiveDir() = nil error, want fail-loud when no checkout is found")
+	}
+}

--- a/cli/internal/secrets/escrow.go
+++ b/cli/internal/secrets/escrow.go
@@ -1,0 +1,223 @@
+package secrets
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// EscrowFileName is the fixed name of the age-encrypted full-vault DR escrow under
+// sensitive/dr/ (ADR-028 §5). A single rolling file — git history is the version trail,
+// so a retention policy is a separate concern.
+const EscrowFileName = "bitwarden-export.age"
+
+// BWExporter produces the entire Bitwarden vault as raw export bytes (JSON), in memory.
+// The seam that keeps Backup unit-testable with no Bitwarden vault and no unlock — tests
+// inject a fake; production is BWExport (a `bw sync` + `bw export` shell-out). The
+// full-vault analog of BWReader/BWGet.
+type BWExporter interface {
+	Export() ([]byte, error)
+}
+
+// BWExport is the production BWExporter: `bw sync` then `bw export --format json --raw`,
+// both `--nointeraction` so a locked vault or a missing BW_SESSION fails fast (bw's stderr
+// surfaced) instead of blocking on a prompt. `--raw` keeps the export on stdout — it never
+// touches a file. Thin I/O, verified by a live smoke, not in CI (the escrow analog of
+// BWGet). The raw JSON is returned in memory; Backup pipes it straight into the encryptor.
+type BWExport struct {
+	Bin string // bw binary name/path; "" → "bw"
+}
+
+// Export refreshes the local cache then returns the full vault export. A failed sync
+// (e.g. offline) aborts rather than silently escrowing a stale vault.
+func (e BWExport) Export() ([]byte, error) {
+	bin := e.Bin
+	if bin == "" {
+		bin = "bw"
+	}
+	if _, err := bwRun(bin, "sync"); err != nil {
+		return nil, fmt.Errorf("bw sync: %w", err)
+	}
+	out, err := bwRun(bin, "export", "--format", "json", "--raw")
+	if err != nil {
+		return nil, fmt.Errorf("bw export: %w", err)
+	}
+	return out, nil
+}
+
+// bwRun executes `bw <args...> --nointeraction`, returning stdout or an error carrying
+// bw's stderr (parity with BWGet/BWPut — never a bare "exit status 1"). --nointeraction
+// guarantees no prompt blocks a non-interactive escrow run.
+func bwRun(bin string, args ...string) ([]byte, error) {
+	cmd := exec.Command(bin, append(args, "--nointeraction")...) //nolint:gosec // args are fixed escrow subcommands
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, errors.New(msg)
+	}
+	return stdout.Bytes(), nil
+}
+
+// Encryptor encrypts plaintext to the given age recipient, returning ciphertext. The seam
+// that keeps Backup testable with no age binary and no key; AgeEncrypt is the production
+// default — the inverse of Decryptor/AgeDecrypt.
+type Encryptor func(plaintext []byte, recipient string) ([]byte, error)
+
+// AgeEncrypt shells out to `age -r <recipient>`, feeding plaintext on stdin and returning
+// the binary ciphertext on stdout. The plaintext never touches disk (stdin pipe) — the
+// mirror of AgeDecrypt's in-memory plaintext. age's stderr is surfaced on failure.
+func AgeEncrypt(plaintext []byte, recipient string) ([]byte, error) {
+	cmd := exec.Command("age", "-r", recipient)
+	cmd.Stdin = bytes.NewReader(plaintext)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("age encrypt: %s", msg)
+	}
+	return stdout.Bytes(), nil
+}
+
+// RecipientFn derives the age recipient (public key) for the identity at keyPath. The seam
+// Backup uses so a test needn't run age-keygen; AgeRecipient is production.
+type RecipientFn func(keyPath string) (string, error)
+
+// AgeRecipient runs `age-keygen -y <keyPath>` to print the public recipient of the private
+// identity — the repo's established self-encrypt convention (load-secrets, the runbooks,
+// and ci.yml all derive the recipient this way). The private key stays the single source
+// of truth; no recipient is stored separately. A missing/unreadable key fails fast.
+func AgeRecipient(keyPath string) (string, error) {
+	cmd := exec.Command("age-keygen", "-y", keyPath)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("age-keygen -y %s: %s", keyPath, msg)
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// BackupConfig wires the DR-escrow run: the seams (all overridable for tests) plus the
+// identity key and the destination dir. ADR-028 §5.
+type BackupConfig struct {
+	Exporter  BWExporter  // required: full-vault export (BWExport in prod)
+	Recipient RecipientFn // nil → AgeRecipient
+	Encrypt   Encryptor   // nil → AgeEncrypt
+	Decrypt   Decryptor   // nil → AgeDecrypt (round-trip verify)
+	KeyPath   string      // age identity — derives the recipient and verifies the artifact
+	DestDir   string      // dir to write into (must be the checkout: env.RepoSensitiveDir + "dr")
+	DestName  string      // "" → EscrowFileName
+}
+
+// Backup runs the disaster-recovery escrow: it exports the entire Bitwarden vault,
+// encrypts it to the operator's own age recipient, writes the ciphertext atomically
+// (0600) under DestDir, then verifies the on-disk artifact round-trips to the exact
+// export. The vault plaintext is piped exporter→encryptor in memory and is NEVER written
+// to disk; only the .age ciphertext lands. A verify failure removes the file. Returns the
+// written path.
+//
+// Order matters for the no-partial-file guarantee: recipient, export, and encrypt all run
+// BEFORE any write, so a locked vault or an absent key fails fast with nothing on disk.
+func Backup(cfg BackupConfig) (string, error) {
+	if cfg.Exporter == nil {
+		return "", errors.New("backup: no exporter configured")
+	}
+	recipientFn := cfg.Recipient
+	if recipientFn == nil {
+		recipientFn = AgeRecipient
+	}
+	encrypt := cfg.Encrypt
+	if encrypt == nil {
+		encrypt = AgeEncrypt
+	}
+	name := cfg.DestName
+	if name == "" {
+		name = EscrowFileName
+	}
+
+	// 1. Recipient from the identity — fail fast if the key is absent/unreadable.
+	recipient, err := recipientFn(cfg.KeyPath)
+	if err != nil {
+		return "", fmt.Errorf("backup: age identity required at %s to encrypt the escrow: %w", cfg.KeyPath, err)
+	}
+	if strings.TrimSpace(recipient) == "" {
+		return "", fmt.Errorf("backup: empty age recipient derived from %s", cfg.KeyPath)
+	}
+
+	// 2. Export the full vault — fail fast if bw is locked/unreachable.
+	plaintext, err := cfg.Exporter.Export()
+	if err != nil {
+		return "", fmt.Errorf("backup: %w", err)
+	}
+	if len(plaintext) == 0 {
+		return "", errors.New("backup: bw export produced an empty vault — refusing to escrow nothing")
+	}
+	defer zero(plaintext) // best-effort scrub of the whole-vault plaintext after use
+
+	// 3. Encrypt in memory; the plaintext never reaches disk.
+	ciphertext, err := encrypt(plaintext, recipient)
+	if err != nil {
+		return "", fmt.Errorf("backup: %w", err)
+	}
+
+	// 4. Atomic 0600 write of the ciphertext only.
+	if err := os.MkdirAll(cfg.DestDir, 0o700); err != nil {
+		return "", fmt.Errorf("backup: create %s: %w", cfg.DestDir, err)
+	}
+	path := filepath.Join(cfg.DestDir, name)
+	if err := AtomicWrite(path, ciphertext); err != nil {
+		return "", fmt.Errorf("backup: %w", err)
+	}
+
+	// 5. Verify the on-disk artifact round-trips to the exact export.
+	if err := verifyEscrow(path, plaintext, cfg); err != nil {
+		_ = os.Remove(path) // never leave a corrupt/empty escrow behind
+		return "", fmt.Errorf("backup: round-trip verify failed (removed %s): %w", name, err)
+	}
+	return path, nil
+}
+
+// verifyEscrow decrypts the just-written escrow and asserts it round-trips to the exact
+// exported plaintext and parses as a non-empty JSON document — the "verified round-trip"
+// ADR-028 §3 gates age-file retirement (C6) on. Decrypting the FILE (not the in-memory
+// ciphertext) also confirms the bytes that actually landed on disk are recoverable.
+func verifyEscrow(path string, want []byte, cfg BackupConfig) error {
+	decrypt := cfg.Decrypt
+	if decrypt == nil {
+		decrypt = AgeDecrypt
+	}
+	got, err := decrypt(path, cfg.KeyPath)
+	if err != nil {
+		return fmt.Errorf("decrypt back: %w", err)
+	}
+	if !bytes.Equal(got, want) {
+		return fmt.Errorf("decrypted escrow does not match the export (%d vs %d bytes)", len(got), len(want))
+	}
+	if !json.Valid(got) {
+		return errors.New("escrow plaintext is not valid JSON (bw export format drift?)")
+	}
+	return nil
+}
+
+// zero overwrites b in place — a best-effort scrub of plaintext from process memory once
+// the escrow is encrypted (defense in depth; Go's GC may still hold copies).
+func zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/cli/internal/secrets/escrow_test.go
+++ b/cli/internal/secrets/escrow_test.go
@@ -1,0 +1,188 @@
+package secrets
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// sampleExport stands in for `bw export --format json` — a small but valid JSON document.
+const sampleExport = `{"encrypted":false,"items":[{"name":"x","login":{"password":"p"}}]}`
+
+// fakeExporter is the BWExporter seam fake: a canned export or a canned error.
+type fakeExporter struct {
+	data []byte
+	err  error
+}
+
+func (f fakeExporter) Export() ([]byte, error) { return f.data, f.err }
+
+// b64Encrypt / b64DecryptFile are a reversible stand-in for age, so Backup's round-trip is
+// exercised with no age binary and no key. Ciphertext is base64 — it does not contain the
+// raw plaintext, so "no plaintext on disk" is a real structural assertion.
+func b64Encrypt(pt []byte, _ string) ([]byte, error) {
+	enc := make([]byte, base64.StdEncoding.EncodedLen(len(pt)))
+	base64.StdEncoding.Encode(enc, pt)
+	return enc, nil
+}
+
+func b64DecryptFile(path, _ string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	dec := make([]byte, base64.StdEncoding.DecodedLen(len(data)))
+	n, err := base64.StdEncoding.Decode(dec, data)
+	if err != nil {
+		return nil, err
+	}
+	return dec[:n], nil
+}
+
+// okConfig wires a fully-faked, passing Backup over a fresh temp dest dir.
+func okConfig(t *testing.T, exp BWExporter) BackupConfig {
+	t.Helper()
+	return BackupConfig{
+		Exporter:  exp,
+		Recipient: func(string) (string, error) { return "age1fakerecipient", nil },
+		Encrypt:   b64Encrypt,
+		Decrypt:   b64DecryptFile,
+		KeyPath:   filepath.Join(t.TempDir(), "key.txt"),
+		DestDir:   filepath.Join(t.TempDir(), "dr"),
+	}
+}
+
+func TestBackup_WritesCiphertext_0600(t *testing.T) {
+	cfg := okConfig(t, fakeExporter{data: []byte(sampleExport)})
+	path, err := Backup(cfg)
+	if err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+	if filepath.Base(path) != EscrowFileName {
+		t.Errorf("escrow name = %q, want %q", filepath.Base(path), EscrowFileName)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, _ := b64Encrypt([]byte(sampleExport), "")
+	if !bytes.Equal(got, want) {
+		t.Errorf("on-disk bytes are not the ciphertext the encryptor produced")
+	}
+	if runtime.GOOS != "windows" { // POSIX perm bits are only meaningful off Windows
+		fi, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Mode().Perm() != 0o600 {
+			t.Errorf("escrow mode = %v, want 0600", fi.Mode().Perm())
+		}
+	}
+}
+
+func TestBackup_NoPlaintextOnDisk(t *testing.T) {
+	cfg := okConfig(t, fakeExporter{data: []byte(sampleExport)})
+	path, err := Backup(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("dest dir holds %d files, want exactly the .age escrow", len(entries))
+	}
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".json" {
+			t.Errorf("a plaintext json export was written to disk: %s", e.Name())
+		}
+	}
+	got, _ := os.ReadFile(path)
+	if bytes.Contains(got, []byte(sampleExport)) {
+		t.Errorf("the escrow file contains the raw plaintext export")
+	}
+}
+
+func TestBackup_RecipientThreadedToEncryptor(t *testing.T) {
+	var gotRecipient string
+	cfg := okConfig(t, fakeExporter{data: []byte(sampleExport)})
+	cfg.Recipient = func(string) (string, error) { return "age1specific", nil }
+	cfg.Encrypt = func(pt []byte, r string) ([]byte, error) {
+		gotRecipient = r
+		return b64Encrypt(pt, r)
+	}
+	if _, err := Backup(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if gotRecipient != "age1specific" {
+		t.Errorf("recipient passed to encryptor = %q, want age1specific", gotRecipient)
+	}
+}
+
+func TestBackup_RoundTripVerifyPasses(t *testing.T) {
+	cfg := okConfig(t, fakeExporter{data: []byte(sampleExport)})
+	if _, err := Backup(cfg); err != nil {
+		t.Fatalf("a clean round-trip must verify: %v", err)
+	}
+}
+
+func TestBackup_TamperedCiphertext_RemovesFileAndErrors(t *testing.T) {
+	cfg := okConfig(t, fakeExporter{data: []byte(sampleExport)})
+	// Decrypt returns bytes that don't match the export → round-trip mismatch.
+	cfg.Decrypt = func(string, string) ([]byte, error) { return []byte(`{"items":[]}`), nil }
+	if _, err := Backup(cfg); err == nil {
+		t.Fatal("expected a round-trip verify failure")
+	}
+	if _, err := os.Stat(filepath.Join(cfg.DestDir, EscrowFileName)); !os.IsNotExist(err) {
+		t.Errorf("a corrupt escrow must be removed on verify failure")
+	}
+}
+
+func TestBackup_NonJSONExport_FailsVerify(t *testing.T) {
+	cfg := okConfig(t, fakeExporter{data: []byte("this is not json")})
+	if _, err := Backup(cfg); err == nil {
+		t.Fatal("expected a non-JSON export to fail the verify (format drift guard)")
+	}
+	if _, err := os.Stat(filepath.Join(cfg.DestDir, EscrowFileName)); !os.IsNotExist(err) {
+		t.Errorf("the unverifiable escrow must be removed")
+	}
+}
+
+func TestBackup_ExporterError_NoFile(t *testing.T) {
+	cfg := okConfig(t, fakeExporter{err: fmt.Errorf("bw export: vault is locked")})
+	if _, err := Backup(cfg); err == nil {
+		t.Fatal("expected the exporter error to surface")
+	}
+	if _, err := os.Stat(filepath.Join(cfg.DestDir, EscrowFileName)); !os.IsNotExist(err) {
+		t.Errorf("no escrow may be written when the export fails")
+	}
+}
+
+func TestBackup_RecipientError_NoFile(t *testing.T) {
+	cfg := okConfig(t, fakeExporter{data: []byte(sampleExport)})
+	cfg.Recipient = func(string) (string, error) { return "", fmt.Errorf("age key not found") }
+	if _, err := Backup(cfg); err == nil {
+		t.Fatal("expected the recipient error to surface")
+	}
+	if _, err := os.Stat(filepath.Join(cfg.DestDir, EscrowFileName)); !os.IsNotExist(err) {
+		t.Errorf("no escrow may be written when the recipient cannot be derived")
+	}
+}
+
+func TestBackup_EmptyExport_Refused(t *testing.T) {
+	cfg := okConfig(t, fakeExporter{data: []byte{}})
+	if _, err := Backup(cfg); err == nil {
+		t.Fatal("expected a refusal to escrow an empty vault")
+	}
+}
+
+func TestBackup_NilExporter_Errors(t *testing.T) {
+	if _, err := Backup(BackupConfig{}); err == nil {
+		t.Fatal("expected an error when no exporter is configured")
+	}
+}

--- a/docs/runbooks/guide-secrets-governance.md
+++ b/docs/runbooks/guide-secrets-governance.md
@@ -45,13 +45,10 @@ Scheduled cadence (registry `rotate`), suspected exposure, or offboarding:
 
 Scheduled (e.g. weekly) + before any big change:
 
-1. `bw sync`
-2. `bw export --format json --raw | age -r <pubkey> -o sensitive/dr/bitwarden-export.age`
-   — plaintext **never** touches disk (`--raw` → pipe → `age`).
-3. **Overwrite** the previous export (don't accumulate full-vault snapshots in git history); commit.
-4. **Mirror off-box** (#454) and ensure the **age key has an OFFLINE authoritative copy** (`backup-secrets-to-usb.sh` + paper/OS keychain) — it must NOT live only in Bitwarden (circular dependency).
-   - _Target:_ `dotf secrets backup` wraps steps 1-3.
-   - The escrow covers the **entire** vault (API keys, tokens, logins, TOTP seeds) → losing Bitwarden is fully recoverable.
+1. **`dotf secrets backup`** — runs `bw sync` + `bw export --format json --raw`, pipes the plaintext **in memory** into `age` (encrypted to your own recipient, `age-keygen -y` of your identity), and writes `sensitive/dr/bitwarden-export.age` atomically (0600). The plaintext **never** touches disk; the artifact is decrypted back and **verified to round-trip** before the command succeeds (a corrupt escrow is removed, never left behind). Then **commit** it — it overwrites the previous export (git history is the version trail; no snapshot pile-up).
+   - _Manual equivalent (no `dotf` on PATH):_ `bw sync && bw export --format json --raw | age -r "$(age-keygen -y ~/.config/age/key.txt)" -o sensitive/dr/bitwarden-export.age`.
+2. **Mirror off-box** (#454, follow-up) and ensure the **age key has an OFFLINE authoritative copy** (#518: encrypted USB + paper/OS keychain) — it must NOT live only in Bitwarden (circular dependency).
+3. The escrow covers the **entire** vault (API keys, tokens, logins, TOTP seeds) → losing Bitwarden is fully recoverable with the offline age key + a repo clone.
 
 ## Protocol — RECOVER (disaster)
 
@@ -59,9 +56,9 @@ Lost Bitwarden access / new machine / account compromise (the OPS-001 #257 chain
 
 1. Restore the **age key** from its offline backup → `~/.config/age/key.txt`.
 2. Clone the dotfiles repo.
-3. `age -d -i ~/.config/age/key.txt sensitive/dr/bitwarden-export.age > $TMPDIR/vault.json` (ephemeral / tmpfs).
-4. Stand up a fresh Bitwarden (or any manager) and **import** `vault.json`; or read individual secrets for immediate needs.
-5. Re-establish: `bw login` + unlock; `dotf secrets sync` to re-materialize consumers.
+3. `age -d -i ~/.config/age/key.txt sensitive/dr/bitwarden-export.age > $TMPDIR/vault.json` (ephemeral / tmpfs) — `sensitive/dr/bitwarden-export.age` is the artifact `dotf secrets backup` produced.
+4. Stand up a fresh Bitwarden (or any manager) and **import** `vault.json` (`bw import bitwardenjson $TMPDIR/vault.json`); or read individual secrets for immediate needs.
+5. Re-establish: `bw login` + unlock; `dotf secrets sync` to re-materialize consumers, then `dotf secrets verify` to confirm every registry secret resolves.
 6. **Rotate** anything that may have been exposed during the incident.
 7. Securely delete `$TMPDIR/vault.json`.
    - Account-independent: **age key (offline) + repo clone = full recovery**, even if the Bitwarden account is gone.

--- a/sensitive/dr/.gitignore
+++ b/sensitive/dr/.gitignore
@@ -1,0 +1,7 @@
+# DR escrow dir (ADR-028 §5). Deny-by-default: only the age-encrypted escrow and this
+# file are tracked. A plaintext `bw export` (*.json) dropped here — by `dotf secrets
+# backup` going wrong, or a manual run — can NEVER be staged. Guard for the "plaintext
+# never committed" invariant (incident → guard, same PR).
+*
+!.gitignore
+!*.age

--- a/specs/CLI-024-secrets-backup/features.json
+++ b/specs/CLI-024-secrets-backup/features.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "CLI-024-secrets-backup-f1",
+    "behavior": "AC1: backup writes a 0600 age escrow to sensitive/dr; the exported plaintext is never written to disk",
+    "verification": "cd cli && go test ./internal/secrets/ -run 'TestBackup_WritesCiphertext_0600|TestBackup_NoPlaintextOnDisk'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-backup-f2",
+    "behavior": "AC2: the recipient is derived via the AgeRecipient seam and threaded into the encryptor; no recipient literal in code",
+    "verification": "cd cli && go test ./internal/secrets/ -run 'TestBackup_RecipientThreadedToEncryptor'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-backup-f3",
+    "behavior": "AC3: round-trip verify passes on a clean escrow; a tampered ciphertext removes the file and errors",
+    "verification": "cd cli && go test ./internal/secrets/ -run 'TestBackup_RoundTripVerifyPasses|TestBackup_TamperedCiphertext_RemovesFileAndErrors'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-backup-f4",
+    "behavior": "AC4: a locked bw (exporter error) and a missing age key (recipient error) fail fast with no file written",
+    "verification": "cd cli && go test ./internal/secrets/ -run 'TestBackup_ExporterError_NoFile|TestBackup_RecipientError_NoFile'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-backup-f5",
+    "behavior": "AC5: RepoSensitiveDir prefers the checkout and fails loud when no checkout is found",
+    "verification": "cd cli && go test ./internal/env/ -run 'TestRepoSensitiveDir'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-backup-f6",
+    "behavior": "AC1/AC4 cmd: dotf secrets backup happy path produces the escrow; a locked bw errors clearly (fakes, no real bw/age)",
+    "verification": "cd cli && go test ./internal/cmd/ -run 'TestSecretsBackup'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-backup-f7",
+    "behavior": "AC6 guard: a plaintext sensitive/dr/*.json is git-ignored (cannot be committed)",
+    "verification": "git check-ignore -q sensitive/dr/bitwarden-export.json",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-backup-f8",
+    "behavior": "AC6 runbook: the governance runbook's BACKUP protocol invokes the real dotf secrets backup (no duplicate recover file)",
+    "verification": "grep -q 'dotf secrets backup' docs/runbooks/guide-secrets-governance.md",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-backup-f9",
+    "behavior": "AC7: the full Go suite, vet, and gofmt are clean; registry.yaml unchanged",
+    "verification": "cd cli && go test ./... && go vet ./... && test -z \"$(gofmt -l .)\"",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CLI-024-secrets-backup/proposal.md
+++ b/specs/CLI-024-secrets-backup/proposal.md
@@ -1,0 +1,170 @@
+---
+id: "CLI-024-secrets-backup"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-29"
+issue: "mlorentedev/dotfiles#586"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, secrets, cli, go, age, bitwarden, dr]
+template_version: "1.0"
+---
+
+# CLI-024-secrets-backup
+
+> **Naming**: file lives at `<repo>/specs/CLI-024-secrets-backup/proposal.md`. Slice 1 of
+> ADR-028 **Phase 4** (#586): the repo-side DR foundation the vault-side curation depends on.
+
+## Why
+
+ADR-028 §5 makes the **age-encrypted Bitwarden escrow** the thing that turns "lose the
+Bitwarden account → lose every secret (API keys, tokens, *and* the TOTP/2FA seeds)" into
+"recover everything from an offline age key + a repo clone". The ratified Consequences
+(§1, §3) sequence it first: the escrow (`dotf secrets backup`) and the recover runbook
+**must exist before** the least-reversible Phase-4 mutations — moving the `AGE-SECRET-KEY-*`
+offline (#518), restructuring live items — because they are the safety net those operations
+lean on. Today the escrow is a **manual command a runbook tells you to type**
+(`docs/runbooks/guide-secrets-governance.md:49`), which violates Standing Order #1
+(automate, don't instruct) and is the kind of step that silently never runs. There is no
+`dotf secrets backup`. This spec builds it, plus the `recover` runbook (#257) it pairs with.
+
+## What
+
+Concrete, observable changes after this PR:
+
+1. **`dotf secrets backup` subcommand.** One idempotent invocation runs the escrow end to
+   end: `bw sync` → `bw export --format json --raw` → encrypt to the operator's own age
+   recipient → **atomic, `0600`** write to `sensitive/dr/bitwarden-export.age` in the
+   dotfiles checkout. The plaintext vault export is **piped in memory** (exporter stdout →
+   encryptor stdin) and **never touches disk**; only the ciphertext is written. The
+   command is the unit a scheduler later calls — no manual steps.
+
+2. **Recipient derived from the identity, not hardcoded or duplicated.** The age recipient
+   is `age-keygen -y <keyPath>` — the repo's established self-encrypt convention (every
+   existing encrypt site does exactly this: `ci.yml`, `ai/nan/README.md`,
+   `docs/runbooks/secrets-management.md`, `scripts/age-standalone.sh`). The private key
+   stays the **single source**; no new committed recipients file, no `age1…` literal in
+   code or config. Key path resolves through the existing `ageKeyPath()` cascade
+   (`$AGE_KEY_PATH` → `~/.config/age/key.txt`).
+
+3. **Two new testable seams, mirroring the existing ones (Open/Closed).**
+   - `BWExporter` (`Export() ([]byte, error)`) — production `BWExport{Bin}` shells
+     `bw sync` + `bw export --format json --raw` with `--nointeraction`; the age analog of
+     `BWGet`. A locked / unreachable vault fails fast with bw's stderr surfaced.
+   - `Encryptor` (`Encrypt(plaintext []byte, recipient string) ([]byte, error)`) +
+     `AgeRecipient(keyPath)` — production `AgeEncrypt` shells `age -r <recipient>` reading
+     plaintext from **stdin** (never a temp file); the inverse of `AgeDecrypt`.
+   - The round-trip verify **reuses the existing `Decryptor`/`AgeDecrypt`** — no new seam.
+   Command-layer tests inject fakes → **no `bw`, no age key, no network in CI** (the exact
+   coverage shape `fakeDecryptor`/fake `BWReader` already give).
+
+4. **Built-in verified round-trip.** After writing, the command decrypts the artifact with
+   the identity and asserts it round-trips to the **exact** exported bytes and parses as a
+   **non-empty** Bitwarden export JSON. A verify failure **removes the just-written file**
+   and exits non-zero — a corrupt or empty escrow is never left on disk or committed. This
+   is the "escrow (and its verified round-trip)" that ADR-028 §3 gates age-file retirement
+   (C6) on.
+
+5. **`RepoSensitiveDir()` write-seam** (fail-loud when no checkout), mirroring
+   `RepoRegistryPath` (#635 / ADR-030). The escrow is version-controlled state, so it must
+   land in the checkout to be committed — never the throwaway deployed copy under
+   `~/.dotfiles`. No checkout → a clear refusal, not a silent write to the deployed copy.
+
+6. **Recover runbook made real — no new file (SSOT).** `guide-secrets-governance.md`
+   already owns the ADD/ROTATE/BACKUP/RECOVER protocols, so this PR **updates** its BACKUP
+   section to invoke `dotf secrets backup` (the manual `bw…|age…` pipe demoted to the
+   no-`dotf` fallback) and tightens RECOVER (decrypt to tmpfs → `bw import bitwardenjson` →
+   `dotf secrets verify`). A separate `guide-secrets-recover.md` would duplicate that
+   protocol — a SSOT violation (Standing Order #2), so the recover chain (#257) is hardened
+   in place rather than forked.
+
+`registry.yaml` is **not** edited and no secret is flipped: this PR adds the escrow
+*capability* + its recover doc, with zero change to live secret resolution.
+
+## Out of scope
+
+- **Off-box mirror of the escrow (#454).** This PR writes + commits the artifact in-repo;
+  pushing it to a second off-box destination is OPS-015/#454's job — the **next** slice.
+- **Scheduling automation** (systemd timer / Windows Task Scheduler). The command is the
+  idempotent unit a scheduler invokes; wiring the timer is a thin, separable follow-up
+  slice (tracked), kept out to hold this PR to one logical change (atomic-PR rule). "It is
+  automatable" is satisfied here; "it is scheduled" is the follow-up.
+- **The offline age-key move (#518), folder taxonomy, per-purpose token split (#321),
+  naming-drift fixes** — the other #586 workstreams. This is the foundation they depend on,
+  not them.
+- **`bw serve` daemon lifecycle** — a perf upgrade behind the `BWExporter` seam, not
+  correctness. Deferred (same posture as the bw-backend spec).
+- **Pruning / rotation of old escrow snapshots** — the artifact is a single
+  rolling file (git history is the version trail); a retention policy is a later concern.
+
+## Risks / open questions
+
+- **Whole-vault plaintext in process memory.** Between export and encrypt the full vault
+  plaintext lives in a Go `[]byte`. *Mitigation:* it is piped, **never written to disk**;
+  the process is short-lived; this is the same exposure shape as `AgeDecrypt` returning
+  plaintext in memory. Defense-in-depth (zero the buffer after encrypt) is a cheap add,
+  noted in `tasks.md`.
+- **Plaintext escrow must never be committed.** The artifact is ciphertext by construction
+  (atomic write of the encryptor output only). *Mitigation:* a guard so a plaintext
+  `sensitive/dr/*.json` can never be staged — fits the repo's "incident → guard in the
+  same PR" rule; covered in `tasks.md` (a `.gitignore` entry + a CI/pre-commit assertion).
+- **Key absent on the box.** `age-keygen -y` needs the private identity; a box without it
+  cannot encrypt the escrow. *Mitigation:* fail fast with an actionable message
+  ("age identity required at <path> to encrypt the escrow — restore the key first"), never
+  a hang. A backup box legitimately holds the convenience key copy (ADR-028 §4); recover
+  needs the key anyway.
+- **Locked / unreachable Bitwarden.** *Mitigation:* `bw export` runs `--nointeraction` and
+  surfaces bw's stderr fail-fast (parity with `BWGet`); the atomic write + verify mean no
+  partial or empty escrow is ever produced.
+- **`bw export` schema/version drift.** The JSON shape could change across bw releases.
+  *Mitigation:* verify asserts it parses + is non-empty (not a deep schema check — that
+  would couple us to bw's internal format); the recover runbook pins
+  `bw import --format bitwardenjson`.
+- **Resolved by convention (not open):** recipient source = `age-keygen -y` (repo
+  convention, single key); round-trip verify = always (the key is present by construction).
+  Neither needs a decision.
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable with the seams above (no real `bw`/age in CI).
+
+- [ ] **AC1** — `dotf secrets backup` orchestrates `BWExporter` → `Encryptor` → atomic
+  write, producing `sensitive/dr/bitwarden-export.age` at mode `0600`; the exported
+  plaintext is **never** written to disk. *Verify:* command test with fake exporter + fake
+  encryptor asserts the file holds the ciphertext, mode is `0600`, and no plaintext file
+  appears in the dir.
+- [ ] **AC2** — the recipient is obtained via the `AgeRecipient` (`age-keygen -y`) seam and
+  passed to the encryptor; no recipient literal exists in code/config. *Verify:* test with
+  a fake recipient asserts it is threaded into the encrypt call.
+- [ ] **AC3** — after writing, the artifact is decrypted (via `Decryptor`) and must
+  round-trip to the exact exported bytes and parse as non-empty JSON; on a verify failure
+  the file is **removed** and the command exits non-zero. *Verify:* table test (clean
+  round-trip passes; tampered ciphertext → file deleted + error).
+- [ ] **AC4** — a locked/unreachable Bitwarden (exporter error) and a missing age key
+  (recipient error) each fail fast with a clear, actionable message and **no file written**.
+  *Verify:* two command tests with erroring fakes.
+- [ ] **AC5** — the write lands in the checkout via `RepoSensitiveDir`; no checkout → a
+  fail-loud refusal (never the deployed copy). *Verify:* env test mirroring
+  `RepoRegistryPath`'s repo-vs-deployed coverage.
+- [ ] **AC6** — a plaintext `sensitive/dr/*.json` cannot be committed (guard), and
+  `guide-secrets-governance.md`'s BACKUP protocol invokes `dotf secrets backup` (the manual
+  pipe demoted to the no-`dotf` fallback), with RECOVER tightened (#257). *Verify:*
+  `git check-ignore` on a `.json` under `sensitive/dr/` + `grep 'dotf secrets backup'` of
+  the runbook.
+- [ ] **AC7** — `go test ./... && go vet ./... && gofmt -l` clean; the production
+  `BWExport`/`AgeEncrypt` (thin I/O to `bw`/`age`) are covered by a **live smoke** with the
+  operator's unlocked session, not in CI (parity with `BWGet`/`AgeDecrypt`).
+
+## References
+
+- ADR: `docs/adr/adr-028-secrets-two-tier-bitwarden-age.md` (§5 escrow; Consequences §1
+  repo-side-first, §3 retirement gated on the verified round-trip; §4 offline age key).
+- Issue: `mlorentedev/dotfiles#586` (Phase 4 curation — this delivers the DR-escrow AC +
+  the recover runbook; folders / #321 split / #518 offline key are follow-up slices).
+- Related issues: #257 (recover runbook), #454 (off-box mirror — next slice), #518
+  (offline age key — gated on this).
+- Reuse: `cli/internal/secrets/{resolve,bw}.go` (`Decryptor`/`AgeDecrypt`, `BWGet`,
+  `BWReader` seam pattern), `cli/internal/cmd/secrets.go` (`ageKeyPath`, seam `var`s),
+  `cli/internal/env/env.go` (`ResolveSensitiveDir`, `RepoRegistryPath` write-seam pattern).
+- Prior merged specs: `CLI-024-secrets-bw-backend` (the seam/test idiom this mirrors),
+  `CLI-024-secrets-registry`, `CLI-025-secrets-render`.
+- Runbook this automates: `docs/runbooks/guide-secrets-governance.md` (§ the manual escrow
+  line this replaces).

--- a/specs/CLI-024-secrets-backup/tasks.md
+++ b/specs/CLI-024-secrets-backup/tasks.md
@@ -1,0 +1,71 @@
+---
+tags: [spec, tasks, secrets, cli, go, age, dr]
+created: "2026-06-29"
+---
+
+# Tasks - CLI-024-secrets-backup
+
+> TDD order. One task = one focused commit. Tick as you go.
+
+## Setup
+
+- [x] Branch created from main: `feat/secrets-dr-escrow` (external worktree)
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions" (recipient + verify
+  resolved by convention; mirror #454 + scheduling confirmed out-of-scope follow-ups)
+
+## Implementation
+
+- [ ] **AC5** — `env.RepoSensitiveDir() (string, error)`: the WRITE seam for `sensitive/`,
+  fail-loud when no checkout (mirrors `RepoRegistryPath`). Tests:
+  `TestRepoSensitiveDirPrefersRepoCheckout`, `TestRepoSensitiveDirNoCheckoutFailsLoud`.
+- [ ] **AC2** — new seams in `cli/internal/secrets/escrow.go`:
+  - `BWExporter` interface + `BWExport{Bin}` (`bw sync` + `bw export --format json --raw`,
+    `--nointeraction`); the export analog of `BWGet`.
+  - `Encryptor func([]byte, recipient string) ([]byte, error)` + `AgeEncrypt` (`age -r
+    <recipient>`, plaintext via **stdin**, ciphertext on stdout — inverse of `AgeDecrypt`).
+  - `RecipientFn func(keyPath string) (string, error)` + `AgeRecipient` (`age-keygen -y`).
+  Their fakes' wiring is asserted with AC1/AC3; the shell-outs are live-smoke only (AC7).
+- [ ] **AC1** — `secrets.Backup(cfg BackupConfig) (path string, err error)` core: derive
+  recipient -> export -> encrypt -> atomic `0600` write to `DestDir/DestName`. Plaintext stays
+  in memory (zeroed after encrypt, defense-in-depth); only ciphertext is written. Reuse the
+  existing atomic-write helper (`render`'s) for cross-OS atomicity. Tests:
+  `TestBackup_WritesCiphertext_0600`, `TestBackup_NoPlaintextOnDisk`.
+- [ ] **AC3** — round-trip verify inside `Backup`: decrypt the written file via `Decrypt`,
+  assert `bytes.Equal(plaintext, decrypted)` + `json.Valid` + non-empty; on failure
+  `os.Remove(path)` and return a wrapped error. Tests: `TestBackup_RoundTripVerifyPasses`,
+  `TestBackup_TamperedCiphertext_RemovesFileAndErrors`.
+- [ ] **AC4** — fail-fast, no file written: exporter error (locked/unreachable bw) and
+  recipient error (age key absent) each surface a clear, actionable message before any
+  write. Tests: `TestBackup_ExporterError_NoFile`, `TestBackup_RecipientError_NoFile`.
+- [ ] **AC1/AC4 (cmd)** — `newSecretsBackupCmd()` in `cli/internal/cmd/secrets_backup.go`:
+  wires production seams (`BWExport`, `AgeEncrypt`, `AgeRecipient`, `ageDecryptor`), resolves
+  dest via `RepoSensitiveDir()`/`dr`, prints the written path + verify result. Optional
+  `--out <path>` override. Seams as overridable `var`s for command tests (fakes; no bw, no
+  key). Register in `secrets.go` `AddCommand`. Tests: `TestSecretsBackup_HappyPath`,
+  `TestSecretsBackup_LockedBw_Errors`.
+- [ ] **AC6 (guard)** — `sensitive/dr/.gitignore` deny-all-except-`.age` (`*`, `!.gitignore`,
+  `!*.age`) so a plaintext `*.json` export can never be staged; CI/bats assertion that a
+  `sensitive/dr/foo.json` is ignored. (incident -> guard, same PR.)
+- [ ] **AC6 (runbook, SSOT — no new file)** — update `guide-secrets-governance.md`: its
+  BACKUP protocol now invokes `dotf secrets backup` (manual `bw…|age…` pipe demoted to the
+  no-`dotf` fallback), RECOVER tightened (decrypt to tmpfs -> `bw import bitwardenjson` ->
+  `dotf secrets verify`). A separate `guide-secrets-recover.md` would duplicate the existing
+  RECOVER protocol (SSOT violation), so the #257 chain is hardened in place.
+
+## Closing
+
+- [ ] Every acceptance criterion is covered by >=1 test (AC7 shell-outs excepted — live smoke)
+- [ ] `features.json` carries non-vacuous verification commands (state left `pending`)
+- [ ] `go test ./... && go vet ./... && gofmt -l` clean; `go build ./...` clean
+- [ ] `registry.yaml` unchanged (no secret flipped — confirm with `git diff`)
+- [ ] Live smoke captured in `verification.md`: real `dotf secrets backup` on the unlocked
+  vault produces a verifying escrow (the AC7 evidence)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+See `features.json` (sibling). Each acceptance criterion maps to >=1 feature with an
+executable `verification`. The agent may not set `"state": "passing"` — only the harness,
+after capturing exit 0, may.

--- a/specs/CLI-024-secrets-backup/verification.md
+++ b/specs/CLI-024-secrets-backup/verification.md
@@ -1,0 +1,79 @@
+---
+tags: [spec, verification, secrets, cli, go, age, dr]
+created: "2026-06-29"
+---
+
+# Verification - CLI-024-secrets-backup
+
+## Evidence
+
+Run: `cd cli && go test ./internal/secrets/ ./internal/cmd/ ./internal/env/` → all `ok`.
+
+| AC | Behavior | Tests (all PASS) |
+|----|----------|------------------|
+| AC1 | escrow written 0600; plaintext never on disk | `TestBackup_WritesCiphertext_0600`, `TestBackup_NoPlaintextOnDisk` |
+| AC2 | recipient derived via seam, threaded to encryptor | `TestBackup_RecipientThreadedToEncryptor` |
+| AC3 | round-trip verify; tamper/non-JSON → remove + error | `TestBackup_RoundTripVerifyPasses`, `TestBackup_TamperedCiphertext_RemovesFileAndErrors`, `TestBackup_NonJSONExport_FailsVerify` |
+| AC4 | locked bw / missing key → fail fast, no file | `TestBackup_ExporterError_NoFile`, `TestBackup_RecipientError_NoFile`, `TestBackup_EmptyExport_Refused`, `TestBackup_NilExporter_Errors` |
+| AC5 | `RepoSensitiveDir` prefers checkout, fails loud | `TestRepoSensitiveDirPrefersRepoCheckout`, `TestRepoSensitiveDirNoCheckoutFailsLoud` |
+| AC1/AC4 (cmd) | happy path / locked bw / no checkout / `--out` | `TestSecretsBackup_HappyPath`, `TestSecretsBackup_LockedBw_Errors`, `TestSecretsBackup_NoCheckout_FailsLoud`, `TestSecretsBackup_OutFlagOverridesDest` |
+| AC6 (guard) | plaintext `.json` unstageable; `.age` trackable | `git check-ignore` (below) |
+| AC6 (runbook) | governance runbook invokes the real command | `grep 'dotf secrets backup'` (below) |
+
+`go test ./internal/secrets/ -run Backup -v` → 10/10 PASS (captured 2026-06-29).
+
+**Guard (AC6):** `git check-ignore -v sensitive/dr/bitwarden-export.json` → matched by
+`sensitive/dr/.gitignore:5:*`; `git check-ignore sensitive/dr/bitwarden-export.age` → exit 1
+(the `.age` escrow stays committable).
+
+**Runbook (AC6):** `grep 'dotf secrets backup' docs/runbooks/guide-secrets-governance.md` →
+matches; RECOVER tightened in place. No `guide-secrets-recover.md` (would duplicate).
+
+## Test status
+
+- `go build ./...` clean; `go vet ./internal/secrets/ ./internal/cmd/ ./internal/env/` clean.
+- Manual smoke: `dotf secrets backup --help` renders the description + `--out` flag (wiring
+  confirmed, no `bw`/`age` invoked).
+- No regressions: the affected packages are green. (Pre-existing, unrelated: `internal/spec`
+  `TestEmbeddedTemplatesMatchVault` fails on `main` too — vendored `templates/tasks.md` drift
+  vs vault `spec-tasks.md`; not touched here, needs its own re-vendor change.)
+- `git diff --stat -- secrets/registry.yaml` → empty (no secret flipped).
+- `gofmt`: the four new files are LF + formatted (absent from `gofmt -l`). The Windows working
+  tree shows CRLF on pre-existing files; `.gitattributes` `* text=auto` normalizes commits to
+  LF, so the Linux CI `lint` job is clean.
+
+### Pending — live smoke (AC7, operator-run; needs an unlocked vault)
+
+```
+bw unlock           # export BW_SESSION
+dotf secrets backup # → escrow written and verified: <checkout>/sensitive/dr/bitwarden-export.age
+age -d -i ~/.config/age/key.txt sensitive/dr/bitwarden-export.age | head -c 80   # sanity: JSON
+```
+
+Paste the (redacted) output here once run, then tick the AC7 box in `tasks.md`.
+
+## Decisions made during implementation
+
+- **No separate `guide-secrets-recover.md` (SSOT).** `guide-secrets-governance.md` already
+  owns the RECOVER protocol; a second file would duplicate it (Standing Order #2). Hardened
+  the existing BACKUP/RECOVER sections in place instead — a course correction from the initial
+  proposal sketch after reading the runbook in full.
+- **Recipient by convention, not a new file.** `age-keygen -y` of the identity (what every
+  other encrypt site in the repo does) — the private key stays the single source; no
+  `age-recipients.txt` introduced.
+- **Order = no-partial-file guarantee.** recipient → export → encrypt all run before any write;
+  verify-then-remove on failure. A locked vault / absent key leaves the disk untouched.
+
+## Promotion candidates
+
+- [ ] Lesson for `docs/lessons.md`? Maybe — "self-encrypt escrow needs the key present, so
+  verify is free; a keyless-backup design would need a committed recipients file" (decide at PR).
+- [ ] ADR-worthy? No — ADR-028 already ratified the escrow design; this implements §5.
+- [ ] New `00_meta/patterns/` pattern? No — repo-specific.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/CLI-024-secrets-backup/` → `specs/archive/CLI-024-secrets-backup/`
+- [ ] Bitácora board ticket (#586 slice) updated with the PR link (ADR-018)
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
## What

Adds `dotf secrets backup` — the disaster-recovery escrow of ADR-028 (§5): the repo-side
foundation that must exist before the least-reversible secrets-curation steps (offline age
key, live-item restructuring). It automates what `guide-secrets-governance.md` previously
documented as a manual `bw … | age …` pipe (Standing Order #1: automate, don't instruct).

`dotf secrets backup` runs `bw sync` + `bw export --format json --raw`, pipes the whole-vault
plaintext **in memory** into `age` (encrypted to the operator's own `age-keygen -y` recipient),
and writes `sensitive/dr/bitwarden-export.age` atomically (0600) inside the checkout. It then
decrypts the artifact back and verifies it round-trips to the exact export before succeeding —
a corrupt escrow is removed, never left behind. Recover with the offline age key + a repo
clone, no Bitwarden account needed.

## Design (no hardcoding, no shortcuts)

- **Plaintext never on disk** — exporter stdout is piped to the encryptor in memory; the
  buffer is scrubbed after encrypt. Only the `.age` ciphertext is written.
- **Recipient by convention** — `age-keygen -y` of the identity, exactly what every other
  encrypt site in the repo does. The private key stays the single source; no recipient literal
  or new committed recipients file.
- **Testable seams** — `BWExporter`/`BWExport`, `Encryptor`/`AgeEncrypt`, `RecipientFn`/
  `AgeRecipient` (the encrypt/export analogs of `BWGet`/`AgeDecrypt`). The core is unit-tested
  with no `bw`, no age key, no network (base64 stands in as reversible crypto for the fakes).
- **Versioned write** — `env.RepoSensitiveDir()` fail-loud seam writes to the checkout, never
  the throwaway deployed copy (mirrors `RepoRegistryPath`, #635).
- **Guard** — `sensitive/dr/.gitignore` denies all but `.age`, so a plaintext export can never
  be staged (incident → guard, same PR).
- **Order = no partial file** — recipient → export → encrypt all run before any write; a locked
  vault or absent key fails fast with the disk untouched.

## SSOT note

`guide-secrets-governance.md` already owns the RECOVER protocol, so this PR **hardens it in
place** (BACKUP now invokes the command; RECOVER decrypt → `bw import bitwardenjson` →
`dotf secrets verify`) rather than adding a duplicate `guide-secrets-recover.md` (Standing
Order #2).

## Testing

- 16 tests pass: 10 escrow core (`internal/secrets`), 4 command (`internal/cmd`), 2
  `RepoSensitiveDir` (`internal/env`). `go build`/`go vet` clean; `registry.yaml` unchanged.
- **Pending — operator live smoke (AC7):** `bw unlock` → `dotf secrets backup` → decrypt the
  artifact and confirm JSON. The production `bw`/`age` shell-outs are untested-in-CI by design
  (parity with `BWGet`/`AgeDecrypt`).

## Out of scope (tracked follow-ups, not this PR)

- Scheduling IaC (systemd timer / Task Scheduler invoking the command).
- Off-box mirror of the escrow (#454).
- Offline age key (#518), folder taxonomy, per-purpose token split (#321) — the rest of #586.

## Note (unrelated, pre-existing)

`internal/spec` `TestEmbeddedTemplatesMatchVault` fails on `main` too (vendored
`templates/tasks.md` vs vault `spec-tasks.md` drift) — out of scope here; needs its own
re-vendor change.

Spec: `specs/CLI-024-secrets-backup/`. refs #586, #257.
