### PR TITLE
fix(setup): survive an empty crontab on a fresh node

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -1421,7 +1421,11 @@ if command -v crontab >/dev/null 2>&1; then
     if crontab -l 2>/dev/null | grep -q "vault-maintenance-weekly"; then
         log_info "Weekly vault maintenance cron already installed"
     else
-        (crontab -l 2>/dev/null; echo "$CRON_CMD # dotfiles: vault-maintenance-weekly") | crontab -
+        # `crontab -l` exits 1 when the user has no crontab yet. Under the
+        # script's `set -euo pipefail` that kills the subshell before the echo
+        # runs, and pipefail then aborts the whole setup — so a fresh node never
+        # gets past this line. `|| true` keeps the empty-crontab case benign.
+        (crontab -l 2>/dev/null || true; echo "$CRON_CMD # dotfiles: vault-maintenance-weekly") | crontab -
         log_success "Installed weekly vault maintenance cron (Sundays 10:07)"
     fi
 else


### PR DESCRIPTION
## Summary

`setup-linux.sh` aborts partway through on any node whose user has no crontab yet.

The weekly-vault-maintenance step runs:

```bash
(crontab -l 2>/dev/null; echo "$CRON_CMD ...") | crontab -
```

`crontab -l` exits 1 when there is no crontab. Under the script's `set -euo pipefail`, `set -e` kills the **subshell** before the `echo` ever runs, and `pipefail` then propagates the non-zero status and aborts the whole setup. Adding `|| true` keeps the empty-crontab case benign.

Reproduced in isolation:

```console
$ bash -c 'set -euo pipefail; (false 2>/dev/null; echo REACHED) | cat; echo survived'
$ echo $?
1

$ bash -c 'set -euo pipefail; (false 2>/dev/null || true; echo REACHED) | cat; echo survived'
REACHED
survived
```

## Why it was never seen

The bug is invisible on any machine that already has a crontab — which is every machine this script had been run on. It only appears on a node being provisioned for the first time.

Found while provisioning ace2 through the kubelab `dev_node` Ansible role (mlorentedev/kubelab#859): the script did 37s of clean work (opencode, configs, skills all deployed) and then died at the cron step, leaving the provision red with no obvious cause.

## Test plan

- [x] Failure mode and fix reproduced in isolation (above)
- [x] Pre-commit hooks pass (secret detection, dotfiles tests)
- [ ] End-to-end: re-run the kubelab dev_node provision against ace2 (a genuinely crontab-less node) and confirm setup-linux.sh runs to completion
