### PR TITLE
docs(adr): add codebase, documentation, and process audit reports

### DIFF
--- a/docs/adr/audit-008-codebase-comprehensive.md
+++ b/docs/adr/audit-008-codebase-comprehensive.md
@@ -1,10 +1,11 @@
 ---
-id: codebase-audit-2026-07-06
-type: research
+id: audit-008-codebase-comprehensive
+type: audit
 status: active
-tags: [audit, adversarial-review, dotfiles, cross-platform]
+date: "2026-07-06"
+related: [audit-009-documentation, audit-010-process-workflows, audit-001-repo-structure, audit-002-cross-os-duplication, audit-005-scripts-classification, audit-007-cli-convergence-state]
+tags: [audit, adversarial-review, dotfiles, cross-platform, codebase]
 ---
-
 # Codebase Audit — dotfiles — 2026-07-06
 
 > Exhaustive, adversarial audit. Every file under `git ls-files` (954 tracked files) was read
@@ -20,6 +21,8 @@ tags: [audit, adversarial-review, dotfiles, cross-platform]
 > PowerShell layer around it is where the real defects live** — silent-failure idioms, twin
 > drift, dead configuration that lies about being read, and a class of Windows/Linux encoding
 > and path divergences that the Go layer already fixed but the shells did not.
+>
+> **Companion audits:** `audit-009-documentation.md` (docs), `audit-010-process-workflows.md` (process) — same series; see `related:` frontmatter. Vault decide/position layer: `10_projects/dotfiles/research/2026-07-02-project-coherence-audit.md` (external benchmarking + methodology + backlog).
 
 ---
 

--- a/docs/adr/audit-009-documentation.md
+++ b/docs/adr/audit-009-documentation.md
@@ -1,0 +1,418 @@
+---
+id: audit-009-documentation
+type: audit
+status: active
+date: "2026-07-07"
+related: [audit-008-codebase-comprehensive, audit-010-process-workflows, audit-003-docs-drift]
+tags: [audit, documentation, dotfiles, drift]
+---
+# Documentation audit — 2026-07-07
+
+> Full audit of every reader-facing surface: README, `docs/**` (ADRs, audits, runbooks,
+> troubleshooting, lessons, inventory), `specs/README.md`, `cli/README.md`, doc-bearing
+> code (CLI help text, config-file comments, module headers, aliases), and all existing
+> diagrams. Every accuracy claim was checked against the working tree (`main`, clean, at
+> `ccc3189`); the installed `dotf` binary is stale, so CLI claims were verified against
+> `cli/internal/**` source. Findings marked **CONFIRMED** were verified by a concrete
+> check (quoted in §3); **PLAUSIBLE** means suspected but not fully verified.
+>
+> Coverage note (verify-don't-assert honesty): all runbooks, all troubleshooting entries,
+> `secrets-inventory.md`, `architecture.md`, the architecture map, `specs/README.md`,
+> `cli/README.md`, and ADRs 001/002/005/007/008/009/012/013/020/021/024/025/028/029/030/031
+> plus AUDIT-003/007 were read line-by-line. ADRs 003/010/011/014/015/017/018/019/022/023/026/027
+> and AUDIT-001/002/005/BUG-006 were swept (full-text grep for retired artifacts, status
+> fields, supersession markers, and link resolution) rather than line-audited; `lessons.md`
+> was audited structurally (headings + sampled entries). No finding below rests on an
+> unswept file.
+>
+> **Companion audits:** `audit-008-codebase-comprehensive.md` (code), `audit-010-process-workflows.md` (process) — same series; see `related:` frontmatter. Vault decide/position layer: `10_projects/dotfiles/research/2026-07-02-project-coherence-audit.md` (external benchmarking + methodology + backlog).
+
+---
+
+## 1. Summary table
+
+| ID | Severity | Document | Issue | Status |
+|----|----------|----------|-------|--------|
+| D1 | Critical | `README.md` (§Structure, §Human entrypoints, §Key Commands/Secrets, §Sync) | Teaches the retired secrets interface (`secrets_add`…`secrets_check`, `. scripts/load-secrets.sh`) and `dotfiles-sync` with no banner; `dotf secrets` never mentioned | CONFIRMED |
+| D2 | Critical | `docs/runbooks/ai-tools-setup.md` | Wholesale stale (ai/skills, ai/gemini, drawio/socket MCPs, claude-mem plugin, `pip install google-generativeai` as "Gemini CLI", `CLAUDE_HOME`, `gp`); no banner; teaches adding skill dirs to the repo — a pattern the README explicitly forbids | CONFIRMED |
+| D3 | Critical | `docs/runbooks/guide-knowledge-distillation.md` | Instructs creating vault `11-tasks.md` (directly violates ADR-018 / AGENTS.md); knowledge loop built on retired claude-mem + retired `claude-session-start.{sh,ps1}` scripts | CONFIRMED |
+| D4 | Critical | `docs/adr/adr-031` vs `docs/runbooks/guide-bitacora-setup.md` §7a | Direct contradiction on `BITACORA_PAT`: ADR-031 says fine-grained PAT works via github-script GraphQL; the runbook says fine-grained fails even on GraphQL and demands a classic PAT | CONFIRMED (contradiction) |
+| D5 | Major | `README.md` | Documented commands don't exist as written: `vault`, `obs`, `dotfiles-sync` (real names `vault.sh`, `obs-cli.sh`, `dotfiles-sync.sh`; `obs` alias absent); "scripts are NOT on PATH" is false | CONFIRMED |
+| D6 | Major | `README.md` | Stale counts: "316 BATS tests" (941), "21 custom skills" (34), "~50 scripts" (35), `cli/` "(doctor, init, env, spec)" (11 subcommands) | CONFIRMED |
+| D7 | Major | `docs/adr/dotfiles-architecture-map.md` | 2026-05-19 snapshot presented as the orientation map: SSOT list includes `env-mapping.conf`, runtime diagram shows secrets→shell-env (reversed by ADR-028), Layers/Where-does-X-live cite ≥8 retired scripts, `ai/gemini` row, stale counts | CONFIRMED |
+| D8 | Major | `cli/README.md` | Documents 2 of 11 subcommands (review, doctor); secrets/env/init/spec/mem/vault/tools/update/version absent | CONFIRMED |
+| D9 | Major | `README.md` §AI Tools + `docs/runbooks/guide-opencode-go-setup.md` | OpenCode default model drift: docs say `deepseek-v4-pro` under provider `opencode-go`; deployed config default is `nan/qwen3.6`; `qq` maps to `nan/qwen3.6`, not "qwen3.6-plus". Same fact stated in 3 places, only the config is true | CONFIRMED |
+| D10 | Major | `docs/adr/` (statuses) | ADR-009 `proposed` but fully live; ADR-029 `proposed` but shipped (v0.29.0); ADR-002/005 lack "partially superseded by ADR-028/030" banners; ADR-006 lacks the ADR-012 supersession banner; ADR-016 lacks the ADR-026 banner; ADR-021 has stale "(in progress)" markers and its `eval "$(dotf secrets env)"` shim plan was reversed by ADR-028 with no amendment | CONFIRMED |
+| D11 | Major | `docs/troubleshooting/ai-tools.md` | Stale sibling of D2: `gp` (now `gpr`), `ai/skills/`, manual drawio/socket `claude mcp add` recovery commands for servers removed 2026-05-25 | CONFIRMED |
+| D12 | Major | `docs/troubleshooting/setup-windows-session-hook-path.md`, `docs/runbooks/guide-gemini-cli-recovery.md` | Both are dead weight in the active tree: the first is `status: resolved` and entirely about a retired script; the second self-declares obsolescence ("needed for a few more weeks", sunset 2026-06-18 passed) | CONFIRMED |
+| D13 | Major | `docs/secrets-inventory.md` | 2026-06-25/28 working snapshot at `docs/` root with no historical banner; ADR-030 makes `secrets/registry.yaml` the SSOT it seeded; readers can mistake the table for live state; the re-added `sensitive/env-mapping.conf` split-brain (#669) is documented nowhere reader-facing | CONFIRMED |
+| D14 | Major | `.zsh/aliases.zsh:32` | Alias `cl` → `changelog-gen.sh` which no longer exists (retired to release-please, CLI-011) — broken doc-bearing code | CONFIRMED |
+| D15 | Major | `tmux.conf:2`, `docs/runbooks/guide-tmux.md` §deploy, arch-map | All three say `~/.tmux.conf` is a **symlink**; setup deploys it by **copy** (`deploy_file`, ADR-012). Contradicts the repo's own deploy ADR | CONFIRMED |
+| D16 | Major | `AGENTS.md:31` | "37 universal patterns in `00_meta/patterns/`" — the vault dir has 72 files | CONFIRMED |
+| D17 | Major | `specs/README.md:24-26` | "archive contains ~44 specs … active tree ~26" — real: 75 archived, 57 active (dated "as of 2026-06" but 2× off a month later; a count that structurally rots) | CONFIRMED |
+| D18 | Major | 3 dead relative links | `adr-026` → `pattern-knowledge-placement` (vault note linked as repo-relative path); `hive-mcp-rejection-disconnect.md` → `claude-mem-broken-marketplace.md` (moved to `archive/`); `archive/claude-mem-broken-marketplace.md` → `ai-tools.md` (missing `../`) | CONFIRMED |
+| D19 | Minor | `env-contract.json` `_comment`+`DOTFILES_DIR` descr., `session-start-config.json` `doctor_drift` comment | Reference retired `doctor.{sh,ps1}` / `healthcheck` as consumers | CONFIRMED |
+| D20 | Minor | `docs/adr/adr-012` (Consequences) | Cites a `dot` alias as the retraining mitigation — no such alias exists in any profile | CONFIRMED |
+| D21 | Minor | `README.md` §Quick Start vs ADR-005 | Quick start clones the repo *into* `~/.dotfiles`; the two-directory model defines `~/.dotfiles` as the deploy target that is "never modified directly" and the repo home as `~/Projects/dotfiles` (also the `env-contract.json` default). Two onboarding stories | CONFIRMED (doc conflict; runtime behavior of repo==deploy not tested) |
+| D22 | Minor | `docs/README.md` | Index omits `architecture.md` and `secrets-inventory.md`; no audience/task routing ("I want to change X → read Y") | CONFIRMED |
+| D23 | Minor | `docs/lessons.md` | 1,462-line append-only log with no TOC/topic index; a maintainer hunting one lesson can only grep | CONFIRMED |
+| D24 | Minor | `docs/runbooks/guide-opencode-go-setup.md` | 247 lines: one-time setup + billing guardrail + ~140 lines of deep troubleshooting/latency forensics in one doc; references `specs/AI-011-opencode-bootstrap/` (no longer in the active tree) | CONFIRMED (spec path: PLAUSIBLE archived) |
+| D25 | Minor | `docs/adr/adr-007` | MCP table (drawio/socket global servers) predates the 2026-05-25 removal; no pointer to `mcp-servers.json` `_history` as the current record | CONFIRMED (historical record; banner missing) |
+| D26 | Minor | `docs/adr/audit-007-cli-convergence-state.md` | `status: active` frontmatter on a dated snapshot whose plan is now half-executed (secrets/mem/update shipped since 2026-06-20) | CONFIRMED |
+| D27 | Minor | `docs/architecture.md:27` | `.zsh/` described as "(aliases, completions)"; contents are aliases + functions + nvm, no completions module | CONFIRMED |
+| D28 | Minor | `docs/runbooks/secrets-management.md`, `docs/troubleshooting/secrets.md` | Both carry correct "out of date, pending #600" banners (good), but the bodies still walk retired commands step-by-step; the SSH/backup/USB sections (still valid) are trapped inside a legacy doc | CONFIRMED |
+
+Verified-accurate surfaces worth naming (one line each, per the "one line where they lead with truth" rule): `guide-self-deploy-timer.md` (all commands verified incl. `dotf update` + `DOTFILES_AUTODEPLOY` tri-state), `guide-secrets-governance.md` (`dotf secrets backup` exists: `cli/internal/cmd/secrets_backup.go`), `guide-antigravity-cli-migration.md`, `guide-bitacora-setup.md` (except D4), the two hive-MCP troubleshooting notes (model citizens: explicit retire-criteria sections), `copilot-cli-v1-vs-v2-detection.md`, ADR-020/024/025/028/030/031, `machine.json.example`, `versions.conf` comments, `mcp-servers.json` `_comment`/`_history`, `git-hooks/pre-commit` header, systemd unit descriptions, `setup-{linux,windows}` headers, README's tmux quick block (all binds verified against `tmux.conf`), README's shell-helpers block (all 6 functions exist), `.zshrc.local.example`/`.bashrc.local.example`, `install-precommit.sh --with-sdd-gate`, `hc`/`dch` wrappers.
+
+---
+
+## 2. Documentation map — current vs proposed
+
+### Current
+
+| Surface | Purpose (claimed) | Audience | Found via | State |
+|---|---|---|---|---|
+| `README.md` (252) | Entry point: quick start, features, commands | Newcomer + returning maintainer | GitHub landing | Structure good; §Secrets/§Sync/§entrypoints teach a retired interface (D1/D5/D6) |
+| `docs/README.md` (10) | docs/ index | Anyone routed into docs/ | README §Documentation | Incomplete index (D22) |
+| `docs/architecture.md` (78) | Normative repo tree ("where does X live"), CI-guarded | Maintainer/agent orienting | README + AGENTS.md | Accurate (guarded by `architecture-md.bats`); one cosmetic row (D27) |
+| `docs/adr/` 31 ADRs + 6 audits + map | Decision record | Maintainer/agent | architecture.md, cross-links | Recent ADRs excellent; status/banner hygiene inconsistent (D10); map badly stale (D7) |
+| `docs/runbooks/` (11) | Operational procedures | Operator (often future-you) | docs/README | 5 current+verified, 2 legacy-with-banner, 2 critically stale (D2/D3), 1 obsolete (D12), 1 oversized (D24) |
+| `docs/troubleshooting/` (6+2 archived) | Symptom→cause→fix | Operator mid-incident | runbook cross-links | hive/copilot entries exemplary; ai-tools stale (D11); one resolved entry unarchived (D12) |
+| `docs/lessons.md` (1,462) | Append-only gotcha log | Maintainer + agents | AGENTS.md Standing Order #3 | Healthy discipline, no index (D23) |
+| `docs/secrets-inventory.md` (100) | Migration working artifact | Migration executor (past) | ADR-028 reference | Snapshot without banner (D13) |
+| `specs/README.md` (34) | SDD workspace explainer | Contributor hitting spec-gate | spec-gate failure links | Good; stale counts (D17) |
+| `cli/README.md` (88) | dotf CLI overview | CLI contributor | cli/ tree | 2/11 commands (D8) |
+| Doc-bearing code | help text, config comments, headers | All | — | dotf help text excellent; a few retired-script mentions (D19); aliases file has one broken entry (D14) |
+| `specs/**/quickstart.md` | (in audit scope) | — | — | None exist — scope item is empty, not a gap |
+| CONTRIBUTING/onboarding | — | External contributor | — | No file; README §Contributing (5 lines) covers the spec-gate contract — adequate for a solo repo |
+
+### Proposed (executable by a maintainer)
+
+1. **`README.md` — rewrite three sections in place** (no split needed; 252 lines is right):
+   - §Key Commands/Secrets → `dotf secrets {run,show,set,verify,ls,backup}` with one `run --` example; link `guide-secrets-governance.md`.
+   - §Human entrypoints → real names (`vault.sh`, `obs-cli.sh`, `dotfiles-sync.sh`), correct the PATH claim, add `dotf update`/`dotf tools`; drop the load-secrets row.
+   - §Structure + §Features → drop hand-counted numbers ("316 tests", "21 skills", "~50 scripts") or state them as ranges; list the full `dotf` noun set.
+2. **`docs/runbooks/ai-tools-setup.md` → replace**, splitting by audience:
+   - `guide-agent-provisioning.md` — what setup deploys per agent today (claude/agy/copilot/opencode/pi/hermes/nan), MCP registration from `mcp-servers.json`, plugin list from `ai/claude/settings.json`. Reference mode.
+   - Skills pipeline how-to → already exists as vault pattern + README §AI-skills paragraph; the runbook only needs a pointer, not a copy (SSOT).
+3. **`guide-knowledge-distillation.md` → rewrite around the current loop** (`dotf mem session-start`/`session-end`, `session-start-config.json`, Hive, `/crystallize`), delete the claude-mem diagram and the `11-tasks.md` instruction; the cross-machine-sync half (§Cross-Machine Memory Sync onward) is current and could stand alone as `guide-memory-sync.md` — the two halves serve different tasks (weekly hygiene vs new-machine wiring).
+4. **Secrets doc triangle → one canonical home**: `guide-secrets-governance.md` stays the operational SSOT; fold the still-valid parts of `secrets-management.md` (SSH key deploy, USB/VeraCrypt backup, restore) into it (or into a slim `guide-age-floor.md`) and delete the legacy walkthrough (#600); move `secrets-inventory.md` → `docs/adr/audit-008-secrets-inventory.md`-style dated artifact or `specs/archive/`, and add one paragraph on the #669 env-mapping split-brain until it's resolved.
+5. **Archive mechanics**: create `docs/runbooks/archive/` (mirroring troubleshooting) and move `guide-gemini-cli-recovery.md`; move `setup-windows-session-hook-path.md` → `docs/troubleshooting/archive/`.
+6. **`guide-opencode-go-setup.md` → split**: keep setup+guardrail (~100 lines); move the stall/latency/cwd forensics to `docs/troubleshooting/opencode.md`.
+7. **`cli/README.md`**: add a one-line-per-subcommand table (11 rows) pointing at `dotf <cmd> --help`; keep the review/doctor deep sections.
+8. **`docs/README.md`**: index all direct children + a 6-row task-routing table; link the architecture map with an explicit "dated snapshot" caveat (or retire the map per D7).
+9. **`dotfiles-architecture-map.md`**: either regenerate (AUDIT-004 pattern, new date) or stamp `status: superseded-snapshot` and point orientation readers at `docs/architecture.md`. Its two diagrams are worth regenerating (see §5).
+10. **ADR hygiene batch** (one PR): flip ADR-009 → accepted, ADR-029 → accepted; add supersession/amendment banners to ADR-002/005/006/016/021 (ADR-001/008/014 already model the pattern); demote `audit-007` frontmatter to a dated-snapshot status.
+11. **`docs/lessons.md`**: add a generated TOC (or `## Index by topic` block) at top; keep append-only body.
+
+---
+
+## 3. Drift verification (claim → check → result)
+
+Every CONFIRMED accuracy finding, with the exact check run:
+
+| # | Claim (doc:line) | Check run | Result |
+|---|---|---|---|
+| 1 | `scripts/load-secrets.sh / .ps1` exists (README:54,94) | `ls scripts/` | 35 files, no `load-secrets.*` — **gone** |
+| 2 | `secrets_add`/`secrets_rotate`/`secrets_show`/`secrets_list`/`secrets_check`/`secrets_add_file` (README:101-106; secrets-management.md; troubleshooting/secrets.md) | `grep -rn "secrets_add\|secrets_rotate\|…" .zsh/ .bashrc powershell/ scripts/` | No definitions anywhere — functions retired |
+| 3 | "316 BATS tests" (README:44) | `grep -c "^@test" tests/*.bats \| awk` | **941** tests across 62 files |
+| 4 | "21 custom skills" (README:41; ai-tools-setup.md:19) | `ls harness/skills \| wc -l` | 34 skill dirs (+ATTRIBUTION.md) |
+| 5 | "~50 scripts total" (README:56) | `ls scripts/ \| wc -l` | 35 |
+| 6 | `cli/` = "(doctor, init, env, spec)" (README:51) | `ls cli/internal/` + `dotf --help` | 12 packages / 11 user subcommands: doctor, env, init, mem, review, secrets, spec, tools, update, vault, version |
+| 7 | "Scripts in scripts/ are **not on PATH**" (README:81) | `grep -n PATH .zshrc .bashrc` | `.zshrc:93` `PATH="$DOTFILES_DIR/scripts:$PATH"`, `.zshrc:153` `PATH="$HOME/.dotfiles/scripts:$PATH"` (same in `.bashrc`) — **on PATH** |
+| 8 | `vault <subcommand>` / `obs` / `dotfiles-sync` commands (README:91-93,152) | `grep -nE "alias (vault\|obs\|dotfiles-sync)=" .zsh/ .zshrc .bashrc` + `ls scripts/` | No aliases; scripts are `vault.sh`, `obs-cli.sh`, `dotfiles-sync.sh` — commands as written fail (only `alias obsidian='obsidian --no-sandbox'` exists) |
+| 9 | `oc` default "DeepSeek V4 Pro" (README:139); "Default model: deepseek-v4-pro (set in opencode.jsonc)" (guide-opencode:81) | `grep -n model ai/opencode/opencode.jsonc` | `"model": "nan/qwen3.6"` (line 34); provider renamed `opencode-go` → `nan` |
+| 10 | `qq` → "qwen3.6-plus" (README:140) | `.zsh/aliases.zsh:44` | `alias qq='noglob _qq_call nan/qwen3.6 qq'` |
+| 11 | `cl` alias → `changelog-gen.sh` (aliases.zsh:32) | `ls scripts/changelog-gen.sh` | No such file |
+| 12 | tmux.conf "Deployed … via setup-linux.sh **symlink**" (tmux.conf:2; guide-tmux §deploy `ln -sf`; arch-map:169) | `grep -n tmux setup-linux.sh` | `setup-linux.sh:94 deploy_file "$DOTFILES_DIR/tmux.conf" "$HOME/.tmux.conf"` — copy, per ADR-012 |
+| 13 | Arch-map Foundation/Health/Secrets/Hooks layers cite `load-secrets.sh`, `healthcheck.sh`, `doctor.sh`, `diff-check.sh`, `claude-session-start.*`, `claude-mem-heal.*`, `init-project.*`, `github-secrets-manager.sh`, `skills-to-opencode.sh` | `ls scripts/` | None of the nine exist — retired into `dotf` (doctor/init/mem/secrets/update per `cli/internal/`) |
+| 14 | Arch-map "five SSOTs" incl. `sensitive/env-mapping.conf`; "Add a secret → env-mapping.conf + secrets_add_file" (arch-map:14,154) | `ls secrets/` + ADR-030 | `secrets/registry.yaml` is the mapping SSOT; env-mapping.conf exists only as the #669 split-brain re-add |
+| 15 | ADR-029 `status: proposed` (frontmatter) | `dotf secrets --help` lists `sync`; ADR-028 §Ratification: "sync/verify … shipped (#612 Phase B, v0.29.0)"; `cli/internal/cmd/secrets_sync.go` exists | Shipped — status stale |
+| 16 | ADR-009 `status: proposed` | AGENTS.md header ("Single Source of Truth"); every per-agent file delegates; `tests/agents-md.bats` guards it | Fully implemented — status stale |
+| 17 | ADR-012 "`dot` alias opens $DOTFILES_DIR" | `grep -rn "alias dot=" .zsh/ .zshrc .bashrc powershell/` | No match |
+| 18 | AGENTS.md "37 universal patterns" (AGENTS.md:31) | `ls $VAULT/00_meta/patterns \| wc -l` | 72 files |
+| 19 | specs/README "~44 archived / ~26 active" | `ls -d specs/*/ \| grep -v archive \| wc -l`; `ls -d specs/archive/*/ \| wc -l` | 57 active / 75 archived |
+| 20 | ai-tools-setup: setup copies `ai/skills/*`, `ai/gemini/*`; MCPs drawio+socket; claude-mem essential plugin; `g`→gemini, `gp` function | `ls ai/` (no skills/, no gemini/); `mcp-servers.json` `_history` ("removed drawio … socket", servers = seq-thinking/context7/hive); CHANGELOG #645 ("complete claude-mem retirement"); `.zshrc:116 alias g='agy'`; `gp` undefined (`gpr` in functions.sh:167) | All five drifted |
+| 21 | ai-tools-setup "until a Windows dotf install path exists (#380)" | `command -v dotf` on this Windows box + AUDIT-007 corrected-fact #1 | dotf installed via `install-dotf.ps1` (WIN-006) — claim stale |
+| 22 | `CLAUDE_HOME` env var (ai-tools-setup:268) | `env-contract.json` CLAUDE_CONFIG_DIR description | Contract says canonical var is `CLAUDE_CONFIG_DIR`, "intentionally NOT renamed" — doc contradicts contract |
+| 23 | guide-knowledge-distillation §new-project: create `11-tasks.md — active backlog` | AGENTS.md Knowledge Placement ("The vault no longer holds task state (no 11-tasks.md)"); guide-bitacora §1 | Direct contradiction with ADR-018 doctrine |
+| 24 | BITACORA_PAT type: ADR-031:23 "a **fine-grained PAT**" + workflows-work-via-github-script vs guide-bitacora:151-155 "must be a **classic** PAT … fine-grained … both add-to-project and the Projects v2 GraphQL (§7b) fail" | Read both (quoted); both dated 2026-06-25/26 | Mutually exclusive claims; unresolvable from docs alone (open question Q1) |
+| 25 | `dotf secrets backup` described as shipped (guide-secrets-governance §BACKUP) | `ls cli/internal/cmd/secrets_backup.go cli/internal/secrets/escrow.go` | Exists — runbook accurate (note: ADR-028 §Ratification still says "not yet built", now stale by #661) |
+| 26 | guide-self-deploy-timer: `dotf update`, `DOTFILES_AUTODEPLOY`, unit names | `systemd/dotfiles-selfupdate.service:14 ExecStart=%h/.local/bin/dotf update`; `grep DOTFILES_AUTODEPLOY setup-*.{sh,ps1}` | All verified accurate |
+| 27 | README tmux binds (`C-b` prefix, h/j/k/l, `%`/`"` splits, `r` reload) | `grep -nE "^bind\|prefix" tmux.conf` | All present; no prefix remap — accurate |
+| 28 | README shell helpers (mkd, gz, dataurl, targz, server, getcertnames) | `grep -nE "^[a-z_]+\(\)" .zsh/functions.sh` | All six exist — accurate |
+| 29 | env-contract `_comment` "read by … the legacy doctor.{sh,ps1}"; session-start-config `doctor_drift`: "via scripts/doctor.{sh,ps1}" | `ls scripts/doctor.sh` | Gone (dotf doctor `--quick` is the real runner per its help text) |
+| 30 | Dead links | Link-resolver script over all md (relative links → `realpath -m` → `-e` test), false positives manually disproved (audit-003's `../AGENTS.md` is inside a quoted diff — discarded) | 3 real: adr-026→`pattern-knowledge-placement`; hive-mcp-rejection-disconnect→`claude-mem-broken-marketplace.md`; archive/claude-mem-broken-marketplace→`ai-tools.md` |
+
+---
+
+## 4. Findings by hunt category
+
+### 4.1 Drift / inaccuracy (primary)
+
+**D1 — README teaches a secrets interface that no longer exists. CONFIRMED, Critical.**
+Reader scenario broken: a newcomer (or an agent using the README as spec) needs to add a
+secret; they run `secrets_add MY_TOKEN my.token` → `command not found`; nothing in the
+README names `dotf secrets`, so there is no recovery path from this doc. Checks §3 #1-2, #8.
+Direction: rewrite §Key Commands/Secrets around `dotf secrets` + registry; fix the
+entrypoints table; add `dotf secrets` to §Structure's `cli/` line. The runbooks got
+banners (#600) — the README, the highest-traffic surface, never did.
+
+**D2 — `ai-tools-setup.md` describes a system that was dismantled. CONFIRMED, Critical.**
+Scenario: an operator provisions a new machine for AI tools; they create `ai/skills/api/`
+per §Adding a New Skill (the README explicitly forbids repo skill dirs; the harness
+pipeline ignores them), `pip install google-generativeai` expecting a CLI, register
+drawio/socket MCPs that setup removed on purpose, and look for the claude-mem plugin
+retired in #645. Checks §3 #20-22. Direction: replace per §2 proposal 2; until then a
+top banner like secrets-management.md's is the 5-minute stopgap.
+
+**D3 — knowledge-distillation runbook contradicts ADR-018. CONFIRMED, Critical.**
+Scenario: maintainer starts a new project; §"What to do when starting a new project"
+step 1 says create `11-tasks.md — active backlog` in the vault — the exact anti-pattern
+ADR-018/AGENTS.md abolished, and guide-bitacora (same folder) declares forbidden. An agent
+following this runbook re-introduces vault task state. The loop diagram routes through
+retired claude-mem. Check §3 #23. Direction: §2 proposal 3.
+
+**D5/D6 — README command names & counts. CONFIRMED, Major.** Checks §3 #3-8. Notably the
+"NOT on PATH" claim inverts reality — the *reason* the alias-less script names work at all.
+
+**D7 — architecture map. CONFIRMED, Major.** It carries the two best diagrams in the repo
+and is recommended as first-read orientation, but both diagrams and 3 of its 4 tables
+describe the pre-ADR-028/pre-strangler world (checks §3 #12-14). A dated header is not
+enough when the doc is actively routed to as current ("Read first when orienting").
+Direction: regenerate or demote (§2 proposal 9).
+
+**D9 — OpenCode model facts triplicated and all stale except the config. CONFIRMED, Major.**
+Check §3 #9-10. Direction: docs state "default lives in `ai/opencode/opencode.jsonc`"
+and name models only as examples.
+
+**D10 — ADR status/banner hygiene. CONFIRMED, Major.** Checks §3 #15-17. The repo already
+has the right convention (ADR-001/008 carry "supersession proposed by ADR-013" banners;
+ADR-014 carries a superseded note; ADR-020 an Amendment) — it's applied inconsistently.
+An agent reading ADR-002/005 today learns an ambient-export model that ADR-028 reversed.
+
+**D11-D15, D19-D21, D25-D28** — itemized in §1 with checks in §3; all follow the same
+class: the code moved (strangler-fig, secrets redesign, agy migration) and the paper trail
+lagged on exactly the surfaces without CI guards.
+
+### 4.2 Inverted-pyramid violations
+
+Mostly healthy — README, ADRs (decision-first), runbooks (what-it-does first), and
+troubleshooting (symptom→cause→fix) all open correctly. Two exceptions:
+
+- **`secrets-management.md`**: after the banner, the first 100 lines walk the *retired*
+  architecture before any current fact appears (the one live section, `dotf secrets sync
+  ci`, is buried mid-document at line 88). A reader skimming past the banner learns the
+  wrong 80% first.
+- **`guide-knowledge-distillation.md`**: opens with philosophy/token-cost rationale for
+  ~35 lines before any actionable step; the "what do I actually run" (crystallize/insights
+  cadence table) sits at line 176.
+
+### 4.3 Sizing / decomposition
+
+- **Split — `guide-opencode-go-setup.md` (247)**: setup/guardrail vs. deep troubleshooting
+  (stall forensics, cwd analysis, latency benchmarks). Reader task defeated: mid-incident
+  "why does my stream stall" requires scrolling past billing setup; conversely first-time
+  setup readers hit 140 lines of failure lore. → `troubleshooting/opencode.md` (§2 prop. 6).
+- **Split — `guide-knowledge-distillation.md` (385)**: weekly-hygiene loop vs.
+  cross-machine memory-sync reference; the sync half is current and useful, the loop half
+  is stale — splitting also isolates the rewrite (§2 prop. 3).
+- **Merge — secrets triangle**: `guide-secrets-governance.md` (canonical) + the still-valid
+  age-floor/USB/SSH mechanics stranded in `secrets-management.md` + the historical
+  `secrets-inventory.md` (§2 prop. 4).
+- **Merge/absorb — `tool-installation.md` (197)**: hand-listed install commands + version
+  pins that duplicate `versions.conf` (`sdk install java 21.0.1` vs pin `21.0.4`) and
+  ignore `packages.json`/`dotf tools install` (CLI-029) — the repo's own answer to this
+  doc. Direction: shrink to "setup installs most things; `dotf tools list/install` for the
+  catalog; here's what needs manual sudo (tmux, xclip, docker)". Rationale to keep: brew/mac
+  lines serve the planned macOS port — keep them in one "manual installs" appendix.
+- **`lessons.md` (1,462)**: keep as one log (append-only is the value), fix findability
+  with an index (D23) — no split needed.
+
+### 4.4 Architecture as drawn process
+
+Only 3 Mermaid/ASCII diagrams exist in reader docs: the two in the (stale) architecture
+map and one ASCII loop in knowledge-distillation (stale) + small ASCII trees (deploy
+chain in guide-tmux — wrong per D15; sync flow in ADR-007). The current-era decisions
+(ADR-028/029/030 secrets, ADR-025 cascade, dotf update lifecycle) are prose-only.
+See §5 backlog + drafts.
+
+### 4.5 Usefulness / audience fit
+
+- The **hive troubleshooting pair** and **guide-self-deploy-timer** are the gold standard:
+  scoped symptom, verified commands, explicit retire-criteria.
+- **`tool-installation.md`** and post-rewrite **`ai-tools-setup.md`** currently serve
+  nobody end-to-end (both predate the automation that replaced their steps).
+- Mode-mixing: `guide-opencode-go-setup` mixes how-to + reference + troubleshooting
+  (§4.3); `guide-bitacora-setup` deliberately mixes reference (IDs) + how-to and it
+  *works* — no change needed there.
+- Newcomer zero-to-first-success: Linux quick start works (clone → setup → new shell);
+  but the first secrets task fails (D1) and the D21 clone-location ambiguity means a
+  newcomer who later becomes a contributor has their repo in the "wrong" place per
+  ADR-005. One clarifying sentence in Quick Start fixes it.
+
+### 4.6 Coverage — see §6 for the backlog
+
+Headlines: 7 of 11 `dotf` subcommands are absent from every prose doc (only `--help`
+covers them); `dotf secrets backup` is documented solely inside the governance runbook;
+the #669 env-mapping split-brain has no reader-facing note; no troubleshooting entry
+exists for `dotf update` failures (the runbook's diagnose table covers the happy skips)
+or for `bw` unlock friction.
+
+### 4.7 Single source of truth
+
+- **BITACORA_PAT type** (D4) — the sharpest instance: two authoritative-looking docs,
+  opposite claims, both load-bearing at rotation time.
+- **OpenCode default model** (D9) — stated in 3 places; only the config is real.
+- **Counts** (D6/D17/D16) — test/skill/script/spec/pattern counts hand-copied into prose
+  rot on every merge. Direction: remove precise counts from prose, or guard them (the
+  repo's own incident→guard pattern; `architecture-md.bats` proves the approach works).
+- **Version pins** — `tool-installation.md` duplicates `versions.conf` values (§4.3).
+- **Terminology** — "two-tier deploy" vs "two-directory sync" refer to the same thing
+  across README/ADR-005/arch-map/guide-tmux; pick one term and alias the other once.
+
+### 4.8 Findability / navigation
+
+- `docs/README.md` (10 lines) under-routes: no `architecture.md`, no inventory, no
+  audits dir, no task-based routing (D22).
+- Orphans: `secrets-inventory.md` (only inbound links from ADR-028 §references) and the
+  architecture map (linked as "read first" from maintainer memory but not from
+  `docs/README.md`).
+- Dead links: 3 (D18).
+- Cross-link quality is otherwise high — ADR↔runbook↔troubleshooting references are dense
+  and mostly resolve.
+
+---
+
+## 5. Diagram backlog (value order)
+
+1. **Secrets two-tier architecture + command flows** → new section in
+   `guide-secrets-governance.md` (and referenced from ADR-028). The single most
+   prose-locked architecture in the repo (ADR-028 §Decision + §Phased plan + ADR-029/030).
+
+```mermaid
+flowchart LR
+    classDef store fill:#fef3c7,stroke:#d97706,color:#000
+    classDef cmd fill:#dbeafe,stroke:#1e40af,color:#000
+    classDef target fill:#dcfce7,stroke:#15803d,color:#000
+
+    BW[("Bitwarden\nlive SSOT\nDotfiles/{apps,infra,personal,floor}")]:::store
+    AGE[("age floor\nsensitive/*.secret.age\n+ offline key")]:::store
+    REG["secrets/registry.yaml\nmapping SSOT\nid → backend → expose → consumers"]:::store
+
+    RUN["dotf secrets run -- cmd\n(child env only)"]:::cmd
+    SYNC["dotf secrets sync ci\n(ahead-of-time)"]:::cmd
+    MIG["dotf secrets migrate\n(age→bw, parity-gated)"]:::cmd
+    BAK["dotf secrets backup\n(bw export | age)"]:::cmd
+
+    LOCAL["local process"]:::target
+    CI["GitHub Actions secrets"]:::target
+    DR["sensitive/dr/bitwarden-export.age\n(committed escrow)"]:::target
+
+    REG --> RUN & SYNC & MIG
+    BW --> RUN --> LOCAL
+    AGE --> RUN
+    BW --> SYNC --> CI
+    AGE --> MIG --> BW
+    BW --> BAK --> DR
+    AGE -. "offline key decrypts" .-> DR
+```
+
+2. **Runtime data-flow refresh** → replaces the stale diagram in the architecture map
+   (or lives in `docs/architecture.md`). Key correction: no secrets at shell startup;
+   session hooks via `dotf mem`.
+
+```mermaid
+flowchart LR
+    classDef trigger fill:#fee2e2,stroke:#dc2626,color:#000
+    classDef hook fill:#dcfce7,stroke:#15803d,color:#000
+    classDef sink fill:#f3e8ff,stroke:#7e22ce,color:#000
+
+    NS([New shell]):::trigger --> RC[".zshrc/.bashrc\nsource ~/.dotfiles/paths.sh"]:::hook --> ENV["structural env vars\n(ADR-025 — no secrets)"]:::sink
+    CS([New agent session]):::trigger --> MEM["dotf mem session-start\n(session-start-config.json)"]:::hook --> CTX["additionalContext"]:::sink
+    CMD([Secret needed]):::trigger --> SEC["dotf secrets run -- cmd"]:::hook --> CHILD["child process env only"]:::sink
+    TIMER([Daily systemd timer /\nScheduled Task]):::trigger --> UPD["dotf update\n(ff-only + setup)"]:::hook --> DEPLOY["~/.dotfiles converged"]:::sink
+    PR([PR opened]):::trigger --> GATE["spec-gate.yml"]:::hook --> FAIL[CI red]:::sink
+```
+
+3. **`dotf update` self-deploy lifecycle** → `guide-self-deploy-timer.md` (its skip
+   ladder is a textbook state flow).
+
+```mermaid
+flowchart TB
+    T([timer fires]) --> D{worktree dirty?}
+    D -- yes --> S1["skip (exit 0)"]
+    D -- no --> F{git fetch ok?}
+    F -- no --> S2["skip — network (exit 0)"]
+    F -- yes --> FF{fast-forward possible?}
+    FF -- no --> S3["skip — diverged (exit 0)"]
+    FF -- yes --> M{HEAD moved?}
+    M -- no --> S4["skip — already current (exit 0)"]
+    M -- yes --> SETUP["re-run setup"]
+    SETUP --> OK([exit 0]) & ERR(["exit ≠0 — only real failure"])
+```
+
+4. **ADR-025 path-resolution cascade** → README §Cross-machine paths or ADR-025
+   (`env var → machine.json → env-contract default → dotf env generate → paths.{sh,ps1}
+   → shells/hooks/CLI`). Flowchart; ~8 nodes; replaces three prose paragraphs.
+5. **ADR-030 registry read/write asymmetry** → ADR-030 (sequence diagram: `migrate`
+   writes checkout-only fail-loud; reads checkout-first-fallback-deployed) — the bug it
+   fixed is subtle enough that the prose takes 3 readings.
+6. **Bitácora status lifecycle** → guide-bitacora §5 (stateDiagram: Backlog→In
+   Progress→Blocked→Done with the automation labels).
+
+Stale diagrams to fix/retire: the two in `dotfiles-architecture-map.md` (setup-time one
+is refreshable — its shape is right, its labels stale; runtime one → replace with #2),
+the knowledge-loop ASCII in guide-knowledge-distillation (claude-mem era), the deploy
+chain in guide-tmux (symlink step wrong, D15).
+
+---
+
+## 6. Missing-docs backlog (by unblocking value)
+
+1. **README secrets section rewrite** (D1) — unblocks the single most common operator
+   task; every day it stands it mis-trains agents reading the repo as spec.
+2. **`dotf` subcommand coverage**: a table in `cli/README.md` (11 rows) + README
+   §Structure line fix. `mem`, `vault`, `tools`, `update`, `version` currently exist
+   only in `--help`.
+3. **env-mapping split-brain note** (#669): one paragraph in `guide-secrets-governance.md`
+   ("`sensitive/env-mapping.conf` re-appeared via #659; registry.yaml is authoritative;
+   removal tracked in #669") — prevents a reader from 'fixing' either side ad hoc.
+4. **`troubleshooting/opencode.md`** (from the D24 split) + a stub
+   **`troubleshooting/dotf-update.md`** (non-skip failures: setup errored mid-run,
+   binary self-replace on Windows).
+5. **Agent-provisioning reference** (replacement for ai-tools-setup, §2 prop. 2).
+6. **BITACORA_PAT resolution** (D4): once Q1 below is answered, one doc wins and the
+   other links to it.
+7. **`docs/README.md` routing table** (D22) + lessons.md index (D23).
+8. **Onboarding clarification** (D21): one sentence in README Quick Start distinguishing
+   "user install" (clone anywhere, setup deploys to `~/.dotfiles`) from "contributor
+   layout" (`~/Projects/dotfiles` per env-contract default).
+9. **ADR-013/harness engine status note**: `compile-harness.sh` ships the engine's shell
+   form while ADR-013 stays `proposed` and CLI-026 is an active spec — one status line in
+   ADR-013 ("shell implementation live; Go port = CLI-026") would stop readers from
+   re-deriving this. (PLAUSIBLE — status intent may be deliberate pending the Go port.)
+10. **macOS placeholder**: README already handles it well; when `setup-macos` lands,
+    Requirements + platform table already have slots — nothing needed now.
+
+---
+
+## 7. Open questions (maintainer-only)
+
+- **Q1 (D4)**: Which BITACORA_PAT claim is true today — is the live token classic or
+  fine-grained? ADR-031 (2026-06-26) and guide-bitacora §7a gotcha (2026-06-25) cannot
+  both be right about the GraphQL path. The answer decides which doc gets corrected.
+- **Q2 (D7)**: Architecture map — regenerate as AUDIT-00x-2026-07 snapshot, or retire in
+  favor of `docs/architecture.md` + the §5 diagrams? (It's the only doc with the full
+  deploy-target fan-out; losing it un-regenerated loses real content.)
+- **Q3 (D13)**: `secrets-inventory.md` — archive as dated artifact, or keep alive as a
+  generated view over `registry.yaml` (`dotf secrets ls` output + bw cross-section)?
+- **Q4 (D6/D16/D17)**: For rotting counts, prefer removal ("dozens of skills") or a CI
+  guard that greps the number against reality (the repo's incident→guard doctrine argues
+  for guards, but each guard adds maintenance)?
+- **Q5 (D21)**: Is clone-into-`~/.dotfiles` actually supported by `setup-linux.sh`
+  (repo == deploy dir)? If yes, ADR-005 deserves a note; if no, the README quick start
+  is teaching a broken layout and needs the two-directory story.
+- **Q6**: `docs/runbooks/archive/` does not exist — is frontmatter `status: archived`
+  (hive-mcp note's plan) the preferred retirement mechanism over a directory move?
+  Troubleshooting uses a directory; pick one convention.

--- a/docs/adr/audit-010-process-workflows.md
+++ b/docs/adr/audit-010-process-workflows.md
@@ -1,0 +1,291 @@
+---
+id: audit-010-process-workflows
+type: audit
+status: active
+date: "2026-07-07"
+related: [audit-008-codebase-comprehensive, audit-009-documentation]
+tags: [audit, process, workflow, dotfiles, end-to-end]
+---
+# Process Audit — end-to-end workflow walk (2026-07-07)
+
+**Method.** Every documented journey was walked twice — as a first-time human following only the docs, and as an agent chaining exit codes — empirically, in throwaway environments: four Ubuntu 24.04 containers (E1–E4: README-requirements-only newcomer; full README Quick Start; copy-branch + self-deploy precision pass; checkout-dirt identification), the CI integration image built from this working tree, and scrubbed-environment sandbox runs of a locally-built `dotf` on Windows. No repo state was modified beyond this report. Findings marked **CONFIRMED** were reproduced with the command sequences given; **PLAUSIBLE** were traced in source only.
+
+**Scope note.** The audit prompt is a generic template (distributed via the maintainer's gist, run from whatever repo it targets); its Context/Scope sections name subsystems of a different codebase (ingest preview, review sidecars, publication.status, vault manifests, `somostodos-init`). An exhaustive search of this machine (all Workspace repos, `~/Projects`, home, other drives, `gh repo list`) found no codebase containing them; the maintainer directed this run at the dotfiles repo explicitly. Each scoped process was therefore mapped to its real counterpart here; §3 verifies this repo's own recently shipped fixes (#667, #663, #661, #664, HARNESS-040) through full workflows, and the template's named prior-audit defects are N/A (no such subsystems exist to regress).
+
+**Spec coverage matrix** (template scope item → what was walked here → where):
+
+| Spec scope item | Mapping in this codebase | Walked | Report |
+|---|---|---|---|
+| 1. Onboarding: empty install → health → init → manual config → health green; newcomer stranding; fix_suggestions executable verbatim | `git clone` → `setup-linux.sh`/`setup-windows.ps1` → `dotf doctor` → `machine.json` + `dotf env generate` → doctor green | E1 (README-requirements-only), E2 S1-S5 (Quick Start verbatim), real-machine doctor; every fix_suggestion re-executed | P2, P3, P6, P8; §2.1 |
+| 2. Ingest lifecycle: first run → re-run same source → changed inputs → duplicates; durable registry | Deploy lifecycle: first setup → re-run setup → repo-vs-deploy drift → registry/store integrity (`secrets/registry.yaml` + `sensitive/`) | E2 S5 (second call), E4 (what a run leaves behind), real-machine drift FAILs, orphan store file | P1, P2, P13; §2.4 |
+| 3. Review loop: state consistency, recovery/reopen path | Spec lifecycle (nearest per-record review flow): init → gate → fill seam → archive → abandoned → reopen path | E2 S10-S12, W1/W1c gate probes; no unarchive command found | P14, §2.3 |
+| 4. Filing: apply → re-apply idempotency AND exit code → partial failure → does config control destination | `dotf env generate`/`tools install`/`vault project`: re-run idempotency, exit codes, half-completed prior run (post-abort setup state), machine.json controlling destinations | E2 S16-S17, S19-S20, E3 T5; P2 (half-completed setup), P3 (config not consulted — phantom default) | P3, P9, P10 |
+| 5. Publication: can a record reach the terminal state purely via CLI; which command owns the status write | Self-deploy: can a machine reach "updated" purely via `dotf update`; which process owns deploy-state freshness | E3 T3-T4 (full behind→ff→setup walk), E2 S7-S9 | P1, P3; §2.1 |
+| 6. Side processes: memory lifecycle, artifact writers vs validators, health/doctor as preflight | `dotf mem session-start/end`, harness/skills compile-deploy seam, doctor as preflight for every flow | E2 S18, doctor before/after each walk, generate-vs-doctor validator disagreement | P4, P6, P8 |
+| 7. Cross-process coherence: enumerate every state, command that moves each forward; real state machine; unreachable states + absorbing dead ends | Machine install state, secret state, spec state, paths/config state | §2.1–2.4 with owning commands, 2 absorbing dead ends, 1 unreachable state marked | §2 |
+| Hunt-for: dead ends / missing processes / re-run semantics / agent ergonomics (exit codes, JSON, help vs flags) / docs drift / concurrency | All six bullets walked against the real CLI surface (12 nouns, every subcommand help + probes) | E2 S6/S13-S15/S19-S20, E3 T5-T7, W5-W6b, docs walk | P5, P7, P9, P11, P12 |
+
+**Audit-harness disclosure.** One sandbox invocation of `dotf env generate` early in the audit leaked through ambient `DOTFILES_DIR` and rewrote the real `~/.dotfiles/paths.ps1` with sandbox paths; it was restored by re-running `dotf env generate` from a correct environment. The incident is itself evidence for P10 (generate trusts ambient env, no confirmation, no backup) and demonstrated the recovery path works.
+
+**Companion audits:** `audit-008-codebase-comprehensive.md` (code), `audit-009-documentation.md` (docs) — same series; see `related:` frontmatter. Vault decide/position layer: `10_projects/dotfiles/research/2026-07-02-project-coherence-audit.md` (external benchmarking + methodology + backlog).
+
+---
+
+## 1. Summary
+
+| ID | Severity | Process | Issue | Status |
+|----|----------|---------|-------|--------|
+| P1 | critical | self-deploy | Setup rewrites a tracked file inside the checkout (`.github/copilot-instructions.md`); every subsequent `dotf update` skips on "dirty worktree" with exit 0 — self-deploy disables itself after the first run, silently | CONFIRMED |
+| P2 | critical | onboarding (Linux) | README's documented layout (clone into `~/.dotfiles`) kills setup mid-run (`cp` same-file + `set -e`) and self-destructs the git-hooks dispatcher with a false `[SUCCESS]`; second run refuses; doctor's advice is circular | CONFIRMED |
+| P3 | high | all `dotf` flows | Contract default `DOTFILES_REPO_DIR=~/Projects/dotfiles` matches no documented install path and no journey creates `machine.json` → `dotf update` is a permanent no-op (exit 0), `mem session-start` probes phantom paths, `doctor --fix` tells users to export the phantom | CONFIRMED |
+| P4 | high | diagnostics | `dotf doctor` resolves `env-contract.json`/`versions.conf` deployed-copy-first while `dotf env generate` resolves repo-first → contradictory verdicts on the same machine ("paths.ps1 is stale" vs "ok: up to date") and nonsense version-drift directions | CONFIRMED |
+| P5 | high | secrets / AI deploy | Both setups fetch a deploy-time secret as `dotf secrets show openrouter-api-key` — an id that does not exist in the registry — swallowed by `\|\| true` → agy MCP config is baked with an empty API key on every deploy, both OSes | CONFIRMED |
+| P6 | high | onboarding → doctor green | Doctor-green is unreachable on a docs-faithful fresh machine: `bw` is npm-sourced with npm undeclared/uninstalled, doctor's fix commands fail identically, one fix references the retired `secrets_refresh`; 31 FAILs right after documented onboarding | CONFIRMED |
+| P7 | medium | docs | README promises retired commands (`secrets_add`/`secrets_show`/…, `. scripts/load-secrets.sh`) and three human entrypoints (`vault`, `obs`, `dotfiles-sync`) that exist in no shell; `.zshrc` hard-requires oh-my-zsh that nothing installs or documents; Requirements omit `curl` (E1 dies on it); Windows setup prints retired `project-init` as a next step | CONFIRMED |
+| P8 | medium | diagnostics | `doctor --fix` prints "Applied 11 fix action(s)" when it only printed suggestions; the suggestions (hand-added profile exports) permanently shadow `machine.json` via cascade rule #1 — the exact corruption class this audit accidentally demonstrated | CONFIRMED |
+| P9 | medium | agent ergonomics | No JSON output anywhere in the CLI; `dotf env path UNKNOWN_KEY` → empty line + exit 0; `spec archive` re-run errors instead of no-op; `secrets set` without bw installed reports misleading "item not found"; `secrets render` is default-lax (exit 0 leaving placeholders — setup depends on it); `migrate` guard recommends `--split`, which does not exist | CONFIRMED |
+| P10 | medium | env generation | `dotf env generate` trusts ambient `DOTFILES_DIR`/`HOME` for target and rendering with no confirmation, no atomic write, no backup — a mis-set environment silently rewrites the live paths file | CONFIRMED |
+| P11 | medium | cross-platform | `.gitattributes` misses extensionless rc files (`.bashrc`, `.zshrc`, `.profile`, `*.local.example`) → CRLF on Windows checkouts → any Windows→Linux copy deploys a syntactically broken `.bashrc`; the existing bats syntax guard can only run where the bug cannot occur | CONFIRMED |
+| P12 | low | concurrency | Paths-file writes are non-atomic (`os.WriteFile`); concurrent `env generate` observed benign but a sourcing shell can read a torn file; `update`'s dirty check counts untracked files, so any stray file blocks self-deploy (compounds P1) | PLAUSIBLE |
+| P13 | low | state hygiene | States with no owning command on the real machine: orphan `sensitive/kubelab-dispatch-token.secret.age` (doctor FAILs it; only hand-edit fixes it); deployed-copy staleness accumulates silently when the opt-in timer is off (observed: deployed contract missing #663's AGE keys) | CONFIRMED |
+| P14 | low | spec lifecycle | Gate errors conflate "issue not found" with "gh failed"; archive of an already-archived spec says "spec not found" instead of acknowledging the state | CONFIRMED |
+
+Counts: **2 critical, 4 high, 5 medium, 3 low** — 13 CONFIRMED, 1 PLAUSIBLE.
+
+---
+
+## 2. Process map — the real state machines
+
+### 2.1 Machine install state (per machine)
+
+```
+NOT_INSTALLED
+  └─ git clone (README)
+       ├─ layout A: clone INTO ~/.dotfiles  (README-documented)
+       │    └─ ./setup-linux.sh → ✖ DIES mid-run (P2) → PARTIALLY_SETUP
+       │         └─ re-run setup → git-hooks step refuses (P2) → ABSORBING without
+       │            undocumented `git checkout -- git-hooks` knowledge
+       └─ layout B: clone elsewhere (~/dotfiles-repo; only CI exercises this)
+            └─ setup → exit 0 → DEPLOYED_UNCONFIGURED
+DEPLOYED_UNCONFIGURED  (no machine.json; contract defaults point at ~/Projects/dotfiles)
+  ├─ dotf update            → no-op "not a git repo", exit 0 (P3)  [silent dead end]
+  ├─ dotf doctor            → exit 1 forever (P6)                  [green unreachable]
+  └─ MANUAL, UNDOCUMENTED: write machine.json + dotf env generate → CONFIGURED
+CONFIGURED
+  └─ any setup run from the checkout → checkout dirty (P1) → SELF_DEPLOY_DISABLED
+       └─ dotf update → "dirty worktree — skipping", exit 0, forever  [ABSORBING]
+            recovery: manual `git checkout -- .github/copilot-instructions.md`
+                      (undocumented; re-dirtied by the next setup run)
+DRIFTED  (repo moved, deploy dir stale — observed live: contract missing AGE keys)
+  ├─ owning command: re-run setup (manual memory only; timer opt-in & off)
+  └─ doctor flags file drift, but reads the STALE side as truth for its own
+     checks (P4) → contradicts env generate; fix texts do not converge
+```
+
+**Dead ends:** PARTIALLY_SETUP after a layout-A run (P2); SELF_DEPLOY_DISABLED (P1). Both are absorbing given only documented commands.
+**Unreachable state:** doctor-green on a fresh docs-faithful machine (P6).
+
+### 2.2 Secret state (per registry id)
+
+```
+registry-mapped ── backend: age ──► resolvable (age key present) / FAILED (absent)
+      │                              verify → exit 1 on FAILED  ✓ (good agent contract)
+      │
+      ├─ backend: bw ──► requires bw CLI: npm-sourced, no npm on fresh box (P6)
+      │                   set/migrate/backup fail; `set` error text misattributes (P9)
+      ├─ migrate age→bw: parity-gated ✓; shared-source refusal points at
+      │                   nonexistent `migrate --split` (P9/C9)  [dead-end pointer]
+      ├─ rotate: declared in registry (`rotate: 90d`) — NO command; manual bw edit
+      │                   (runbook admits "manual today")         [missing process]
+      └─ orphan file in sensitive/ (no registry entry) — doctor FAILs it;
+                          no adopt/remove command                 [dead end, P13]
+DR escrow: backup ✓ (round-trip verified; clean failure w/o bw). restore: manual
+runbook only (age -d + bw import) — no command                    [missing process]
+```
+
+### 2.3 Spec state (per feature id)
+
+```
+(no spec) ─ spec init [--issue gate ✓ / --force-no-gate] ─► active
+active ─ spec archive ─► archived          (re-archive → "spec not found" error, P14)
+active ─ spec archive --abandoned ─► abandoned
+archived ─ (no reopen/unarchive command — hand-move only)          [dead end, minor]
+Vault promotion + backlog tick: deliberately manual/agent seam (printed by the CLI).
+```
+
+### 2.4 Paths/config state
+
+```
+contract(repo) ─ commit ─► contract(deployed)   [only via setup; ages silently, P13]
+contract + machine.json ─ env generate ─► paths.{sh,ps1}
+  ├─ --check drift detection ✓ (exit 1 on drift)
+  ├─ doctor's own stale-check uses the OTHER contract copy (P4)   [split verdicts]
+  └─ ambient env poisons render/target (P10)
+machine.json: created by NO journey (P3) — the load-bearing file onboarding never makes.
+```
+
+---
+
+## 3. Prior-fix verification (this repo's recent merges, exercised through full flows)
+
+| Fix | Verdict | Evidence |
+|---|---|---|
+| #667 `dotf update` self-deploy port | **PARTIAL** | Core loop works: with `DOTFILES_REPO_DIR` set to a clean behind checkout, update fast-forwarded (ccc3189 → 70654ea), re-ran setup, exit 0 (E3 T3). But in every documented journey it is inert: phantom repo default → "not a git repo" no-op (P3), and after one setup run → permanent "dirty worktree" skip (P1). The unit shipped; the process it serves does not close. |
+| #663 age root-of-trust (AGE_KEY_PATH/SOPS_AGE_KEY_FILE in contract + doctor) | **PARTIAL / AT-RISK** | Works from the repo: generate renders both keys; doctor's secrets-integrity section ran green (34 checks) in-container. Regression vector live: this machine's deployed contract predates #663 — a `dotf env generate` resolving deployed-first (any run without the repo reachable) renders paths WITHOUT the age keys, silently reintroducing the #518 failure. Observed empirically during the audit-harness incident. |
+| #661 `dotf secrets backup` DR escrow | **PASS (surface)** | Command present, help accurate; without bw it fails loud and clean (`backup: bw sync: exec: "bw": not found`, exit 1 — E2 S15). Full escrow round-trip not exercisable in sandboxes (no Bitwarden session); runbook RECOVER remains manual (§5). |
+| #664 help-text dangling-doc guard | **PASS-lite** | No dangling doc references observed across the full `--help` walk of all 12 nouns. One adjacent gap: help text and error text still reference non-commands (`secrets_refresh` in doctor SKIP text, `migrate --split`) — the guard covers docs refs, not command refs (P6/P9). |
+| HARNESS-040 junction repair (`doctor --fix`) | **PASS (observed)** | Real-machine doctor: auto-memory junction checks green among 96 passes, read-only run. Creation path traced (`checks_automemory.go` + unit tests); not re-created empirically on Windows in this audit. |
+| Prompt-template prior findings (ingest/review/publication/vault-manifest) | **N/A** | No such subsystems exist in this codebase. |
+
+---
+
+## 4. Gaps and errors by process (severity order)
+
+### P1 — Setup dirties the checkout; self-deploy permanently self-disables (critical, CONFIRMED)
+
+**Where:** `setup-linux.sh:918-935` (SDD-005 parity sync writes `$CURRENT_DIR/.github/copilot-instructions.md`); `cli/internal/update/update.go:51` (dirty = any `git status --porcelain` output, tracked or untracked).
+
+**Repro (container, clean GitHub clone):**
+```
+git clone --depth 5 https://github.com/mlorentedev/dotfiles.git ~/dotfiles-repo
+cd ~/dotfiles-repo && bash setup-linux.sh        # exit 0
+git status --porcelain                            # " M .github/copilot-instructions.md"
+DOTFILES_REPO_DIR=$HOME/dotfiles-repo dotf update # "dirty worktree — skipping", exit 0
+```
+E3 showed the full arc: reset-behind → update works ONCE (its own setup re-run re-dirties) → every later update skips. A machine with the opt-in timer enabled reports green (exit 0) daily while never updating again.
+
+**Stranded user:** enables the self-deploy timer per `guide-self-deploy-timer.md`, sees `systemctl status` green forever, machine quietly ages. Nothing in doctor points at the checkout's dirt as the cause.
+
+**Also implied:** the committed `.github/copilot-instructions.md` is out of parity with `ai/copilot/copilot-instructions.md` in HEAD right now (the sync produced a 2+/4− diff on a fresh clone) and no CI check enforces the parity rule.
+
+**Direction:** setup must never write into the checkout (deploy-dir writes only), or the parity sync must move to CI/pre-commit; `dotf update` could additionally diagnose *which* files dirty the tree and say so.
+
+### P2 — README's Linux Quick Start layout kills setup and destroys the git-hooks dispatcher (critical, CONFIRMED)
+
+**Where:** README.md:16-19 documents `git clone … ~/.dotfiles && cd ~/.dotfiles && ./setup-linux.sh`; `setup-linux.sh:11` (`set -euo pipefail`); the env-contract deploy `cp` (~line 1437) errors "same file" when `CURRENT_DIR == DOTFILES_DIR` and set -e aborts the run there — everything after (env generate, final doctor) never runs. `scripts/install-git-hooks.sh:60-63`: `rm -rf dest` + unchecked `cp src/. dest` with src==dest empties the dispatcher and still logs `[SUCCESS]` (E3 T8); the second setup run then refuses (`has no pre-commit dispatcher`), and doctor's fix text ("run dotfiles setup to deploy git-hooks/") is circular.
+
+**Repro:** E2 S1 (SETUP1_EXIT=1, log ends at the same-file cp), E2 S5 (second-run git-hooks refusal), E3 T8 (targeted same-dir destruction, `DEPLOY_SAMEDIR_2ND_EXIT=1`).
+
+**Stranded user:** follows the four documented commands; ends with exit 1, no `paths.sh`, no final doctor, an inert GUARD-001, and a re-run that fails differently. Recovery (`git checkout -- git-hooks`) is documented nowhere.
+
+**Note:** CI's integration image deliberately clones to `~/dotfiles-repo` "to trigger the copy branch" (tests/Dockerfile.integration:48) — the CI-tested layout and the README-taught layout are disjoint; E1 additionally dies earlier (no `curl`, `setup-linux.sh:238` assignment under set -e) because README Requirements omit curl.
+
+**Direction:** either support repo==`~/.dotfiles` (guard every same-file copy; make install-git-hooks a no-op when src==dest) and add a CI variant for it, or change the README to the copy layout and have setup hard-refuse the in-place layout with a clear message.
+
+### P3 — The phantom repo default: no journey creates `machine.json` (high, CONFIRMED)
+
+**Where:** `env-contract.json` default `DOTFILES_REPO_DIR` = `~/Projects/dotfiles` (Linux) — matching neither README location; `setup-linux.sh:1473` exports the same phantom fallback; README.md:117-130 explains machine.json only as a *relocation* tool, not an onboarding step.
+
+**Repro (E2, right after documented onboarding):** `dotf update` → `not a git repo: /home/u/Projects/dotfiles — nothing to self-update` exit 0 (S7-S9); `dotf mem session-start` → `vault-health.sh not found at /home/u/Projects/dotfiles/... — run dotfiles setup to install` (S18 — setup HAD run); `doctor --fix` → `export DOTFILES_REPO_DIR="/home/u/Projects/dotfiles"` (S4 — advice to export a path that doesn't exist).
+
+**Stranded user/agent:** every repo-anchored flow (update, registry writes, session brief) silently targets a nonexistent directory; exit codes say success.
+
+**Direction:** first-run setup should write `machine.json` with `DOTFILES_REPO_DIR=$CURRENT_DIR` (it knows the answer) and run generate; alternatively `update`/`mem` should fall back to the cwd walk-up resolver (`env.RepoDir()`) the secrets/spec commands already use — today two different "where is the repo" answers coexist.
+
+### P4 — doctor and env generate read opposite sources of truth (high, CONFIRMED)
+
+**Where:** `cli/internal/doctor/config.go:34-43` (deployed-first, repo fallback) vs `cli/internal/env/env.go:116-138` (repo-first via DOTFILES_REPO_DIR, deployed fallback).
+
+**Repro (real machine, same shell, same binary):** `dotf doctor` → `[FAIL] paths.ps1 is stale — run dotf env generate`; `dotf env generate --check` → `ok: … up to date`, exit 0. Doctor also reported `dotf version drift: installed=0.28.0 pinned=0.23.0 (run ./scripts/install-dotf.sh)` while the repo pins `DOTF_VERSION=0.30.0` — the "fix" would act on a stale pin.
+
+**Stranded user:** obeys doctor, runs generate, nothing changes, doctor still red — an infinite loop between the two commands' verdicts. An agent keying on doctor's FAIL count can never converge.
+
+**Direction:** one shared resolver (repo-first with explicit provenance in output: "contract: <path>"). Doctor printing *which* copy it read would have made this self-diagnosing.
+
+### P5 — Deploy-time secret fetched by a nonexistent id, silently (high, CONFIRMED)
+
+**Where:** `setup-linux.sh:272` (`OPENROUTER_API_KEY="$(dotf secrets show openrouter-api-key 2>/dev/null || true)"`, again at :404) and `setup-windows.ps1:606`; registry id is `OPENROUTER_API_KEY` and `Lookup` matches id/exposed-var only.
+
+**Repro:** `dotf secrets show openrouter-api-key` → `Error: unknown secret "openrouter-api-key" (try dotf secrets ls)`, exit 1 (E2 S14). In setup the `|| true` turns that into an empty exported key.
+
+**Stranded user:** every fresh deploy bakes an empty `OPENROUTER_API_KEY` into agy's MCP config; the agy MCP silently fails at runtime with no deploy-time signal. This is the registry-rename split-brain class (#635/#659) recurring in the setup seam.
+
+**Direction:** fix the id at both call sites; drop the blanket `|| true` in favor of a WARN with the actual error; add a bats/CI grep asserting every `dotf secrets show <id>` call site names an id present in `registry.yaml`.
+
+### P6 — Doctor-green is unreachable on a fresh, docs-faithful machine (high, CONFIRMED)
+
+**Where/Repro (E2 S3-S5, E3 T7):** after documented onboarding, doctor = 83 pass / **31 FAIL** / exit 1. The FAIL set includes: `bw not in PATH — run 'dotf tools install'` → that command fails (`npm: executable file not found`; `packages.json` sources bw as `npm:@bitwarden/cli`; npm is only an "optional dependency" warning); `[SKIP] … run secrets_refresh` → function retired (#587); `opencode … not in PATH (reload shell)` / `pi … re-run setup` → both already done per docs. `doctor --fix` then `doctor` again: still exit 1.
+
+**Stranded user:** cannot tell real breakage from fresh-box noise; an agent using doctor as a preflight gate is permanently blocked.
+
+**Direction:** every fix_suggestion must be executable verbatim and converging (test: run the suggestion, re-run doctor, the item flips); bw needs a non-npm acquisition path (native binary in packages.json) or npm must be a declared dependency; retire the `secrets_refresh` text.
+
+### P7 — README/docs promise processes that no longer exist (medium, CONFIRMED)
+
+- README.md:100-107: `secrets_add`, `secrets_add_file`, `secrets_rotate`, `secrets_show`, `secrets_list`, `secrets_check` — zero definitions anywhere in `.zsh/`, `.bashrc`, `.profile` (retired with load-secrets, #587). README's primary "Secrets" section teaches an interface that is gone; the ADR-028 `dotf secrets` facade is not mentioned there.
+- README.md:94 + :54: `. scripts/load-secrets.sh` — file does not exist.
+- README.md:91-93 (Human entrypoints): `vault`, `obs`, `dotfiles-sync` resolve in **no** shell (E3 T6: MISSING even in interactive zsh; only `dch`, `profile-shell`, `tx` exist, zsh-only — bash gets none).
+- `.zshrc:13` hard-`source`s oh-my-zsh; no installer, no README mention → documented `source ~/.zshrc` errors on every fresh machine (E1+E2 S2).
+- README Requirements omit `curl` (E1: setup dies at `setup-linux.sh:238`), and `xz-utils`/`ca-certificates` that the integration Dockerfile had to add.
+- `setup-windows.ps1:2050-2051` prints `3. Initialize a project: project-init test-project python` — retired command (now `dotf init`).
+- `docs/runbooks/secrets-management.md` is banner-flagged out-of-date but README repeats its retired content without a flag.
+
+**Direction:** README secrets section rewrite to the facade (already tracked as #600 — extend to README explicitly); alias or de-document `vault`/`obs`/`dotfiles-sync`; declare or auto-install oh-my-zsh (or make `.zshrc` degrade); complete Requirements; fix the Windows next-steps text.
+
+### P8 — `doctor --fix` misreports and its advice fights the cascade (medium, CONFIRMED)
+
+**Repro (E2 S4):** `--fix` printed 11 `export …` suggestions and then `Applied 11 fix action(s)` — nothing was applied (by design a subprocess cannot export; the label lies). The suggestions duplicate exactly what the deployed-but-unsourced `paths.sh` already contains, and a user following them plants permanent profile exports that from then on win cascade rule #1 over `machine.json` — the very shadowing class behind this audit's harness incident (see disclosure).
+
+**Direction:** count only real wiring actions as "applied"; phrase env suggestions as "ensure your profile sources paths.sh" instead of raw exports; suggest machine.json for path relocations.
+
+### P9 — Agent ergonomics: contract gaps across the CLI (medium, CONFIRMED)
+
+- No command offers `--json`; agents parse prose (inventory: zero occurrences of a JSON flag CLI-wide).
+- `dotf env path NO_SUCH_KEY` → empty stdout, **exit 0** (E3 T5) — unknown key indistinguishable from unset value.
+- `dotf spec archive` re-run → `Error: spec not found`, exit 1 (E2 S12) — not idempotent, message doesn't acknowledge "already archived".
+- `dotf secrets set` with bw missing → `Error: item "nan-api-key" not found; re-run with --yes…` (E2 S15) — misattributes a missing binary as a missing item; `secrets backup` gets it right.
+- `dotf secrets render` default exits 0 leaving `{env:VAR}` unresolved (warning only); both setups call it non-strict, so half-baked configs deploy silently (pi models.json FAIL in doctor is downstream of exactly this).
+- `dotf secrets migrate` shared-source guard (good) recommends `migrate --split` → `Error: unknown flag: --split` (W6b).
+- Good contracts worth keeping: `secrets verify` exit 1 on FAILED; `render --strict` exit 1; `secrets run --only UNKNOWN` exit 1; `update`'s skip-vs-fail split; `env generate --check` exit 1 on drift.
+
+### P10 — `env generate` trusts ambient env for target and content (medium, CONFIRMED)
+
+`DotfilesDir()` honors ambient `DOTFILES_DIR` and `Home()` prefers `HOME` (Git Bash sets a POSIX-style one); render inputs and output path follow them with no confirmation, no `-w`-style guard, no backup, non-atomic write (`generate.go:110-119`). Demonstrated: a single overridden-HOME invocation rewrote the live `~/.dotfiles/paths.ps1` with Temp-dir paths (restored by re-running generate in a sane env). A `dotf env generate` run from Git Bash on Windows (POSIX HOME) is one plausible real-world trigger of the same corruption.
+**Direction:** atomic write + print old→new diff summary; refuse (or require `--force`) when the resolved home/target disagree with the OS convention or with the file being replaced.
+
+### P11 — CRLF hole for extensionless shell rc files (medium, CONFIRMED)
+
+`.gitattributes` normalizes `*.sh/*.bash/*.zsh/*.bats` but `.bashrc`/`.zshrc`/`.profile`/`.{bash,zsh}rc.local.example` fall to `text=auto` → CRLF working tree on Windows (`git ls-files --eol`: `i/lf w/crlf`). Effect reproduced: integration image built from this Windows checkout → `verify-setup.bats` test 42 fails (`syntax error near unexpected token 'in\r'` in deployed `.bashrc`). The guard test only ever runs in CI on LF checkouts — it can never catch the case it guards against. Any Windows→Linux copy flow (docker build, WSL, rsync) ships a broken `.bashrc`.
+**Direction:** add explicit `eol=lf` lines for the rc files; renormalize; optionally a CI job that greps the tree for CR in shell-sourced files.
+
+### P12 — Concurrency and torn state (low, PLAUSIBLE)
+
+Two concurrent `dotf env generate` resolved benignly ("wrote"/"unchanged", E2 S19) but the write is non-atomic — a shell sourcing `paths.sh` mid-write can read a torn file. `update.go`'s untracked-counts-as-dirty is fail-safe alone, absorbing when combined with P1. No file locking exists anywhere in the CLI; low practical risk at current usage.
+
+### P13 — States with no owning command (low, CONFIRMED)
+
+- `sensitive/kubelab-dispatch-token.secret.age` exists with no registry entry → real doctor FAILs it (`orphan: … no registry entry`); no `dotf secrets adopt/rm` — only hand-editing files fixes the FAIL.
+- Deployed-copy staleness (observed live: contract missing #663 keys, versions.conf pin at 0.23.0 vs repo 0.30.0, github.token drift) accumulates invisibly when the opt-in timer is absent — nothing nags "your deploy is N commits behind".
+- Windows: GUARD-001 dispatcher missing at `~\.dotfiles\git-hooks` and doctor's fix says "run dotfiles setup" — but `setup-windows.ps1` has no git-hooks deploy step (the Windows twin is a "tracked follow-up" in install-git-hooks.sh's header) → non-converging FAIL on every Windows box.
+
+### P14 — Spec-gate error attribution (low, CONFIRMED)
+
+`dotf spec init X --issue 999999 --bitacora-repo mlorentedev/dotfiles` with unauthenticated gh → `work-gate issue #999999 not found (or gh failed): To get started with GitHub CLI…` — a real "issue doesn't exist" and "gh broken" produce the same exit and prefix. Repo-detection error without origin is good (offers `--bitacora-repo`/`DOTF_BITACORA_REPO` verbatim). Archive/re-archive asymmetry noted in P9.
+
+---
+
+## 5. Missing-process backlog (by unblocking value)
+
+> **Filed 2026-07-07:** items 1→#694 (P1), 3→#695 (P2), 2→#696 (P3), 4→#697 (P4), 5→#698 (P5), 6→#699 (P6/P8/P13-orphan), 7→#700 (P9). Mapped onto existing tickets by comment instead of duplicating: README truth pass → #677 (P7), CRLF/.gitattributes → #693 (P11), Windows GUARD-001 twin → #691 (P13), bw non-npm source → #649. Items 8 (`secrets rotate/restore`), 11 (atomic generate) and 12 (staleness nag) remain unfiled — lower unblocking value; revisit at triage.
+
+1. **Repo-write-free setup + parity CI** (unblocks P1, the self-deploy promise): move the `.github/copilot-instructions.md` sync out of setup into CI/pre-commit; assert `git status --porcelain` clean at end of the integration test.
+2. **machine.json bootstrap at first setup** (unblocks P3 and every repo-anchored flow): setup writes `DOTFILES_REPO_DIR=$CURRENT_DIR` into `~/.config/dotfiles/machine.json` when absent, then generates. Alternative: make `update`/`mem` use `env.RepoDir()` cwd walk-up like secrets/spec do.
+3. **README-layout decision + guard** (unblocks P2): either support clone-into-`~/.dotfiles` (same-file-safe copies, same-dir-safe git-hooks, CI variant) or teach the copy layout and refuse in-place with a message. Include curl/oh-my-zsh/Requirements truth-up (P7).
+4. **Single contract/versions resolver shared by doctor and env** (+ provenance line in output) (unblocks P4, protects #663 from the stale-copy regression).
+5. **Secrets deploy-seam integrity**: fix `openrouter-api-key` call sites (P5); CI grep gating `dotf secrets show` ids against `registry.yaml`; make setup's render/show failures visible (WARN with cause, not `\|\| true`).
+6. **Converging doctor fixes** (P6/P8): non-npm bw source in packages.json; retire `secrets_refresh` text; "applied" only for applied actions; a meta-test that executes each fix_suggestion and re-runs the check.
+7. **Agent-mode contract** (P9): repo-wide exit-code doc + `--json` on doctor/verify/ls/update at minimum; `env path` unknown-key exit 1; idempotent `spec archive`; accurate bw-absent errors; implement or un-advertise `migrate --split` (C9).
+8. **`dotf secrets rotate`/`restore`** — registry already declares cadence; runbook admits manual; the two missing verbs of ADR-028's lifecycle.
+9. **Windows GUARD-001 deploy step** (P13) — the tracked follow-up, plus doctor fix text that matches reality until then.
+10. **`.gitattributes` rc-file normalization + CR guard in CI** (P11).
+11. **Atomic, guarded `env generate`** (P10, P12).
+12. **Deploy-staleness nag**: doctor INFO "deploy dir is behind the checkout (N files differ)" exists per-file — add an aggregate hint that maps to "re-run setup or enable the timer" (P13).
+
+## 6. Open questions (maintainer-only)
+
+1. Is clone-into-`~/.dotfiles` a layout you intend to support (README teaches it) or should the README move to the copy layout the CI tests? P2's fix differs completely by answer.
+2. `DOTF_VERSION` pin semantics: minimum (then doctor's "installed 0.28.0 > pinned 0.23.0" WARN is noise) or exact (then the fix text should say "downgrade")? Related: should the pin track releases automatically (release-please touchpoint)?
+3. Should `terraform` be a hard-FAIL required binary on every machine, including boxes that never run IaC? (It is the only tool FAIL on the otherwise-green real machine.)
+4. `ai/copilot/copilot-instructions.md` vs `.github/copilot-instructions.md`: which is the SSOT, and is the banner transform intentional? They are out of parity in HEAD today.
+5. The orphan `kubelab-dispatch-token.secret.age`: adopt into the registry or delete? (Doctor FAILs it on every run; no command can resolve it.)
+6. `setup-windows.ps1` was NOT executed end-to-end in this audit (no throwaway Windows environment; a real run mutates `$PROFILE`, junctions, Scheduled Tasks). Its P5 call site and P13 gap were verified by trace + real-machine doctor. Worth a dedicated Windows-sandbox (VM) pass?

--- a/docs/audits/codebase-audit-2026-07-06.md
+++ b/docs/audits/codebase-audit-2026-07-06.md
@@ -1,0 +1,346 @@
+---
+id: codebase-audit-2026-07-06
+type: research
+status: active
+tags: [audit, adversarial-review, dotfiles, cross-platform]
+---
+
+# Codebase Audit — dotfiles — 2026-07-06
+
+> Exhaustive, adversarial audit. Every file under `git ls-files` (954 tracked files) was read
+> or covered by a dedicated read-only agent: the two setup scripts in full, the entire `cli/`
+> Go tree's load-bearing packages, `scripts/` (35 files), `tests/` (66) + `.github/` (10),
+> `secrets/`/`git-hooks/`/`systemd/`/`ssh/`, `harness/` + `ai/` + the shell rc payload, all
+> ADRs/runbooks, and every root config. Findings are marked **CONFIRMED** (both sides traced)
+> or **PLAUSIBLE** (suspected, not fully traced). Where a subsystem is sound it is said once
+> and left alone — effort is spent where it isn't.
+>
+> **Headline:** the Go `dotf` CLI is the best-engineered layer (atomic writes, fail-loud
+> secrets, validated registry, Open/Closed resolvers, CI-tested on both OSes). The **shell +
+> PowerShell layer around it is where the real defects live** — silent-failure idioms, twin
+> drift, dead configuration that lies about being read, and a class of Windows/Linux encoding
+> and path divergences that the Go layer already fixed but the shells did not.
+
+---
+
+## 1. Summary table (severity order)
+
+| ID | Sev | Area | One-line issue | file:line | Status |
+|----|-----|------|----------------|-----------|--------|
+| C1 | Critical | scripts/health | `grep -c \|\| echo 0` double-emits "0\n0" → arithmetic crash under `set -e`; a *healthy* vault exits FAILED | `scripts/vault-health.sh:132,135,175,201,225` | CONFIRMED |
+| C2 | High | rc/bash | All bash aliases are dead: setup writes `~/.bash/bash_aliases`, `.bashrc` sources `~/.bash_aliases` | `setup-linux.sh:148` vs `.bashrc:129` | CONFIRMED |
+| C3 | High | scripts/gate | SDD spec-gate fails **open**: an unresolvable base ref → `TOTAL_LOC=0` → "0 LOC < threshold", exit 0 | `scripts/check-spec-gate.sh:181` | CONFIRMED |
+| C4 | High | config/mem | The 11 `injectors.*.enabled` flags are dead config — `ClaudeContext` never calls `injectorEnabled()` | `cli/internal/mem/session_start_adapter.go:44-80` | CONFIRMED |
+| C5 | High | scripts/win | Windows weekly maintenance task has never run: `--all` can't bind to a `[switch]$All` param | `scripts/vault-maintenance-weekly.ps1:23` | CONFIRMED |
+| C6 | High | config/win | `SCRIPTS_DIR` self-contradiction: contract default `.dotfiles\scripts`, PATH+deploy use `~\scripts` | `env-contract.json:40` vs `:129` / `setup-windows.ps1:79` | CONFIRMED |
+| C7 | High | scripts/sync | `dotfiles-sync.sh` secrets "newest-wins" ping-pongs forever (`cat >` resets mtime) | `scripts/dotfiles-sync.sh:76` | CONFIRMED |
+| C8 | High | scripts/policy | `bitacora-rollout.sh` runs `gh pr merge --auto` — the one thing every AGENTS.md forbids | `scripts/bitacora-rollout.sh:124` | CONFIRMED |
+| C9 | High | tests/CI | 15 agy regression guards never run in CI (blanket `skip`, no job installs agy) | `tests/antigravity.bats:17` | CONFIRMED |
+| C10 | High | docs | README documents a retired command surface (`secrets_add/rotate/show/list/check`, `dotfiles-sync`) | `README.md:100-107,152` | CONFIRMED |
+| C11 | High | scripts/win | `knowledge-crystallize.ps1` single-project mode always misses on Windows (drops a dash in the key) | `scripts/knowledge-crystallize.ps1:57` | CONFIRMED |
+| C12 | Med-High | git-hooks | commit-msg hook rejects the repo's own scoped-Conventional-Commit convention | `.github/hooks/validate-commit-msg.sh:5` | CONFIRMED |
+| C13 | Med | scripts/sync | `dotfiles-sync.ps1` dirty-check tests only the *last* git exit code → pushes over unstaged changes | `scripts/dotfiles-sync.ps1:133` | CONFIRMED |
+| C14 | Med | scripts/sync | Twin drift: `.sh` rsync-copies (ADR-005), `.ps1` `git pull`s `~/.dotfiles`; PS exits 0 on failure | `scripts/dotfiles-sync.{sh,ps1}` | CONFIRMED |
+| C15 | Med | rc/bash | `.bashrc` hard-resets `PATH` to system dirs; `.zshrc` deliberately does not | `.bashrc:105` vs `.zshrc:83` | CONFIRMED |
+| C16 | Med | setup/win | Auto-memory junction built at the wrong key on Windows (`:`→'' single-dash, not `:`→'-') | `setup-windows.ps1:867` | CONFIRMED |
+| C17 | Med | config | Dead version pins: `OBSIDIAN_/EZA_/ZOXIDE_VERSION` have zero consumers; the manifest lies | `versions.conf:16-18` | CONFIRMED |
+| C18 | Med | setup | `eza` installed from a `latest/download/` URL — the exact rot pattern the repo's own lesson bans | `setup-linux.sh:214` | CONFIRMED |
+| C19 | Med | scripts/guard | `check-backlog-merged.sh` is structurally inert on the `~/Projects/Workspace/` layout | `scripts/check-backlog-merged.sh:86` | CONFIRMED |
+| C20 | Med | doctor/win | `checkAntigravity` uses `HasPrefix(path,"/")` for "absolute" → false-FAIL on any Windows abs path | `cli/internal/doctor/checks_deploy.go:350` | CONFIRMED |
+| C21 | Med | harness | `skill_targets_agent` substring match: `pi` matches `targets:[copilot]`; Windows twin uses `\b` | `scripts/compile-harness.sh:208` | CONFIRMED |
+| C22 | Med | harness | Marker-injection has no "exactly one marker" guard → a lost END marker duplicates + eats user text | `scripts/compile-harness.sh:606`; `setup-windows.ps1:1856` | CONFIRMED |
+| C23 | Med | harness/win | The whole `manifest.agents` (curator + presence) stage is not ported to Windows | `setup-windows.ps1:1733` (Deploy-SkillRecord) | CONFIRMED |
+| C24 | Med | tests/CI | CI PSScriptAnalyzer covers 4 of ~12 production `.ps1`; `utils.ps1` (the shared lib) is unlinted | `.github/workflows/ci.yml:57` | CONFIRMED |
+| C25 | Med | tests/CI | spec-gate has three bypass routes (label, any-spec-touch, `*generated*` glob) | `scripts/check-spec-gate.sh:98,139,207` | CONFIRMED |
+| C26 | Med | scripts/secrets | Secret material passed on `argv` (visible in `/proc/*/cmdline`): rollout PAT + `nan-*` API keys | `scripts/bitacora-rollout.sh:148`; `scripts/nan-bench.sh:39` | CONFIRMED |
+| C27 | Med | scripts/secrets | `age-encrypt-decrypt.sh` leaves plaintext `.dec` at mode 0644, no cleanup on failure | `scripts/age-encrypt-decrypt.sh:73` | CONFIRMED |
+| C28 | Med | setup | Linux vault-maintenance cron keys on script name; a relocated repo leaves a stale dead-path cron | `setup-linux.sh:1405` | CONFIRMED |
+| C29 | Med | rc/bash | bash never gets nvm (only `.zshrc` loads it); setup re-deploys `.bashrc` wiping installer init | `.bashrc` (no nvm block); `setup-linux.sh:174` | CONFIRMED |
+| C30 | Med | config | env-contract.json `_comment`s cite deleted `doctor.{sh,ps1}`/`healthcheck.*` (also `cli/README.md:43`) | `env-contract.json:2,7` | CONFIRMED |
+| C31 | Med | ci-coupling | Go CLI CI is path-filtered to `cli/**`; a breaking edit to its config inputs never runs `go test` | `.github/workflows/cli.yml:5` | CONFIRMED |
+| C32 | Med | tests/CI | Supply chain: every GitHub Action pinned by moving tag, none by SHA (runs with write-scope PATs) | `.github/workflows/*` | CONFIRMED |
+| C33 | Med | docs/process | PR template still requires a vault `11-tasks.md` entry abolished by ADR-018 | `.github/pull_request_template.md:11` | CONFIRMED |
+| C34 | Med | specs | 35 of 57 active specs are shipped-but-unarchived; 2 ID collisions; 1 missing `tasks.md` | `specs/` | CONFIRMED |
+| C35 | Med | secrets | `sensitive/env-mapping.conf` re-added with zero code consumers — split-brain vs registry SSOT | `sensitive/env-mapping.conf` | CONFIRMED |
+| C36 | Med | harness/setup | Vault-dependent harness steps run before the ADR-025 path cascade loads → wrong `VAULT_PATH` on run 1 | `setup-linux.sh:411,508` vs `:1446` | CONFIRMED |
+| C37 | Med-High | docs | Committed overlays hardcode `~/Projects/Workspace/…` as the fallback; contract says `~/Projects/…` | `ai/claude/CLAUDE.md:5`; `env-contract.json` | CONFIRMED |
+| C38 | Low-Med | git/local | 12 tracked shell files sit CRLF-in-worktree despite `eol=lf`; break under bash, git stays clean | `git ls-files --eol` | CONFIRMED |
+| C39 | Low-Med | rc | `.zshrc` sources oh-my-zsh unguarded and unconditionally; no repo step installs it | `.zshrc:13` | CONFIRMED |
+| C40 | Low-Med | setup | `OPENCODE_VERSION` used bare under `set -u`; a checkout missing `versions.conf` aborts setup | `setup-linux.sh:654` | CONFIRMED |
+| C41 | Low | tests | Tests that cannot fail (literal `true`; whitespace-eating `$(...)`; one-sided OR asserts) | `tests/verify-setup.bats:308`; `tests/utils.bats:243` | CONFIRMED |
+| C42 | Low | .gitconfig/win | `helper = !/usr/bin/gh …` deployed verbatim to Windows where that path doesn't exist | `.gitconfig` | CONFIRMED |
+| C43 | Low | docs | README metrics stale: "316 BATS tests" (actual ~949), "~50 scripts" (actual 35) | `README.md:44,56` | CONFIRMED |
+| C44 | Low | secrets | `render` substitutes a secret verbatim into JSON; a `"`/`\` in the value corrupts the config | `cli/internal/secrets/render.go:90` | PLAUSIBLE |
+| C45 | Low | harness | `--refresh` silently reverts in-marker manual edits with no diff (stderr sent to `/dev/null`) | `setup-linux.sh:509` | CONFIRMED |
+| C46 | Low | ssh | Committed `ssh/config` publishes VPS public IP + usernames + a root-login host in a public repo | `ssh/config:49,91,144` | CONFIRMED |
+| C47 | Low | model-docs | Model facts (`deepseek` default, ctx sizes) duplicated across 6 files and already drifted | `ai/nan/README.md` vs `ai/opencode/opencode.jsonc:34` | CONFIRMED |
+| C48 | Low | harness | Deploy-dir `~/.dotfiles/harness` mirror never prunes; doctor's drift allowlist omits it → zombie records | `setup-linux.sh:543`; `checks_deploy.go:486` | CONFIRMED |
+
+*(Lower-severity confirmed items — duplicate `@test` names, tautological helper tests, dead aliases (`cl=changelog-gen.sh`), `EDITOR` login/non-login split, stale `tmux.conf` symlink comment, non-ASCII in `.ps1` vs the excluded BOM rule — are folded into §3 by category rather than listed individually here.)*
+
+---
+
+## 2. System map (verify my understanding)
+
+**What this repo is.** A cross-platform (Linux + Windows; macOS planned, unimplemented) personal
+dev-environment bootstrapper. Two shell entrypoints deploy configs + install tooling; a Go CLI
+(`dotf`) is the growing user-facing surface that a strangler-fig (ADR-020) is migrating the
+`.sh`/`.ps1` twins into. Knowledge/AI-agent memory lives in an external Obsidian vault, linked in.
+
+**Layers (by language boundary, ADR-020):**
+- **Go (`cli/`, own module)** — `dotf {doctor,init,env,spec,vault,tools,mem,secrets,update,review}`.
+  ~10k LOC + 67 test files. The user-facing logic destination.
+- **Shell bootstrap** — `setup-linux.sh` (1491 lines), `setup-windows.ps1` (2052), and `scripts/`
+  (35 files, `.sh`/`.ps1` twins + libraries + CI/hook guards). Provisions the Go binary and wires
+  profile/env; per ADR-020 C7 the bootstrap itself stays shell.
+- **Payload** — rc files (`.bashrc/.zshrc/.profile/.inputrc/.zsh/`), `powershell/profile.ps1`,
+  `ai/` per-agent overlays, `harness/` compiled skill/agent records, `secrets/registry.yaml` +
+  `sensitive/*.age`, `ssh/config`, `systemd/` units, `git-hooks/`.
+
+**Real execution paths (traced):**
+1. **Bootstrap** — `setup-linux.sh`: source `versions.conf` → copy repo→`~/.dotfiles` →
+   `deploy_file` rc files → install tools to `~/.local/bin` → `install-dotf.sh` → `dotf secrets show`
+   deploy-time key → per-agent config (agy/claude/opencode/pi/copilot) → MCP register (with the
+   `.claude.json` truncation guard) → plugins → auto-memory symlinks → `compile-harness --refresh`
+   (vault→committed blocks) then `--deploy` (records→`$HOME`) → cron → `check_deployed` → `dotf env
+   generate` → `dotf doctor`. `setup-windows.ps1` mirrors most of this with junctions + Scheduled
+   Tasks, but **omits GUARD-001 git-hooks, `--refresh`/`--check`, and the harness `agents` stage.**
+2. **Path resolution (ADR-025)** — `env-contract.json` defaults ⊕ `~/.config/dotfiles/machine.json`
+   overrides → `dotf env generate` renders `~/.dotfiles/paths.{sh,ps1}` → rc profiles source it.
+   The Go `env` package is the one true resolver; rc files carry a bootstrap fallback subset.
+3. **Session-start hook** — Claude's `SessionStart` → `dotf mem session-start` → agnostic brief
+   (vault detect, `vault-health.sh`, spec counts, lessons) + Claude injectors (doctor-drift,
+   hive-project, auto-memory `memlink`, knowledge/memory-temperature, `.claude.json` canary) →
+   `additionalContext` JSON envelope. `session-end` archives the `## Session Handoff` block.
+4. **Secrets (ADR-028)** — `secrets/registry.yaml` (var→age|bw source SSOT) → `dotf secrets
+   {run,show,render,set,migrate,sync,backup}`. `render` bakes `{env:VAR}` into opencode/pi configs
+   at deploy; `run` injects into a child env fail-fast; age is the floor, Bitwarden the migration target.
+5. **CI** — `ci.yml` (shell lint, PSSA-on-4-files, bats, PR-only Windows e2e, Docker integration),
+   `cli.yml` (Go build/test/lint/goreleaser, **path-filtered to `cli/**`**), `spec-gate.yml`,
+   `release-please.yml`, `pat-expiry.yml`, board automation.
+
+**Key invariants (where actually enforced):**
+- *One var → one secret source* — enforced in Go at parse (`registry.go:validate`), **not** in the
+  parallel `env-mapping.conf` (which no longer has code consumers — C35).
+- *Deploy = copy, never symlink; drift is asserted* — enforced by `dotf doctor` (`checks_deploy.go`)
+  for a fixed allowlist that **omits `harness/`, `AGENTS.md`, `ai/`** (C48).
+- *Memory sinks only in the vault* — enforced by the `git-hooks/` pre-commit guard **on Linux only**
+  (never installed by `setup-windows.ps1`).
+- *Claude project-key encoding* (`/ \ :` → `-`) — correct in Go `memlink` (self-heals), **wrong** in
+  the `setup-windows.ps1` inline junction loop (C16) and `knowledge-crystallize.ps1` (C11).
+
+---
+
+## 3. Findings by hunt category (severity order within each)
+
+### 3.1 Correctness — logic errors, swallowed failures, wrong propagation
+
+**C1 — `vault-health.sh` crashes on a healthy vault (`grep -c || echo 0`). CONFIRMED.**
+`scripts/vault-health.sh:132` `ORPHAN_COUNT=$(echo "$ORPHAN_OUTPUT" | grep -c '[^[:space:]]' 2>/dev/null || echo "0")` (and `:135,:175,:201,:225`). `grep -c` on no match prints `0` **and** exits 1, so `|| echo "0"` appends a *second* `0` → the variable holds `"0\n0"`. At `:138` `ORPHAN_PCT=$((ORPHAN_COUNT * 100 / TOTAL_FILES))` that is an arithmetic syntax error; `set -euo pipefail` (`:10`) then aborts the whole report. A vault with 0 orphans / dead-ends / unresolved-links — i.e. a *perfect* vault — exits FAILED.
+*Scenario:* clean vault → `dotf mem session-start` runs `vault-health.sh` → crash → the session brief shows a garbage "Results: 0 0" / FAIL instead of "ALL CHECKS PASSED"; the Sunday cron logs a truncated error (masked by `|| true` at `vault-maintenance-weekly.sh:26`). The correct idiom is documented one file over (`knowledge-crystallize.sh:115-117`: "use `|| count=0` … NOT `|| echo 0`"). *Fix:* `|| count=0` (assignment, not echo) at all five sites.
+
+**C2 — All bash aliases are dead (path mismatch). CONFIRMED.**
+`setup-linux.sh:148` writes the generated alias file to `$HOME/.bash/bash_aliases`, but the deployed repo `.bashrc:129-130` sources `~/.bash_aliases` (a different location). The only `.bashrc` that sources the correct path is the *fallback heredoc* at `setup-linux.sh:162-163`, used solely when no repo `.bashrc` exists — which never happens. So in bash the entire alias payload (`gs/gd/gl/gp/k/kc/dch/tx/oclog/qq/qf…`) silently never loads; zsh is unaffected. The final check (`setup-linux.sh:1430`) only asserts the file *exists*, so it always passes. *Compounding:* had it loaded, `alias qq='noglob _qq_call …'` (zsh `noglob`) would error in bash and shadow the bash `qq()` function. *Fix:* point `.bashrc` at `~/.bash/bash_aliases`, or write the file to `~/.bash_aliases`.
+
+**C3 — SDD spec-gate fails open. CONFIRMED.**
+`scripts/check-spec-gate.sh:181` `done < <(git diff --numstat "${BASE_REF}...${HEAD_REF}" 2>/dev/null || true)`. If `BASE_REF` doesn't resolve (shallow clone, typo, detached worktree), `git diff` errors, stderr is discarded, `|| true` swallows the exit → the loop reads nothing → `TOTAL_LOC=0` → `:202` prints "Production diff 0 LOC < threshold" and exits 0. The Tier-4 discipline gate — the mechanism that supposedly forces a spec on every ≥50-LOC PR — silently passes wherever the base ref is unavailable. CI (`spec-gate.yml:26`) fetches the ref first so it's usually fine there, but the opt-in local pre-push hook (`.pre-commit-config.yaml:32`) and any manual run inherit the fail-open. *Fix:* a `git diff` error must be fail-closed (exit 2), not `|| true`.
+
+**C4 — `injectors.*.enabled` is dead config. CONFIRMED.**
+`session-start-config.json` declares 11 injector toggles and its `_comment` promises "The Go adapter reads these thresholds + injector flags". `injectorEnabled()` exists at `cli/internal/mem/session_start_config.go:51`, but `ClaudeContext` (`session_start_adapter.go:44-80`) **never calls it** — every injector runs unconditionally (verified: `injectorEnabled` has no non-test caller). Only the 6 `thresholds` keys are honored. *Scenario:* a user sets `"vault_health": {"enabled": false}` to silence a noisy injector; nothing happens. The config file and the SDD-004 spec both describe a contract that stopped being honored at the CLI-025 Go port. *Fix:* gate each injector on `cfg.injectorEnabled(name)`, or delete the block and fix the comment.
+
+**C5 — Windows weekly maintenance task has never worked. CONFIRMED.**
+`scripts/vault-maintenance-weekly.ps1:23` `& "$ScriptDir\knowledge-crystallize.ps1" --all`. `knowledge-crystallize.ps1` declares `[switch]$All` (bound as `-All`); the literal string `--all` binds positionally to `$ProjectDir`, `$All` stays `$false`, and `Resolve-Path '--all'` throws under `$ErrorActionPreference='Stop'` → caught by the weekly script → every Sunday the task (`DotfilesVaultMaintenance`, `setup-windows.ps1:1899`) logs "Cannot find path '--all'" and processes zero projects. The bash twin works. *Fix:* pass `-All`.
+
+**C7 — Secrets sync ping-pongs forever. CONFIRMED (logic traced).**
+`scripts/dotfiles-sync.sh:76` `cat "$local_file" > "${repo_file}.tmp" && mv "${repo_file}.tmp" "$repo_file"`. `cat >` stamps the destination with *now*. Run N: local newer → copy to repo (repo mtime=now). Run N+1: repo now "newer" → copy back (local mtime=now). Every run flips direction and reports "1 synced"; "All secrets already in sync" (`:97`) is unreachable. Worse, *newest-wins* is corrupted — a genuinely newer edit can be overwritten by a stale file whose mtime the previous sync refreshed. The PowerShell twin uses `Copy-Item` (preserves `LastWriteTime`) and converges. *Fix:* `cp -p` / `touch -r`.
+
+**C11 — `knowledge-crystallize.ps1` single-project mode always misses on Windows. CONFIRMED.**
+`scripts/knowledge-crystallize.ps1:57` `return $Path.Replace('\','-').Replace(':','')` yields `C-Users-…` (colon deleted), but Claude's real key is `C--Users-…` (colon→dash). `Get-MemoryFilePath` builds a nonexistent path → the script warns "No MEMORY.md found" and exits 0 for every project on Windows. `-All` mode survives only because a decode heuristic tolerates the doubled backslash. Same encoding bug class as C16.
+
+**C13 — `dotfiles-sync.ps1` dirty-check is dead. CONFIRMED.**
+`scripts/dotfiles-sync.ps1:133-135` runs `git diff --quiet` then `git diff --cached --quiet` then tests `if ($LASTEXITCODE -ne 0)`. `$LASTEXITCODE` reflects only the *second* command, so an unstaged-only dirty repo passes the guard and syncs over dirty state. The bash twin correctly requires both (`dotfiles-sync.sh:104`).
+
+**C40 — `OPENCODE_VERSION` unguarded under `set -u`. CONFIRMED.**
+`setup-linux.sh:11` sets `set -euo pipefail`; `:31` sources `versions.conf` only `[ -f ... ] &&`; `:654/666/674` reference `$OPENCODE_VERSION` bare. A checkout missing `versions.conf` (partial/corrupt clone) → unbound-variable abort, contradicting the adjacent comment ("OPENCODE_VERSION is empty — fall back to latest"). Sibling vars are guarded (`${YARN_VERSION:-}`, `${PI_VERSION:+…}`, `${SHELLCHECK_VERSION:-0.11.0}`); this one isn't. *Fix:* `${OPENCODE_VERSION:-}`.
+
+**C44 — `render` can corrupt a JSON config. PLAUSIBLE.**
+`cli/internal/secrets/render.go:90` `strings.ReplaceAll(out, "{env:"+name+"}", value)` substitutes the decrypted secret verbatim into `opencode.jsonc`/`models.json`. `stripNewlines` removes CR/LF but not `"` or `\`; such a value would produce invalid JSON. API keys are almost always `[A-Za-z0-9._-]`, so low-probability, but nothing enforces it. *Fix:* JSON-encode the value for JSON targets, or validate the rendered file.
+
+### 3.2 Alternative / unintended paths
+
+**C36 — Vault-dependent steps run before the path cascade loads. CONFIRMED.**
+`setup-linux.sh:411` and `:508` read `${VAULT_PATH:-$HOME/Projects/knowledge}` to render agy's MCP config and gate the harness `--refresh`, but `dotf env generate` + `. paths.sh` don't run until `:1446-1449`. On a machine whose `machine.json` relocates the vault (this machine: `~/Projects/Workspace/knowledge`), a *first* run from a shell that never sourced a prior `paths.sh` silently takes "Vault absent; deploying committed blocks" and bakes a wrong `VAULT_PATH` into agy's config; it self-heals only on a later run after the profile is re-sourced. The engine repeats the stale literal (`compile-harness.sh:72`).
+
+**C16 — Windows auto-memory junction built at the wrong key. CONFIRMED.**
+`setup-windows.ps1:867` `$encodedPath = $cwdPath.Replace('\','-').Replace(':','')` produces `C-Users-…` (colon deleted). Claude Code and the Go `memlink.ClaudeProjectKey` (`:106`, `NewReplacer("/","-","\\","-",":","-")`) produce `C--Users-…` — confirmed against this machine's `~/.claude/projects/`, which contains *both* keys. setup creates a junction Claude never reads, prints a misleading "Linked auto-memory", and the real link is created later by `dotf mem session-start` (correct key). This is exactly the #551/HARNESS-040 encoding bug the Go layer fixed — the setup twin was not updated. Non-fatal (Go self-heals) but deposits junk junctions.
+
+**C22 — Marker injection has no "exactly one marker" guard. CONFIRMED.**
+`scripts/compile-harness.sh:606-617` (`inject_agent_presence`) guards only with `grep -q BEGIN && grep -qF END`. If the END marker is lost (merge/manual edit), the next run appends a second BEGIN; the run after that takes the replace branch whose awk fires on *both* BEGIN lines, emitting the block twice and discarding everything between the orphan and appended markers. The patterns region avoids this via `validate_markers` (exactly 1/1); presence never calls an equivalent. The Windows catalog injector (`setup-windows.ps1:1856`) has the identical flaw and *silently truncates* `~/.copilot/copilot-instructions.md` to head+bullets when the END marker is missing.
+
+**C39 — `.zshrc` errors on a fresh box. CONFIRMED.**
+`.zshrc:13` `source $ZSH/oh-my-zsh.sh` — unguarded, and no repo step installs oh-my-zsh. setup deploys `.zshrc` unconditionally, so a clean machine prints an error on every zsh start until OMZ is installed by hand.
+
+### 3.3 Incoherences — names/config that lie, duplicated SSOTs, twin drift
+
+**C6 — `SCRIPTS_DIR` self-contradiction (Windows). CONFIRMED.** `env-contract.json:40` declares the Windows default `$env:USERPROFILE\.dotfiles\scripts`, but the same file's `required_path_entries.windows` (`:129`) puts `$env:USERPROFILE\scripts` on PATH, and `setup-windows.ps1:79` deploys to `~\scripts`. Two divergent script trees result: on this machine `~/.dotfiles/scripts` holds only `load-secrets.ps1` while `~/scripts` holds the real scripts *plus* retired orphans (`claude-session-start.ps1`, `doctor.ps1`, `healthcheck.ps1`, `claude-mem-heal.ps1`, `diff-check.ps1`) still on PATH. The doctor pre-export (`setup-windows.ps1:1938`) uses a third value. `REFACTOR-007` has tracked this undecided since 2026-05-27.
+
+**C14 — `dotfiles-sync` twins implement two deploy models. CONFIRMED.** `.sh:118` `rsync -a --delete …` (ADR-005: `~/.dotfiles` is a copy); `.ps1:148` `git -C $DotfilesLocal pull` (treats it as a clone). On a copy-deployed Windows box the pull fails, `Write-Err "Pull failed"` fires, then execution continues to `Write-Ok "Sync complete."` and exits 0 — architectural drift *and* a lost failure signal.
+
+**C17 / C18 — versions.conf lies about being a manifest. CONFIRMED.** `OBSIDIAN_VERSION`, `EZA_VERSION`, `ZOXIDE_VERSION` (`versions.conf:16-18`) have zero consumers repo-wide; the header claims "the Windows CI downloads" eza/zoxide but `.github/` contains no such download. Meanwhile `setup-linux.sh:214` installs eza from `releases/latest/download/…` — unpinned, ignoring the pin and reusing the `latest`-URL rot pattern the repo's own lesson (and #648) condemns.
+
+**C21 — `pi` matches `copilot` (substring). CONFIRMED.** `compile-harness.sh:208` `case "$line" in *"$agent"*)`. `"pi"` ⊂ `"copilot"`, so a `targets:[copilot]` record deploys to `~/.pi/agent/skills/`. Latent today (every copilot record also names pi), but the Windows twin uses a `\b` word boundary (`setup-windows.ps1:1749`) — so the first copilot-only skill makes Linux and Windows deploy different skill sets from identical records.
+
+**C30 / C33 / C35 / C37 / C47 — stale SSOTs & dead references.** env-contract `_comment`s cite deleted `doctor.{sh,ps1}`/`healthcheck.*` (C30, also `cli/README.md:43`, `session-start-config.json:14`, `ai/opencode/opencode.jsonc:38`). The PR template still demands the ADR-018-abolished vault `11-tasks.md` (C33). `sensitive/env-mapping.conf` is tracked again with no code consumers, duplicating the registry (C35, = the #669 split-brain). Six committed overlays hardcode `~/Projects/Workspace/…` as the fallback path while the contract default is `~/Projects/…` (C37). Model facts (`deepseek` "default in opencode" vs `opencode.jsonc:34` `nan/qwen3.6`; ctx "1M"/"500K"/"262144"/"256000") are duplicated across six files and already disagree (C47). Also: `ai/claude/settings.json` enables `feature-dev`/output-style plugins never in either install loop (silent no-ops), and references a nonexistent `Skill(bender-config)`.
+
+**C12 — commit-msg hook rejects the repo's own convention. CONFIRMED.** `.github/hooks/validate-commit-msg.sh:5` `grep -Eq '^[a-z]+: .+'` rejects scoped Conventional Commits — `feat(cli): x` fails on the parenthesized scope, yet the repo's live history is scoped (`feat(cli):`, `chore(spec):`, `test(cli):`) and release-please consumes scopes. Wired via `.pre-commit-config.yaml` (commit-msg stage) + `install-precommit.sh:48`. Any machine that ran `install-precommit.sh` is blocked from the standard scoped message (forced to `--no-verify` or unscoped). `tests/validate-commit-msg.bats:21` tests only the unscoped `feat:` case, hiding the drift. *Fix:* `^[a-z]+(\([a-z0-9-]+\))?: .+`.
+
+**C19 — `check-backlog-merged.sh` is structurally inert on this machine's layout. CONFIRMED.** `scripts/check-backlog-merged.sh:86` infers `REPO="$HOME/Projects/$proj"`, but repos here live under `~/Projects/Workspace/`, so `[ ! -d "$REPO/specs/archive" ]` always trips → `SKIP … exit 0`. `vault-health.sh:265` invokes it *without* `--repo`, so the stale-merged advisory never fires while reporting a clean pass — the silent scope-drop the fix-or-ticket rule bans. (ADR-025 seam violation, #463 class.)
+
+**C15 / C29 — bash vs zsh PATH & nvm drift. CONFIRMED.** `.bashrc:105` hard-resets `PATH` to system dirs; `.zshrc:83` has that line commented out. Any nested interactive bash (tmux pane, IDE terminal) wipes inherited PATH (nvm node, `/snap/bin`, `~/bin`). nvm loads only in zsh; `.bashrc` has no nvm block, and `setup-linux.sh:174` re-deploys `.bashrc` each run, deleting installer-appended init lines — while the comment at `:1426` calls that drift "expected". Node-via-nvm therefore exists in zsh but not bash, and intermittently vanishes from bash after a setup.
+
+### 3.4 Affordance mismatches — the API shape promises what the code doesn't deliver
+
+- **C4 (again):** the config shape (`injectors: { X: { enabled: false } }`) *invites* toggling injectors; the code ignores it. The most discoverable knob is a no-op.
+- **C10 / README §Secrets:** README teaches `secrets_add VAR file`, `secrets_rotate`, `secrets_show`, `secrets_list`, `secrets_check`, `secrets_add_file` and `dotfiles-sync [--secrets-only]` as commands. None resolve (grep across `.zsh/`, `.bashrc`, `scripts/*.sh` = empty); ADR-028 replaced them with the `dotf secrets` facade. A newcomer following the README's headline "Key Commands" hits command-not-found. README's own "Human entrypoints" note ("scripts are NOT on PATH") also contradicts the bare `dotfiles-sync`/`vault` invocations elsewhere in the same file.
+- **C20:** `dotf doctor` on Windows (if agy is on PATH) reports `AGY_APP_DATA is relative or unset` for a valid `C:\Users\…` path, because `checks_deploy.go:350` tests `HasPrefix(path,"/")` for "absolute". The easy read ("doctor says my agy config is broken") is wrong.
+
+### 3.5 Missing functionality
+
+- **GUARD-001 is Linux-only.** `setup-windows.ps1` never wires `core.hooksPath` / installs `git-hooks/` (grep = zero hits). AGENTS.md's "MEMORY SINGLE-SINK" claims a *machine-wide* pre-commit guard; on Windows the guard does not exist. `dotf doctor`'s `checkGuardHooks` still runs on Windows and FAILs "core.hooksPath unset" with a `--fix` that points at a `git-hooks/` dir setup never deployed.
+- **C23 — harness `agents` stage un-ported to Windows.** No `~/.claude/agents/curator.md`, no AGENT-PRESENCE region on Windows; `dotf doctor` flags none of it.
+- **C48 — no prune + no drift coverage for the harness mirror.** `setup-linux.sh:543` copies `harness/.`→`~/.dotfiles/harness/` without `--delete`, and `isManagedDeployPath` (`checks_deploy.go:486`) omits `harness/`, `AGENTS.md`, `ai/` despite its own comment claiming it mirrors the copy block. A skill deleted from the repo lives on as a zombie record that doctor validates and calls "no drift".
+- **C28 — Linux cron never self-heals a moved repo** (name-keyed grep); the Windows task does (arg-diff).
+- **DR restore has no end-to-end test** (`dotf secrets backup`/restore — matches open OPS-019).
+
+### 3.6 Boundary & safety
+
+- **C26 — secrets on argv.** `bitacora-rollout.sh:148` `gh secret set BITACORA_PAT --body "$BITACORA_PAT"` and `nan-{bench,debug,quality-bench}.sh` `-H "Authorization: Bearer $NAN_API_KEY"` expose secret material in `/proc/<pid>/cmdline`. `utils.sh:316` already shows the correct stdin idiom.
+- **C27 — plaintext at rest.** `age-encrypt-decrypt.sh:73` / `age-standalone.sh:91` write `.dec` files at umask 0644, with no `chmod 600` and no trap-cleanup; a mid-loop failure leaves earlier `.dec` plaintext behind.
+- **C8 — auto-merge.** `bitacora-rollout.sh:124` `gh pr merge … --squash --auto`. Against a protected repo with auto-merge enabled, the workflow-deploy PR lands the instant CI is green — the exact human-review bypass every AGENTS.md's "Overrides of Harness Defaults" bans.
+- **C46 — infra topology in a public repo.** `ssh/config` commits a VPS public IP (`162.55.57.175`), mesh + LAN IPs, usernames, and a `User root` host (`hermes-nan`). No secrets, but public recon value. **This repo is public** (`gh repo view` → `"visibility":"PUBLIC"`), which also raises the stakes on the deploy-time plaintext OPENROUTER key baked into `~/.gemini/config/mcp_config.json` (by design per agy's no-env-expansion, but two plaintext copies on disk).
+- **C42 — `.gitconfig` Linux path on Windows.** `helper = !/usr/bin/gh auth git-credential` deployed verbatim to `%USERPROFILE%\.gitconfig`; `/usr/bin/gh` doesn't exist in Git-for-Windows → HTTPS auth breaks until edited. Portable form: `!gh auth git-credential`.
+- **C32 — supply chain.** Every Action is tag-pinned, none SHA-pinned. A compromised moving tag runs with `BITACORA_PAT` (repo+project write) or `RELEASE_TOKEN` (contents+PR write) — full write + release forgery.
+
+### 3.7 Documentation
+
+- **C10 / C43 (README):** retired command surface (C10); "316 BATS tests" (actual ~949 `@test`s), "~50 scripts" (actual 35). The clone URL and step order are fine; the drift is in the command tables.
+- **C9 (tests):** `tests/antigravity.bats:17` `skip`s the whole file when agy is absent, and no CI job installs agy, so all 15 tests — including ~8 pure-static regression guards ("--directory must not return", "no hardcoded /home/<user>") that need no agy — never execute. A PR reintroducing `"--directory","/home/manu/Projects/hive"` into `ai/agy/mcp_servers.json` passes CI green while breaking Windows agy exactly as the original bug. The test names claim coverage CI does not provide.
+- **Stale ADR/spec pointers:** many shipped specs reference deleted `healthcheck.{sh,ps1}`/`doctor.{sh,ps1}` sections (#520/#533); `docs/adr/dotfiles-architecture-map.md` still lists `env-mapping.conf` + `load-secrets.{sh,ps1}` among the SSOTs. `tmux.conf:2` says "symlink" but deploy is a copy and doctor *fails* on a symlink — a comment that inverts the enforced invariant.
+
+### 3.8 Developer experience
+
+- **C24 — PSSA covers 4 of ~12 `.ps1`.** `utils.ps1` (the shared `Set-StrictMode` library), `dotfiles-sync.ps1`, `install-dotf.ps1`, `vault-maintenance-weekly.ps1`, `windows/*.ps1`, `paths.ps1` get no analyzer anywhere. The vault's "ps1 must be ASCII / PSSA fails CI on non-ASCII" rule is thus unenforced — em dashes already sit in `setup-windows.ps1`/`install-dotf.ps1` comments — and `.PSScriptAnalyzerSettings.psd1` excludes the BOM rule.
+- **C31 — Go config inputs escape Go CI.** `cli.yml` is path-filtered to `cli/**`. A breaking edit to `env-contract.json`, `secrets/registry.yaml`, `session-start-config.json`, `harness/manifest.json`, or `versions.conf` — all parsed by Go — does not trigger `go test`; only a post-merge runtime failure surfaces it.
+- **C38 — CRLF-in-worktree.** 12 tracked `*.sh`/`.gitconfig` files show `w/crlf` under `git ls-files --eol` despite `eol=lf`; they fail under bash on the `\r` while `git status` stays clean (the `Set-Content`-CRLF hazard the project memory records). A `dotf doctor` guard would catch it (incident→guard rule).
+- **C41 / C25 — tests that can't fail & gate bypasses.** `verify-setup.bats:308` body `true`; `utils.bats:243/258` whitespace-eating `$(...)`; `shell-profile.bats:29` title/body mismatch; `dotfiles-sync.bats:20/33` OR-form asserts; `setup-windows.bats:109` grep that passes even if the source flips to fatal. spec-gate's three bypass routes (`check-spec-gate.sh:98` `*generated*` glob, `:139` `dependencies` label with no actor/rationale check, `:207` any-active-spec-touch — trivially satisfied given the 35 unarchived specs). These erode trust that green means correct.
+- **Positive DX:** the Go smoke tests, the deterministic-age Windows CI (BUG-025), the `.claude.json` truncation guard, the fixture-driven `compile-harness`/`check-spec-gate`/`guard-memory-sink` suites, and `pat-expiry.yml`'s PR-capability probe are genuinely falsifiable and well-built.
+
+---
+
+## 4. Design tensions (the approach, not a line)
+
+**T1 — The strangler-fig is stuck in the middle, so every feature exists 2–3 times and the copies drift.**
+ADR-020 says port a twin to Go "on contact" and delete the pair. In practice the repo is a permanent
+three-body problem: `dotfiles-sync.{sh,ps1}` coexist with `dotf update` (#667 shipped, twins still deployed
+and README-documented); `age-encrypt-decrypt.sh` + `backup-secrets-to-usb.sh` coexist with `dotf secrets
+backup`; `compile-harness.sh` is the engine while `dotf harness` (CLI-026) is designed-not-built. Where the
+Go side is authoritative and the shell side lingers, they *diverge silently* — C7/C13/C14 (sync), C11/C16
+(encoding), C21 (targets matching), C5 (param binding). **The alternative to weigh:** make "on contact"
+enforceable — a CI guard that fails when a `dotf` subcommand and its named `.sh`/`.ps1` twin both exist, so
+the migration can't stall in the drift-prone middle. The Go layer is good enough that finishing the port is
+lower-risk than maintaining the twins.
+
+**T2 — Two setup scripts, one contract, and Windows is a second-class re-implementation.**
+`setup-windows.ps1` is not a port of `setup-linux.sh`; it's a parallel implementation that reproduces some
+stages, silently omits others (GUARD-001 hooks, harness `--refresh`/`--check`, the whole `agents`/presence
+stage — C23), and encodes things differently (junction key C16, catalog dash D2, absolute-path test C20).
+There is no executable contract that says "these two must deploy the same end-state," so drift is invisible
+until a Windows box misbehaves. **The alternative:** push more of the deploy *logic* into `dotf` (which is
+already cross-compiled and CI-tested on both OSes) and shrink both setup scripts toward the "detect-OS,
+fetch-binary, wire-PATH" bootstrap that ADR-020 C7 actually reserves for shell. Every stage that lives in
+Go instead of twinned shell is a class of Linux/Windows divergence that stops being possible.
+
+**T3 — `set -euo pipefail` + a house style of `|| true` / `2>/dev/null` = failures that vanish.**
+The shell layer pairs strict mode with an idiom that defeats it: `|| true`, `|| echo 0`, `2>/dev/null`,
+`>/dev/null 2>&1`. The result is the worst of both — `set -e` aborts on the *unexpected* (C1, C40) while the
+deliberate guards swallow the *expected* failures that should be surfaced (C3 gate fail-open, C14 sync "OK"
+after a failed pull, A7/A8 harness refresh/deploy errors sent to `/dev/null`). The `grep -c || echo 0`
+foot-gun (C1) is documented as *wrong* in one script and copied into another. **The alternative:** a small
+sourced helper library of safe idioms (`count_lines`, `try_or_warn`, atomic-write) plus a shellcheck/CI lint
+that flags `|| echo` after `grep -c` and bare `2>/dev/null` on state-changing commands. The Go layer already
+models the discipline (fail-loud on empty secrets, atomic writes, typed error classification) — the shell
+layer should inherit it, not reinvent silent-failure per script.
+
+**T4 — Config files present a contract the code doesn't honor; the SSOT boundary is porous.**
+`session-start-config.json`'s injector toggles are dead (C4); `versions.conf`'s eza/zoxide/obsidian pins are
+dead (C17); `env-mapping.conf` is a second secrets SSOT with no readers (C35); `env-contract.json` contradicts
+itself on Windows `SCRIPTS_DIR` (C6) and describes consumers that were deleted (C30). Each is a file that
+*looks* load-bearing and isn't. The deeper issue: several of these are inputs the Go CLI parses, yet they live
+outside `cli/` so a breaking edit never runs `go test` (C31). **The alternative:** treat each declarative
+config as code with a test — a schema/consumer test that fails when a declared key has no reader (or a reader
+references an undeclared key), and widen `cli.yml`'s path filter to the files Go actually parses. A config that
+can't drift from its consumers is worth more than one that documents good intentions.
+
+**T5 — The knowledge/provenance machinery is heavier than the thing it governs, and its own guards have gaps.**
+Between `harness/` (compile → refresh → check → deploy across four agents), the marker-injection SSOT dance,
+the spec lifecycle (57 folders, 35 shipped-but-unarchived), and the session-brief injectors, a large fraction
+of the repo exists to keep *other* text in sync. Yet the guards protecting that machinery have holes: marker
+injection can duplicate/truncate on a lost marker (C22), the deploy mirror never prunes and isn't drift-checked
+(C48), spec IDs can collide with no CI guard (C34), and the spec-gate that enforces the whole SDD ritual has
+three bypasses and a fail-open (C3/C25). **The alternative to weigh:** is the marginal governance surface
+earning its keep? A smaller, ruthlessly-guarded core (one injection primitive with an exactly-one-marker
+invariant, an archive-on-merge CI gate, a spec-ID uniqueness check) would likely deliver more actual
+consistency than the current broad-but-porous system.
+
+---
+
+## 5. Expectation gaps (expected X, found Y)
+
+| I expected… | I found… | Ref |
+|---|---|---|
+| `dotf secrets` docs, since ADR-028 | README still teaches `secrets_add/rotate/show/list/check` (none exist) | C10 |
+| `dotfiles-sync` to be a command | It's `scripts/dotfiles-sync.sh`, not on PATH, not aliased; README implies a bare command | C10 |
+| Setting `"vault_health": {enabled:false}` to silence it | The flag is never read; the injector always runs | C4 |
+| A healthy vault → "ALL CHECKS PASSED" | A healthy vault → arithmetic crash → FAILED | C1 |
+| bash aliases to work after setup | They never load (setup writes one path, `.bashrc` sources another) | C2 |
+| The spec-gate to block a big PR with no spec | It passes if the base ref doesn't resolve, or a stale spec is touched, or a `dependencies` label is added | C3, C25 |
+| The memory-sink guard to protect every repo "machine-wide" | It's never installed on Windows | §3.5 |
+| `dotf doctor` green on a correctly-configured Windows agy | `AGY_APP_DATA is relative or unset` FAIL for a valid `C:\…` path | C20 |
+| versions.conf to be the version SSOT | eza/zoxide/obsidian pins have no consumers; eza installs from `latest/` | C17, C18 |
+| Editing a `.ps1` library to be lint-gated | `utils.ps1` (and 7 others) are analyzed by nothing in CI | C24 |
+| A newcomer's README "Key Commands" to run | Several are retired-command or not-on-PATH | C10, C43 |
+| The PR template to match ADR-018 | It still requires a vault `11-tasks.md` entry that was abolished | C33 |
+| One deploy model for `~/.dotfiles` | `.sh` rsync-copies, `.ps1` `git pull`s the same dir | C14 |
+
+---
+
+## 6. Open questions (code alone can't resolve — maintainer answers)
+
+1. **`env-mapping.conf` (C35):** it was deleted by #601 then re-added by #659 with no code consumers. Is any
+   external tool (a script outside this repo, Hermes, a machine not audited here) still reading it, or is this a
+   clean delete (the #669/GUARD-002 outcome)?
+2. **`SCRIPTS_DIR` on Windows (C6 / REFACTOR-007):** is the intended deploy target `~\scripts` or
+   `~\.dotfiles\scripts`? The contract, PATH entry, and setup disagree; the fix is one decision + a small diff,
+   but it's a taste/ownership call the audit can't make.
+3. **`dch` semantics (C43):** README's Diagnostics section describes `dch` as "repo vs `~/.dotfiles` drift" but
+   the alias is now `dotf doctor` (the full sweep). Intended, or should `dch` map to a drift-only subcommand?
+4. **agy MCP forks (F3):** agy still uses `uvx hive-vault` (per-session) while claude/opencode moved to the
+   `hive client` daemon, and agy gets no `context7` — contradicting `mcp-servers.json:3`'s "keep hive+context7+
+   sequential-thinking across all environments". Deliberate (agy limitation) or drift?
+5. **Spec archive policy (C34):** 35 shipped specs sit unarchived with several `status:` fields that lie
+   (`draft`/`implementing` on merged work). Is the plan a one-time #670 sweep + an archive-on-merge CI gate, or
+   is "active folder = in-tree regardless of status" an accepted convention?
+6. **Public-repo posture (C46, deploy-time plaintext key):** given the repo is public, is committing the full
+   `ssh/config` host inventory (public VPS IP, usernames, a root-login host) an accepted trade-off, or should the
+   inventory move to `sensitive/`?
+7. **Windows parity scope (T2, C23, GUARD-001):** is Windows intended to reach full parity (memory-sink guard,
+   harness agents stage), or is it a deliberately reduced surface? That decision changes whether the omissions
+   are bugs or by-design.
+
+---
+
+*Audit method: adversarial read-first (state expected behavior, then confirm/refute against source), with
+every finding tied to a concrete inputs→wrong-result scenario and marked CONFIRMED/PLAUSIBLE. Findings that
+did not survive scrutiny were discarded (e.g. an initial "the Go CLI has no CI" hypothesis — refuted by
+`cli.yml`; "the pre-commit dispatcher orphans repo-local hooks" — refuted by the `chain-local-hook.sh` exec).
+Left uncommitted for the maintainer to triage; each finding carries a stable ID (C1…C48) a fixing agent can cite.*


### PR DESCRIPTION
Three companion audits from the 2026-07-07 review session, added as audit-008 through audit-010 alongside the existing audit-NNN series in docs/adr/ (single taxonomy for this doc type, per the repo's established convention).

- **audit-008-codebase-comprehensive**: 48 findings across the full tracked tree (954 files). Fix arc filed as #685-#693.
- **audit-009-documentation**: 28 findings across every reader-facing doc surface. Fix arc filed as #677-#684.
- **audit-010-process-workflows**: 14 findings from empirical end-to-end workflow walks (throwaway containers + Windows sandbox). Fix arc filed as #694-#700.

Doc-only change (docs/*.md), exempt from spec-gate per _excluded() in check-spec-gate.sh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added several new audit documents that expand coverage of the codebase, documentation set, and end-to-end workflows.
  * Included clearer findings summaries, status tracking, verification notes, and open questions to help guide follow-up work.
  * Added more detailed references for known gaps, inconsistencies, and missing coverage across docs and processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->