### PR TITLE
fix(setup): stop setup writing into the checkout so dotf update keeps deploying

### DIFF
--- a/cli/internal/update/update.go
+++ b/cli/internal/update/update.go
@@ -48,8 +48,16 @@ func Run(cfg Config, d Deps) (Outcome, error) {
 	}
 	// Never touch a dirty worktree (the primary failure mode). An unreadable
 	// status is treated as "cannot confirm clean" → skip (fail-safe).
-	if out, err := d.Git("status", "--porcelain"); err != nil || strings.TrimSpace(out) != "" {
-		return skip("dirty", "dirty worktree in "+cfg.Repo+" — skipping (commit or stash your changes first)")
+	out, err := d.Git("status", "--porcelain")
+	if err != nil {
+		return skip("dirty", "cannot read git status in "+cfg.Repo+" — skipping (fail-safe: cannot confirm the worktree is clean)")
+	}
+	// Name the dirtying paths in the message. A scheduled self-update that skips
+	// on a dirty worktree is otherwise a silent no-op forever (dotfiles#694): the
+	// timer stays green while the deploy never runs. Surfacing the exact paths
+	// makes that state diagnosable from the run log alone.
+	if dirt := strings.TrimSpace(out); dirt != "" {
+		return skip("dirty", "dirty worktree in "+cfg.Repo+" — skipping (commit or stash first). Dirtying paths:\n"+dirt)
 	}
 	// A fetch failure is transient (network) → skip and retry next slot.
 	if _, err := d.Git("fetch", "--quiet"); err != nil {

--- a/cli/internal/update/update_test.go
+++ b/cli/internal/update/update_test.go
@@ -44,15 +44,18 @@ func TestUpdate(t *testing.T) {
 	cfg := Config{Repo: "/repo"}
 
 	tests := []struct {
-		name       string
-		mutate     func(g fakeGit) // tweak the healthy fake for this branch
-		setupErr   error           // RunSetup result
-		wantStatus string
-		wantErr    bool
-		setupRuns  bool // whether RunSetup must be invoked
+		name          string
+		mutate        func(g fakeGit) // tweak the healthy fake for this branch
+		setupErr      error           // RunSetup result
+		wantStatus    string
+		wantMsgSubstr string // if set, out.Message must contain it
+		wantErr       bool
+		setupRuns     bool // whether RunSetup must be invoked
 	}{
 		{name: "not a repo", mutate: func(g fakeGit) { g.fail["rev-parse --git-dir"] = true }, wantStatus: "not-a-repo"},
-		{name: "dirty worktree", mutate: func(g fakeGit) { g.out["status --porcelain"] = " M setup.sh" }, wantStatus: "dirty"},
+		// The dirty-skip message must name the offending path so a silently
+		// skipping scheduled run stays diagnosable (dotfiles#694).
+		{name: "dirty worktree", mutate: func(g fakeGit) { g.out["status --porcelain"] = " M setup.sh" }, wantStatus: "dirty", wantMsgSubstr: "setup.sh"},
 		{name: "fetch offline", mutate: func(g fakeGit) { g.fail["fetch --quiet"] = true }, wantStatus: "offline"},
 		{name: "no upstream", mutate: func(g fakeGit) { g.fail["rev-parse --abbrev-ref --symbolic-full-name @{u}"] = true }, wantStatus: "no-upstream"},
 		{name: "already current", mutate: func(g fakeGit) { g.out["rev-parse @{u}"] = "aaaa" }, wantStatus: "current"},
@@ -82,6 +85,9 @@ func TestUpdate(t *testing.T) {
 			}
 			if out.Status != tt.wantStatus {
 				t.Errorf("status = %q, want %q (msg: %s)", out.Status, tt.wantStatus, out.Message)
+			}
+			if tt.wantMsgSubstr != "" && !strings.Contains(out.Message, tt.wantMsgSubstr) {
+				t.Errorf("message = %q, want it to contain %q", out.Message, tt.wantMsgSubstr)
 			}
 			if ranSetup != tt.setupRuns {
 				t.Errorf("RunSetup invoked = %v, want %v — a skip branch must never re-run setup", ranSetup, tt.setupRuns)

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -919,26 +919,14 @@ else
     log_info "GitHub Copilot CLI not installed, skipping Copilot config (install via snap/apt/curl: https://docs.github.com/copilot/how-tos/copilot-cli)"
 fi
 
-# Sync .github/copilot-instructions.md from ai/copilot/ (SDD-005 parity rule).
-# The .github/ copy is what GitHub's web Copilot Chat reads; ai/copilot/ is the
-# SSOT. Setup keeps them in sync so the docs-drift test never fails.
-# The pointer banner differs: .github/ uses a markdown link [\`AGENTS.md\`](../AGENTS.md)
-# while ai/copilot/ uses a plain backticked reference. Everything else must match.
-GH_COPILOT_DST="$CURRENT_DIR/.github/copilot-instructions.md"
-AI_COPILOT_SRC="$CURRENT_DIR/ai/copilot/copilot-instructions.md"
-if [ -f "$AI_COPILOT_SRC" ]; then
-    # Strip the pointer banner (lines starting with '> ') from ai/copilot/
-    BODY=$(sed -E '/^> /d' "$AI_COPILOT_SRC")
-    # Prepend the .github/-specific pointer banner
-    GH_BANNER="> **First, read [\`AGENTS.md\`](../AGENTS.md) at the repo root** — canonical SSOT for behaviour rules across all agents (Standing Orders, Decision Hierarchy, Neural Hive Loop, MCP usage, Operational Rules). This file contains only Copilot-specific extensions on top.\n>\n> If \`AGENTS.md\` is missing from the current repo, default to the canonical version at \`\$DOTFILES_REPO_DIR/AGENTS.md\` (resolved via \`machine.json\` per ADR-025; falls back to \`~/Projects/Workspace/dotfiles/AGENTS.md\`)."
-    NEW_CONTENT="$GH_BANNER\n\n$BODY"
-    if [ -f "$GH_COPILOT_DST" ] && printf '%s' "$NEW_CONTENT" | cmp -s - "$GH_COPILOT_DST"; then
-        log_info ".github/copilot-instructions.md already in sync"
-    else
-        printf '%s' "$NEW_CONTENT" > "$GH_COPILOT_DST"
-        log_success "Synced .github/copilot-instructions.md from ai/copilot/ (with .github/ pointer banner)"
-    fi
-fi
+# SDD-005 parity (.github/copilot-instructions.md vs ai/copilot/): NOT synced here.
+# Setup deploys to $HOME only and MUST NEVER write into the checkout — a checkout
+# write leaves `git status` dirty, and `dotf update` skips any dirty worktree,
+# so a self-deploying machine silently stops updating after the first run
+# (dotfiles#694). The two copilot-instructions files are kept in parity by the
+# fail-loud test tests/docs-drift.bats (runs in CI), which is the correct
+# enforcement point: drift blocks the merge instead of a deploy rewriting a
+# committed file behind the user's back.
 
 # BUG-004 + BUG-011: defense-in-depth wrapper around EVERY `claude <subcommand>`
 # invocation in this script. The Claude Code CLI's deserialize-modify-serialize

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1718,19 +1718,13 @@ if ($copilotCmd) {
     Write-Info "GitHub Copilot CLI not installed; the dev tools block above attempts auto-install via winget GitHub.Copilot. Re-run setup or open a new shell if the binary was just installed and PATH needs refresh."
 }
 
-# Sync .github/copilot-instructions.md from ai/copilot/ (SDD-005 parity rule).
-# The .github/ copy is what GitHub's web Copilot Chat reads; ai/copilot/ is the
-# SSOT. Setup keeps them in sync so the docs-drift test never fails.
-$ghCopilotDst = Join-Path $DotfilesDir '.github\copilot-instructions.md'
-$aiCopilotSrc = Join-Path $DotfilesDir 'ai\copilot\copilot-instructions.md'
-if (Test-Path -LiteralPath $aiCopilotSrc -PathType Leaf) {
-    if ((Test-Path -LiteralPath $ghCopilotDst) -and (-not (Compare-Object (Get-Content $aiCopilotSrc) (Get-Content $ghCopilotDst)))) {
-        Write-Info ".github/copilot-instructions.md already in sync"
-    } else {
-        Copy-Item -LiteralPath $aiCopilotSrc -Destination $ghCopilotDst -Force
-        Write-Success "Synced .github/copilot-instructions.md from ai/copilot/"
-    }
-}
+# SDD-005 parity (.github/copilot-instructions.md vs ai/copilot/): NOT synced here.
+# Setup MUST NEVER write into the checkout -- a checkout write leaves git status
+# dirty, and `dotf update` skips any dirty worktree, so a self-deploying machine
+# silently stops updating after the first run (dotfiles#694). Parity between the
+# two copilot-instructions files is enforced by the fail-loud CI test
+# tests/docs-drift.bats, which blocks drift at merge instead of rewriting a
+# committed file at deploy time.
 
 # ============================================================================
 # SDD-008: deploy skills from committed records (option A, render-at-deploy)

--- a/specs/BUG-026-setup-no-checkout-writes/proposal.md
+++ b/specs/BUG-026-setup-no-checkout-writes/proposal.md
@@ -1,0 +1,112 @@
+---
+id: "BUG-026-setup-no-checkout-writes"
+type: spec
+status: implementing
+created: "2026-07-09"
+tags: [spec, proposal, setup, idempotency, self-deploy, ci-guard]
+template_version: "1.0"
+---
+
+# BUG-026-setup-no-checkout-writes
+
+Stop setup from writing into the repo checkout, so the scheduled self-deploy
+(`dotf update`) does not silently stop after the first run.
+
+## Why
+
+`setup-linux.sh` (and its Windows twin `setup-windows.ps1`) synced
+`.github/copilot-instructions.md` from `ai/copilot/copilot-instructions.md` on
+every run, writing the result **into the checkout** (`$CURRENT_DIR` /
+`$DotfilesDir`). Two problems compounded:
+
+1. **It dirties the checkout.** The committed `.github/copilot-instructions.md`
+   is not byte-identical to what the sync regenerates, so every setup run left
+   `git status --porcelain` non-empty. Empirically confirmed on this branch:
+   the sync even used `printf '%s'` on a string containing literal `\n`, so it
+   would have written backslash-n sequences and a different banner placement
+   than the committed file — the "sync" produced a *broken* file.
+2. **`dotf update` skips any dirty worktree — with exit 0.**
+   `cli/internal/update/update.go` treats any `git status --porcelain` output as
+   "dirty" and returns a benign skip (nil error). Net effect: a self-deploying
+   machine runs setup once, the checkout goes dirty, and every subsequent
+   scheduled `dotf update` skips forever while the systemd timer / Scheduled
+   Task stays green. The machine silently stops receiving updates.
+
+Root cause is a **misplaced invariant**. Parity between the two
+copilot-instructions files was enforced in two places: a fail-loud test
+(`tests/docs-drift.bats`, correct — blocks drift at merge) and a deploy-time
+auto-rewrite (incorrect — mutates a committed file behind the user's back and
+breaks idempotency). The auto-rewrite is redundant with the test and harmful.
+
+Source: `docs/audits/process-audit-2026-07-07.md` §4 P1 (CONFIRMED, E3/E4);
+GitHub issue #694.
+
+## What
+
+After this PR:
+
+- `setup-linux.sh` no longer writes `.github/copilot-instructions.md`. The sync
+  block is removed and replaced by a comment stating the invariant (*setup
+  deploys to `$HOME` only; it MUST NEVER write into the checkout*) and pointing
+  at `tests/docs-drift.bats` as the parity enforcement point.
+- `setup-windows.ps1` gets the identical treatment for its parallel sync block
+  (cross-OS parity of the fix).
+- `tests/verify-setup.bats` gains a guard: after setup runs in the integration
+  container, `git -C "$REPO_DIR" status --porcelain` MUST be empty. It asserts
+  exactly the condition `update.go` checks, against the same checkout, and trips
+  on *any* future checkout write — not just this one.
+- `cli/internal/update/update.go` names the dirtying paths in its skip message
+  (previously an opaque "dirty worktree — skipping"), so a silently-skipping
+  scheduled run is diagnosable from its log alone. The unreadable-status branch
+  is split out with its own fail-safe message.
+
+## Out of scope
+
+- The other fresh-machine setup bugs from the same audit (#695 in-place layout,
+  #696 machine.json, #697 doctor verdicts). Separate issues, separate PRs.
+- A pre-commit hook that *regenerates* `.github/copilot-instructions.md` from
+  the SSOT. Not needed: `tests/docs-drift.bats` already fails loud on drift, and
+  the two files are hand-synced on the rare edit. Adding a generator would
+  re-duplicate the banner logic that caused this bug. Ticket if manual sync ever
+  becomes a burden.
+- Auditing every other setup write path. The new integration guard makes this
+  empirical: if setup writes anywhere else in the checkout, CI goes red and the
+  offending path is named.
+
+## Risks / open questions
+
+- **Guard depends on `.git` being present in the integration image.** There is
+  no `.dockerignore`, so `COPY . /home/testuser/dotfiles-repo` includes `.git`;
+  the checkout is owned by `testuser` and bats runs as `testuser`, so no
+  `safe.directory` complaint. The guard `skip`s (does not fail) if `.git` is
+  absent, so it degrades safely if the image layout ever changes.
+- **Manual parity burden.** Editing `ai/copilot/copilot-instructions.md` now
+  requires hand-updating `.github/copilot-instructions.md` or `docs-drift.bats`
+  fails. This is the intended trade-off (fail-loud at merge over silent
+  deploy-time rewrite).
+
+## Acceptance criteria
+
+- [ ] `setup-linux.sh` contains no write to `.github/copilot-instructions.md`
+      (no `GH_COPILOT_DST` assignment, no `printf ... > "$GH_COPILOT_DST"`).
+- [ ] `setup-windows.ps1` contains no write to `.github\copilot-instructions.md`
+      (no `Copy-Item ... -Destination $ghCopilotDst`).
+- [ ] `tests/verify-setup.bats` asserts an empty `git status --porcelain` in
+      `$REPO_DIR` after setup (the #694 guard), skipping cleanly if `.git` is
+      absent.
+- [ ] `cli/internal/update/update.go` dirty-skip message includes the porcelain
+      path list; the unreadable-status case has its own message.
+- [ ] `cli/internal/update/update_test.go` asserts the dirty message names the
+      offending path.
+- [ ] `tests/docs-drift.bats` parity test still passes (invariant preserved,
+      enforcement moved not deleted).
+- [ ] `go build ./...`, `go vet`, `go test ./internal/update/` green;
+      `bash -n setup-linux.sh` clean; `setup-windows.ps1` edit ASCII-only.
+
+## References
+
+- GH issue: [#694](https://github.com/mlorentedev/dotfiles/issues/694)
+- Audit: `docs/audits/process-audit-2026-07-07.md` §4 P1
+- Parity enforcement: `tests/docs-drift.bats` (SDD-005)
+- Self-update contract: `cli/internal/update/update.go` (CLI-027 / AUDIT-007)
+- Integration harness: `tests/Dockerfile.integration`, `tests/verify-setup.bats`

--- a/specs/BUG-026-setup-no-checkout-writes/tasks.md
+++ b/specs/BUG-026-setup-no-checkout-writes/tasks.md
@@ -1,0 +1,27 @@
+---
+id: "BUG-026-setup-no-checkout-writes"
+type: spec
+status: implementing
+created: "2026-07-09"
+tags: [spec, tasks]
+template_version: "1.0"
+---
+
+# Tasks — BUG-026-setup-no-checkout-writes
+
+- [x] T1. Remove the `.github/copilot-instructions.md` sync block from
+  `setup-linux.sh`; replace with an invariant comment pointing at
+  `tests/docs-drift.bats`.
+- [x] T2. Remove the parallel sync block from `setup-windows.ps1`; same
+  invariant comment, ASCII-only.
+- [x] T3. Add the checkout-hygiene guard to `tests/verify-setup.bats`
+  (`git -C "$REPO_DIR" status --porcelain` empty; skip if no `.git`).
+- [x] T4. Split the dirty-status branch in `cli/internal/update/update.go`:
+  unreadable status → fail-safe message; dirty → message names the porcelain
+  paths (#694).
+- [x] T5. Extend `cli/internal/update/update_test.go` to assert the dirty
+  message names the offending path (`wantMsgSubstr`).
+- [x] T6. Local verification: `go build ./... && go vet && go test`,
+  `bash -n setup-linux.sh`, bats parse, ps1 ASCII check, docs-drift parity.
+- [ ] T7. CI green (unit `test` incl. docs-drift, `integration` incl. new
+  guard, `lint-powershell`, Go tests).

--- a/specs/BUG-026-setup-no-checkout-writes/verification.md
+++ b/specs/BUG-026-setup-no-checkout-writes/verification.md
@@ -1,0 +1,52 @@
+---
+id: "BUG-026-setup-no-checkout-writes"
+type: spec
+status: implementing
+created: "2026-07-09"
+tags: [spec, verification]
+template_version: "1.0"
+---
+
+# Verification — BUG-026-setup-no-checkout-writes
+
+## Reproduction (pre-fix, from #694)
+
+```
+git clone --depth 5 https://github.com/mlorentedev/dotfiles.git ~/dotfiles-repo
+cd ~/dotfiles-repo && bash setup-linux.sh          # exit 0
+git status --porcelain                              # " M .github/copilot-instructions.md"
+DOTFILES_REPO_DIR=$HOME/dotfiles-repo dotf update   # "dirty worktree — skipping", exit 0
+```
+
+Locally confirmed the drift on `main`: replaying the sync logic against the
+committed files produces a diff (literal `\n`, banner reordered) — proof the
+sync dirties the checkout on every run.
+
+## Automated evidence (this branch)
+
+| Check | Command | Result |
+|---|---|---|
+| Go build | `go build ./...` (in `cli/`) | pass (no output) |
+| Go vet | `go vet ./internal/update/` | pass |
+| Go unit | `go test ./internal/update/` | `ok` — dirty case now asserts message names `setup.sh` |
+| Bash syntax | `bash -n setup-linux.sh` | `OK syntax` |
+| Bats parse | `bats --count tests/verify-setup.bats` | 57 (was 56); new test name unique |
+| PS1 ASCII | `sed -n '1720,1728p' setup-windows.ps1 \| grep -P '[^\x00-\x7F]'` | no match (ASCII-clean) |
+| Parity intact | `cmp` of both files modulo `> ` banner | identical (docs-drift.bats stays green) |
+
+## CI evidence (post-push, T7)
+
+- [ ] `test` (unit bats incl. `docs-drift.bats`) green — parity preserved.
+- [ ] `integration` (Docker: setup-linux + `verify-setup.bats`) green — the new
+      guard "setup leaves the repo checkout clean [#694]" passes, proving the
+      copilot-instructions write is gone and no other checkout write exists.
+- [ ] `lint-powershell` green — `setup-windows.ps1` edit clean.
+- [ ] Go tests in CI green.
+
+## Guard rationale (incident -> guard)
+
+The integration guard asserts the exact predicate `update.go` checks
+(`git status --porcelain` empty) against the exact checkout setup runs from. It
+generalizes past the copilot-instructions symptom: any future setup change that
+writes into the checkout — the whole bug *class* — trips it, red-teaming the
+idempotency contract on every CI run.

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -346,3 +346,26 @@ setup() {
     tmux -L "$socket" kill-server 2>/dev/null || true
     [ "$rc" -eq 0 ]
 }
+
+# =============================================================================
+# Section: Checkout hygiene — setup must never write into the repo checkout
+# =============================================================================
+
+# Guard for dotfiles#694. Setup deploys to $HOME only; it must NEVER write into
+# the checkout it runs from. A checkout write leaves `git status` dirty, and
+# `dotf update` (cli/internal/update/update.go) skips any dirty worktree with
+# exit 0 — so a self-deploying machine silently stops updating after the first
+# run while the timer stays green forever. This asserts exactly what update.go
+# checks (empty `git status --porcelain`) against the same checkout: setup ran at
+# image-build time, this runs at container-run time. Any future checkout write —
+# not just the copilot-instructions sync that motivated this — trips the guard.
+@test "setup leaves the repo checkout clean (no dirty worktree) [#694]" {
+    [ -d "$REPO_DIR/.git" ] || skip "repo checkout is not a git repo in this container"
+    run git -C "$REPO_DIR" status --porcelain
+    [ "$status" -eq 0 ]
+    if [ -n "$output" ]; then
+        echo "setup dirtied the checkout — dotf update would skip forever (#694):" >&2
+        echo "$output" >&2
+    fi
+    [ -z "$output" ]
+}


### PR DESCRIPTION
## Problem

`setup-linux.sh` and `setup-windows.ps1` synced `.github/copilot-instructions.md` from `ai/copilot/copilot-instructions.md` **into the checkout** on every run. The committed file is not byte-identical to what the sync regenerates (the Linux sync even used `printf '%s'` on a string with literal `\n`, so it wrote broken content), so every setup run left `git status --porcelain` non-empty.

`dotf update` (`cli/internal/update/update.go`) treats any dirty worktree as a benign skip with **exit 0**. Net effect: a self-deploying machine runs setup once, the checkout goes dirty, and every subsequent scheduled `dotf update` skips forever while the systemd timer / Scheduled Task stays green. The machine silently stops receiving updates after the first run.

Root cause is a **misplaced invariant**: parity between the two copilot-instructions files was enforced both by a fail-loud test (`tests/docs-drift.bats`, correct) and a deploy-time auto-rewrite (incorrect — mutates a committed file and breaks idempotency). The auto-rewrite is redundant and harmful.

## Fix

- **`setup-linux.sh` / `setup-windows.ps1`**: remove the `.github/copilot-instructions.md` sync block. Setup deploys to `$HOME` only and never writes into the checkout. Replaced with an invariant comment pointing at `tests/docs-drift.bats`.
- **`tests/verify-setup.bats`**: new guard — after setup runs in the integration container, `git -C "$REPO_DIR" status --porcelain` must be empty. Asserts exactly what `update.go` checks, against the same checkout, and trips on *any* future checkout write (the whole bug class), not just this symptom. Skips cleanly if `.git` is absent.
- **`cli/internal/update/update.go`**: name the dirtying paths in the skip message (was an opaque "dirty worktree — skipping"); split the unreadable-status branch with its own fail-safe message.

## Verification

Local (all green): `go build ./... && go vet && go test ./internal/update/`; `bash -n setup-linux.sh`; `bats --count tests/verify-setup.bats` (57, unique name); `setup-windows.ps1` edit ASCII-only; `docs-drift.bats` parity still holds.

CI to confirm: `test` (unit incl. docs-drift), `integration` (new #694 guard), `lint-powershell`, Go tests.

Spec: `specs/BUG-026-setup-no-checkout-writes/`.

Closes #694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Setup no longer modifies the repository checkout, preventing unexpected dirty worktrees after running it.
  * Update skips now give clearer messages, including the paths that caused the checkout to be dirty.
  * Added validation to ensure setup leaves the repo clean after it finishes.

* **Tests**
  * Expanded automated coverage for dirty-worktree messaging and checkout cleanliness checks.

* **Documentation**
  * Added and updated setup and verification guidance to reflect the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->