### PR TITLE
ci(spec-gate): full base-ref fetch so the merge-base is reachable

### DIFF
--- a/.github/workflows/spec-gate.yml
+++ b/.github/workflows/spec-gate.yml
@@ -23,7 +23,13 @@ jobs:
       - name: Fetch base ref
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: git fetch --no-tags --prune --depth=1 origin "$BASE_REF"
+        # Full fetch (NOT --depth=1): check-spec-gate.sh diffs "origin/BASE...HEAD",
+        # whose three-dot form needs the merge-base. A shallow depth-1 base ref
+        # cannot reach the merge-base of a branch that lags main by more than one
+        # commit, so `git diff` errors and the gate (correctly) fails closed
+        # (#686/C3). checkout above already fetched full head history (fetch-depth
+        # 0); this brings the base's full history so the merge-base is reachable.
+        run: git fetch --no-tags --prune origin "$BASE_REF"
 
       - name: Run SDD spec-gate
         env:


### PR DESCRIPTION
## Problem

After the C3 fail-closed change (#686, #716) landed on main, PR #728 failed `spec-gate` with:

> git diff "origin/main...HEAD" failed — base/head ref could not be resolved. The Discipline Gate fails closed (exit 2).

`check-spec-gate.sh` diffs `origin/BASE...HEAD` (three-dot), which needs the **merge-base**. `spec-gate.yml` fetched the base ref with `--depth=1`, so for a PR branch that lags main by more than one commit (#728 was 6 behind), the merge-base is not reachable from the shallow base tip → `git diff` errors → the gate correctly fails closed.

This is the exact "shallow/fresh clone" case #686/C3 warned about — my C3 fix made a latent CI-fetch inadequacy **loud** instead of silently passing with `TOTAL_LOC=0`. Left unfixed, any PR branch behind main fails the gate.

## Fix

Drop `--depth=1` from the base-ref fetch (one line). `actions/checkout` already fetches full head history (`fetch-depth: 0`); this brings the base's full history so the merge-base is always reachable.

## Verification

- YAML valid; branch is based on current main (recent merge-base), and its own `spec-gate` run uses this fixed workflow → passes.
- Unblocks #728 (also being rebased onto current main).