### PR TITLE
fix(shell-profile): keep the profiled shell's exit status from aborting the run

### DIFF
--- a/scripts/shell-profile.sh
+++ b/scripts/shell-profile.sh
@@ -54,7 +54,10 @@ fi
 if $DETAIL; then
     echo "=== Detail profile: $SHELL_CHOICE (DOTFILES_PROFILE=1) ==="
     echo ""
-    DOTFILES_PROFILE=1 "$SHELL_CHOICE" -i -c exit
+    # `|| true`: an interactive shell reports the status of the last command its
+    # profile ran, so a non-zero exit is ordinary, not a failure to profile.
+    # Without this, `set -e` aborts here and the run reports failure (BUG-035).
+    DOTFILES_PROFILE=1 "$SHELL_CHOICE" -i -c exit || true
     exit 0
 fi
 
@@ -64,8 +67,16 @@ echo ""
 
 samples=""
 for _ in $(seq 1 "$RUNS"); do
-    # `time` writes to stderr in `real Xm Y.YYYs` format; capture and convert to seconds.
-    raw=$( { time "$SHELL_CHOICE" -i -c exit ; } 2>&1 | awk '/^real/ {print $2}')
+    # `time` writes to stderr in `real Xm Y.YYYs` format; capture and convert to
+    # seconds. The `|| true` keeps the *profiled* shell's exit status from
+    # aborting the run: under `set -euo pipefail` a non-zero exit propagated
+    # through the pipeline and killed the script before any stats were printed
+    # (BUG-035). A loaded interactive profile exits non-zero routinely — the
+    # status reflects the last command it ran, not a failure to start — which is
+    # why this only bit on real machines and never in CI, where a bare
+    # `bash -i -c exit` happens to return 0. Scoping it to the shell keeps
+    # `set -e` protecting the awk that parses the measurement.
+    raw=$( { time "$SHELL_CHOICE" -i -c exit || true ; } 2>&1 | awk '/^real/ {print $2}')
     # Format: "0m0.234s" → 0.234
     seconds=$(printf '%s' "$raw" | awk -F'[ms]' '{ printf "%.3f", $1 * 60 + $2 }')
     printf '  run: %ss\n' "$seconds"

--- a/tests/shell-profile.bats
+++ b/tests/shell-profile.bats
@@ -4,6 +4,17 @@
 setup() {
     SCRIPTS_DIR="$BATS_TEST_DIRNAME/../scripts"
     REPO_ROOT="$BATS_TEST_DIRNAME/.."
+    STUB_DIR="$BATS_TEST_TMPDIR/stub"
+}
+
+# Put a fake `bash` first on PATH that exits with $1, modelling a real
+# interactive shell: `bash -i -c exit` inherits the status of the last command
+# the profile ran, so a non-zero exit is ordinary, not a malfunction.
+stub_shell_exiting() {
+    mkdir -p "$STUB_DIR"
+    printf '#!/bin/sh\nexit %s\n' "$1" > "$STUB_DIR/bash"
+    chmod +x "$STUB_DIR/bash"
+    PATH="$STUB_DIR:$PATH"
 }
 
 @test "shell-profile.sh --help shows usage" {
@@ -48,6 +59,32 @@ setup() {
     local run_count
     run_count=$(printf '%s' "$output" | grep -c "^  run:" || true)
     [[ "$run_count" -eq 4 ]]
+}
+
+@test "time-only mode still reports stats when the shell exits non-zero" {
+    # BUG-035: the script runs under `set -euo pipefail`, so the profiled
+    # shell's non-zero exit propagated through the pipeline and aborted the run
+    # before any stats were printed. A loaded interactive profile exits non-zero
+    # routinely, which is why this reproduced on a real machine but never in CI,
+    # where a bare `bash -i -c exit` happens to return 0.
+    stub_shell_exiting 1
+
+    run "$SCRIPTS_DIR/shell-profile.sh" --shell bash --runs 2
+    [[ $status -eq 0 ]]
+    [[ "$output" == *"min:"* ]]
+    [[ "$output" == *"median:"* ]]
+    [[ "$output" == *"mean:"* ]]
+    [[ "$output" == *"max:"* ]]
+}
+
+@test "detail mode survives a shell that exits non-zero" {
+    # Same root cause on the --detail path: the profiling run is the last
+    # command before `exit 0`, so `set -e` swallowed the success exit too.
+    stub_shell_exiting 1
+
+    run "$SCRIPTS_DIR/shell-profile.sh" --shell bash --detail
+    [[ $status -eq 0 ]]
+    [[ "$output" == *"Detail profile"* ]]
 }
 
 @test ".bashrc has DOTFILES_PROFILE opt-in hook" {


### PR DESCRIPTION
Fixes #746.

## Problem

`scripts/shell-profile.sh` printed its header and exited **1** without producing any measurement:

```console
$ ./scripts/shell-profile.sh --shell bash --runs 3
Profiling bash startup (3 runs)...

$ echo $?
1
```

The script runs under `set -euo pipefail`, and both profiling paths let the profiled shell's exit status escape. An interactive shell reports the status of the last command its profile ran, so a non-zero exit is **ordinary** — not a failure to start:

```console
$ bash -i -c exit >/dev/null 2>&1; echo $?
1
```

With `pipefail` that status became the pipeline's, and `set -e` aborted right after the assignment, before the stats block ever ran.

## Fix

Scope the tolerance to the shell invocation itself, so `set -e` still guards the `awk` that parses the measurement:

- the timed run: `{ time "$SHELL_CHOICE" -i -c exit || true ; }`
- the `--detail` run, which had the **same defect** and is not mentioned in the issue: its profiling call is the last command before `exit 0`, so the abort swallowed the success path too.

## Testing

The interesting part is why this was invisible. The existing tests exercised exactly this code path and passed in CI — because a bare `bash -i -c exit` on a runner has no profile to fail and returns 0. The defect only reproduced on a machine with a loaded profile, so CI could never have caught it.

The new tests remove that host dependence: they put a stub `bash` first on PATH that exits non-zero, pinning both modes deterministically anywhere.

- `time-only mode still reports stats when the shell exits non-zero`
- `detail mode survives a shell that exits non-zero`

Both confirmed red before the fix, green after. `shellcheck -x` clean. End-to-end smoke run now completes and exits 0.

## Note

`.zshrc and .bashrc remain valid syntax with profile hook` fails in this suite on a Windows checkout, but it is **pre-existing and unrelated** — `.bashrc` is extensionless, so `.gitattributes` hands it CRLF. Filed separately as #761.
