### PR TITLE
docs(agents): add nested cli/AGENTS.md + HARNESS sha-marker integrity guard

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md — `cli/` (dotf Go module)
+
+Nearest-file instructions for the Go CLI. The repo-root `AGENTS.md` remains the
+SSOT for **behaviour** (Standing Orders, commit/PR rules, SDD); this file adds
+only the Go build/test/lint contract for work under `cli/`. For command
+semantics see `cli/README.md`.
+
+Module: `github.com/mlorentedev/dotfiles/cli` (nested module, `go 1.26`, cobra).
+Entry point: `cmd/dotf`. Logic lives in `internal/<area>/` (doctor, env, mem,
+memlink, secrets, spec, tools, review, initrepo).
+
+## Commands (run from `cli/` — this is CI's `working-directory`)
+
+```sh
+go build ./...                 # build all packages
+go test ./...                  # run all unit tests
+go vet ./...                   # vet
+gofmt -l .                     # list unformatted files (must be empty)
+golangci-lint run              # lint (CI: golangci-lint-action@v8, defaults)
+go run ./cmd/dotf --help       # run locally
+go run ./cmd/dotf version      # smoke: version
+```
+
+CI (`.github/workflows/cli.yml`) runs `go build ./...`, `go test ./...`, a
+`--help`/`version` smoke, and `golangci-lint`. Release is goreleaser on a plain
+`vX.Y.Z` tag (binaries, not `go install`).
+
+## Conventions
+
+- **Testable seams over globals.** External surfaces (git, exec, filesystem) are
+  injected via a `Deps` struct so `Run` is unit-tested with no real side effects
+  (see `internal/update`). Add behaviour behind such a seam, not a direct call.
+- **Table-driven tests**, one case per branch; assert the stable status tag, not
+  prose. Test files (`*_test.go`) do not count toward the SDD spec-gate.
+- **Benign-skip contracts**: scheduler-invoked paths return a non-nil error only
+  on a real failure; every "nothing to do" branch is a nil-error skip.
+- Keep new subcommands in their own `internal/<area>/` package with a thin
+  `cmd/` wiring layer; mirror the strangler-fig migration notes in `README.md`.

--- a/tests/harness-generated-sha.bats
+++ b/tests/harness-generated-sha.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# Guard for #673/GOV-004: every HARNESS GENERATED region carries a truncated
+# sha256 of its own between-markers content in the BEGIN marker. That sha is
+# emitted by scripts/compile-harness.sh (sha_of = `sha256sum | cut -c1-16`) so a
+# reader WITHOUT the vault can spot a hand-edited or corrupted generated block.
+# Nothing enforced it before — the marker could silently go stale. This asserts
+# each marker's declared sha equals the recomputed content sha.
+#
+# Region CONTENT drift vs the committed harness/enforced/ records is a separate,
+# stronger check already run in CI (`compile-harness.sh --check`, ci.yml). This
+# guard adds integrity of the self-describing sha marker itself.
+#
+# Note (#710 self-match): the BEGIN-marker pattern is ANCHORED at column 0 (^).
+# This test file never starts a line with the marker text (references above are
+# prose / assignments), so `git grep` never lists this file.
+
+setup() {
+    DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    BEGIN_RE='^<!-- BEGIN HARNESS GENERATED \(sha256:'
+}
+
+@test "every HARNESS GENERATED block's sha256 marker matches its content (#673)" {
+    cd "$DOTFILES_DIR"
+    local failed=0 f declared recomputed
+    for f in $(git grep -lE "$BEGIN_RE" 2>/dev/null); do
+        declared="$(grep -oE 'sha256:[0-9a-f]{16}' "$f" | head -1 | cut -d: -f2)"
+        recomputed="$(awk '/^<!-- BEGIN HARNESS GENERATED/{inb=1;next} /^<!-- END HARNESS GENERATED -->/{inb=0} inb{print}' "$f" | sha256sum | cut -c1-16)"
+        if [ "$declared" != "$recomputed" ]; then
+            echo "DRIFT: $f declared=$declared recomputed=$recomputed — re-run scripts/compile-harness.sh" >&2
+            failed=1
+        fi
+    done
+    [ "$failed" -eq 0 ]
+}
+
+@test "the sha guard is not vacuously green: at least one marker exists (#673)" {
+    cd "$DOTFILES_DIR"
+    local n
+    n="$(git grep -lE "$BEGIN_RE" 2>/dev/null | wc -l)"
+    [ "$n" -ge 1 ]
+}


### PR DESCRIPTION
Delivers the two **mechanical** parts of GOV-004 (#673). The root AGENTS.md diet (part a) is deferred to a dedicated pass with maintainer input on what to keep vs move.

## (b) Nested `cli/AGENTS.md`

Nearest-file agent instructions for the Go module: exact `build`/`test`/`vet`/`lint`/`run` commands (matching `.github/workflows/cli.yml`, `working-directory: cli`), module facts (`github.com/mlorentedev/dotfiles/cli`, go 1.26, cobra, `cmd/dotf` + `internal/<area>/`), and the module's conventions (testable `Deps` seams, table-driven tests, benign-skip contracts). The root `AGENTS.md` stays the behaviour SSOT; nearest-file precedence means agents working in `cli/` pick this up automatically.

## (c) HARNESS generated-block freshness

**Finding:** the CI freshness check the issue asks for **already exists and is stronger than the proposed sha approach.** `scripts/compile-harness.sh --check` runs in CI (`ci.yml`) and diffs the generated region **content** of both marker targets (`AGENTS.md`, `ai/claude/CLAUDE.md`) against the committed `harness/enforced/` records. That catches any content drift without the vault (ADR-013).

What was missing: the `sha256:` value in each `<!-- BEGIN HARNESS GENERATED (sha256:…) -->` marker was **decorative** — nothing verified it. `tests/harness-generated-sha.bats` now asserts each marker's declared sha equals the recomputed first-16 of `sha256sum` over its own between-markers content (the exact function `compile-harness.sh` uses). So the marker can no longer silently lie.

- Anchored at column 0 → the guard never self-matches (#710 class).
- A second test asserts the guard is not vacuously green (≥1 marker exists).

## Scope / verification

- `cli/AGENTS.md` is 38 LOC (< 50) → no spec required; `tests/` is excluded from the gate.
- New bats: 2/2 green locally; `git grep` confirms exactly the two marker files are covered.

Optional follow-up: fold the sha-marker assertion into `compile-harness.sh --check` itself so setup + healthcheck enforce it too (kept as a bats guard here to avoid touching load-bearing runtime code).

Addresses #673 (parts b + c). Root AGENTS.md diet (part a) remains open on #673.