### PR TITLE
chore: drop 8 Claude Code plugins with zero recorded usage

### DIFF
--- a/ai/claude/settings.json
+++ b/ai/claude/settings.json
@@ -62,18 +62,10 @@
     ]
   },
   "enabledPlugins": {
-    "code-review@claude-plugins-official": true,
-    "feature-dev@claude-plugins-official": true,
-    "code-simplifier@claude-plugins-official": true,
-    "ralph-loop@claude-plugins-official": true,
     "explanatory-output-style@claude-plugins-official": true,
     "learning-output-style@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true,
-    "claude-code-setup@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
-    "frontend-design@claude-plugins-official": true,
-    "commit-commands@claude-plugins-official": true,
-    "pr-review-toolkit@claude-plugins-official": true
+    "frontend-design@claude-plugins-official": true
   }
 }

--- a/docs/runbooks/ai-tools-setup.md
+++ b/docs/runbooks/ai-tools-setup.md
@@ -194,16 +194,23 @@ claude mcp list
 | Plugin | Purpose |
 |--------|---------|
 | `claude-mem@thedotmack` | Long-term memory across sessions |
-| `code-simplifier` | Simplify complex code |
 | `github` | GitHub API integration |
 | `security-guidance` | Security best practices |
-| `claude-md-management` | CLAUDE.md management |
-| `claude-code-setup` | Project setup assistance |
 | `frontend-design` | Frontend design |
-| `ralph-loop` | Iterative development loop |
-| `code-review` | Automated code review |
-| `commit-commands` | Git commit helpers |
-| `pr-review-toolkit` | PR review workflow |
+| `gopls-lsp` | Go language server |
+| `explanatory-output-style` | Educational insights output style |
+| `learning-output-style` | Interactive learning output style |
+
+Removed 2026-08-06 (zero invocations across all recorded session transcripts —
+superseded by a built-in or a vault-native skill, see `docs/lessons.md`):
+`code-simplifier` (-> `/simplify`), `claude-md-management` (-> `/handoff`,
+`/crystallize`, `/context-refresh`), `claude-code-setup` (-> this repo's own
+`compile-harness.sh`), `ralph-loop` (-> built-in `loop` skill), `code-review`
+plugin (-> built-in `/code-review`), `commit-commands` (-> AGENTS.md git
+Standing Orders), `pr-review-toolkit` (-> `/code-review` + `/security-review`),
+`feature-dev` (-> `architecture-session` + `writing-plans` + `executing-plans`).
+Also dropped the unmanaged duplicate `ralph-wiggum@claude-code-plugins` (never
+declared here, installed out-of-band, identical to `ralph-loop`).
 
 ### Language-Specific (Optional, per-machine)
 

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -1180,16 +1180,9 @@ if command -v claude >/dev/null 2>&1; then
     plugins_added=0
     plugins_skipped=0
     for plugin in \
-        "code-simplifier@claude-plugins-official" \
         "gopls-lsp@claude-plugins-official" \
         "security-guidance@claude-plugins-official" \
-        "claude-md-management@claude-plugins-official" \
-        "claude-code-setup@claude-plugins-official" \
-        "frontend-design@claude-plugins-official" \
-        "ralph-loop@claude-plugins-official" \
-        "code-review@claude-plugins-official" \
-        "commit-commands@claude-plugins-official" \
-        "pr-review-toolkit@claude-plugins-official"; do
+        "frontend-design@claude-plugins-official"; do
         if printf '%s' "$installed_plugins" | grep -qF "$plugin"; then
             plugins_skipped=$((plugins_skipped + 1))
         else

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -767,16 +767,9 @@ if ((Get-Command hive -ErrorAction SilentlyContinue) -and $hiveVer -and ([versio
 if ($claudeCmd) {
     Write-Info "Installing Claude Code plugins..."
     $plugins = @(
-        "code-simplifier@claude-plugins-official",
         "gopls-lsp@claude-plugins-official",
         "security-guidance@claude-plugins-official",
-        "claude-md-management@claude-plugins-official",
-        "claude-code-setup@claude-plugins-official",
-        "frontend-design@claude-plugins-official",
-        "ralph-loop@claude-plugins-official",
-        "code-review@claude-plugins-official",
-        "commit-commands@claude-plugins-official",
-        "pr-review-toolkit@claude-plugins-official"
+        "frontend-design@claude-plugins-official"
     )
     # BUG-011: wrap the read-only `claude plugin list` pre-fetch with the
     # snapshot guard -- the CLI still rewrites .claude.json on any invocation.

--- a/tests/claude-settings-template.bats
+++ b/tests/claude-settings-template.bats
@@ -90,10 +90,10 @@ setup() {
     [[ "$status" -ne 0 ]]
 }
 
-# --- enabledPlugins: 13 universal plugins, all true (was 14 pre-BUG-007) ---
+# --- enabledPlugins: 5 universal plugins, all true (was 13 pre-usage-audit) ---
 
-@test "template enabledPlugins has exactly 13 universal plugins" {
-    [[ "$(jq '.enabledPlugins | length' "$SETTINGS_TEMPLATE")" == "13" ]]
+@test "template enabledPlugins has exactly 5 universal plugins" {
+    [[ "$(jq '.enabledPlugins | length' "$SETTINGS_TEMPLATE")" == "5" ]]
 }
 
 @test "template enabledPlugins values all set to true" {
@@ -101,32 +101,42 @@ setup() {
 }
 
 @test "template enabledPlugins includes core plugins from the existing user setup" {
-    # Sample 5 representative plugins. Asserting a sample catches accidental
-    # removal while keeping the test list maintainable. (`github` was on this
-    # list pre-BUG-007; replaced with `feature-dev` which is also widely used.)
-    jq -e '.enabledPlugins["code-review@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
-    jq -e '.enabledPlugins["commit-commands@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
-    jq -e '.enabledPlugins["feature-dev@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
-    jq -e '.enabledPlugins["pr-review-toolkit@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
-    jq -e '.enabledPlugins["claude-md-management@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
+    # Exactly 5 remain (not a sample) — each has recorded usage: security-guidance
+    # and gopls-lsp have real saved findings/diagnostics; the output-style pair
+    # drives the current session mode; frontend-design has no substitute yet.
+    jq -e '.enabledPlugins["security-guidance@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
+    jq -e '.enabledPlugins["gopls-lsp@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
+    jq -e '.enabledPlugins["frontend-design@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
+    jq -e '.enabledPlugins["explanatory-output-style@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
+    jq -e '.enabledPlugins["learning-output-style@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
 }
 
-# Inverse assertion (BUG-007, incident → guard pattern from SDD-006):
-# `github@claude-plugins-official` is broken/unused and was removed. CI MUST
-# fail if it ever returns to the template (accidental re-add, copy-paste
-# from old docs, etc.). The setup scripts' plugin install loop is checked
-# below as a cross-OS parity guard.
-@test "template enabledPlugins must NOT include github (BUG-007 removed)" {
-    run jq -e '.enabledPlugins["github@claude-plugins-official"]' "$SETTINGS_TEMPLATE"
-    [ "$status" -ne 0 ]
+# Inverse assertions (BUG-007, incident → guard pattern from SDD-006):
+# these plugins were removed for zero recorded usage across every saved
+# session transcript (2026-08-06 audit) or, for `github`, being broken
+# (BUG-007). CI MUST fail if any returns to the template (accidental re-add,
+# copy-paste from old docs, etc.). The setup scripts' plugin install loops
+# are checked below as a cross-OS parity guard.
+@test "template enabledPlugins must NOT include plugins removed for zero usage" {
+    for plugin in github code-simplifier claude-md-management claude-code-setup \
+        ralph-loop code-review commit-commands pr-review-toolkit feature-dev; do
+        run jq -e ".enabledPlugins[\"${plugin}@claude-plugins-official\"]" "$SETTINGS_TEMPLATE"
+        [ "$status" -ne 0 ]
+    done
 }
 
-@test "setup-linux.sh plugin install loop must NOT include github (BUG-007 removed)" {
-    ! grep -qE '"github@claude-plugins-official"' "$DOTFILES_DIR/setup-linux.sh"
+@test "setup-linux.sh plugin install loop must NOT include plugins removed for zero usage" {
+    for plugin in github code-simplifier claude-md-management claude-code-setup \
+        ralph-loop code-review commit-commands pr-review-toolkit feature-dev; do
+        ! grep -qE "\"${plugin}@claude-plugins-official\"" "$DOTFILES_DIR/setup-linux.sh"
+    done
 }
 
-@test "setup-windows.ps1 plugin install loop must NOT include github (BUG-007 removed)" {
-    ! grep -qE '"github@claude-plugins-official"' "$DOTFILES_DIR/setup-windows.ps1"
+@test "setup-windows.ps1 plugin install loop must NOT include plugins removed for zero usage" {
+    for plugin in github code-simplifier claude-md-management claude-code-setup \
+        ralph-loop code-review commit-commands pr-review-toolkit feature-dev; do
+        ! grep -qE "\"${plugin}@claude-plugins-official\"" "$DOTFILES_DIR/setup-windows.ps1"
+    done
 }
 
 # --- Negative assertions: user/machine-specific keys MUST NOT be in template ---


### PR DESCRIPTION
Audited plugin usage by grepping all 41 saved session transcripts (`~/.claude/projects/`) for real Skill/Agent/slash-command invocations — not just whether the plugin was installed. None of these 8 ever fired, across the full recorded history:

- `code-simplifier` -> built-in `/simplify`
- `claude-md-management` -> `/handoff`, `/crystallize`, `/context-refresh` (vault-native, actively used)
- `claude-code-setup` -> this repo's own `compile-harness.sh`
- `ralph-loop` -> built-in `loop` skill
- `code-review` (plugin) -> built-in `/code-review` (multi-level, cloud "ultra" mode)
- `commit-commands` -> AGENTS.md git Standing Orders
- `pr-review-toolkit` -> `/code-review` + `/security-review`
- `feature-dev` -> `architecture-session` + `writing-plans` + `executing-plans`

Kept: `security-guidance` and `gopls-lsp` (both have real recorded activity — security-guidance has 8 saved finding-state files, gopls-lsp has a real diagnostic captured in a past dotfiles session), `explanatory-output-style`/`learning-output-style` (drive the current session's output mode), and `frontend-design` (no clear substitute, left for a separate decision).

Also removes the now-stale table rows in `docs/runbooks/ai-tools-setup.md` and updates both install scripts (`setup-linux.sh`, `setup-windows.ps1`) plus `ai/claude/settings.json` `enabledPlugins` so a fresh machine doesn't reinstall them.