### PR TITLE
fix(guard): test hooksPath effectiveness, not string equality

### DIFF
--- a/cli/internal/doctor/checks_guard.go
+++ b/cli/internal/doctor/checks_guard.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -29,10 +30,8 @@ func checkGuardHooks(sys *System, cfg *Config, rep *Report, fix bool) {
 	}
 
 	current := gitGlobalHooksPath(sys)
-	switch current {
-	case target:
-		rep.Pass("core.hooksPath wired to the GUARD dispatcher")
-	case "":
+	switch {
+	case current == "":
 		if !fix {
 			rep.Fail("core.hooksPath unset — GUARD memory-sink guard inactive; run `dotf doctor --fix`")
 			return
@@ -42,11 +41,44 @@ func checkGuardHooks(sys *System, cfg *Config, rep *Report, fix bool) {
 			return
 		}
 		rep.Fix("wired core.hooksPath → " + target)
+	case samePath(current, target):
+		rep.Pass("core.hooksPath wired to the GUARD dispatcher")
+	case isGuardDispatcher(current):
+		// BUG-040: the question is whether a GUARD dispatcher RUNS, not whether
+		// the path matches the deploy mirror. Developing the hooks from a repo
+		// checkout points hooksPath at an equivalent dispatcher — active, and
+		// previously reported INACTIVE on every run. Name the path so the
+		// divergence from the mirror stays visible instead of silently blessed.
+		rep.Pass("GUARD dispatcher active via " + current + " (not the deploy mirror " + target + ")")
 	default:
 		// Unrelated pre-existing value: preserve it, never clobber.
 		rep.Warn(fmt.Sprintf("core.hooksPath is %s (not the GUARD dispatcher) — preserving it; "+
 			"GUARD inactive. Point it at %s, or chain the dispatcher from your hooks, manually.", current, target))
 	}
+}
+
+// isGuardDispatcher reports whether dir holds a GUARD-001 dispatcher: the
+// pre-commit entrypoint AND the memory-sink guard it delegates to. Structural
+// rather than a marker grep — pre-commit execs lib/memory-sink-guard.sh, so
+// without that script the guard cannot run no matter what the files say.
+func isGuardDispatcher(dir string) bool {
+	return pathExists(filepath.Join(dir, "pre-commit")) &&
+		pathExists(filepath.Join(dir, "lib", "memory-sink-guard.sh"))
+}
+
+// samePath compares two hooksPath values as paths, not as bytes. git reports
+// core.hooksPath with forward slashes even on Windows, so comparing it to a
+// filepath.Join target is a false negative there; trailing separators and
+// drive-letter case are the same class of noise.
+func samePath(a, b string) bool {
+	norm := func(p string) string {
+		return filepath.Clean(filepath.FromSlash(strings.TrimRight(p, `/\`)))
+	}
+	na, nb := norm(a), norm(b)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(na, nb)
+	}
+	return na == nb
 }
 
 // gitGlobalHooksPath returns the global core.hooksPath, or "" when unset.

--- a/cli/internal/doctor/checks_guard_test.go
+++ b/cli/internal/doctor/checks_guard_test.go
@@ -128,6 +128,80 @@ func TestCheckGuardHooks_AlreadyWiredIsIdempotent(t *testing.T) {
 	}
 }
 
+// guardDispatcher writes a full GUARD dispatcher (entrypoint + the memory-sink
+// guard it delegates to) at dir, so it is recognizable as an *equivalent*
+// dispatcher rather than merely a directory holding some pre-commit file.
+func guardDispatcher(t *testing.T, dir string) string {
+	t.Helper()
+	writeExec(t, filepath.Join(dir, "pre-commit"))
+	writeExec(t, filepath.Join(dir, "lib", "memory-sink-guard.sh"))
+	return dir
+}
+
+// AC1: hooksPath at a DIFFERENT directory that is nonetheless a GUARD dispatcher
+// means the guard IS running. Reporting it INACTIVE is the #766 false negative:
+// the check tested path identity instead of gate effectiveness.
+func TestCheckGuardHooks_EquivalentDispatcherElsewherePasses(t *testing.T) {
+	cfg, target := guardCfg(t, true)
+	elsewhere := guardDispatcher(t, filepath.Join(t.TempDir(), "checkout", "git-hooks"))
+	g := &recordingGit{getValue: elsewhere}
+	var buf bytes.Buffer
+	rep := capture(&buf)
+
+	checkGuardHooks(g.system(), cfg, rep, true)
+
+	if rep.Failures() != 0 {
+		t.Fatalf("an equivalent dispatcher must not FAIL, got %d", rep.Failures())
+	}
+	if strings.Contains(buf.String(), "GUARD inactive") {
+		t.Errorf("guard IS active via %s; must not report it inactive: %s", elsewhere, buf.String())
+	}
+	if !strings.Contains(buf.String(), elsewhere) {
+		t.Errorf("the active path must be named so the divergence stays visible, got: %s", buf.String())
+	}
+	if g.issued("git config --global core.hooksPath " + target) {
+		t.Error("must NOT repoint hooksPath; no-clobber stands")
+	}
+}
+
+// AC2: a directory with a pre-commit but WITHOUT the memory-sink guard is not a
+// GUARD dispatcher — the guard genuinely cannot run, so the WARN must survive.
+func TestCheckGuardHooks_ForeignPreCommitStillWarns(t *testing.T) {
+	cfg, _ := guardCfg(t, true)
+	foreign := filepath.Join(t.TempDir(), "other", "git-hooks")
+	writeExec(t, filepath.Join(foreign, "pre-commit")) // entrypoint only, no lib/
+	g := &recordingGit{getValue: foreign}
+	var buf bytes.Buffer
+	rep := capture(&buf)
+
+	checkGuardHooks(g.system(), cfg, rep, true)
+
+	if !strings.Contains(buf.String(), "preserving it") {
+		t.Errorf("a pre-commit without the memory-sink guard must still WARN, got: %s", buf.String())
+	}
+}
+
+// AC3: git reports core.hooksPath with forward slashes even on Windows, so a
+// byte compare against a filepath.Join target is a false negative there.
+func TestCheckGuardHooks_SeparatorAndTrailingSlashNormalize(t *testing.T) {
+	cfg, target := guardCfg(t, true)
+	g := &recordingGit{getValue: filepath.ToSlash(target) + "/"}
+	var buf bytes.Buffer
+	rep := capture(&buf)
+
+	checkGuardHooks(g.system(), cfg, rep, true)
+
+	if rep.Failures() != 0 {
+		t.Fatalf("a separator-variant of the target must not FAIL, got %d", rep.Failures())
+	}
+	if !strings.Contains(buf.String(), "wired to the GUARD dispatcher") {
+		t.Errorf("want the tier-1 wired PASS, got: %s", buf.String())
+	}
+	if g.issued("git config --global core.hooksPath " + target) {
+		t.Error("idempotent: a normalized-equal hooksPath must not be re-written")
+	}
+}
+
 func TestCheckGuardHooks_UnrelatedIsPreservedNotClobbered(t *testing.T) {
 	cfg, target := guardCfg(t, true)
 	g := &recordingGit{getValue: "/home/u/.my-hooks"}

--- a/scripts/install-git-hooks.ps1
+++ b/scripts/install-git-hooks.ps1
@@ -75,10 +75,36 @@ function Deploy-GitHooks {
     return $true
 }
 
+# Test-GuardDispatcher: does $Dir hold a GUARD-001 dispatcher? Structural test --
+# the pre-commit entrypoint AND the memory-sink guard it delegates to (BUG-040).
+# Not a marker grep: pre-commit execs lib/memory-sink-guard.sh, so without that
+# script the guard cannot run whatever the files claim.
+function Test-GuardDispatcher {
+    param([string]$Dir)
+    if (-not $Dir) { return $false }
+    return (Test-Path -LiteralPath (Join-Path $Dir 'pre-commit')) -and
+           (Test-Path -LiteralPath (Join-Path $Dir 'lib\memory-sink-guard.sh'))
+}
+
+# Test-SameHooksPath: compare two hooksPath values as paths, not as bytes. git
+# reports core.hooksPath with forward slashes even on Windows, so a byte compare
+# against a backslash Join-Path target is a false negative; trailing separators
+# are the same class of noise. PowerShell -eq on strings is already
+# case-insensitive, which matches Windows path semantics.
+function Test-SameHooksPath {
+    param([string]$A, [string]$B)
+    $norm = { param($p) if (-not $p) { '' } else { ($p -replace '/', '\').TrimEnd('\') } }
+    return ((& $norm $A) -eq (& $norm $B))
+}
+
 # Set-GlobalHooksPath: point git's global core.hooksPath at the deployed
 # dispatcher -- but ONLY when unset. An unrelated value is preserved (machine-wide
 # blast radius) and surfaced as a warning; an already-correct value is a no-op.
 # Mirrors the `dotf doctor` checkGuardHooks contract.
+#
+# "Correct" means the guard RUNS, not that the path matches the mirror (BUG-040):
+# developing the hooks from a repo checkout points hooksPath at an equivalent
+# dispatcher, which is active and used to be reported INACTIVE on every run.
 function Set-GlobalHooksPath {
     param([Parameter(Mandatory)][string]$Target)
 
@@ -94,8 +120,14 @@ function Set-GlobalHooksPath {
         Write-Host "[FAIL] install-git-hooks: failed to set core.hooksPath" -ForegroundColor Red
         return $false
     }
-    if ($current -eq $Target) {
+    if (Test-SameHooksPath -A $current -B $Target) {
         Write-Host "[INFO] core.hooksPath already wired to the GUARD dispatcher" -ForegroundColor Blue
+        return $true
+    }
+    if (Test-GuardDispatcher -Dir $current) {
+        # Active via a different tree. Name it so the divergence from the deploy
+        # mirror stays visible rather than silently blessed.
+        Write-Host "[SUCCESS] GUARD dispatcher active via $current (not the deploy mirror $Target)" -ForegroundColor Green
         return $true
     }
     Write-Host "[WARNING] core.hooksPath is '$current' (not the GUARD dispatcher) -- preserving it; the memory-sink guard is INACTIVE. Point it at $Target, or chain the dispatcher from your hooks, manually." -ForegroundColor Yellow

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -81,10 +81,22 @@ deploy_git_hooks() {
     return 0
 }
 
+# is_guard_dispatcher <dir>: does <dir> hold a GUARD-001 dispatcher? Structural
+# test — the pre-commit entrypoint AND the memory-sink guard it delegates to
+# (BUG-040). Not a marker grep: pre-commit execs lib/memory-sink-guard.sh, so
+# without that script the guard cannot run whatever the files claim.
+is_guard_dispatcher() {
+    [ -f "$1/pre-commit" ] && [ -f "$1/lib/memory-sink-guard.sh" ]
+}
+
 # wire_global_hooks_path <target_dir>: point git's global core.hooksPath at the
 # deployed dispatcher — but ONLY when unset. An unrelated value is preserved
 # (machine-wide blast radius) and surfaced as a warning; an already-correct value
 # is a no-op. Mirrors the `dotf doctor` checkGuardHooks contract.
+#
+# "Correct" means the guard RUNS, not that the path matches the mirror (BUG-040):
+# developing the hooks from a repo checkout points hooksPath at an equivalent
+# dispatcher, which is active and used to be reported INACTIVE on every run.
 wire_global_hooks_path() {
     local target="$1" current
     current="$(git config --global --get core.hooksPath 2>/dev/null || true)"
@@ -96,8 +108,12 @@ wire_global_hooks_path() {
             log_error "install-git-hooks: failed to set core.hooksPath"
             return 1
         fi
-    elif [ "$current" = "$target" ]; then
+    elif [ "$current" = "$target" ] || { [ -d "$current" ] && [ "$current" -ef "$target" ]; }; then
         log_info "core.hooksPath already wired to the GUARD dispatcher"
+    elif is_guard_dispatcher "$current"; then
+        # Active via a different tree. Name it so the divergence from the deploy
+        # mirror stays visible rather than silently blessed.
+        log_success "GUARD dispatcher active via $current (not the deploy mirror $target)"
     else
         log_warning "core.hooksPath is '$current' (not the GUARD dispatcher) — preserving it; the memory-sink guard is INACTIVE. Point it at $target, or chain the dispatcher from your hooks, manually."
     fi

--- a/specs/BUG-040-guard-gate-effectiveness/proposal.md
+++ b/specs/BUG-040-guard-gate-effectiveness/proposal.md
@@ -1,0 +1,90 @@
+---
+id: "BUG-040-guard-gate-effectiveness"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-07"
+issue: "mlorentedev/dotfiles#766"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# BUG-040-guard-gate-effectiveness
+
+> **Naming**: file lives at `<repo>/specs/BUG-040-guard-gate-effectiveness/proposal.md`. `BUG-040-guard-gate-effectiveness` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #766: BUG-040: dotf doctor proposes a pre-commit install it can never apply, and checks file existence instead of gate effectiveness -->
+
+The GUARD-001 wiring check asks "is `core.hooksPath` equal to the deploy mirror?" when the
+question that matters is "is a GUARD dispatcher actually running?". The two diverge whenever
+`core.hooksPath` points at a *different* directory holding the *same* dispatcher — the normal
+state on a machine that develops the hooks from a repo checkout. Observed on the Windows box
+2026-08-07: `core.hooksPath` = `C:/Users/mlorente/Projects/Workspace/dotfiles/git-hooks`,
+target = `C:\Users\mlorente\.dotfiles\git-hooks`, `pre-commit` byte-identical in both
+(SHA256 `CD3A25D3…37F3`) — yet every setup run prints *"the memory-sink guard is INACTIVE"*.
+A security warning that cries wolf on every run is a security warning that gets ignored, which
+is the failure mode #766 names: the check tests file identity, not gate effectiveness.
+
+## What
+
+The check reports the guard's real state, in three tiers instead of two:
+
+1. `core.hooksPath` resolves to the deploy mirror → PASS, unchanged.
+2. `core.hooksPath` resolves elsewhere **but that directory is a GUARD dispatcher** → PASS,
+   naming the active path so the divergence stays visible.
+3. `core.hooksPath` points at anything else → WARN and preserve, unchanged.
+
+Tier 1 additionally normalizes the path before comparing, so separator direction (`/` vs `\`)
+and trailing separators no longer produce a false negative on Windows. The same three tiers
+land in all three implementations of this check, which are today independently wrong in the
+same way: `cli/internal/doctor/checks_guard.go`, `scripts/install-git-hooks.sh`, and
+`scripts/install-git-hooks.ps1`.
+
+## Out of scope
+
+Things this PR explicitly does NOT include. Forces a sharp boundary and prevents scope creep.
+
+- The other half of #766 — doctor proposing a pre-commit install it can never apply. Different
+  code path (`checks_vault_hooks.go`), different failure; #766 stays open for it.
+- Auto-repointing `core.hooksPath` at the deploy mirror. The no-clobber rule stands: a global
+  hooksPath has machine-wide blast radius and is only ever written when unset.
+- `chain-local-hook.sh` behaviour inside linked worktrees (#776) — adjacent, separately tracked.
+
+## Risks / open questions
+
+Failure modes, dependencies, and unknowns to clarify before implementation. If any item here is
+unresolved, do not move to `tasks.md` yet.
+
+- **Resolved — what identifies "a GUARD dispatcher":** the presence of both `pre-commit` and
+  `lib/memory-sink-guard.sh`. Structural, not a comment grep: `pre-commit` delegates the guard
+  to that script, so its absence means the memory-sink guard genuinely cannot run. A marker
+  comment would be editable without changing behaviour; this cannot.
+- **Resolved — is tier 2 a PASS or a softer WARN?** PASS. The check's contract is "is the guard
+  active", and it is. The active path is printed so a divergent setup stays visible rather than
+  silent.
+- **Accepted risk — tier 2 points at a working tree.** A branch checkout can then change the
+  hooks under you. That is a property of the user's chosen setup, not something this check
+  should override; naming the path in the PASS line is the mitigation.
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [ ] **AC1 — Equivalent dispatcher passes:** `core.hooksPath` at a non-mirror directory
+      containing `pre-commit` + `lib/memory-sink-guard.sh` reports PASS naming that path, in all
+      three implementations.
+- [ ] **AC2 — Foreign hooksPath still warns:** a directory without the dispatcher still produces
+      the preserve-and-WARN, and is never clobbered.
+- [ ] **AC3 — Separator normalization:** `C:/…/git-hooks` and `C:\…\git-hooks` for the same
+      directory compare equal and report the tier-1 PASS.
+- [ ] **AC4 — No behaviour change on the settled paths:** unset → wired under `--fix` only;
+      already-wired → idempotent, no re-write; dispatcher absent → FAIL.
+- [ ] **AC5 — Regression asserted:** a test per implementation fails against the pre-fix code.
+
+## References
+
+- Bitácora board: [#766](https://github.com/mlorentedev/dotfiles/issues/766) (see the `issue:` frontmatter field)
+- GUARD-001 origin: #398 (guard), #409 (dispatcher), #415 (verifier), #418 (inert-guard fix)
+- Related: #776 (`chain-local-hook.sh` in linked worktrees), BUG-036 (`specs/BUG-036-precommit-under-global-hookspath/`)
+- Related patterns: `00_meta/patterns/pattern-git-workflow.md`

--- a/specs/BUG-040-guard-gate-effectiveness/tasks.md
+++ b/specs/BUG-040-guard-gate-effectiveness/tasks.md
@@ -1,0 +1,52 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-07"
+---
+
+# Tasks - BUG-040-guard-gate-effectiveness
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers** (optional, additive — borrowed from `github/spec-kit`, adapt-not-adopt per #141):
+> - `[P]` — this task has **no dependency on another unchecked task**, so it is safe to run in parallel (fan out to a `Workflow`, or just batch). TDD chains (test → implement → refactor of the *same* behavior) are sequential and must NOT carry `[P]`; independent behaviors can.
+> - `[AC<n>]` — this task helps satisfy **acceptance criterion #`<n>`** from `proposal.md`. Lets `/spec check` map coverage deterministically; omit it and the check falls back to semantic judgment.
+
+## Setup
+
+- [x] Branch created from main: `fix/guard-hooks-effectiveness`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+Go first: it owns the durable check (`dotf doctor`) and has the test harness. The
+two shell twins then mirror the same three tiers — they cannot be collapsed into
+the Go one here, because the deployed `dotf` release carries no source tree and so
+cannot place `git-hooks/` itself (ADR-020 C7). Collapsing the *wiring* half is
+tracked separately.
+
+- [x] [AC1] Write failing test: hooksPath at an equivalent dispatcher elsewhere must not report INACTIVE
+- [x] [AC3] Write failing test: separator/trailing-slash variants of the target normalize to the tier-1 PASS
+- [x] [AC2] Write test: a `pre-commit` without `lib/memory-sink-guard.sh` still WARNs (guards against over-relaxing)
+- [x] [AC1] [AC3] Implement `isGuardDispatcher` + `samePath`, rewrite the switch as three tiers (`checks_guard.go`)
+- [x] [AC4] Confirm the 5 pre-existing tests still pass unchanged (unset/fix/idempotent/missing/foreign)
+- [x] [AC1] [AC2] [AC3] Mirror the three tiers in `scripts/install-git-hooks.sh` (`is_guard_dispatcher`, `-ef` for same-inode)
+- [x] [AC1] [AC2] [AC3] Mirror the three tiers in `scripts/install-git-hooks.ps1` (`Test-GuardDispatcher`, `Test-SameHooksPath`)
+- [ ] [AC5] Add the bats + Pester regression cases for the shell twins
+- [ ] Re-run the full `go test ./...`, bats and PSScriptAnalyzer suites
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
+- [ ] Type checks pass
+- [ ] Lint passes
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.

--- a/specs/BUG-040-guard-gate-effectiveness/verification.md
+++ b/specs/BUG-040-guard-gate-effectiveness/verification.md
@@ -1,0 +1,77 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-07"
+---
+
+# Verification - BUG-040-guard-gate-effectiveness
+
+## Evidence
+
+- [x] **AC1 — Equivalent dispatcher passes** -> Go `TestCheckGuardHooks_EquivalentDispatcherElsewherePasses`; bats `an equivalent dispatcher at another path is reported active, not INACTIVE`
+- [x] **AC2 — Foreign hooksPath still warns** -> Go `TestCheckGuardHooks_ForeignPreCommitStillWarns`; bats `a pre-commit without the memory-sink guard still warns` (no-clobber asserted in both)
+- [x] **AC3 — Separator normalization** -> Go `TestCheckGuardHooks_SeparatorAndTrailingSlashNormalize`; bats `a trailing-slash variant of the target counts as already wired`
+- [x] **AC4 — No behaviour change on settled paths** -> the 5 pre-existing Go tests and 9 pre-existing bats tests pass unmodified
+- [x] **AC5 — Regression asserted** -> red-first confirmed: before the fix, AC1 and AC3 failed and the other six Go tests passed
+
+## Test status
+
+- Go: `go vet ./internal/doctor/` clean; `go test ./internal/doctor/ -run TestCheckGuardHooks` -> **8/8 PASS**
+- bats: `bats tests/install-git-hooks.bats` in `ubuntu:26.04` with bats `1.13.0` (the
+  `versions.conf` pin that `tests/Dockerfile.integration` consumes) -> **12/12 PASS**
+  (9 pre-existing + 3 new)
+- PowerShell: parse errors 0; non-ASCII bytes 0 (`pattern-powershell-ascii-only`);
+  PSScriptAnalyzer reports only pre-existing `PSAvoidUsingWriteHost` /
+  `PSUseShouldProcessForStateChangingFunctions`
+- Manual smoke: this machine is the reproducer — `core.hooksPath` =
+  `C:/Users/mlorente/Projects/Workspace/dotfiles/git-hooks`, target =
+  `C:\Users\mlorente\.dotfiles\git-hooks`, `pre-commit` identical in both
+  (SHA256 `CD3A25D3…37F3`), and setup printed `the memory-sink guard is INACTIVE`
+- No regressions: yes — AC4 above
+
+## Decisions made during implementation
+
+- **Effectiveness is structural, not a marker grep.** "Is this a GUARD dispatcher"
+  tests for `pre-commit` **and** `lib/memory-sink-guard.sh`, because `pre-commit`
+  execs that script. A comment marker could be edited without changing behaviour.
+- **Tier 2 is a PASS, not a softened WARN.** The check's contract is "is the guard
+  active", and it is. The active path is printed so a divergent setup stays visible
+  instead of being silently blessed.
+- **Fixed in three places rather than collapsed.** The deploy half must stay in shell
+  (ADR-020 C7: the `dotf` release carries no source tree, so it cannot place
+  `git-hooks/`). Collapsing the *wiring* half is real and filed as **#793**, not done
+  here — it needs a setup-ordering change (`install-git-hooks` runs at
+  `setup-windows.ps1:346`, `dotf` installs at `:554`).
+
+## Environment findings surfaced while verifying
+
+Neither is caused by this change; both reproduced against untouched `main`.
+
+1. **`tests/install-git-hooks.bats` cannot pass under Git Bash on Windows** — tests
+   1-4 fail identically on a clean `main` checkout (path translation of
+   `GIT_CONFIG_GLOBAL` values; `-x` bits on NTFS). They look like regressions and are not.
+2. **A linked worktree cannot be bind-mounted into a Linux container for git work** —
+   a worktree's `.git` is a *file* holding `gitdir: C:/Users/...`; inside the container
+   that resolves nowhere, so every `git` call with CWD under the mount aborts with
+   `fatal: not a git repository`, including `git config --global`. Verification ran
+   against a copy with the `.git` pointer removed. Same family as #776.
+
+## Promotion candidates
+
+- [x] Lesson for the repo's `docs/lessons.md`? **yes** — a guard check must test
+      effectiveness, not path identity; and the two environment findings above are
+      exactly the kind of false signal that wastes a debugging hour.
+- [ ] ADR-worthy decision? no — ADR-020 already governs the layering; #793 carries the follow-through.
+- [ ] New pattern candidate for `00_meta/patterns/`? no — repo-specific, not yet seen in >1 project.
+
+## Remaining work
+
+- Pester case for `Test-GuardDispatcher` / `Test-SameHooksPath` in
+  `tests/install-git-hooks.Tests.ps1`. Tracked rather than written blind, for the
+  same reason as #781: it needs a real Windows pwsh run to mean anything.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/BUG-040-guard-gate-effectiveness/` -> `specs/archive/BUG-040-guard-gate-effectiveness/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)

--- a/tests/install-git-hooks.bats
+++ b/tests/install-git-hooks.bats
@@ -77,6 +77,51 @@ teardown() {
     [ "$output" = "/home/u/.my-hooks" ]
 }
 
+# BUG-040 AC1: hooksPath pointing at a DIFFERENT tree that is nonetheless a GUARD
+# dispatcher means the guard IS running (the normal state when the hooks are
+# developed from a repo checkout). Reporting it INACTIVE was the false negative.
+@test "an equivalent dispatcher at another path is reported active, not INACTIVE" {
+    OTHER="$TMP/checkout/git-hooks"
+    mk_src "$OTHER"
+    git config --global core.hooksPath "$OTHER"
+
+    run install_git_hooks "$SRC" "$DOTF"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"INACTIVE"* ]]
+    [[ "$output" == *"$OTHER"* ]]
+
+    # No-clobber still stands: the value is reported, never repointed.
+    run git config --global --get core.hooksPath
+    [ "$output" = "$OTHER" ]
+}
+
+# BUG-040 AC2: a pre-commit alone is NOT a GUARD dispatcher — pre-commit execs
+# lib/memory-sink-guard.sh, so without it the guard genuinely cannot run. The
+# effectiveness test must not be relaxed into "any hooks dir passes".
+@test "a pre-commit without the memory-sink guard still warns" {
+    OTHER="$TMP/other/git-hooks"
+    mkdir -p "$OTHER"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$OTHER/pre-commit"
+    git config --global core.hooksPath "$OTHER"
+
+    run install_git_hooks "$SRC" "$DOTF"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"preserving it"* ]]
+    [[ "$output" == *"INACTIVE"* ]]
+}
+
+# BUG-040 AC3: a trailing separator names the same directory; it must resolve to
+# the already-wired tier, not fall through to the foreign-path WARN.
+@test "a trailing-slash variant of the target counts as already wired" {
+    install_git_hooks "$SRC" "$DOTF"
+    git config --global core.hooksPath "$DEST/"
+
+    run install_git_hooks "$SRC" "$DOTF"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already wired to the GUARD dispatcher"* ]]
+    [[ "$output" != *"INACTIVE"* ]]
+}
+
 @test "clean-mirror removes a stale hook on re-deploy" {
     install_git_hooks "$SRC" "$DOTF"
     touch "$DEST/stale-hook"


### PR DESCRIPTION
Refs #766 (the "checks file existence instead of gate effectiveness" half). Spec: `specs/BUG-040-guard-gate-effectiveness/`.

## The bug

The GUARD-001 wiring check asked *"is `core.hooksPath` equal to the deploy mirror?"* when the question that matters is *"is a GUARD dispatcher actually running?"*.

Those diverge on any machine that develops the hooks from a repo checkout. Observed here:

```
core.hooksPath : <repo>/git-hooks
target         : ~/.dotfiles/git-hooks
pre-commit     : byte-identical in both (SHA256 CD3A25D3...37F3)

[WARNING] core.hooksPath is '...' (not the GUARD dispatcher)
          -- the memory-sink guard is INACTIVE.
```

The guard was active. Every setup run said otherwise. A security warning that cries wolf on every run is one that gets ignored.

## The fix

Three tiers instead of two:

| | `core.hooksPath` | Verdict |
|---|---|---|
| 1 | resolves to the deploy mirror | PASS (unchanged) |
| 2 | elsewhere, **but is a dispatcher** | PASS, naming the path |
| 3 | anything else | WARN + preserve (unchanged) |

"Is a dispatcher" is **structural** — `pre-commit` *and* the `lib/memory-sink-guard.sh` it execs. A hooks dir with a `pre-commit` but no guard still warns, so the check is not relaxed into "any hooks dir passes". Tier 1 normalizes separators and trailing slashes, because git reports `core.hooksPath` with forward slashes even on Windows.

Tier 2 prints the active path rather than staying silent, so a setup diverging from the mirror stays visible instead of being quietly blessed.

## Three implementations, one bug

The same check exists three times and all three were independently wrong in the same way:

- `cli/internal/doctor/checks_guard.go` (`switch current { case target: }`)
- `scripts/install-git-hooks.sh` (`[ "$current" = "$target" ]`)
- `scripts/install-git-hooks.ps1` (`$current -eq $Target`)

Having to write this fix three times is the cost of that duplication. The *deploy* half genuinely must stay in shell (ADR-020 C7 — the `dotf` release carries no source tree, so it cannot place `git-hooks/`), but the *wiring* half does not. Collapsing it is filed as **#793**, which also documents the setup-ordering constraint that blocks it today (`install-git-hooks` runs at `setup-windows.ps1:346`, `dotf` installs at `:554`).

## Verification

- **Go:** `go vet` clean; `go test -run TestCheckGuardHooks` -> **8/8 PASS**. Red-first confirmed: before the fix the two new behavioural tests failed and the other six passed — the regression signal and the no-change signal in one run.
- **bats:** `tests/install-git-hooks.bats` -> **12/12 PASS** (9 pre-existing + 3 new), run in `ubuntu:26.04` with bats `1.13.0`, the `versions.conf` pin `tests/Dockerfile.integration` consumes.
- **PowerShell:** 0 parse errors; 0 non-ASCII bytes (`pattern-powershell-ascii-only`); PSScriptAnalyzer reports only pre-existing `PSAvoidUsingWriteHost` / `PSUseShouldProcess`.

No-clobber is untouched throughout: a foreign `core.hooksPath` is never rewritten, and only an unset one is wired (under `--fix`).

## Not in this PR

- The other half of #766 (doctor proposing a pre-commit install it can never apply) — different code path, so #766 stays open.
- Auto-repointing `core.hooksPath` at the mirror. The machine-wide blast radius rule stands.
- The Pester case for the two new PowerShell helpers, for the same reason as #781: it needs a real Windows pwsh run to mean anything. Noted in `verification.md` under Remaining work.

## Note on the spec

`Refs #766`, not `Closes` — the issue's other half is still open. That also sidesteps the archive-on-merge / Discipline Gate contradiction filed as **#800**, which #799 had to use a `skip-archive` label to get around.
