### PR TITLE
chore(harness): refresh skill records - add research-prompt, read-all-adrs

### DIFF
--- a/harness/skills/handoff/SKILL.md
+++ b/harness/skills/handoff/SKILL.md
@@ -102,7 +102,7 @@ gh issue list --repo mlorentedev/dotfiles --state open --json number,title,assig
 
 Or manually check each issue: `gh issue view <N> --json state,assignees,title`.
 
-Leaving an actively-worked issue in `Backlog` is the exact gap HARNESS-010 closes. Mechanics: `dotfiles/docs/runbooks/guide-bitacora-setup.md` §5.
+Leaving an actively-worked issue in `Backlog` is the exact gap HARNESS-010 closes. Mechanics: [[bitacora-project-setup]] §5.
 
 **Best-effort, never a blocker:** if the `gh project` query is unavailable (auth, permissions, or a sandbox denial), do NOT stall the handoff. Instead make sure each touched issue is at least self-assigned or carries a status comment, and record the board change you couldn't apply in **Open threads** so the next session (or Manu) finishes it.
 

--- a/harness/skills/new-ticket/SKILL.md
+++ b/harness/skills/new-ticket/SKILL.md
@@ -27,7 +27,7 @@ allowed-tools: [Bash, Read, AskUserQuestion]
 ## Environment (resolve once)
 
 - **Board:** owner `mlorentedev`, project number `1`, Project ID `PVT_kwHOAM7xJs4BZ6GY`.
-- **Canonical field/ID + convention reference:** dotfiles `docs/runbooks/guide-bitacora-setup.md` §2 (fields), §3 (ID convention), §1b (home repo), §5 (status lifecycle). Resolve field/option IDs **at runtime** (snippet below) — do NOT paste a third copy into a ticket; embedded copies drift (the exact failure class behind OPS-002's protected-branch/rollout lessons).
+- **Canonical field/ID + convention reference:** [[bitacora-project-setup]] §2 (fields), §3 (ID convention), §1b (home repo), §5 (status lifecycle). Resolve field/option IDs **at runtime** (snippet below) — do NOT paste a third copy into a ticket; embedded copies drift (the exact failure class behind OPS-002's protected-branch/rollout lessons).
 - `gh` authenticated with `repo` + `project` scope.
 
 ## The flow (interactive — suggestion-first)
@@ -198,6 +198,14 @@ print('%03d' % (max(ns)+1 if ns else 1))"
 
 NNN is **zero-padded to 3 digits** to match the convention (`HARNESS-016`, `OPS-002`). Scans both open and closed issues (forward-only, per §3 — never reuse a retired number). If the AREA also has `specs/<AREA>-NNN-*` directories that outrun the issues, cross-check and take the higher.
 
+### Concurrency guard — parallel sessions race scan-then-create (2026-07-07)
+
+`scan → create` is not atomic: on 2026-07-07 three parallel sessions filing tickets minutes apart produced three duplicate IDs (TOOL-017 ×2, DOCS-001 ×2, then TOOL-020 ×2 during remediation). Harden every create:
+
+1. **Re-scan immediately before `gh issue create`** — at create time, not minutes earlier when the proposal was computed.
+2. **Scan the board's `ID` field too, not only the home repo's issue titles** — a concurrent session may have claimed `AREA-NNN` from another repo or before its issue lands in your scan window. If GraphQL is rate-limited, fall back to REST title scans (`gh api repos/<owner>/<repo>/issues`) across the bitácora repos.
+3. **Verify right after creating** — re-run the scan; if a duplicate raced in, renumber immediately. Yield rule: the ticket WITHOUT its board `ID` field set renumbers; if neither is set, the higher issue `#number` yields.
+
 ## Common mistakes
 
 - **Hardcoding field/option IDs** into the skill or a script → silent drift when the project changes. Resolve at runtime (step 4.3); runbook §2 is the human reference, not a copy to fork.
@@ -208,7 +216,7 @@ NNN is **zero-padded to 3 digits** to match the convention (`HARNESS-016`, `OPS-
 
 ## References
 
-- Runbook: dotfiles `docs/runbooks/guide-bitacora-setup.md` — §1b (home repo), §2 (fields & IDs), §3 (ID convention, CUR-008), §5 (status lifecycle, HARNESS-010).
+- Runbook: [[bitacora-project-setup]] — §1b (home repo), §2 (fields & IDs), §3 (ID convention, CUR-008), §5 (status lifecycle, HARNESS-010).
 - `AGENTS.md` — Standing Order #8 (bitácora status reconciliation) and the detect→ticket rule.
 - Related skills: [[handoff]] (reconciles board status at session end), [[spec]] (`init` is gated on an open issue this skill can create).
 - ADR: dotfiles `docs/adr/adr-018-de-vault-task-placement.md` (task state lives on the board).

--- a/harness/skills/read-all-adrs/SKILL.md
+++ b/harness/skills/read-all-adrs/SKILL.md
@@ -1,0 +1,51 @@
+---
+id: read-all-adrs-skill
+type: skill
+status: active
+created: "2026-07-07"
+owner: manu
+name: read-all-adrs
+description: Force a full read of every ADR in a repo before starting architecture-affecting work, producing a short decision inventory as an explicit completion artifact. Triggers on /read-all-adrs, "read all the ADRs", "give me the ADR map for this repo", "what decisions have already been made here", and as a mandatory pre-step before architecture-session, large refactors, or any change the Discipline Gate flags as warranting a Socratic Guardrail pause. Adapted from davidondrej/skills' read-all-adrs, rewritten with a real completion artifact instead of a bare "read them" instruction.
+allowed-tools: [Read, Grep, Glob]
+---
+
+# Read All ADRs — full ingestion before architecture work
+
+> Agents under time pressure sample ADRs (grep for a keyword, read the top hit) instead of reading the corpus, and re-propose something already decided-and-rejected, or miss a supersession banner and build on a dead decision. This skill forces full ingestion and produces a durable inventory so the reading actually happened — a bare "I read them" claim is not verifiable; a decision-map table is.
+
+## When to use
+
+- Before `architecture-session` (Phase B's "Regla del 3" reference audit needs this as input).
+- Before any refactor the Discipline Gate flags as warranting a Socratic Guardrail pause (schema design, concurrency, breaking changes).
+- When picking up a repo cold, or returning after a long gap — "what has already been decided here?"
+- When the user asks directly for an ADR map / decision inventory.
+
+## When to skip
+
+- A one-file, low-risk change with no architectural surface — don't gate trivial work behind a full ADR sweep.
+- The repo has no `docs/adr/` (or equivalent) — nothing to read; say so and stop.
+
+## Procedure
+
+1. **Locate the corpus.** Glob `docs/adr/**/*.md` (or the repo's documented equivalent — check `docs/README.md` / `AGENTS.md` for the actual path first, don't assume). Include audit-style records that live alongside ADRs (e.g. `audit-NNN-*.md`) if the repo's convention co-locates them, per that repo's own placement decision.
+2. **Read every file — no sampling.** Full read (or full `view` in range chunks for large files), not a keyword grep. A grep hit tells you a file mentions a term; it does not tell you the file is irrelevant when it doesn't.
+3. **Build the inventory** as you go — one row per ADR:
+
+   | ID | Title | Status | One-line decision | Superseded by / relates to |
+   |---|---|---|---|---|
+
+   Pull `status` from frontmatter (`accepted`/`proposed`/`superseded`/`active`), not from assumption — a stale `status: proposed` on a fully-shipped decision is itself a finding worth flagging (see step 4).
+4. **Flag drift while reading, don't silently pass over it:** a `status` that contradicts the body, a missing supersession banner where a later ADR clearly overrides an earlier one, or two ADRs making contradictory claims about the same fact (the exact class of finding a docs audit looks for). Surface these explicitly in the inventory's last column or a short "Flags" section — don't fix them unprompted unless the fix is trivial and directly in scope.
+5. **State completion explicitly**: "Read N/N ADRs in `<repo>`" with the inventory table, before proceeding to the architecture work that triggered this skill. The inventory IS the completion artifact — if you can't produce it, you haven't actually read the corpus.
+
+## Anti-patterns
+
+- **Grep-and-call-it-read** — searching for a keyword across ADRs and treating the hits as "having read the ADRs". This skill exists specifically to close that gap.
+- **Silent supersession** — noticing ADR-004 contradicts ADR-012 and saying nothing because it's out of scope for the current task. Flag it (a one-line note is enough); fixing it is a separate, ownable decision.
+- **Inventory without action** — producing the table and then not actually using it to inform the architecture work that triggered the read. The point is input to a decision, not a checkbox.
+
+## References
+
+- Adapted from `davidondrej/skills/read-all-adrs` (external skills audit, 2026-07-07) — the original is a bare "read them all" instruction with no completion artifact; this version adds the inventory table and drift-flagging as the verifiable output.
+- [[architecture-session]] — Phase B's reference audit consumes this skill's inventory.
+- [[pattern-knowledge-placement]] — where ADRs live (repo `docs/adr/`, project-bound, never the vault).

--- a/harness/skills/research-prompt/SKILL.md
+++ b/harness/skills/research-prompt/SKILL.md
@@ -1,0 +1,52 @@
+---
+id: research-prompt-skill
+type: skill
+status: active
+created: "2026-07-07"
+owner: manu
+name: research-prompt
+description: Turn a vague research ask ("look into X", "what's the state of Y", "is there a better way to do Z") into one tight, sourceable research brief BEFORE dispatching it to a research agent or subagent. Triggers on /research-prompt, "help me phrase this research question", "what should the researcher look for", "turn this into a research brief", "tighten this research ask", and whenever a research/explore/task subagent is about to be launched from an under-specified request. Adapted from davidondrej/skills' research-prompt, re-targeted at this system's research subagent + web_fetch instead of a third-party research API.
+allowed-tools: [Read, Grep, Glob]
+---
+
+# Research Prompt — sharpen the ask before you dispatch it
+
+> A fuzzy research request ("look into X") produces a fuzzy report — the agent has to guess scope, sources, and what "done" means, and usually guesses wrong at least one of the three. This skill is a five-minute sharpening pass run BEFORE launching a `research` (or `explore`/`task`) subagent, not a replacement for one.
+
+## When to use
+
+- Before delegating to the `research` subagent (or `explore` for a lighter lookup) when the request is one sentence and open-ended.
+- When the user asks "what should I have the researcher look for?" or hands you a half-formed question.
+- Before any deep-research web session where getting the scope wrong wastes a long-running agent's full run.
+
+## When to skip
+
+- The ask is already scoped (specific question, named sources, clear output format) — dispatch directly.
+- It's a quick factual lookup answerable in 1-2 `web_fetch`/`grep` calls — don't ceremony a two-minute lookup into a five-minute brief.
+
+## The five slots (fill all before dispatching)
+
+1. **Question** — one sentence, falsifiable. Not "look into observability tools" but "which of Prometheus/Victoria Metrics/Grafana Mimir handles our current cardinality (~2M series) on the homelab's resource budget?"
+2. **Scope boundary** — what's explicitly OUT. Time range, geography, tech stack, versions. The fastest way to blow a research budget is an unbounded "also check...".
+3. **Sources to check first** — named repos, docs sites, standards bodies, or "GitHub code search for X" — not just "the internet". If you don't know good sources, say so explicitly rather than silently omitting this slot.
+4. **Output shape** — inventory table? prioritized shortlist? a single recommendation with tradeoffs? Match the shape to what happens next (a shortlist feeds a decision; a table feeds a comparison doc).
+5. **Done-criteria** — what makes the report sufficient vs. what would make you ask for another pass. ("Cite at least one production case study" / "must cover the last 12 months only".)
+
+## Procedure
+
+1. Read the user's raw ask. Identify which of the five slots are already implied and which are missing.
+2. For each missing slot, either infer a reasonable default from context (state the assumption explicitly) or ask ONE targeted question — never all five at once.
+3. Write the tightened brief as a short paragraph or a 5-line list, not a form — it should read naturally to whichever subagent receives it.
+4. Dispatch: `research` for external/citation-heavy work, `explore` for fast internal-codebase lookups, `task` for command-output-style checks. Include the brief verbatim in the subagent prompt (sub-agent prompts are stateless — full context every time).
+5. State placement of the resulting artifact **before** the agent starts, per [[pattern-knowledge-placement]]'s research sub-rule: project-bound research → that repo's `docs/` (or `10_projects/<project>/research/` if genuinely pre-repo/decide-layer); cross-project tooling/methodology research → vault `00_meta/research/`. Don't leave the placement to be decided after the report lands.
+
+## Anti-patterns
+
+- **Ceremony tax** — running the full five-slot pass on a question you could answer yourself in one `grep`. Match the process to the cost of getting it wrong.
+- **Silent scope creep** — accepting "also look into whatever else seems relevant" as a slot-2 answer. That's not a boundary, it's the absence of one; push back once.
+- **Brief without a home** — dispatching before slot 5's artifact placement is decided, producing an orphan report that gets asked "where does this go?" after the expensive part is already done.
+
+## References
+
+- [[pattern-knowledge-placement]] — research artifact placement sub-rule (project-bound vs cross-project).
+- Adapted from `davidondrej/skills/research-prompt` (external skills audit, 2026-07-07) — re-targeted at the `research`/`explore`/`task` subagents and `web_fetch` instead of a third-party research API, since this system has no DeepAPI-equivalent dependency.

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -292,11 +292,11 @@ setup() {
     # Post-SDD-008: setup-linux.sh runs compile-harness.sh --deploy, which renders
     # each committed vault skill record whose targets[] includes opencode to a
     # command .md. The container has no vault, so --refresh is skipped and --deploy
-    # uses the committed records (34 skills, 6 Claude-only opt out -> 28 commands).
+    # uses the committed records (36 skills, 6 Claude-only opt out -> 30 commands).
     [ -d "$HOME/.config/opencode/commands" ]
     local count
     count=$(find "$HOME/.config/opencode/commands" -maxdepth 1 -name '*.md' | wc -l)
-    [ "$count" -eq 28 ]  # 27 -> 28: added dispose-proposals record (curator inbox triage skill, targets: all agents)
+    [ "$count" -eq 30 ]  # 28 -> 30: added research-prompt + read-all-adrs records (external-skills audit, targets: all agents)
     # Spot check: audit.md present (portable), creating-skills.md absent (targets:[claude]).
     [ -f "$HOME/.config/opencode/commands/audit.md" ]
     [ ! -f "$HOME/.config/opencode/commands/creating-skills.md" ]


### PR DESCRIPTION
Runs `compile-harness.sh --refresh` to pull the two new vault skills into the committed `harness/skills/` record:

- **research-prompt**: sharpens a vague research ask into a 5-slot brief (question, scope boundary, sources, output shape, done-criteria) before dispatching to the research/explore/task subagents. Adapted from davidondrej/skills, re-targeted at this system's tooling.
- **read-all-adrs**: forces full ADR ingestion before architecture-affecting work, producing a decision-inventory table as a verifiable completion artifact. Adapted from davidondrej/skills, rewritten with a real completion artifact instead of a bare instruction.

Both originate from the 2026-07-07 external-skills audit (dotCMS/core + davidondrej/skills) and follow the established SKILL.md frontmatter/authoring convention.

Also picks up two small reference fixes already in the vault's `handoff`/`new-ticket` skill records (bitacora runbook path, from #702) that hadn't been refreshed into this repo yet, plus a concurrency-guard note `new-ticket` gained independently.

Note: running the refresh under real Git-Bash surfaced repo-wide CRLF/LF worktree drift on ~34 unrelated skill files (content-identical, whitespace-only per `git diff`) - left untouched here as out of scope; it's the same class as codebase-audit finding C38.

## SDD skip rationale

Spec-gate counts this diff at 117 LOC (>= 50 threshold) because `harness/skills/**` isn't in the doc-only exclusion list, but the content is inert SKILL.md documentation (agent-behavior definitions), not executable production code or a public contract change. Both skills were designed, scoped, and reviewed with the maintainer earlier in the same session that produced the external-skills audit (dotCMS/core + davidondrej/skills) driving this change; the SKILL.md files themselves already carry the equivalent of a proposal (problem statement, when-to-use/skip, procedure, anti-patterns, references). This is a mechanical `compile-harness.sh --refresh` render of vault-authored content into its committed repo record, not a fresh design needing its own spec lifecycle.