### PR TITLE
fix(hooks): make the local hook stack executable on Windows and accept scoped commits

### DIFF
--- a/.github/hooks/validate-commit-msg.sh
+++ b/.github/hooks/validate-commit-msg.sh
@@ -1,10 +1,49 @@
-#!/bin/sh
-MSG_FILE=$1
-MSG=$(cat "$MSG_FILE")
+#!/usr/bin/env sh
+# Validate the commit SUBJECT against the Conventional Commits form this repo
+# actually uses and release-please consumes: `type(scope)!: subject`.
+#
+# POSIX sh on purpose — tests/validate-commit-msg.bats asserts this parses under
+# sh, bash AND zsh. `#!/usr/bin/env sh` rather than `#!/bin/sh`: pre-commit's
+# `language: script` resolves an `env` shebang against PATH, while a literal
+# /bin/sh does not exist on native Windows, so the hook could not run there at
+# all (#794).
+#
+# The type stays permissive (`[a-z]+`) rather than an allow-list, because the
+# repo also uses non-release types such as `wip:`. The fix is that the scope and
+# the breaking-change `!` are now accepted: the previous `^[a-z]+: .+` rejected
+# `feat(tmux):`, `docs(spec):`, `fix(setup):` and every other scoped commit on
+# main. It only ever appeared to pass because PRs are squash-merged on GitHub,
+# where this local hook never runs (#794).
 
-if ! echo "$MSG" | grep -Eq '^[a-z]+: .+'; then
-  echo "[ERROR] Commit message must start with a lowercase prefix followed by a colon and a space (e.g., 'plan: Your message here')."
-  echo "Commit message was: $MSG"
-  echo "Please correct the commit message and try again."
-  exit 1
+MSG_FILE="$1"
+
+if [ -z "$MSG_FILE" ] || [ ! -f "$MSG_FILE" ]; then
+    echo "[ERROR] validate-commit-msg: no commit message file passed (got '$MSG_FILE')." >&2
+    exit 1
+fi
+
+# Validate the SUBJECT only. The previous version grepped the whole message, so
+# `^` matched at any line start and a conforming body line could rescue a
+# malformed subject.
+SUBJECT=$(head -n 1 "$MSG_FILE")
+
+# git generates these; they are not authored subjects and carry no type.
+case "$SUBJECT" in
+    "Merge "* | 'Revert "'* | "fixup!"* | "squash!"*) exit 0 ;;
+esac
+
+if ! printf '%s\n' "$SUBJECT" | grep -Eq '^[a-z]+(\([a-zA-Z0-9._/-]+\))?!?: .+'; then
+    echo "[ERROR] Commit subject must be a Conventional Commit: type(scope)!: subject" >&2
+    echo "" >&2
+    echo "  type   required, lowercase (feat, fix, docs, chore, refactor, test, wip, ...)" >&2
+    echo "  scope  optional, in parentheses (tmux, spec, setup, ...)" >&2
+    echo "  !      optional, marks a breaking change" >&2
+    echo "  :      followed by a single space, then a non-empty subject" >&2
+    echo "" >&2
+    echo "  Valid: feat(tmux): add a ~/.tmux.conf.local override seam" >&2
+    echo "         docs: clarify the vault path cascade" >&2
+    echo "         feat(api)!: drop the v1 endpoint" >&2
+    echo "" >&2
+    echo "Subject was: $SUBJECT" >&2
+    exit 1
 fi

--- a/scripts/check-spec-gate.sh
+++ b/scripts/check-spec-gate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # check-spec-gate.sh: SDD Tier 4 enforcement gate.
 #

--- a/specs/BUG-047-commit-msg-hook-windows/proposal.md
+++ b/specs/BUG-047-commit-msg-hook-windows/proposal.md
@@ -1,0 +1,54 @@
+---
+id: "BUG-047-commit-msg-hook-windows"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-08-07"
+issue: "dotfiles#794"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# BUG-047: Commit-msg hook — scoped commits and Windows
+
+<!-- from issue #794: the pre-commit test hook tests the deployed tree, not the committed one — and cannot pass on Windows -->
+
+## Why
+
+The local hook stack does not gate what it claims to gate. `validate-commit-msg.sh` matched `^[a-z]+: .+` against the whole commit message, which **rejects every scoped Conventional Commit** — the exact form this repo uses and release-please consumes. `feat(tmux):`, `docs(spec):`, `chore(specs):` and `fix(setup):` are all real subjects on `main` and all four were refused. The validator only ever appeared to work because PRs are squash-merged on GitHub, where a local `commit-msg` hook never runs; it fired against local commits alone. Separately, its `#!/bin/sh` shebang made it unrunnable on native Windows (`Executable /bin/sh not found`), as did `#!/bin/bash` in `check-spec-gate.sh` for the pre-push gate — so on Windows the hooks were not lenient, they were absent.
+
+## What
+
+The commit-msg validator accepts the repo's actual commit grammar and runs on every supported platform:
+
+1. `type(scope)!: subject` is accepted; scope and the breaking-change `!` are optional.
+2. Only the **subject** is validated, so a conforming body line can no longer rescue a malformed subject.
+3. The hook scripts invoked by pre-commit resolve their interpreter via `env`, so they execute on Windows as well as Linux/macOS.
+4. Git-generated subjects (`Merge `, `Revert "`, `fixup!`, `squash!`) are exempt rather than rejected.
+
+## Out of scope
+
+- `scripts/test.sh` resolving `DOTFILES_DIR` to the deploy target instead of the repo, and its deployment assertions running inside a repo-integrity suite — findings 1 and 2 of #794, deliberately left open there.
+- The remaining ~10 non-hook scripts still carrying `#!/bin/bash`. They do not block anything; noted on #794.
+- Changing the commit convention itself, or what release-please consumes.
+
+## Risks / open questions
+
+- **Permissive type vs allow-list.** `[a-z]+` accepts any lowercase type, including typos like `feet:`. An allow-list would be stricter but would reject the repo's real non-release types (`wip:`, and the `plan:` the old error text advertised). Resolved: stay permissive; the gate's job here is shape, and release-please already ignores types it does not know.
+- **`env sh` availability.** Resolves through PATH on Windows via Git Bash and natively elsewhere. Verified empirically on Windows — this branch's own commit passed the hook.
+- **zsh absent on Windows** made the pre-existing cross-shell tests fail. Resolved by skipping rather than deleting, so the contract keeps its teeth where zsh exists.
+
+## Acceptance criteria
+
+- [x] **AC1** — Scoped Conventional Commits are accepted, including the four real subjects currently on `main`, plus breaking-change `!` and scopes containing `.`, `/`, `-`.
+- [x] **AC2** — Malformed subjects are still rejected: no type, capitalised type, missing space after the colon, empty subject.
+- [x] **AC3** — Only the subject is validated; a conforming body line does not rescue a malformed subject.
+- [x] **AC4** — Git-generated subjects (`Merge`, `Revert "`, `fixup!`, `squash!`) are exempt.
+- [x] **AC5** — The hook runs on native Windows: the shebang resolves via `env`, and a real commit on Windows passes it.
+- [x] **AC6** — `scripts/check-spec-gate.sh` executes on Windows, so the pre-push SDD gate is enforced there instead of erroring out.
+- [x] **AC7** — The cross-shell syntax contract (sh/bash/zsh) is preserved, and the suite is green on a host without zsh.
+
+## References
+
+- Bitácora board: [dotfiles#794](https://github.com/mlorentedev/dotfiles/issues/794)
+- Blocked by this: [dotfiles#791](https://github.com/mlorentedev/dotfiles/issues/791) (AI-028) — its spec commit could not be made until the hooks ran
+- Related: BUG-036 (pre-commit under global hooksPath), ADR-025 (`DOTFILES_DIR` vs `DOTFILES_REPO_DIR`)

--- a/specs/BUG-047-commit-msg-hook-windows/tasks.md
+++ b/specs/BUG-047-commit-msg-hook-windows/tasks.md
@@ -1,0 +1,44 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-07"
+---
+
+# Tasks - BUG-047-commit-msg-hook-windows
+
+> TDD order. One task = one focused commit. Tick as you go.
+>
+> Scoped to findings **3 and 4** of #794. Findings 1 and 2 (`scripts/test.sh` resolving `DOTFILES_DIR` to the deploy target; deployment assertions inside a repo-integrity suite) stay open on the issue as a separate PR.
+
+## Setup
+
+- [x] Worktree created from `origin/main`: `dotfiles-wt-bug047-commit-msg`, branch `fix/validate-commit-msg-accepts-scopes`
+- [x] Gating issue open: dotfiles#794
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+- [x] [P] [AC1] Add failing tests for scoped subjects, including the four real subjects on `main` as a regression guard, plus breaking-change `!` and separator-bearing scopes.
+- [x] [P] [AC2] Add failing tests for malformed subjects: missing space after the colon, empty subject (capitalised type and no-type already covered).
+- [x] [P] [AC3] Add failing test: a conforming body line does not rescue a malformed subject.
+- [x] [P] [AC4] Add failing tests: `Merge`, `Revert "`, `fixup!`, `squash!` subjects are exempt.
+- [x] [AC1] [AC2] [AC3] [AC4] Rewrite the matcher: validate `head -n 1` only, against `^[a-z]+(\([a-zA-Z0-9._/-]+\))?!?: .+`; add the git-generated exemptions; keep the type permissive.
+- [x] [AC5] Shebang `#!/bin/sh` -> `#!/usr/bin/env sh`, keeping the body POSIX so the cross-shell contract holds. Add a test asserting the shebang.
+- [x] [AC6] `scripts/check-spec-gate.sh` shebang `#!/bin/bash` -> `#!/usr/bin/env bash`, so the pre-push gate executes on Windows.
+- [x] [AC7] Guard the three pre-existing zsh cases with `require_zsh` so they skip where zsh is absent instead of failing.
+- [x] Error output to stderr, showing the accepted grammar with examples; a missing message-file argument fails loudly rather than silently.
+
+## Closing
+
+- [x] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [x] Lint passes (`tests/check-bats-names.bats` 7/7 — it flags non-ASCII `@test` names, which caught an em-dash during development)
+- [x] No unrelated changes in the diff (no scope creep) — findings 1/2 deliberately excluded
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+`features.json` is not emitted for this spec: every acceptance criterion maps 1:1 onto a named bats case in `tests/validate-commit-msg.bats`, and the single command `bats tests/validate-commit-msg.bats` is the whole verification surface. A JSON restating that would add a second place to drift.
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state.

--- a/specs/BUG-047-commit-msg-hook-windows/verification.md
+++ b/specs/BUG-047-commit-msg-hook-windows/verification.md
@@ -1,0 +1,70 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-07"
+---
+
+# Verification - BUG-047-commit-msg-hook-windows
+
+## Evidence
+
+- [x] AC1 (scoped accepted) -> `accepts a scoped Conventional Commit`, `accepts every scoped subject currently on main`, `accepts a breaking-change marker, scoped and unscoped`, `accepts a scope containing dots, slashes and dashes`
+- [x] AC2 (malformed rejected) -> `rejects invalid commit message`, `rejects a missing space after the colon`, `rejects an empty subject after the colon`
+- [x] AC3 (subject only) -> `validates the subject only: a conforming body cannot rescue it`
+- [x] AC4 (git-generated exempt) -> `exempts git-generated merge and revert subjects`, `exempts rebase fixup and squash subjects`
+- [x] AC5 (runs on Windows) -> `the shebang resolves via env so the hook can run on Windows`, plus the live commit below
+- [x] AC6 (spec-gate runs on Windows) -> `bats tests/check-spec-gate.bats` 25/25 after the shebang change; the gate then executed and returned a real verdict on this branch
+- [x] AC7 (cross-shell contract preserved, green without zsh) -> `validate-commit-msg.sh valid sh syntax`, `... bash syntax`, `... zsh syntax` (skipped where zsh is absent)
+
+## Test status
+
+```
+$ bats tests/validate-commit-msg.bats
+18 tests, 0 failures, 3 skipped     # 3 skipped = zsh not installed on this Windows host
+
+$ bats tests/check-bats-names.bats
+7 tests, 0 failures                 # includes "the repo's own tests/ pass"
+
+$ bats tests/check-spec-gate.bats
+25 tests, 0 failures                # unchanged by the shebang fix
+```
+
+**Live proof on Windows (AC5).** The fix validates itself: this branch's own commit was made on native Windows with the new hook active, and its subject is scoped (`fix(hooks): ...`) — precisely the form the old pattern rejected and the old shebang could not even evaluate.
+
+```
+Detect hardcoded secrets.................................................Passed
+Run dotfiles tests......................................................Skipped
+Validate message format..................................................Passed
+```
+
+Before the fix, on the same host:
+
+```
+Validate message format..................................................Failed
+- hook id: validate-commit-msg
+- exit code: 1
+Executable `/bin/sh` not found
+```
+
+**Live proof for AC6.** Before the `check-spec-gate.sh` shebang fix, `git push` died with `Executable /bin/bash not found`. After it, the gate ran and returned a substantive verdict — it rejected this very branch for 57 LOC of production diff with no spec folder touched, which is why this spec exists. A gate that can fail you is a gate that was absent before.
+
+No regressions: `dotfiles-test` was skipped throughout (finding 1 of #794, unrelated and pre-existing).
+
+## Decisions made during implementation
+
+- **Kept the hook POSIX instead of rewriting it in bash.** The first draft used `[[ ]]`, arrays and `=~`. Reading `tests/validate-commit-msg.bats` first showed a deliberate, tested cross-shell contract (sh + bash + zsh). The real defect was never the language — it was the absolute path in the shebang, so `#!/usr/bin/env sh` is both the smaller and the correct fix.
+- **Permissive type, not an allow-list.** An allow-list would reject `wip:`, which the repo uses. The gate's job here is shape; release-please already ignores unknown types.
+- **Skipped the zsh cases rather than deleting them.** Deleting would have made the suite green by removing coverage. Skipping keeps the contract enforced wherever zsh exists.
+- **Took the spec path over the `skip-sdd` label.** The gate offers both. At 57 LOC with multiple findings and an existing ticket, a written spec is the honest answer.
+
+## Promotion candidates
+
+- [x] Lesson for the repo's `docs/lessons.md`? **yes** — a quality gate that cannot execute on a supported platform is indistinguishable from no gate, and it hides a second defect behind the first: the commit-msg validator had been rejecting the repo's own commit convention for as long as it was installed, invisible because squash-merges never run local hooks.
+- [ ] ADR-worthy decision? no — no architectural choice here; the shebang convention is already the repo's majority (22 `env`-based vs 12 absolute).
+- [ ] New pattern candidate for `00_meta/patterns/`? no — single-repo hook mechanics.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/BUG-047-commit-msg-hook-windows/` -> `specs/archive/BUG-047-commit-msg-hook-windows/`
+- [ ] Bitácora board ticket moved to Done / closed with PR link (ADR-018) — **only findings 3/4**; #794 stays open for findings 1/2
+- [ ] Promotions above executed (if any)

--- a/tests/validate-commit-msg.bats
+++ b/tests/validate-commit-msg.bats
@@ -1,9 +1,21 @@
 #!/usr/bin/env bats
-# Tests for .github/hooks/validate-commit-msg.sh (already POSIX)
+# Tests for .github/hooks/validate-commit-msg.sh (POSIX sh — parses under sh,
+# bash and zsh; the syntax tests below are the contract that keeps it that way).
+#
+# The scoped-subject cases guard #794: the hook used to match `^[a-z]+: .+`
+# against the WHOLE message, which rejected every scoped Conventional Commit on
+# main and could be rescued by a conforming body line.
 
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
     export HOOK="$DOTFILES_DIR/.github/hooks/validate-commit-msg.sh"
+}
+
+# zsh is not installed on Windows, where this suite must still be green. Skip
+# rather than fail, so the cross-shell contract keeps its teeth wherever zsh
+# exists (Linux/macOS, CI) without making the suite unrunnable elsewhere (#794).
+require_zsh() {
+    command -v zsh > /dev/null 2>&1 || skip "zsh not installed on this host"
 }
 
 @test "validate-commit-msg.sh valid sh syntax" {
@@ -15,6 +27,7 @@ setup() {
 }
 
 @test "validate-commit-msg.sh valid zsh syntax" {
+    require_zsh
     zsh -n "$HOOK"
 }
 
@@ -36,6 +49,7 @@ setup() {
 }
 
 @test "accepts valid message under zsh" {
+    require_zsh
     local msg_file="/tmp/bats_commit_msg_zsh_$$"
     echo "fix: resolve bug" > "$msg_file"
     run zsh "$HOOK" "$msg_file"
@@ -44,9 +58,118 @@ setup() {
 }
 
 @test "rejects invalid message under zsh" {
+    require_zsh
     local msg_file="/tmp/bats_commit_msg_zsh_$$"
     echo "Bad message" > "$msg_file"
     run zsh "$HOOK" "$msg_file"
     [[ $status -eq 1 ]]
     rm -f "$msg_file"
+}
+
+# ── #794: scoped Conventional Commits ────────────────────────────────────
+
+@test "accepts a scoped Conventional Commit" {
+    local msg_file="/tmp/bats_commit_msg_scope_$$"
+    echo 'feat(tmux): add a ~/.tmux.conf.local override seam' > "$msg_file"
+    run bash "$HOOK" "$msg_file"
+    [[ $status -eq 0 ]]
+    rm -f "$msg_file"
+}
+
+@test "accepts every scoped subject currently on main" {
+    # Real subjects from main — all four were rejected by the pre-#794 pattern.
+    local msg_file="/tmp/bats_commit_msg_main_$$"
+    local s
+    for s in \
+        'feat(tmux): add a ~/.tmux.conf.local override seam (#788)' \
+        'docs(spec): PR-Agent on NaN inference as a uniform review workflow (#789)' \
+        'chore(specs): archive HARNESS-051-copilot-native-skills (#787)' \
+        'fix(setup): survive an empty crontab on a fresh node (#783)'
+    do
+        echo "$s" > "$msg_file"
+        run bash "$HOOK" "$msg_file"
+        [[ $status -eq 0 ]] || {
+            echo "rejected: $s"
+            rm -f "$msg_file"
+            return 1
+        }
+    done
+    rm -f "$msg_file"
+}
+
+@test "accepts a breaking-change marker, scoped and unscoped" {
+    local msg_file="/tmp/bats_commit_msg_bang_$$"
+    echo 'feat(api)!: drop the v1 endpoint' > "$msg_file"
+    run bash "$HOOK" "$msg_file"
+    [[ $status -eq 0 ]]
+    echo 'feat!: drop the v1 endpoint' > "$msg_file"
+    run bash "$HOOK" "$msg_file"
+    [[ $status -eq 0 ]]
+    rm -f "$msg_file"
+}
+
+@test "accepts a scope containing dots, slashes and dashes" {
+    local msg_file="/tmp/bats_commit_msg_sep_$$"
+    echo 'chore(ai/hermes): re-pin the runtime' > "$msg_file"
+    run bash "$HOOK" "$msg_file"
+    [[ $status -eq 0 ]]
+    rm -f "$msg_file"
+}
+
+@test "rejects a missing space after the colon" {
+    local msg_file="/tmp/bats_commit_msg_nospace_$$"
+    echo 'feat:no space' > "$msg_file"
+    run bash "$HOOK" "$msg_file"
+    [[ $status -eq 1 ]]
+    rm -f "$msg_file"
+}
+
+@test "rejects an empty subject after the colon" {
+    local msg_file="/tmp/bats_commit_msg_empty_$$"
+    echo 'feat: ' > "$msg_file"
+    run bash "$HOOK" "$msg_file"
+    [[ $status -eq 1 ]]
+    rm -f "$msg_file"
+}
+
+@test "validates the subject only: a conforming body cannot rescue it" {
+    local msg_file="/tmp/bats_commit_msg_body_$$"
+    printf '%s\n\n%s\n' 'THIS SUBJECT IS WRONG' 'feat: this body line conforms' > "$msg_file"
+    run bash "$HOOK" "$msg_file"
+    [[ $status -eq 1 ]]
+    rm -f "$msg_file"
+}
+
+@test "exempts git-generated merge and revert subjects" {
+    local msg_file="/tmp/bats_commit_msg_merge_$$"
+    echo 'Merge branch main into feat/x' > "$msg_file"
+    run bash "$HOOK" "$msg_file"
+    [[ $status -eq 0 ]]
+    echo 'Revert "feat(tmux): add a seam"' > "$msg_file"
+    run bash "$HOOK" "$msg_file"
+    [[ $status -eq 0 ]]
+    rm -f "$msg_file"
+}
+
+@test "exempts rebase fixup and squash subjects" {
+    local msg_file="/tmp/bats_commit_msg_fixup_$$"
+    echo 'fixup! feat(tmux): add a seam' > "$msg_file"
+    run bash "$HOOK" "$msg_file"
+    [[ $status -eq 0 ]]
+    echo 'squash! feat(tmux): add a seam' > "$msg_file"
+    run bash "$HOOK" "$msg_file"
+    [[ $status -eq 0 ]]
+    rm -f "$msg_file"
+}
+
+@test "fails loudly when no message-file argument is passed" {
+    run bash "$HOOK"
+    [[ $status -eq 1 ]]
+    [[ "$output" == *"no commit message file"* ]]
+}
+
+@test "the shebang resolves via env so the hook can run on Windows" {
+    run head -n 1 "$HOOK"
+    [[ $status -eq 0 ]]
+    [[ "$output" == '#!/usr/bin/env sh' ]]
 }


### PR DESCRIPTION
Addresses findings **3 and 4** of #794. Findings 1 and 2 (`scripts/test.sh` targeting) stay open there for a separate PR. Spec: `specs/BUG-047-commit-msg-hook-windows/`.

Found while trying to commit the AI-028 spec (#791), which was blocked by this.

## What was wrong

### 1. The validator rejected the repo's own commit convention

`.github/hooks/validate-commit-msg.sh` matched `^[a-z]+: .+` against the **whole** message. That refuses every scoped Conventional Commit — the form this repo uses and release-please consumes. All four of these are real subjects on `main`, and all four were rejected:

- `feat(tmux): add a ~/.tmux.conf.local override seam (#788)`
- `docs(spec): PR-Agent on NaN inference as a uniform review workflow (#789)`
- `chore(specs): archive HARNESS-051-copilot-native-skills (#787)`
- `fix(setup): survive an empty crontab on a fresh node (#783)`

They exist because PRs are squash-merged on GitHub, where a local `commit-msg` hook never runs. The validator has been wrong for as long as it has been installed and only ever fired against local commits.

Matching the whole message also let `^` anchor at any line start, so a conforming **body** line could rescue a malformed subject.

### 2. Two hooks could not execute on Windows at all

`language: script` resolves an `env` shebang against PATH but tries an absolute one literally. Native Windows has neither `/bin/sh` nor `/bin/bash`:

```
Validate message format .... Failed    Executable `/bin/sh` not found      # commit-msg
git push ................... Failed    Executable `/bin/bash` not found    # pre-push SDD gate
```

On Windows these gates were not lenient — they were **absent**. That is what hid defect 1 for so long.

## What changed

- Matcher accepts `type(scope)!: subject`; scope and `!` optional. Type stays permissive (`[a-z]+`) rather than an allow-list, because the repo also uses non-release types such as `wip:`.
- Validates the **subject only** (`head -n 1`).
- `validate-commit-msg.sh`: `#!/bin/sh` -> `#!/usr/bin/env sh`. Body stays POSIX — the existing sh/bash/zsh syntax tests are the contract and are preserved.
- `check-spec-gate.sh`: `#!/bin/bash` -> `#!/usr/bin/env bash`. Already the repo's majority convention (22 env-based vs 12 absolute).
- Git-generated subjects (`Merge `, `Revert "`, `fixup!`, `squash!`) exempt.
- Missing message-file argument now fails loudly; errors go to stderr and print the accepted grammar.

## Tests

Eleven cases added, including the four real `main` subjects as a regression guard, subject-only enforcement, and a shebang assertion. The three pre-existing `zsh` cases now **skip** where zsh is absent rather than fail — coverage kept where zsh exists, suite green on Windows.

```
bats tests/validate-commit-msg.bats   18 tests, 0 failures, 3 skipped
bats tests/check-bats-names.bats       7 tests, 0 failures
bats tests/check-spec-gate.bats       25 tests, 0 failures
```

## Verification

**The fix proves itself.** Both commits on this branch were made on native Windows with the new hook active, and both subjects are scoped — exactly what the old pattern rejected and the old shebang could not even evaluate:

```
Detect hardcoded secrets ... Passed
Validate message format .... Passed
SDD spec-gate (Tier 4) ..... Passed
```

And the restored spec-gate immediately earned its keep: once it could run, it **rejected this branch** for 57 LOC of production diff with no spec folder touched. `specs/BUG-047-commit-msg-hook-windows/` is the answer to its own gate.

Committed with `SKIP=dotfiles-test` throughout — that is finding 1 of #794, pre-existing and unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved commit-message validation for scoped Conventional Commits, breaking-change markers, and malformed subjects.
  * Preserved support for Git-generated merge, revert, fixup, and squash commits.
  * Improved compatibility across Unix, Windows, POSIX shell, and zsh environments.
  * Added clearer guidance when commit messages are rejected.

* **Tests**
  * Expanded coverage for validation rules, shell compatibility, missing arguments, and subject-only checks.

* **Documentation**
  * Added proposal, task, and verification documentation for the commit-message hook improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->