### PR TITLE
chore(pi): drop the free OpenRouter tier and make the README answer to settings.json

### DIFF
--- a/ai/pi/README.md
+++ b/ai/pi/README.md
@@ -14,6 +14,11 @@ SSOT (see root `AGENTS.md`).
 
 Not managed: `auth.json` (OAuth/secret state) and `skills/` (runtime symlinks).
 
+Because `settings.json` is seed-if-missing, editing it **here** changes only what a fresh
+machine gets. To adopt a change on a machine that already has `~/.pi/agent/settings.json`,
+edit that file too (or delete it and re-run setup, losing the runtime keys pi wrote there:
+`lastChangelogVersion`, `theme`, and any model picked in the TUI).
+
 ## Install
 
 Pinned via `PI_VERSION` in `versions.conf`, installed by `setup-{linux,windows}` (guarded on `npm`):
@@ -24,13 +29,17 @@ npm install -g --ignore-scripts @earendil-works/pi-coding-agent@<PI_VERSION>
 
 ## Model environment
 
-Curated for a consistent free + NaN environment, shared with opencode's picker:
+Curated NaN-first: NaN covers the free tier, with three paid OpenRouter models behind it.
 
-- **NaN** (free, primary): `qwen3.6`, `gemma4`, `deepseek-v4-flash`, `mimo-v2.5`
-- **Free OpenRouter** (most powerful, rate-limited): `qwen3-coder:free`, `kimi-k2.6:free`, `nemotron-3-ultra-550b-a55b:free`
+- **NaN** (free, primary): `qwen3.6`, `gemma4`, `deepseek-v4-flash`, `deepseek-v4-flash-0731`, `mimo-v2.5`
 - **Paid OpenRouter** (3, none from OpenAI/Google/Anthropic): `deepseek-v4-pro`, `qwen3-coder-plus`, `minimax-m3`
 
-Default: `nan/mimo-v2.5` (1M context), thinking level `high`. Change in `settings.json`.
+pi's picker omits the rate-limited `:free` OpenRouter tier that `ai/opencode/opencode.jsonc`
+still lists — the two sets are curated independently. `tests/pi-config.bats` asserts this list
+stays equal to `settings.json`'s `enabledModels`.
+
+Default: `nan/qwen3.6`, thinking level `high`. Change in `settings.json`. (Per-model context
+windows live in `models.json` — the one place they cannot drift from.)
 
 ## Secret
 

--- a/ai/pi/settings.json
+++ b/ai/pi/settings.json
@@ -8,9 +8,6 @@
     "nan/deepseek-v4-flash",
     "nan/deepseek-v4-flash-0731",
     "nan/mimo-v2.5",
-    "openrouter/qwen/qwen3-coder:free",
-    "openrouter/moonshotai/kimi-k2.6:free",
-    "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free",
     "openrouter/deepseek/deepseek-v4-pro",
     "openrouter/qwen/qwen3-coder-plus",
     "openrouter/minimax/minimax-m3"

--- a/tests/pi-config.bats
+++ b/tests/pi-config.bats
@@ -1,12 +1,13 @@
 #!/usr/bin/env bats
 # Guard (incident->guard, AI-025): the pi coding agent config carries no
 # plaintext secret in git, and the curated model set stays consistent with
-# opencode (NaN + free + non-big-3 paid OpenRouter).
+# its own README (NaN + non-big-3 paid OpenRouter).
 
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
     export PI_MODELS="$DOTFILES_DIR/ai/pi/models.json"
     export PI_SETTINGS="$DOTFILES_DIR/ai/pi/settings.json"
+    export PI_README="$DOTFILES_DIR/ai/pi/README.md"
 }
 
 @test "ai/pi/models.json exists" {
@@ -83,6 +84,44 @@ setup() {
     dupes="$(jq -r '.. | objects | select(has("id") and has("name")) | .name' "$PI_MODELS" \
         | LC_ALL=C sort | uniq -d)"
     [ -z "$dupes" ] || { echo "duplicate model display names: $dupes"; return 1; }
+}
+
+# --- Config vs its own documentation -------------------------------------
+# Same class one level up (2026-08-05): dropping the `:free` OpenRouter tier
+# from enabledModels left ai/pi/README.md advertising three models the picker
+# no longer offers -- and exposed two older drifts nobody had noticed, both
+# from edits that changed the config without reading the doc beside it. A
+# reader trusts the README; nothing made the README answer to the config.
+
+@test "ai/pi/README.md model list matches settings.json enabledModels" {
+    command -v jq >/dev/null || skip "jq not available"
+    # The tier bullets under "## Model environment" are the documented set:
+    # take every backticked token from the "- **Tier**: `a`, `b`" lines.
+    doc="$(sed -n '/^## Model environment/,/^## /p' "$PI_README" \
+        | grep '^- \*\*' | grep -o '`[^`]*`' | tr -d '`' | LC_ALL=C sort -u)"
+    # enabledModels are provider-qualified (`nan/x`, `openrouter/vendor/y`)
+    # while the README names the bare id, so compare on the last path segment.
+    cfg="$(jq -r '.enabledModels[]' "$PI_SETTINGS" | sed 's|.*/||' | LC_ALL=C sort -u)"
+    # Set equality, not containment: one-directional would have missed the
+    # model added to the config in #749 and never listed in the README.
+    [ "$doc" = "$cfg" ] || {
+        echo "README model list and settings.json enabledModels disagree (< README, > config):"
+        diff <(printf '%s\n' "$doc") <(printf '%s\n' "$cfg") | sed 's/^/  /'
+        return 1
+    }
+}
+
+@test "ai/pi/README.md documents the actual default model" {
+    command -v jq >/dev/null || skip "jq not available"
+    # The README advertised `nan/mimo-v2.5` while the config had shipped
+    # `qwen3.6` for who knows how long: the default is the single value a new
+    # user meets first, and it was the one the doc got wrong.
+    want="$(jq -r '.defaultProvider + "/" + .defaultModel' "$PI_SETTINGS")"
+    got="$(grep -m1 '^Default: ' "$PI_README" | grep -o '`[^`]*`' | head -1 | tr -d '`')"
+    [ "$got" = "$want" ] || {
+        echo "README Default: says '$got', settings.json says '$want'"
+        return 1
+    }
 }
 
 # CLI-018: the "missing age identity is optional for pi models.json" assertion


### PR DESCRIPTION
> **Correction.** This PR's title and body were edited minutes after it had already been merged, while work continued on the branch, and briefly described a `setup-*.sh` fix that is **not** in this PR. Restored below to what actually merged (`1979b2a`). The seed-if-missing fix lives in #756.

## What

Removes the three rate-limited `:free` OpenRouter models from pi's curated `enabledModels`. NaN already covers the free tier; `ai/opencode/opencode.jsonc` keeps its own `:free` set, so the two pickers are curated independently from here on.

## Why the diff is bigger than three deleted lines

Updating `ai/pi/README.md` to match surfaced two drifts that predate this change:

| README claimed | `settings.json` actually shipped |
|---|---|
| NaN: 4 models | 5 — `deepseek-v4-flash-0731` was added in #749 and never documented |
| Default `nan/mimo-v2.5` | `qwen3.6` |

Both came from edits that changed the config without reading the doc beside it — the #752 lesson one level up: validating each file on its own says nothing about the pairing.

## Guards

Two assertions in `tests/pi-config.bats` so the README answers to the config: bidirectional set equality on the model list, and an exact match on the documented default. Each verified to fail on a planted drift in each direction.

(The set-equality check was later hardened in #756 to compare `provider/leaf` rather than the bare leaf, so a model documented under the wrong tier no longer passes.)
