### PR TITLE
fix(hive-upgrade): distinguish a missing install from an idle no-op (AI-028 PR1)

### DIFF
--- a/specs/AI-028-hive-install-model-migration/proposal.md
+++ b/specs/AI-028-hive-install-model-migration/proposal.md
@@ -1,0 +1,61 @@
+---
+id: "AI-028-hive-install-model-migration"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-07"
+issue: "dotfiles#791"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# AI-028: Hive install model migration
+
+<!-- from issue #791: AI-028: hive bootstrap, daemon activation and auto-upgrade all silently no-op when the uv-tool install is gone -->
+
+## Why
+
+Four mechanisms in this repo — the MCP `prerequisite_command`, the daemon-activation version gate, the 15-minute upgrade timer, and by transitivity hive's A3 versioned layout — all infer *"is hive installed?"* from `uv tool list`. When that install disappeared on the maintainer's Windows box, all four degraded to a **silent no-op**: the scheduled task has reported `LastTaskResult: 0` every 15 minutes for months while doing nothing, no `HiveVaultDaemon` task was ever registered, and the Claude MCP `hive` entry points at an orphaned uv trampoline that cannot start. The vault has been unreachable from Claude Code on that machine and nothing said so. The same failure is already documented in `docs/troubleshooting/hive-mcp-orphaned-trampoline.md` (2026-06-29) with a manual recipe — it has now recurred, which is the evidence that a manual recipe is not a fix.
+
+## What
+
+The install model stops being "a uv tool that dotfiles upgrades in place" and becomes "a versioned layout hive owns, that dotfiles bootstraps and triggers". Observable after this change:
+
+1. `windows/hive-upgrade.ps1` **reports** when it finds no install, instead of exiting 0 in silence. "Already current" stays quiet by design; "no install found" is loud.
+2. Setup **bootstraps** hive on a machine that has none, deterministically and without a pre-existing `hive` binary, via `uvx --from hive-vault hive self-upgrade`.
+3. The steady-state upgrade trigger is a bare `hive self-upgrade` (A3 junction swap — no daemon stop needed), replacing the A1 stop-upgrade-start orchestration.
+4. `AI-022`'s recorded A1 decision no longer contradicts hive's shipped A3.
+
+## Out of scope
+
+- **MCP registration across agent clients** → AI-029 (dotfiles#792). This spec does not touch which clients use the daemon.
+- **Detection/repair of an already-broken install** → #574 (HARNESS-049), `dotf doctor --fix`. Complementary safety net; neither subsumes the other.
+- **Hive's own launcher + `_resolve_exec()` hardening** → [hive#328](https://github.com/mlorentedev/hive/issues/328). This spec consumes that fix; it does not implement it.
+- macOS / launchd activation.
+
+## Risks / open questions
+
+- **Hive builds the layout but installs no PATH launcher — RESOLVED as a dependency, not a blocker for all of it.** `src/hive/_runtime.py` creates `versions/<v>` and flips the `current` junction, then stops; nothing puts `<current>/Scripts/hive.exe` on PATH. Worse, `_service.py:63` `_resolve_exec()` does a bare `shutil.which("hive")`, which on the broken machine returns the dead trampoline — so `hive service install` would register a daemon pointed at a binary that cannot start. Filed as hive#328. **PR2 is gated on it; PR1 and PR3 are not.**
+- **Bootstrap chicken-and-egg — RESOLVED, verified empirically.** `pyproject.toml:77-78` ships both a `hive` and a `hive-vault` console script for the same `hive.server:main`, so `uvx --from hive-vault hive --version` works with no prior install (`hive-vault 1.43.0`, rc=0, 2026-08-07). `_runtime.build_version()` is pure `uv venv` + `uv pip install --python <venv> hive-vault==<v>`, so the only prerequisite is `uv` — which `mcp-servers.json` already declares via `prerequisite_binary`.
+- **The script under test is a deployed copy.** `~/.claude/scripts/hive-upgrade.ps1` is deployed by setup from the SSOT at `windows/hive-upgrade.ps1`. Verification must exercise the SSOT (or re-deploy first), or a stale copy will read as a pass.
+- **Linux path.** A3 is a Windows mechanism (in-use-file locking does not apply on POSIX). `ai/hermes/setup.sh:83` and `setup-linux.sh` plausibly keep `uv tool`. [AGENT-DRAFT — review before archive] Proposed resolution: Linux keeps `uv tool install --upgrade`, and the decision is recorded explicitly in this spec and in the amended `AI-022`, so it is a choice rather than an omission.
+- **Blast radius.** This changes how the maintainer's daily hive install resolves on Windows. Mitigated by the stdio fallback remaining available throughout, and by PR1 landing independently of the model change.
+
+## Acceptance criteria
+
+- [ ] **AC1** — `windows/hive-upgrade.ps1` emits a distinguishable, non-empty message when no hive install is found, and stays silent when the install is present and already current. Asserted by `tests/hive-upgrade-timer.bats`, not by convention.
+- [ ] **AC2** — On a machine with no hive install and no `hive` on PATH, setup bootstraps a working install; `hive --version` succeeds from a fresh shell afterwards.
+- [ ] **AC3** — The steady-state upgrade trigger is a bare `hive self-upgrade` with no daemon stop/start orchestration, and re-running it when already current is a no-op.
+- [ ] **AC4** — No mechanism in this repo infers "hive is installed" from `uv tool list` alone on the Windows path.
+- [ ] **AC5** — `AI-022`'s A1 decision is reconciled with hive's shipped A3, and archived `AI-023` carries a forward pointer; ADR-015 is referenced consistently.
+- [ ] **AC6** — The Linux path is explicitly decided and documented, not left implicit.
+- [ ] **AC7** — On the maintainer's currently-broken Windows box, all four before-state symptoms flip (see `verification.md`), and Claude Code's `hive` MCP entry resolves to a working binary.
+
+## References
+
+- Bitácora board: [dotfiles#791](https://github.com/mlorentedev/dotfiles/issues/791)
+- Sibling spec: AI-029 / [dotfiles#792](https://github.com/mlorentedev/dotfiles/issues/792) — MCP registration SSOT
+- Upstream dependency: [hive#328](https://github.com/mlorentedev/hive/issues/328) — PATH launcher + `_resolve_exec()` hardening
+- Safety net: [dotfiles#574](https://github.com/mlorentedev/dotfiles/issues/574) (HARNESS-049) — `dotf doctor --fix`
+- Predecessors: `specs/AI-022-hive-daemon-activation/`, `specs/archive/AI-023-hive-auto-upgrade-timer/`
+- hive: `specs/HIVE-267-upgrade-swap/` (A3 mechanism), `docs/adr/adr-015-windows-daemon-supervision-upgrade.md` (`proposed`), [hive#292](https://github.com/mlorentedev/hive/issues/292), [hive#176](https://github.com/mlorentedev/hive/issues/176)
+- Troubleshooting: `docs/troubleshooting/hive-mcp-orphaned-trampoline.md`

--- a/specs/AI-028-hive-install-model-migration/tasks.md
+++ b/specs/AI-028-hive-install-model-migration/tasks.md
@@ -20,10 +20,12 @@ created: "2026-08-07"
 
 ### PR1 — loud-vs-quiet failure (AC1) — independent, ships first
 
-- [ ] [P] [AC1] Write failing test in `tests/hive-upgrade-timer.bats`: with no hive install resolvable, the script emits a non-empty message naming the condition (not a bare `exit 0`).
-- [ ] [P] [AC1] Write failing test: with the install present and already at the latest version, the script stays silent (the deliberate 15-minute no-op is preserved — this guards against "fix the silence by making it noisy always").
-- [ ] [AC1] `windows/hive-upgrade.ps1`: split the single `-not $installed -or ... -ge ...` guard into two branches — "no install found" (loud, distinct exit path) and "already current" (quiet `exit 0`).
-- [ ] [AC1] Refactor: keep the step-0 fast-path contract intact (still no daemon restart on a no-op tick) and the function under the repo's size conventions.
+- [x] [P] [AC1] Write failing test in `tests/hive-upgrade-timer.bats`: with no hive install resolvable, the script emits a non-empty message naming the condition (not a bare `exit 0`).
+- [x] [P] [AC1] Write failing test: with the install present and already at the latest version, the script stays silent (the deliberate 15-minute no-op is preserved — this guards against "fix the silence by making it noisy always").
+- [x] [AC1] `windows/hive-upgrade.ps1`: split the single `-not $installed -or ... -ge ...` guard into **three** branches, not two. The plan said two; the collapsed guard actually hid a third outcome — PyPI unreachable — which is transient rather than a fault. Final contract: already-current → silent, `exit 0`; PyPI unreachable → message, `exit 0`; no install → message, **`exit 1`**.
+- [x] [AC1] Exit non-zero on the no-install branch, so the condition surfaces in Task Scheduler's `LastTaskResult`. Stdout is not captured by the scheduler, so the exit code is the only signal visible without running the script by hand — and it is precisely the one that read green throughout the outage.
+- [x] [AC1] Add a test pinning that the branches stay separate (`! grep -qF '-not $installed -or'`), so a future tidy-up cannot silently re-collapse them.
+- [x] [AC1] Refactor: step-0 fast-path contract intact (still no daemon restart on a no-op tick); `.DESCRIPTION` documents the three outcomes; script stays ASCII-only for PSScriptAnalyzer.
 
 ### PR2 — bootstrap + A3 trigger (AC2, AC3, AC4) — gated on hive#328
 

--- a/specs/AI-028-hive-install-model-migration/tasks.md
+++ b/specs/AI-028-hive-install-model-migration/tasks.md
@@ -1,0 +1,63 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-07"
+---
+
+# Tasks - AI-028-hive-install-model-migration
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Decomposed into three PRs.** PR1 is independent and ships first — it converts the silent-failure class into a loud one, so the next recurrence surfaces in minutes instead of months. PR2 is gated on [hive#328](https://github.com/mlorentedev/hive/issues/328). PR3 is bookkeeping and can land any time after PR1.
+
+## Setup
+
+- [x] Worktree created from `origin/main`: `dotfiles-wt-hive-install-model`, branch `feat/hive-install-model-migration`
+- [x] Gating issue open and assigned: dotfiles#791
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No open questions left in `proposal.md` "Risks / open questions" — 1 `[AGENT-DRAFT]` remains (Linux path)
+
+## Implementation
+
+### PR1 — loud-vs-quiet failure (AC1) — independent, ships first
+
+- [ ] [P] [AC1] Write failing test in `tests/hive-upgrade-timer.bats`: with no hive install resolvable, the script emits a non-empty message naming the condition (not a bare `exit 0`).
+- [ ] [P] [AC1] Write failing test: with the install present and already at the latest version, the script stays silent (the deliberate 15-minute no-op is preserved — this guards against "fix the silence by making it noisy always").
+- [ ] [AC1] `windows/hive-upgrade.ps1`: split the single `-not $installed -or ... -ge ...` guard into two branches — "no install found" (loud, distinct exit path) and "already current" (quiet `exit 0`).
+- [ ] [AC1] Refactor: keep the step-0 fast-path contract intact (still no daemon restart on a no-op tick) and the function under the repo's size conventions.
+
+### PR2 — bootstrap + A3 trigger (AC2, AC3, AC4) — gated on hive#328
+
+- [ ] **GATE:** hive#328 shipped (PATH launcher installed by `self_upgrade`; `_resolve_exec()` no longer selects a dead binary) and published to PyPI.
+- [ ] [P] [AC2] Write failing test: on a machine with no `hive` on PATH, the bootstrap command is the `uvx --from hive-vault hive self-upgrade` form (verified working 2026-08-07: `uvx --from hive-vault hive --version` → `hive-vault 1.43.0`, rc=0).
+- [ ] [AC2] `mcp-servers.json`: replace `prerequisite_command` `uv tool install --upgrade hive-vault` with the bootstrap form. Keep `prerequisite_binary: uv` — it is the real and only prerequisite.
+- [ ] [P] [AC3] Write failing test: the upgrade trigger invokes a bare `hive self-upgrade` with no `Stop-ScheduledTask` / `Start-ScheduledTask` around it.
+- [ ] [AC3] `windows/hive-upgrade.ps1`: drop the A1 stop-before-upgrade orchestration (the A3 junction swap needs no daemon stop) and the defer-if-locked branch it existed to protect.
+- [ ] [AC4] `setup-windows.ps1`: replace the `uv tool list` version gate before `hive service install` with a check against the resolved install, so a machine without a uv tool is bootstrapped rather than skipped.
+- [ ] [P] [AC4] Write failing test: no Windows-path mechanism greps `uv tool list` to decide whether hive exists.
+- [ ] [AC2] Real-hardware validation on the currently-broken box (the before/after table in `verification.md`).
+
+### PR3 — decision reconciliation + docs (AC5, AC6) — independent of PR2
+
+- [ ] [AC5] Amend `specs/AI-022-hive-daemon-activation/tasks.md`: the "A1, NOT A3" decision is superseded — hive spiked A3 on 2026-06-24 and shipped it in 1.43.0. Record the supersession with dates rather than deleting the original reasoning.
+- [ ] [AC5] Add a forward pointer in `specs/archive/AI-023-hive-auto-upgrade-timer/` to this spec.
+- [ ] [AC6] Record the Linux decision explicitly (resolve the `[AGENT-DRAFT]` in `proposal.md` first) in this spec and in the amended `AI-022`.
+- [ ] Update `docs/troubleshooting/hive-mcp-orphaned-trampoline.md`: either retire it (if the new model makes the failure unreachable) or point it at the new install model and at #574 for repair.
+- [ ] Document the install model in one place — what owns the layout, what bootstraps it, what triggers upgrades, and which OS uses which mechanism.
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [ ] Type checks pass (`pwsh` parse / shellcheck as applicable)
+- [ ] Lint passes
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` following [[pattern-feature-list-as-primitive]]. Authored once `tasks.md` freezes (after the Linux `[AGENT-DRAFT]` resolves), so verification commands name real test names rather than guesses.
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state.
+
+**Verification must target the SSOT.** `~/.claude/scripts/hive-upgrade.ps1` is a *deployed copy*; the SSOT is `windows/hive-upgrade.ps1`. A verification command that runs the deployed copy without re-deploying first will pass against stale code.

--- a/specs/AI-028-hive-install-model-migration/verification.md
+++ b/specs/AI-028-hive-install-model-migration/verification.md
@@ -31,7 +31,7 @@ Supporting facts captured at the same time:
 
 Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
 
-- [ ] AC1 (loud-vs-quiet) -> test `<name>` in `tests/hive-upgrade-timer.bats` + B5 flips to non-empty output
+- [x] AC1 (loud-vs-quiet) -> `tests/hive-upgrade-timer.bats`: `hive-upgrade.ps1 is loud and non-zero when no install is found`, `... stays silent when the install is already current`, `... reports an unreachable PyPI without failing the tick`, `... does not collapse no-install into the already-current guard`. Suite green 33/33; script ASCII-clean. B5/B6 flip once the SSOT is deployed (see the deploy caveat below).
 - [ ] AC2 (bootstrap) -> commit `<hash>` + B1/B2/B3 flip on the broken box
 - [ ] AC3 (bare `hive self-upgrade`, no stop/start) -> test `<name>`
 - [ ] AC4 (no `uv tool list` inference on Windows) -> test `<name>` + B4 flips (task registered)
@@ -41,9 +41,16 @@ Map every acceptance criterion from `proposal.md` to concrete proof (commit hash
 
 ## Test status
 
-- Test suite: `<command> -> <output>`
-- Manual smoke test: what was exercised, what was observed
-- No regressions in existing test suite: yes / no (if no, document)
+```
+$ bats tests/hive-upgrade-timer.bats
+33 tests, 0 failures          # 4 new (cases 26-29), 29 pre-existing unchanged
+
+$ LC_ALL=C grep -nP '[^\x00-\x7F]' windows/hive-upgrade.ps1
+(no output)                   # ASCII clean for PSScriptAnalyzer CI
+```
+
+- Manual smoke test: pending for PR2/PR3. PR1 is a text-contract change to a PowerShell script; bats asserts the contract, and the live flip of B5/B6 needs the SSOT deployed to `~/.claude/scripts/` first.
+- No regressions: the 29 pre-existing cases in `hive-upgrade-timer.bats` are untouched and green, including `only acts when a newer version is published`, which pins the fast-path contract this change had to preserve.
 
 > **Do not verify against the deployed copy.** `~/.claude/scripts/hive-upgrade.ps1` is deployed from `windows/hive-upgrade.ps1` by setup. Re-deploy (or invoke the SSOT directly) before treating B5 as flipped, or a stale copy will read as a pass.
 

--- a/specs/AI-028-hive-install-model-migration/verification.md
+++ b/specs/AI-028-hive-install-model-migration/verification.md
@@ -1,0 +1,70 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-07"
+---
+
+# Verification - AI-028-hive-install-model-migration
+
+## Baseline: the broken state, captured before any change (2026-08-07)
+
+This spec is unusual in having a machine sitting in exactly the failure state it targets. The before-state is recorded here verbatim so the after-state is a comparison against evidence, not against memory. Host: maintainer's Windows 11 box, `hive-vault` 1.43.0 latest on PyPI.
+
+| # | Probe | Before (broken) |
+|---|---|---|
+| B1 | `hive --version` | `error: uv trampoline failed to canonicalize script path` |
+| B2 | `uv tool list` | `aider-chat v0.86.2`, `pre-commit v4.6.0` — **no hive-vault** |
+| B3 | `Test-Path $env:LOCALAPPDATA\hive` | `False` — A3 layout never created |
+| B4 | `Get-ScheduledTask` matching hive | only `DotfilesHiveUpgrade`; **no `HiveVaultDaemon`** |
+| B5 | `powershell -File ~/.claude/scripts/hive-upgrade.ps1` | *no output*, `exit 0` |
+| B6 | `Get-ScheduledTaskInfo DotfilesHiveUpgrade` | `LastTaskResult: 0`, `LastRunTime: 8/7/2026 11:34:34 AM`, `NextRunTime: 11:49:49 AM` — green while doing nothing |
+| B7 | `~/.claude.json` → `mcpServers.hive` | `C:\Users\mlorente\.local\bin\hive.exe` (the dead trampoline) |
+| B8 | `ToolSearch` for `vault_query` in a Claude session | no match — **zero hive MCP tools registered** |
+| B9 | `python -c "shutil.which('hive')"` | `C:\Users\mlorente\.local\bin\hive.exe` — what `_resolve_exec()` would register (hive#328) |
+
+Supporting facts captured at the same time:
+
+- The 3 live `hive-vault.exe` processes resolve to `...\uv\cache\archive-v0\BWm4N5bVOd2KpnaOdNMHk\Scripts\hive-vault.exe` — ephemeral `uvx` environments belonging to *other* clients, not the daemon and not the uv tool. See AI-029.
+- `uvx --from hive-vault hive --version` → `hive-vault 1.43.0`, rc=0. The bootstrap path works today.
+- `~/.local/share/hive` holds 295 unrotated `hive-<pid>.log` files dating to 2026-05-19.
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] AC1 (loud-vs-quiet) -> test `<name>` in `tests/hive-upgrade-timer.bats` + B5 flips to non-empty output
+- [ ] AC2 (bootstrap) -> commit `<hash>` + B1/B2/B3 flip on the broken box
+- [ ] AC3 (bare `hive self-upgrade`, no stop/start) -> test `<name>`
+- [ ] AC4 (no `uv tool list` inference on Windows) -> test `<name>` + B4 flips (task registered)
+- [ ] AC5 (A1/A3 reconciliation) -> commit `<hash>`
+- [ ] AC6 (Linux decision recorded) -> commit `<hash>`
+- [ ] AC7 (end-to-end on the broken box) -> B1–B8 all flip; B8 is the user-visible one
+
+## Test status
+
+- Test suite: `<command> -> <output>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+> **Do not verify against the deployed copy.** `~/.claude/scripts/hive-upgrade.ps1` is deployed from `windows/hive-upgrade.ps1` by setup. Re-deploy (or invoke the SSOT directly) before treating B5 as flipped, or a stale copy will read as a pass.
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+- **Split into AI-028 + AI-029 rather than one ticket** (2026-08-07). The install model and the multi-client registration SSOT are separate failures with separate blast radii; the repo's own precedent is #574 being split out of #551 for atomic-PR discipline.
+- **PR1 sequenced before the model change.** The loud-vs-quiet fix does not depend on resolving the bootstrap question, and it is what makes the next recurrence visible. Shipping it first means the session produces a durable improvement even if the model migration proves deeper than expected.
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons.md`? **yes** — a fault-tolerance guard and a broken-state guard that share an exit code make failure invisible; "quiet by design" and "quiet because broken" must be distinguishable at the observable surface.
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no — likely no; ADR-015 in the hive repo owns the mechanism decision, this repo consumes it>
+- [ ] New pattern candidate for `00_meta/patterns/`? <yes / no — candidate: "a health signal that cannot distinguish healthy-idle from broken is not a health signal". Only if it recurs outside this incident.>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/AI-028-hive-install-model-migration/` -> `specs/archive/AI-028-hive-install-model-migration/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)

--- a/tests/hive-upgrade-timer.bats
+++ b/tests/hive-upgrade-timer.bats
@@ -178,6 +178,35 @@ setup() {
 # A `uv tool ... --reinstall` removes the locked venv dir (os error 5) and
 # corrupts the install -- the script documents the hazard in a comment but must
 # never actually run it (so the check is on a real uv command, not the word).
+# AI-028 / #791: the three step-0 outcomes used to collapse into one silent
+# `exit 0`, so a machine with NO install was indistinguishable from a healthy
+# idle one. It ran every 15 minutes for months reporting LastTaskResult 0 while
+# the hive MCP was dead. These four cases pin each outcome to its own signal.
+
+@test "hive-upgrade.ps1 is loud and non-zero when no install is found" {
+    run grep -A3 -F 'no hive-vault install found' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"exit 1"* ]]
+}
+
+@test "hive-upgrade.ps1 stays silent when the install is already current" {
+    # The deliberate 15-min no-op: no output, exit 0, daemon untouched.
+    run grep -A2 -F '[version]$installed -ge [version]$latest' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"exit 0"* ]]
+    [[ "$output" != *"Write-Output"* ]]
+}
+
+@test "hive-upgrade.ps1 reports an unreachable PyPI without failing the tick" {
+    run grep -A3 -F 'could not resolve the latest' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"exit 0"* ]]
+}
+
+@test "hive-upgrade.ps1 does not collapse no-install into the already-current guard" {
+    ! grep -qF '-not $installed -or' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
+}
+
 @test "hive-upgrade.ps1 never runs uv tool ... --reinstall" {
     ! grep -qE '\$uv tool.*--reinstall' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
 }

--- a/windows/hive-upgrade.ps1
+++ b/windows/hive-upgrade.ps1
@@ -11,7 +11,12 @@
       0. Only act when a NEWER version is actually published. Otherwise return
          immediately and leave the daemon untouched -- at a 15-minute cadence
          the overwhelming majority of runs are this fast no-op, so the daemon is
-         never restarted just to check for updates.
+         never restarted just to check for updates. Three distinct outcomes,
+         deliberately NOT collapsed into one silent exit (dotfiles#791):
+           - already current  -> silent, exit 0 (the intended common case)
+           - PyPI unreachable -> message,  exit 0 (transient, not a fault)
+           - no install found -> message,  exit 1 (broken machine; surfaces in
+             Task Scheduler's LastTaskResult instead of reading green)
       1. If a hive process OTHER than the daemon holds the uv-tool install
          (an open `hive client` session), DEFER this cycle. The daemon keeps
          running the current version; the upgrade lands the next cycle the
@@ -45,11 +50,39 @@ if (-not (Test-Path $uv)) {
 # Step 0: only proceed when a newer version is actually published. Comparing
 # installed vs latest BEFORE touching the daemon means a 15-minute cadence does
 # not restart the daemon on every tick -- only on an actual release.
+#
+# These three outcomes used to collapse into one guard that exited 0 in silence,
+# which made a BROKEN machine indistinguishable from a healthy idle one. On the
+# maintainer's box the uv-tool install vanished, so this ran every 15 minutes
+# for months reporting LastTaskResult 0 while the hive MCP was dead
+# (dotfiles#791). Fault tolerance became fault invisibility. Each outcome now
+# reports for itself.
 $installedMatch = (& $uv tool list 2>$null | Select-String '^hive-vault\s+v?([\d.]+)')
 $installed = if ($installedMatch) { $installedMatch.Matches[0].Groups[1].Value } else { $null }
+
+# Broken machine: there is nothing to upgrade because there is no install. Exit
+# NON-ZERO so Task Scheduler's LastTaskResult stops reporting success -- that is
+# the only signal visible without capturing stdout, and it is the one that read
+# green throughout the outage.
+if (-not $installed) {
+    Write-Output "hive-upgrade: no hive-vault install found ('uv tool list' reports none)."
+    Write-Output "hive-upgrade: nothing to upgrade. The install is missing or malformed -- see docs/troubleshooting/hive-mcp-orphaned-trampoline.md."
+    exit 1
+}
+
 $latest = $null
 try { $latest = (Invoke-RestMethod 'https://pypi.org/pypi/hive-vault/json' -TimeoutSec 15).info.version } catch { $latest = $null }
-if (-not $installed -or -not $latest -or ([version]$installed -ge [version]$latest)) {
+
+# Transient: PyPI unreachable. Say so, but exit 0 -- an offline tick is not a
+# broken machine, and failing here would cry wolf every 15 minutes on a laptop.
+if (-not $latest) {
+    Write-Output "hive-upgrade: could not resolve the latest hive-vault version from PyPI; skipping this cycle (installed $installed)."
+    exit 0
+}
+
+# Already current: the deliberate quiet no-op. Silent by design so the daemon is
+# never restarted just to discover there is nothing to do.
+if ([version]$installed -ge [version]$latest) {
     exit 0
 }
 


### PR DESCRIPTION
Closes the first slice of #791 (AI-028). Carries the spec scaffold plus PR1; **PR2 and PR3 are not in this PR** — PR2 stays gated on hive#328.

## The bug

`windows/hive-upgrade.ps1` step 0 collapsed three outcomes into one guard that exited 0 in silence:

```powershell
if (-not $installed -or -not $latest -or ([version]$installed -ge [version]$latest)) {
    exit 0
}
```

A machine with **no hive install** was therefore indistinguishable from a healthy idle one. On the maintainer's Windows box the uv-tool install vanished, and this ran every 15 minutes for months:

```
LastRunTime    : 8/7/2026 11:34:34 AM
LastTaskResult : 0
NextRunTime    : 8/7/2026 11:49:49 AM

$ powershell -File ~/.claude/scripts/hive-upgrade.ps1
<no output>
exit code: 0
```

...while the hive MCP was dead in Claude Code and no `vault_*` tool registered at all. The quiet was deliberate — at a 15-minute cadence you do not want to restart the daemon just to check for updates — but "quiet by design" and "quiet because broken" shared an exit code. Fault tolerance became fault invisibility.

## The fix

Each outcome reports for itself:

| Outcome | Output | Exit |
|---|---|---|
| Already current | silent | 0 |
| PyPI unreachable | message | 0 |
| **No install found** | **message** | **1** |

**The non-zero exit is the load-bearing part.** Task Scheduler does not capture stdout, so `LastTaskResult` is the only signal visible without running the script by hand — and it is precisely the one that read green throughout the outage.

The fast-path contract is preserved: an already-current tick is still silent and still never restarts the daemon.

### A third branch the plan did not anticipate

`tasks.md` called for splitting into two. Doing so surfaced a third outcome hiding in the same guard: an **unreachable PyPI** is transient, not a broken machine. Failing there would cry wolf every 15 minutes on a laptop that closed its lid, so it gets a message and `exit 0`. The spec was updated to record this rather than quietly widening the plan.

## Tests

Four cases added to `tests/hive-upgrade-timer.bats`, including one that pins the branches apart so a future tidy-up cannot re-collapse them:

```
ok 26 hive-upgrade.ps1 is loud and non-zero when no install is found
ok 27 hive-upgrade.ps1 stays silent when the install is already current
ok 28 hive-upgrade.ps1 reports an unreachable PyPI without failing the tick
ok 29 hive-upgrade.ps1 does not collapse no-install into the already-current guard

33 tests, 0 failures
```

Script is ASCII-clean for PSScriptAnalyzer. The 29 pre-existing cases are untouched and green, including `only acts when a newer version is published`, which pins the fast-path contract this change had to preserve.

## Note on deployment

The SSOT is `windows/hive-upgrade.ps1`; `~/.claude/scripts/hive-upgrade.ps1` is a deployed copy. The live `LastTaskResult` flip on the broken box only happens after setup re-deploys — verifying against the deployed copy before that would read as a false pass. Recorded in the spec's `verification.md`.

## What this does not do

Nothing about the install model itself. The machine is still broken; this makes the next occurrence visible in minutes instead of months. The `verification.md` baseline (B1-B9) captures that broken state verbatim for PR2 to verify against.