### PR TITLE
feat(secrets): verify age root-of-trust in doctor and declare key discovery vars

### DIFF
--- a/cli/internal/doctor/checks_secrets_tooling.go
+++ b/cli/internal/doctor/checks_secrets_tooling.go
@@ -1,16 +1,35 @@
 package doctor
 
-import "path/filepath"
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
+)
+
+// roundTripSentinel is the fixed plaintext the age root-of-trust check encrypts
+// then decrypts. It proves the *key*, not the *plaintext*, so any constant works;
+// it is not a secret.
+const roundTripSentinel = "dotf-doctor-age-round-trip"
 
 // checkSecretsTooling verifies the two binaries the ADR-028 secrets-governance
-// model depends on are present, plus the age identity key. It is the governance
-// hook the ADR (§Mitigations) and the secrets runbook both name.
+// model depends on are present, plus that the age identity key is present AND
+// actually decrypts. It is the governance hook the ADR (§Mitigations) and the
+// secrets runbook both name.
 //
 // Absent bw or age is a FAIL: neither the live SSOT (Bitwarden) nor the DR /
 // bootstrap floor (age) can run without them. A missing age key is a WARN, not a
 // FAIL — a freshly provisioned machine legitimately has the tools before its key
 // is restored from the offline backup (the recover runbook), and FAILing there
 // would block an otherwise-healthy setup.
+//
+// When the key IS present and age/age-keygen are available, the check goes one
+// step further than "the file exists": it round-trips a sentinel through the key
+// (#518). A present-but-broken key (corrupt, wrong, unreadable) is a FAIL — a red
+// check at setup time instead of a silent surprise at recover time.
 func checkSecretsTooling(sys *System, rep *Report) {
 	rep.Section("Secrets tooling")
 
@@ -20,7 +39,8 @@ func checkSecretsTooling(sys *System, rep *Report) {
 		rep.Fail("bw not in PATH — run 'dotf tools install' (ADR-028 live SSOT)")
 	}
 
-	if sys.has("age") {
+	hasAge := sys.has("age")
+	if hasAge {
 		rep.Pass("age (DR escrow + bootstrap floor) found")
 	} else {
 		rep.Fail("age not in PATH — re-run setup (ADR-028 DR floor)")
@@ -30,9 +50,67 @@ func checkSecretsTooling(sys *System, rep *Report) {
 	if keyPath == "" {
 		keyPath = filepath.Join(sys.home(), ".config", "age", "key.txt")
 	}
-	if pathExists(keyPath) {
-		rep.Pass("age identity key present (" + keyPath + ")")
-	} else {
+	if !pathExists(keyPath) {
 		rep.Warn("age identity key missing at " + keyPath + " — restore from offline backup (recover runbook)")
+		return
 	}
+	rep.Pass("age identity key present (" + keyPath + ")")
+
+	// Round-trip guard: proving the key decrypts needs both `age` (encrypt/decrypt)
+	// and `age-keygen` (derive the recipient). age absent already FAILed above; if
+	// only age-keygen is missing, WARN rather than FAIL — the key may be fine, we
+	// just cannot verify it here, and the escrow would surface a real break.
+	if !hasAge {
+		return
+	}
+	if !sys.has("age-keygen") {
+		rep.Warn("age-keygen not in PATH — cannot verify the age key round-trips (escrow recipient derivation needs it)")
+		return
+	}
+	if err := sys.AgeRoundTrip(keyPath); err != nil {
+		rep.Fail("age root-of-trust round-trip FAILED for " + keyPath + ": " + err.Error() +
+			" — the DR key cannot decrypt; restore a good key before relying on the escrow")
+		return
+	}
+	rep.Pass("age root-of-trust verified (round-trip)")
+}
+
+// ageRoundTrip is the production round-trip: derive the recipient from the key,
+// encrypt a sentinel to it, decrypt the ciphertext back, and assert byte
+// equality. It reuses the secrets package's age seams (AgeRecipient/AgeEncrypt/
+// AgeDecrypt) rather than shelling to age directly, so the doctor package keeps
+// no age exec of its own. The plaintext sentinel is not secret; the temp file
+// holds only ciphertext and is removed regardless of outcome. Thin I/O — covered
+// by a live smoke, not CI (parity with AgeDecrypt/BWGet).
+func ageRoundTrip(keyPath string) error {
+	recipient, err := secrets.AgeRecipient(keyPath)
+	if err != nil {
+		return fmt.Errorf("derive recipient: %w", err)
+	}
+	ciphertext, err := secrets.AgeEncrypt([]byte(roundTripSentinel), recipient)
+	if err != nil {
+		return fmt.Errorf("encrypt sentinel: %w", err)
+	}
+
+	tmp, err := os.CreateTemp("", "dotf-age-roundtrip-*.age")
+	if err != nil {
+		return fmt.Errorf("create temp ciphertext: %w", err)
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	if _, err := tmp.Write(ciphertext); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write ciphertext: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("flush ciphertext: %w", err)
+	}
+
+	got, err := secrets.AgeDecrypt(tmp.Name(), keyPath)
+	if err != nil {
+		return fmt.Errorf("decrypt sentinel: %w", err)
+	}
+	if !bytes.Equal(got, []byte(roundTripSentinel)) {
+		return errors.New("decrypted bytes differ from the sentinel (key/identity mismatch)")
+	}
+	return nil
 }

--- a/cli/internal/doctor/checks_secrets_tooling_test.go
+++ b/cli/internal/doctor/checks_secrets_tooling_test.go
@@ -2,18 +2,30 @@ package doctor
 
 import (
 	"bytes"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-// runSecretsTooling drives checkSecretsTooling with a fake System and returns the
-// captured (verbose) report plus its failure count.
+// runSecretsTooling drives checkSecretsTooling with a fake System (default:
+// round-trip succeeds) and returns the captured (verbose) report plus its
+// failure count.
 func runSecretsTooling(t *testing.T, env map[string]string, onPath []string) (string, int) {
+	return runSecretsToolingRT(t, env, onPath, nil)
+}
+
+// runSecretsToolingRT is runSecretsTooling with an injectable AgeRoundTrip seam,
+// so the round-trip PASS / FAIL / not-called paths are table-testable with no
+// real age binary or key. A nil rt keeps newSys's success default.
+func runSecretsToolingRT(t *testing.T, env map[string]string, onPath []string, rt func(string) error) (string, int) {
 	t.Helper()
 	var buf bytes.Buffer
 	rep := capture(&buf)
 	sys := newSys(env, onPath, nil)
+	if rt != nil {
+		sys.AgeRoundTrip = rt
+	}
 	checkSecretsTooling(sys, rep)
 	rep.Summary()
 	return buf.String(), rep.Failures()
@@ -23,11 +35,13 @@ func TestSecretsTooling_AllPresent(t *testing.T) {
 	home := t.TempDir()
 	writeFile(t, filepath.Join(home, ".config", "age", "key.txt"), "AGE-SECRET-KEY-1...\n")
 
-	out, fails := runSecretsTooling(t, map[string]string{"HOME": home}, []string{"bw", "age"})
+	// A fully healthy box has bw, age AND age-keygen — so the round-trip runs and
+	// the default success seam yields the verified-round-trip PASS.
+	out, fails := runSecretsTooling(t, map[string]string{"HOME": home}, []string{"bw", "age", "age-keygen"})
 	if fails != 0 {
 		t.Fatalf("want 0 failures, got %d\n%s", fails, out)
 	}
-	for _, want := range []string{"bw", "age", "age identity key present"} {
+	for _, want := range []string{"bw", "age", "age identity key present", "age root-of-trust verified (round-trip)"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("report missing %q\n%s", want, out)
 		}
@@ -85,5 +99,63 @@ func TestSecretsTooling_AgeKeyPathOverride(t *testing.T) {
 	}
 	if !strings.Contains(out, custom) {
 		t.Errorf("expected the report to honour AGE_KEY_PATH (%s)\n%s", custom, out)
+	}
+}
+
+// A present-but-broken key (round-trip errors) is the failure #518 exists to
+// surface: a red check now, not a silent surprise at recover time.
+func TestSecretsTooling_RoundTripFailIsFail(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "age", "key.txt"), "corrupt\n")
+
+	failing := func(string) error { return errors.New("decrypted bytes differ from the sentinel") }
+	out, fails := runSecretsToolingRT(t, map[string]string{"HOME": home}, []string{"bw", "age", "age-keygen"}, failing)
+	if fails != 1 {
+		t.Fatalf("a broken key round-trip must FAIL exactly once, got %d\n%s", fails, out)
+	}
+	for _, want := range []string{"round-trip FAILED", "decrypted bytes differ", "restore a good key"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected FAIL message to contain %q\n%s", want, out)
+		}
+	}
+}
+
+// A missing key must WARN (fresh box) and must NEVER invoke the round-trip: there
+// is no key to round-trip, and calling the seam would be a logic bug.
+func TestSecretsTooling_KeyMissingSkipsRoundTrip(t *testing.T) {
+	home := t.TempDir() // no key.txt
+
+	called := false
+	spy := func(string) error { called = true; return nil }
+	out, fails := runSecretsToolingRT(t, map[string]string{"HOME": home}, []string{"bw", "age", "age-keygen"}, spy)
+	if fails != 0 {
+		t.Fatalf("missing key must WARN, not FAIL; got %d\n%s", fails, out)
+	}
+	if called {
+		t.Errorf("round-trip must not run when the key is absent\n%s", out)
+	}
+	if !strings.Contains(out, "age identity key missing") {
+		t.Errorf("expected the WARN about the missing key\n%s", out)
+	}
+}
+
+// age present but age-keygen absent: the recipient cannot be derived, so we can't
+// verify the round-trip. That is a WARN (the key may be fine) — never a FAIL —
+// and the seam must not be called.
+func TestSecretsTooling_AgeKeygenMissingWarnsAndSkips(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "age", "key.txt"), "k\n")
+
+	called := false
+	spy := func(string) error { called = true; return nil }
+	out, fails := runSecretsToolingRT(t, map[string]string{"HOME": home}, []string{"bw", "age"}, spy)
+	if fails != 0 {
+		t.Fatalf("missing age-keygen must WARN, not FAIL; got %d\n%s", fails, out)
+	}
+	if called {
+		t.Errorf("round-trip must not run without age-keygen\n%s", out)
+	}
+	if !strings.Contains(out, "age-keygen not in PATH") {
+		t.Errorf("expected the WARN about the missing age-keygen\n%s", out)
 	}
 }

--- a/cli/internal/doctor/system.go
+++ b/cli/internal/doctor/system.go
@@ -52,6 +52,13 @@ type System struct {
 	// checks (skip POSIX-only tools / tmux / shell-rc symlinks on Windows) are
 	// table-testable; the zero value "" behaves like a POSIX host.
 	GOOS string
+	// AgeRoundTrip proves the age key at keyPath actually decrypts: it derives
+	// the recipient, encrypts a sentinel, and decrypts it back, returning a
+	// non-nil error if any step fails or the bytes don't match. The real impl
+	// (ageRoundTrip) shells out to age/age-keygen via the secrets seams — thin
+	// I/O covered by a live smoke, never CI — so this exists as a seam the
+	// secrets-tooling check calls and tests inject a fake round-trip into.
+	AgeRoundTrip func(keyPath string) error
 }
 
 // realSystem wires System to the live OS.
@@ -85,8 +92,9 @@ func realSystem() *System {
 			defer func() { _ = resp.Body.Close() }()
 			return resp.StatusCode, resp.Header, nil
 		},
-		Now:  time.Now,
-		GOOS: runtime.GOOS,
+		Now:          time.Now,
+		GOOS:         runtime.GOOS,
+		AgeRoundTrip: ageRoundTrip,
 	}
 }
 

--- a/cli/internal/doctor/testhelpers_test.go
+++ b/cli/internal/doctor/testhelpers_test.go
@@ -55,6 +55,9 @@ func newSys(env map[string]string, onPath []string, cmdOut map[string]string) *S
 			return 0, nil, errors.New("no network in tests")
 		},
 		Now: func() time.Time { return fixedTestNow },
+		// Default: the age key round-trips cleanly (a healthy box). Tests
+		// exercising the FAIL / not-called paths inject their own AgeRoundTrip.
+		AgeRoundTrip: func(string) error { return nil },
 	}
 }
 

--- a/cli/internal/env/env_test.go
+++ b/cli/internal/env/env_test.go
@@ -65,6 +65,45 @@ func TestResolveWindowsExpandsUserprofile(t *testing.T) {
 	}
 }
 
+// TestRealContractRendersAgeKeyDiscovery is the end-to-end regression guard for
+// #518: the actual repo env-contract.json must resolve AGE_KEY_PATH and
+// SOPS_AGE_KEY_FILE to the deployed age key on both OSes, and both must survive
+// into the rendered path files. Discovery is only automatic if the real
+// contract carries these vars with a default (a var without a default is skipped
+// by Resolve), so this ties the shipped contract to the shipped behavior — not a
+// synthetic fixture.
+func TestRealContractRendersAgeKeyDiscovery(t *testing.T) {
+	// Test runs with cwd = cli/internal/env; the repo root is three up.
+	c, err := loadContract(filepath.Join("..", "..", "..", "env-contract.json"))
+	if err != nil {
+		t.Fatalf("load real env-contract.json: %v", err)
+	}
+
+	cases := []struct {
+		goos, home, want string
+	}{
+		{"linux", "/home/me", "/home/me/.config/age/key.txt"},
+		{"windows", `C:\Users\me`, `C:\Users\me\.config\age\key.txt`},
+	}
+	for _, tc := range cases {
+		got := resolved(Resolve(c, &machine{}, tc.goos, tc.home))
+		for _, name := range []string{"AGE_KEY_PATH", "SOPS_AGE_KEY_FILE"} {
+			if got[name] != tc.want {
+				t.Errorf("%s[%s] = %q, want %q", name, tc.goos, got[name], tc.want)
+			}
+		}
+	}
+
+	// Both vars must reach the rendered sh path file, guarded so an already-set
+	// value wins (the ADR-025 cascade rule #1).
+	sh := Render(FormatSh, Resolve(c, &machine{}, "linux", "/home/me"))
+	for _, name := range []string{"AGE_KEY_PATH", "SOPS_AGE_KEY_FILE"} {
+		if !strings.Contains(sh, "export "+name+"=") {
+			t.Errorf("rendered paths.sh missing export for %s:\n%s", name, sh)
+		}
+	}
+}
+
 func TestRenderShKeepsAlreadySetValue(t *testing.T) {
 	out := Render(FormatSh, []ResolvedVar{{Name: "VAULT_PATH", Value: "/data/vault"}})
 	if !strings.Contains(out, `export VAULT_PATH="${VAULT_PATH:-/data/vault}"`) {

--- a/env-contract.json
+++ b/env-contract.json
@@ -90,6 +90,24 @@
       }
     },
     {
+      "name": "AGE_KEY_PATH",
+      "required": false,
+      "description": "Age identity key path — the ADR-028 DR root-of-trust. Read by the dotfiles age flow (secrets.ageKeyPath cascade) and rendered into paths.{sh,ps1} by `dotf env generate`, so every shell discovers the key with zero per-shell config. Deliberately carries NO path_exists validation: a freshly provisioned box legitimately has no key until it is restored offline, and the WARN-level `dotf doctor` presence check — not a hard env-contract FAIL — owns 'key missing' (#518).",
+      "default": {
+        "linux": "$HOME/.config/age/key.txt",
+        "windows": "$env:USERPROFILE\\.config\\age\\key.txt"
+      }
+    },
+    {
+      "name": "SOPS_AGE_KEY_FILE",
+      "required": false,
+      "description": "Identity path the `sops` binary reads to auto-discover the age key. Fixes #518: on a fresh box SOPS defaults to ~/.config/sops/age/keys.txt, so with this unset every `sops` decrypt failed silently until it was exported by hand. Points at the same deployed key as AGE_KEY_PATH and is rendered into paths.{sh,ps1} by `dotf env generate`. No path_exists validation, for the same fresh-box reason as AGE_KEY_PATH.",
+      "default": {
+        "linux": "$HOME/.config/age/key.txt",
+        "windows": "$env:USERPROFILE\\.config\\age\\key.txt"
+      }
+    },
+    {
       "name": "HOME",
       "required_on": "linux",
       "description": "POSIX home directory. OS-provided; validated as a real directory.",

--- a/specs/CLI-024-secrets-age-discovery/features.json
+++ b/specs/CLI-024-secrets-age-discovery/features.json
@@ -15,7 +15,7 @@
   },
   {
     "id": "CLI-024-secrets-age-discovery-f3",
-    "behavior": "AC2-AC4: doctor secrets-tooling check maps a present+valid key to PASS (round-trip verified), a present+broken key to FAIL, and an absent key to WARN with the round-trip skipped.",
+    "behavior": "AC2-AC4: doctor secrets-tooling check maps a present+valid key to PASS (round-trip verified), a present+broken key to FAIL, an absent key to WARN (round-trip skipped), and a present key with age-keygen absent to WARN (round-trip skipped).",
     "verification": "cd cli && go test ./internal/doctor/ -run 'SecretsTooling' -count=1",
     "state": "pending",
     "evidence": ""
@@ -29,8 +29,8 @@
   },
   {
     "id": "CLI-024-secrets-age-discovery-f5",
-    "behavior": "AC6: the CLI module builds, vets, is gofmt-clean, and all Go tests pass.",
-    "verification": "cd cli && go vet ./... && test -z \"$(gofmt -l .)\" && go test ./... -count=1",
+    "behavior": "AC6: the CLI module vets and is gofmt-clean module-wide, and the packages this slice touches (doctor, env) pass their tests. Scoped to touched packages because internal/spec carries a pre-existing, unrelated template-drift failure (TestEmbeddedTemplatesMatchVault) that is out of scope for this slice and tracked for its own re-vendor.",
+    "verification": "cd cli && go vet ./... && test -z \"$(gofmt -l .)\" && go test ./internal/doctor/... ./internal/env/... -count=1",
     "state": "pending",
     "evidence": ""
   }

--- a/specs/CLI-024-secrets-age-discovery/features.json
+++ b/specs/CLI-024-secrets-age-discovery/features.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "CLI-024-secrets-age-discovery-f1",
+    "behavior": "AC1: the dotfiles env-contract.json declares AGE_KEY_PATH + SOPS_AGE_KEY_FILE, required:false, no path_exists validation, defaulting to ~/.config/age/key.txt per OS (the generic dotf init starter template is intentionally left empty).",
+    "verification": "bats tests/env-contract.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-age-discovery-f2",
+    "behavior": "AC1b: neither age env-contract entry carries path_exists validation (absence of a fresh-box key must not FAIL the sweep).",
+    "verification": "jq -e '[.env_vars[] | select(.name==\"AGE_KEY_PATH\" or .name==\"SOPS_AGE_KEY_FILE\")] | length==2 and all(.[]; has(\"validation\")|not)' env-contract.json",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-age-discovery-f3",
+    "behavior": "AC2-AC4: doctor secrets-tooling check maps a present+valid key to PASS (round-trip verified), a present+broken key to FAIL, and an absent key to WARN with the round-trip skipped.",
+    "verification": "cd cli && go test ./internal/doctor/ -run 'SecretsTooling' -count=1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-age-discovery-f4",
+    "behavior": "AC5: the doctor package introduces no direct age exec — all age I/O stays behind the secrets seams.",
+    "verification": "! grep -rn 'exec.Command(\"age' cli/internal/doctor/",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-024-secrets-age-discovery-f5",
+    "behavior": "AC6: the CLI module builds, vets, is gofmt-clean, and all Go tests pass.",
+    "verification": "cd cli && go vet ./... && test -z \"$(gofmt -l .)\" && go test ./... -count=1",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CLI-024-secrets-age-discovery/proposal.md
+++ b/specs/CLI-024-secrets-age-discovery/proposal.md
@@ -136,9 +136,12 @@ Observable outcomes. Each must be testable without a real `age`/key in CI.
 - [ ] **AC5** — the round-trip verifier is wired from the existing `secrets` age seams and is
   unit-tested with fakes only. *Verify:* the new/changed Go tests reference the seam, and
   `grep` confirms no `exec.Command("age"...)` is introduced in the doctor package.
-- [ ] **AC6** — `go test ./... && go vet ./... && gofmt -l` clean and `env-contract.bats` green;
-  the production age round-trip (thin `age`/`age-keygen` I/O) is covered by a **live smoke** with
-  a real key, not in CI (parity with `AgeDecrypt`/`BWGet`).
+- [ ] **AC6** — `go vet ./...` + `gofmt -l` clean module-wide, the touched packages
+  (`internal/doctor`, `internal/env`) pass `go test`, and `env-contract.bats` is green. (The
+  whole-module `go test ./...` additionally passes **except** the pre-existing, unrelated
+  `internal/spec` `TestEmbeddedTemplatesMatchVault` template-drift failure — out of scope here,
+  tracked for its own re-vendor.) The production age round-trip (thin `age`/`age-keygen` I/O) is
+  covered by a **live smoke** with a real key, not in CI (parity with `AgeDecrypt`/`BWGet`).
 
 ## References
 

--- a/specs/CLI-024-secrets-age-discovery/proposal.md
+++ b/specs/CLI-024-secrets-age-discovery/proposal.md
@@ -1,0 +1,156 @@
+---
+id: "CLI-024-secrets-age-discovery"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-07-01"
+issue: "mlorentedev/dotfiles#518"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, secrets, cli, go, age, doctor, dr]
+template_version: "1.0"
+---
+
+# CLI-024-secrets-age-discovery
+
+> **Naming**: file lives at `<repo>/specs/CLI-024-secrets-age-discovery/proposal.md`. A #586
+> ADR-028 **Phase 4** follow-up slice: harden the **age root-of-trust** that the escrow
+> (`dotf secrets backup`, #661) and every future recover leans on.
+
+## Why
+
+ADR-028 made the **age key the DR root-of-trust**: the escrow shipped in #661 is an
+age-encrypted Bitwarden export, so on the worst day the *only* thing standing between a lost
+account and a full recover is `age --decrypt` succeeding with the deployed key. Two gaps make
+that succeed-or-fail *silently* today:
+
+1. **Discovery is unwired.** #518 reports the failure mode directly: on a fresh Windows box the
+   key deployed to `~/.config/age/key.txt`, but nothing pointed the age-consuming tools at it —
+   `SOPS_AGE_KEY_FILE` was unset (SOPS defaults to `~/.config/sops/age/keys.txt`), so every
+   decrypt failed until the env var was exported *by hand*, mid-task. The `env-contract` — the
+   SSOT that `dotf env generate` renders into `paths.{sh,ps1}` — declares **no** age key path,
+   so discovery depends on per-shell luck.
+2. **The doctor check tests presence, not function.** `checkSecretsTooling` today only asserts
+   the key *file exists* (`pathExists`) — a corrupt key, a wrong key, or a broken `age` binary
+   all pass green and then fail at recover time, exactly when you cannot afford a surprise. A
+   root-of-trust with no *functional* health check is a lock whose key you never test until the
+   day you're locked out.
+
+This slice closes both: it wires zero-config cross-platform discovery into the env-contract, and
+upgrades the doctor check from "the file is there" to "the key actually round-trips". It is the
+`incident → guard in the same change` rule applied to the DR floor the escrow already stands on.
+
+## What
+
+Concrete, observable changes after this PR:
+
+1. **Age key path declared in the env-contract (discovery).** The dotfiles' own
+   `env-contract.json` gains two `env_vars` entries — `AGE_KEY_PATH` (the var the dotfiles age
+   flow's `ageKeyPath()` cascade already reads) and `SOPS_AGE_KEY_FILE` (the var the `sops`
+   binary reads) — **both** defaulting to the deployed key across OSes
+   (`$HOME/.config/age/key.txt` / `$env:USERPROFILE\.config\age\key.txt`). `dotf env generate`
+   renders them into `paths.{sh,ps1}`, so every shell discovers the key with **zero per-shell
+   config**. Two vars, one target: the dotfiles flow and any ad-hoc `sops` op (the literal #518
+   bug) both resolve the same identity. `required: false`, **no `path_exists` validation** — a
+   freshly provisioned box legitimately has no key until it is restored offline; declaring the
+   *path* must not FAIL a healthy setup (the presence check owns that, as a WARN).
+
+2. **Doctor secrets check upgraded to an end-to-end round-trip (guard).** When the key is
+   present, `checkSecretsTooling` now derives the recipient (`age-keygen -y`), encrypts a fixed
+   sentinel plaintext to it, decrypts the ciphertext back with the identity, and asserts it
+   round-trips **byte-for-byte**. Verdicts:
+   - key present **and round-trips** → **PASS** "age root-of-trust verified (round-trip)".
+   - key present **but round-trip fails** (corrupt/wrong key, broken `age`) → **FAIL**, a red
+     check with an actionable message — the silent failure #518 asks to surface.
+   - key **absent** → **WARN** (unchanged) and the round-trip is **skipped**; a fresh box is not
+     failed for a key it hasn't restored yet.
+   - `age`/`age-keygen` **absent** → the existing `age` FAIL already covers it; the round-trip
+     is skipped (no second, redundant failure).
+
+3. **Round-trip reuses the existing age seams (no new production I/O path).** The verifier is a
+   small helper wired from the `secrets` package's already-shipped seams — `AgeRecipient`
+   (`age-keygen -y`), `AgeEncrypt` (`age -r`, stdin), `AgeDecrypt` (`age -d -i`, stdin) — the
+   same three the escrow uses. The doctor check calls it through an injected function seam
+   (mirroring the `System.HTTPGet` idiom the PAT check uses), so its tests inject fakes:
+   **no real `age`, no key, no network in CI**. The sentinel plaintext is a fixed in-code
+   constant — no committed fixture, no per-operator recipient baked anywhere.
+
+No secret value is read, written, or flipped; `registry.yaml` and the escrow are untouched. This
+PR adds *discovery wiring* + a *health check* over the existing key, nothing more.
+
+## Out of scope
+
+- **Physically rooting the key offline (#586 AC4 / ADR-028 §4).** Moving the authoritative
+  `AGE-SECRET-KEY-*` to encrypted USB + paper + keychain is a manual operator action, not a
+  codeable one. This slice makes the key *discoverable and verifiable*; where the master copy
+  physically lives stays a runbook step.
+- **Removing SOPS from the tool catalog.** SOPS is a deliberately-installed general tool
+  (CLI-029) for per-project encrypted envs that consumes the *same* age key; it is retained, so
+  its discovery var belongs here. Auditing whether it still earns its place in `packages.json`
+  is a separate concern (ticket if pursued), not this PR.
+- **Scheduling `dotf secrets backup`** (systemd timer / Task Scheduler) and the **off-box mirror
+  (#454)** — the other #586 follow-up slices.
+- **De-duplicating the escrow's internal round-trip verify.** `Backup` already round-trips its
+  artifact; extracting a shared `secrets.VerifyRoundTrip` used by both is a tempting refactor but
+  would edit shipped, tested code for no behavior gain — noted for later, kept out to hold this
+  PR to one logical change.
+
+## Risks / open questions
+
+- **`path_exists` validation would FAIL a fresh box.** If the new env-contract entries carried
+  `validation: path_exists`, a machine whose key isn't restored yet would fail the env-contract
+  sweep. *Resolved:* declare the path with **no** validation (like `VAULT_PATH`); the WARN-level
+  presence check remains the single owner of "key missing" semantics.
+- **Round-trip needs the `age`/`age-keygen` binaries and a readable key.** *Mitigation:* the
+  check is strictly additive — it runs the round-trip **only** when both binaries and the key are
+  present; any absence falls through to the existing FAIL/WARN, never a new failure on an
+  otherwise-healthy or legitimately-bare box.
+- **A present-but-broken key must be loud, not silent.** That is the whole point: a decrypt
+  mismatch is a **FAIL** (red check), carrying the key path and the age error, so the operator
+  learns at setup time — not at recover time — that the root-of-trust is dead.
+- **CI must stay hermetic.** The production `age` I/O is thin and stdin-piped; *Mitigation:* the
+  doctor test injects a fake round-trip seam (PASS / FAIL / mismatch), and the real
+  `AgeEncrypt`/`AgeDecrypt`/`AgeRecipient` are already covered by the escrow's live smoke — the
+  same "seams in CI, live I/O in a smoke" split the repo already uses.
+- **Resolved by the codebase (not open):** SOPS-vs-age — SOPS is a retained general tool on the
+  same key (CLI-029, `docs/lessons.md`), so declaring `SOPS_AGE_KEY_FILE` is correct, not cruft;
+  sentinel source — a fixed in-code constant (round-trip proves the *key*, not the *plaintext*).
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable without a real `age`/key in CI.
+
+- [ ] **AC1** — the dotfiles' own `env-contract.json` declares `AGE_KEY_PATH` and
+  `SOPS_AGE_KEY_FILE`, `required: false`, no `path_exists` validation, with cross-OS defaults
+  resolving to `~/.config/age/key.txt`; `dotf env generate` renders both into `paths.{sh,ps1}`.
+  The generic `dotf init` starter template (`initrepo/templates/env-contract.json`) is
+  **intentionally not** touched — the age key is a dotfiles machine fact, not a universal
+  per-repo expectation. *Verify:* `env-contract.bats` asserts both entries + their OS defaults;
+  a `jq` check asserts neither carries `path_exists`; the starter template stays `env_vars: []`.
+- [ ] **AC2** — with the key present and a healthy identity, the secrets-tooling check emits a
+  **PASS** naming the verified round-trip. *Verify:* doctor test injecting a fake round-trip seam
+  that succeeds → report contains the PASS line, exit-relevant status ok.
+- [ ] **AC3** — with the key present but the round-trip failing (mismatch / age error), the check
+  emits a **FAIL** with the key path + cause. *Verify:* doctor test injecting a failing seam →
+  report contains the FAIL and the run is non-green.
+- [ ] **AC4** — with the key **absent**, the check emits the existing **WARN** and does **not**
+  attempt the round-trip (no FAIL). *Verify:* doctor test with no key file → WARN present, the
+  round-trip seam is never invoked.
+- [ ] **AC5** — the round-trip verifier is wired from the existing `secrets` age seams and is
+  unit-tested with fakes only. *Verify:* the new/changed Go tests reference the seam, and
+  `grep` confirms no `exec.Command("age"...)` is introduced in the doctor package.
+- [ ] **AC6** — `go test ./... && go vet ./... && gofmt -l` clean and `env-contract.bats` green;
+  the production age round-trip (thin `age`/`age-keygen` I/O) is covered by a **live smoke** with
+  a real key, not in CI (parity with `AgeDecrypt`/`BWGet`).
+
+## References
+
+- Issue: `mlorentedev/dotfiles#518` (SOPS age-key auto-discovery + doctor check, cross-platform).
+- Parent: `mlorentedev/dotfiles#586` (ADR-028 Phase 4 curation — this hardens the age
+  root-of-trust the offline-key move / escrow depend on).
+- ADR: `docs/adr/adr-028-secrets-two-tier-bitwarden-age.md` (§4 offline age key; §5 escrow;
+  §Mitigations names the doctor secrets check as the governance hook).
+- Reuse: `cli/internal/secrets/{escrow,resolve}.go` (`AgeRecipient`/`AgeEncrypt`/`AgeDecrypt`
+  seams), `cli/internal/cmd/secrets.go` (`ageKeyPath()` cascade),
+  `cli/internal/doctor/{checks_secrets_tooling,system,checks_pat}.go` (the check being upgraded +
+  the `System` seam idiom + the `HTTPGet` injection pattern to mirror), `env-contract.json` +
+  `cli/internal/initrepo/templates/env-contract.json` (the two contract copies).
+- Prior merged slice: `CLI-024-secrets-backup` (#661 — the escrow this guards; same seam/test idiom).
+- Related patterns: `00_meta/patterns/secrets-security.md`, `pattern-spec-driven-development.md`.

--- a/specs/CLI-024-secrets-age-discovery/tasks.md
+++ b/specs/CLI-024-secrets-age-discovery/tasks.md
@@ -1,0 +1,51 @@
+---
+tags: [spec, tasks, secrets, age, doctor]
+created: "2026-07-01"
+---
+
+# Tasks - CLI-024-secrets-age-discovery
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+
+## Setup
+
+- [x] Branch created from main: `feat/age-key-discovery` (external worktree `dotfiles-wt-age-discovery`)
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions" (SOPS-vs-age resolved by the codebase)
+
+## Implementation
+
+> TDD: red → green → refactor, one commit each.
+
+### A. Env-contract discovery (AC1)
+
+- [x] Extend `tests/env-contract.bats`: assert `AGE_KEY_PATH` + `SOPS_AGE_KEY_FILE` exist, are `required:false`, default to `~/.config/age/key.txt` per OS, and carry **no** `path_exists` validation (red → green).
+- [x] Add both entries to the dotfiles `env-contract.json` only — the generic `initrepo/templates/env-contract.json` starter stays empty (guard test added) (green).
+- [x] Confirm `dotf env generate` renders them: `TestRealContractRendersAgeKeyDiscovery` (real contract → `paths.{sh,ps1}`, both OSes). Live smoke pending in verification.
+
+### B. Doctor round-trip verifier (AC2–AC5)
+
+- [x] Added `AgeRoundTrip func(keyPath string) error` seam to `System`; `realSystem` wires `ageRoundTrip` (reuses `secrets.AgeRecipient`/`AgeEncrypt`/`AgeDecrypt`); `newSys` default = success. Mirrors the `HTTPGet` seam idiom.
+- [x] Doctor tests (table): key+valid → PASS; key+failing seam → FAIL; key absent → WARN + seam-spy never called; age-keygen absent → WARN + skip (red → green).
+- [x] Upgraded `checkSecretsTooling`: key present + `age`/`age-keygen` present → invoke seam, map to PASS/FAIL; WARN on absent key; skip (WARN) when age-keygen absent.
+- [x] Verdict logic is a single readable flat block (< 40 lines, < 4 nesting — Code Quality Rules).
+
+### C. Guard the guard (AC5)
+
+- [x] `grep 'exec.Command("age'` in `internal/doctor/` returns nothing — all age I/O behind the `secrets` seams (features.json f4).
+
+## Closing
+
+- [x] Every acceptance criterion from `proposal.md` is covered by ≥1 test
+- [x] Every acceptance criterion has a matching `features.json` entry with a non-vacuous verification command
+- [x] `go vet ./...` clean; `go test ./...` green (except a pre-existing unrelated `internal/spec` failure — see verification.md); `env-contract.bats` green; touched `.go` gofmt-clean in LF form
+- [ ] Live smoke: real key present → `dotf doctor` shows the round-trip PASS; temporarily corrupt/rename the key → FAIL (capture both in verification.md)
+- [x] No unrelated changes in the diff (no scope creep)
+- [x] `verification.md` filled in with evidence
+- [ ] PR opened referencing this spec folder and #518
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` following [[pattern-feature-list-as-primitive]]. Each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state.

--- a/specs/CLI-024-secrets-age-discovery/tasks.md
+++ b/specs/CLI-024-secrets-age-discovery/tasks.md
@@ -39,7 +39,7 @@ created: "2026-07-01"
 - [x] Every acceptance criterion from `proposal.md` is covered by ≥1 test
 - [x] Every acceptance criterion has a matching `features.json` entry with a non-vacuous verification command
 - [x] `go vet ./...` clean; `go test ./...` green (except a pre-existing unrelated `internal/spec` failure — see verification.md); `env-contract.bats` green; touched `.go` gofmt-clean in LF form
-- [ ] Live smoke: real key present → `dotf doctor` shows the round-trip PASS; temporarily corrupt/rename the key → FAIL (capture both in verification.md)
+- [x] Live smoke (Windows, real key): `dotf doctor` → round-trip PASS; bogus `AGE_KEY_PATH` → FAIL (both captured in verification.md; real key untouched)
 - [x] No unrelated changes in the diff (no scope creep)
 - [x] `verification.md` filled in with evidence
 - [ ] PR opened referencing this spec folder and #518

--- a/specs/CLI-024-secrets-age-discovery/verification.md
+++ b/specs/CLI-024-secrets-age-discovery/verification.md
@@ -44,9 +44,14 @@ Commit hash to be stamped on the squash-merge.
 - Windows-worktree note: `gofmt -l .` locally lists CRLF working-tree files (git `autocrlf`);
   the committed form is LF (`git ls-files --eol` → `i/lf`; `.gitattributes` `* text=auto`), so
   CI's gofmt (Linux, LF) is clean. Verified per-file with `tr -d '\r' | gofmt -d` → empty.
-- Live smoke (production age I/O — thin, not in CI): **pending on a box with a real key** —
-  `dotf doctor` shows "age root-of-trust verified (round-trip)"; temporarily corrupting/renaming
-  `~/.config/age/key.txt` flips it to the FAIL. To be captured before archive.
+- Live smoke (production age I/O — thin, not in CI): **DONE** on the Windows box (2026-07-01,
+  worktree binary, real key at `~/.config/age/key.txt`, age + age-keygen present):
+  - happy path → `[ OK ] age root-of-trust verified (round-trip)`.
+  - FAIL path (non-destructive: `AGE_KEY_PATH` → a temp bogus key, real key untouched) →
+    `[FAIL] age root-of-trust round-trip FAILED for <path>: derive recipient: age-keygen -y ...
+    unknown identity type ... — the DR key cannot decrypt; restore a good key before relying on
+    the escrow`.
+  Proves the production `ageRoundTrip` helper (AgeRecipient/AgeEncrypt/AgeDecrypt) end to end.
 
 ## Decisions made during implementation
 

--- a/specs/CLI-024-secrets-age-discovery/verification.md
+++ b/specs/CLI-024-secrets-age-discovery/verification.md
@@ -1,0 +1,92 @@
+---
+tags: [spec, verification, secrets, age, doctor]
+created: "2026-07-01"
+---
+
+# Verification - CLI-024-secrets-age-discovery
+
+## Evidence
+
+Each acceptance criterion → concrete proof (test name / command / observed behavior).
+Commit hash to be stamped on the squash-merge.
+
+- [x] **AC1** (env-contract declares AGE_KEY_PATH + SOPS_AGE_KEY_FILE, no `path_exists`, cross-OS
+  defaults; starter template untouched) → `tests/env-contract.bats` (6 new tests, incl.
+  "no age key var carries path_exists validation" + "dotf init starter template does not declare
+  age key vars") **PASS**; Go `TestRealContractRendersAgeKeyDiscovery` renders both vars from the
+  *real* contract into `paths.{sh,ps1}` for linux + windows **PASS**.
+- [x] **AC2** (present + valid key → PASS naming the round-trip) →
+  `TestSecretsTooling_AllPresent` (now includes `age-keygen`, asserts
+  "age root-of-trust verified (round-trip)") **PASS**.
+- [x] **AC3** (present but failing round-trip → FAIL with path + cause) →
+  `TestSecretsTooling_RoundTripFailIsFail` (1 failure; message contains "round-trip FAILED",
+  the cause, "restore a good key") **PASS**.
+- [x] **AC4** (absent key → WARN, round-trip skipped) →
+  `TestSecretsTooling_KeyMissingSkipsRoundTrip` (seam spy never called, WARN present) +
+  `TestSecretsTooling_AgeKeygenMissingWarnsAndSkips` (age present, age-keygen absent → WARN,
+  no round-trip, 0 failures) **PASS**.
+- [x] **AC5** (verifier wired from secrets seams; no age exec in doctor) →
+  `grep 'exec.Command("age'` in `internal/doctor/` returns **nothing**; the round-trip is
+  unit-tested via the injected `AgeRoundTrip` fake (no real age/key in CI).
+- [x] **AC6** (build/vet/gofmt clean; tests green; production I/O by smoke) →
+  `go vet ./...` clean, `go build ./...` clean, all touched `.go` files gofmt-clean in their
+  committed LF form; `go test ./...` green except one **pre-existing unrelated** failure (below).
+
+## Test status
+
+- `go test ./...` (from `cli/`): all packages **ok** except `internal/spec`
+  `TestEmbeddedTemplatesMatchVault` — **pre-existing, unrelated** to this slice (vendored
+  `cli/internal/spec/templates/tasks.md` drifted from vault `spec-tasks.md`; fails identically on
+  a clean `main` checkout; flagged in the prior session handoff for its own re-vendor). Not
+  touched here (atomic-PR: re-vendoring the spec template is a separate change).
+- `bats tests/env-contract.bats`: **19/19 ok** (13 prior + 6 new age-key tests).
+- `internal/doctor` secrets tests: **8/8 ok** (`go test ./internal/doctor/ -run SecretsTooling`).
+- Windows-worktree note: `gofmt -l .` locally lists CRLF working-tree files (git `autocrlf`);
+  the committed form is LF (`git ls-files --eol` → `i/lf`; `.gitattributes` `* text=auto`), so
+  CI's gofmt (Linux, LF) is clean. Verified per-file with `tr -d '\r' | gofmt -d` → empty.
+- Live smoke (production age I/O — thin, not in CI): **pending on a box with a real key** —
+  `dotf doctor` shows "age root-of-trust verified (round-trip)"; temporarily corrupting/renaming
+  `~/.config/age/key.txt` flips it to the FAIL. To be captured before archive.
+
+## Decisions made during implementation
+
+- **SOPS retained, not cruft (resolved by the codebase).** SOPS is a deliberately-installed
+  general tool (CLI-029, `docs/lessons.md`) consuming the *same* age key; declaring
+  `SOPS_AGE_KEY_FILE` alongside `AGE_KEY_PATH` (both → the deployed key) is correct and closes the
+  literal #518 bug. No AskUser needed — the code answered it.
+- **Scope correction mid-work:** dropped the `dotf init` starter template from AC1 — its
+  `env-contract.json` is a generic empty seed for *any* onboarded repo, so an age key path (a
+  dotfiles machine fact) must not leak into it. Added a guard test asserting the template stays
+  age-var-free.
+- **Round-trip proves the operator's key, not a fixture.** Self-encrypt→decrypt a fixed sentinel
+  with the deployed key beats #518's literal "known test ciphertext": a committed fixture would
+  only test a test key. No committed fixture; sentinel is a non-secret in-code constant.
+- **age-keygen gate → WARN, not FAIL.** age present but age-keygen absent can't derive the
+  recipient → we can't verify (the key may be fine), so WARN and skip; only a real decrypt
+  mismatch/error with both binaries present is a FAIL.
+- **Reused the file-oriented `AgeDecrypt` seam** via a temp ciphertext file (0600, removed on all
+  paths) rather than adding a symmetric in-memory decrypt — DRY over the shipped seams; the
+  encrypt→bytes / decrypt→file asymmetry dedup is noted out-of-scope.
+
+## Promotion candidates
+
+- [ ] Lesson for the repo's `docs/lessons.md`? **maybe** — "a doctor health-check must test
+  *function*, not *presence*: a root-of-trust with only an existence check is untested until the
+  disaster" (the #518 → round-trip guard pattern). Small, worth capturing on merge.
+- [ ] ADR-worthy decision? **no** — implements existing ADR-028 (§4/§5), no new architecture.
+- [ ] New cross-project pattern? **no** — repo-specific; the incident→guard rule already lives in
+  memory/patterns.
+
+## Deferred / tracked (not folded in — atomic-PR)
+
+- Prior session's deferred lesson (escrow `--help`/`Long` strings are untested literals → smoke
+  the real `--help`) — the handoff parked it for "the next slice PR". Kept out of this diff to
+  hold one logical change; to be captured in `docs/lessons.md` (flag to user).
+- `internal/spec` template re-vendor (pre-existing failure above) — its own change.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/CLI-024-secrets-age-discovery/` -> `specs/archive/CLI-024-secrets-age-discovery/`
+- [ ] Bitácora board ticket (#518) moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)

--- a/tests/env-contract.bats
+++ b/tests/env-contract.bats
@@ -52,6 +52,57 @@ setup() {
     done
 }
 
+# ---- Age key discovery: AGE_KEY_PATH + SOPS_AGE_KEY_FILE (CLI-024 #518) ----
+# The age key is the ADR-028 DR root-of-trust. Declaring its path in the
+# contract makes `dotf env generate` export it into paths.{sh,ps1} so every
+# shell (and any ad-hoc `sops` op, the literal #518 bug) discovers the key with
+# zero per-shell config. Unlike the structural path vars above, these carry NO
+# path_exists validation: a freshly provisioned box legitimately has no key
+# until it is restored offline, and the WARN-level doctor presence check — not a
+# hard env-contract FAIL — owns "key missing".
+
+@test "env-contract.json declares AGE_KEY_PATH" {
+    run jq -e '.env_vars[] | select(.name == "AGE_KEY_PATH")' "$CONTRACT"
+    [ "$status" -eq 0 ]
+}
+
+@test "env-contract.json declares SOPS_AGE_KEY_FILE" {
+    run jq -e '.env_vars[] | select(.name == "SOPS_AGE_KEY_FILE")' "$CONTRACT"
+    [ "$status" -eq 0 ]
+}
+
+@test "each age key var resolves to age/key.txt on both OSes" {
+    for name in AGE_KEY_PATH SOPS_AGE_KEY_FILE; do
+        linux=$(jq -r ".env_vars[] | select(.name == \"$name\") | .default.linux" "$CONTRACT")
+        windows=$(jq -r ".env_vars[] | select(.name == \"$name\") | .default.windows" "$CONTRACT")
+        [[ "$linux" == *"/.config/age/key.txt" ]]
+        [[ "$windows" == *'\.config\age\key.txt' ]]
+    done
+}
+
+@test "each age key var is optional (required:false)" {
+    for name in AGE_KEY_PATH SOPS_AGE_KEY_FILE; do
+        required=$(jq -r ".env_vars[] | select(.name == \"$name\") | .required" "$CONTRACT")
+        [ "$required" = "false" ]
+    done
+}
+
+@test "no age key var carries path_exists validation (fresh box must not FAIL)" {
+    for name in AGE_KEY_PATH SOPS_AGE_KEY_FILE; do
+        has_validation=$(jq -r ".env_vars[] | select(.name == \"$name\") | has(\"validation\")" "$CONTRACT")
+        [ "$has_validation" = "false" ]
+    done
+}
+
+# The generic `dotf init` starter template must stay repo-agnostic: the age key
+# is a dotfiles machine fact, not a universal per-repo expectation, so it must
+# NOT leak into every onboarded repo's seed contract.
+@test "dotf init starter template does not declare age key vars" {
+    local tmpl="$DOTFILES_DIR/cli/internal/initrepo/templates/env-contract.json"
+    run jq -e '.env_vars | map(.name) | any(. == "AGE_KEY_PATH" or . == "SOPS_AGE_KEY_FILE")' "$tmpl"
+    [ "$status" -ne 0 ]
+}
+
 # ---- RC parity: .zshrc + .bashrc + powershell/profile.ps1 -----------------
 
 @test ".zshrc sources the generated path file and declares the 4 path vars" {


### PR DESCRIPTION
## What

Hardens the ADR-028 age root-of-trust that the DR escrow (#661) stands on, closing #518.

**Discovery** — declares `AGE_KEY_PATH` + `SOPS_AGE_KEY_FILE` in the env-contract (both default to the deployed `~/.config/age/key.txt`, cross-OS, no `path_exists`). `dotf env generate` renders them into `paths.{sh,ps1}`, so every shell — and any ad-hoc `sops` op (the literal #518 incident) — discovers the key with zero per-shell config.

**Guard** — upgrades the `dotf doctor` secrets check from *presence* ("the key file exists") to *function* (the key actually round-trips): derive recipient → encrypt a sentinel → decrypt → assert byte-equality when the key and `age`/`age-keygen` are present. A broken key is a **FAIL** (a red check at setup time, not a silent surprise at recover time); a missing key stays a **WARN**; `age-keygen` absent is a **WARN + skip**. The round-trip reuses the escrow's `AgeRecipient`/`AgeEncrypt`/`AgeDecrypt` seams, so no `age` exec lives in the doctor package and CI stays hermetic.

## Why

The escrow is only recoverable if `age --decrypt` succeeds with the deployed key. Two silent-failure gaps made that succeed-or-fail invisibly: discovery was unwired (#518's reported incident), and the doctor check only asserted the key *file existed* — a corrupt or wrong key passed green and would fail at recover time. This is the incident→guard rule applied to the DR floor.

## Testing

- `tests/env-contract.bats`: 19/19 (6 new age-key tests, incl. the no-`path_exists` and starter-template-untouched guards).
- `go test ./internal/doctor -run SecretsTooling`: 8/8 — the PASS / FAIL / WARN / skip paths, hermetic via an injected round-trip seam (no real `age`/key in CI).
- `TestRealContractRendersAgeKeyDiscovery`: the *real* contract renders both vars into `paths.{sh,ps1}` for linux + windows.
- `go vet ./...` clean; touched `.go` files gofmt-clean in their committed LF form.
- **Pending live smoke** (empirical, not CI): `dotf doctor` shows "age root-of-trust verified (round-trip)" with a real key; a corrupted/renamed key flips it to the FAIL.

## Scope notes

- The generic `dotf init` starter template is intentionally left age-var-free (the age key is a dotfiles machine fact, not a universal per-repo expectation) — a guard test enforces it.
- A pre-existing, unrelated failure (`internal/spec` `TestEmbeddedTemplatesMatchVault`, vendored `templates/tasks.md` drift vs the vault) is **not** touched here — it is its own re-vendor.

Spec: `specs/CLI-024-secrets-age-discovery/`.

Closes #518


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Age key discovery settings to the environment contract, with default key locations on Linux and Windows.
  * Doctor now checks Age key availability and verifies the key can successfully round-trip a test value.

* **Bug Fixes**
  * Missing keys now produce a warning instead of a hard failure.
  * If Age tooling is unavailable, the check warns and skips the round-trip test.

* **Tests / Documentation**
  * Added coverage for Age key discovery, round-trip success/failure, and skip behavior.
  * Added supporting specification and verification notes for the new Age discovery flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->