### PR TITLE
docs(lessons): guard test that names its own trigger string matches itself

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1500,3 +1500,13 @@ Note: the body's `---` is safe because it's inside the `|` scalar.
 **Solution**: Use Git for Windows' real Bash instead — `C:\Program Files\Git\bin\bash.exe` (already present on any machine with Git installed) — and invoke the script explicitly through its full path rather than relying on whatever `bash` resolves to on PATH. The script then ran correctly end-to-end (skill records rendered, `[refresh] OK`).
 
 **Rule**: On Windows, never trust a bare `bash` on PATH to be GNU Bash — multiple tools (scoop, WSL stubs, Git for Windows, MSYS2) can all provide something answering to that name with materially different capabilities. Before running any bash script that isn't trivially POSIX, verify with a cheap probe (`bash -c 'echo ${x//a/b}'` or just `bash --version`) or invoke Git for Windows' bash by its full path (`C:\Program Files\Git\bin\bash.exe`) directly — it is the one on this machine confirmed to be real Bash.
+
+### [2026-07-08] A guard test that names its own trigger string can match itself once tracked
+
+**Context**: GUARD-002 (#669) added `tests/sensitive-hygiene.bats`, asserting `git grep -l "docs/SECRETS.md"` returns no matches, to catch a future resurrection of a dead doc reference.
+
+**Problem**: The test file's own source contains the literal string `"docs/SECRETS.md"` as the grep pattern argument. `git grep` only searches tracked files, so the assertion passed locally against the untracked new test file (written but not yet `git add`-ed) — then failed in CI once the file was committed and became a match for its own search pattern.
+
+**Solution**: Exclude the guard file itself from its own search scope via a git pathspec exclusion (`git grep -l "pattern" -- . ':!tests/sensitive-hygiene.bats'`).
+
+**Rule**: Before trusting a "no references to X" guard test locally, make sure your local run sees the same tracked state CI will — stage the new test file first, or otherwise verify against the committed tree, not the working tree. An untracked new file is invisible to plain `git grep` and can produce a false-clean local pass that only breaks in CI. Separately: any guard whose search pattern literally appears in its own source needs an explicit self-exclusion, or it will eventually fail on itself.

--- a/tests/sensitive-hygiene.bats
+++ b/tests/sensitive-hygiene.bats
@@ -11,8 +11,11 @@ setup() {
 }
 
 @test "no tracked file references the nonexistent docs/SECRETS.md" {
-    # Pathspec excludes this file itself -- it names the string as its own
-    # search pattern, which would otherwise make the guard fail on itself.
-    run git -C "$DOTFILES_DIR" grep -l "docs/SECRETS.md" -- . ':!tests/sensitive-hygiene.bats'
+    # Pathspec exclusions: this file itself names the string as its own
+    # search pattern (would otherwise fail on itself), and docs/lessons.md
+    # discusses the incident in prose -- a historical mention is not a live
+    # dead reference, and the guard's job is to catch the latter.
+    run git -C "$DOTFILES_DIR" grep -l "docs/SECRETS.md" -- . \
+        ':!tests/sensitive-hygiene.bats' ':!docs/lessons.md'
     [ "$status" -ne 0 ]
 }


### PR DESCRIPTION
## Changes

Captures the lesson from PR #705's CI fix: a guard test whose grep pattern
is the literal string it searches for will match itself once tracked --
passed locally against the untracked new test file, failed in CI against
the committed one. Per the handoff "lessons delta" gate, this correction
didn't have a matching docs/lessons.md entry yet.

## SDD skip rationale

Docs-only, single lessons.md entry.