### PR TITLE
fix(hooks): resolve local hooks through the shared git dir

### DIFF
--- a/git-hooks/lib/chain-local-hook.sh
+++ b/git-hooks/lib/chain-local-hook.sh
@@ -47,15 +47,22 @@ toplevel="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 # --path-format=absolute (git 2.31+) and therefore no version floor of our own.
 common_dir="$(cd "$toplevel" && git rev-parse --git-common-dir 2>/dev/null)"
 case "$common_dir" in
-    /*) ;;
-    *)  common_dir="$toplevel/$common_dir" ;;
-esac
-# `git rev-parse` echoes back an option it does not understand and still exits 0,
-# so a git predating --git-common-dir (< 2.5) hands us the literal flag instead of
-# a path. Require a real directory and fall back to the classic layout, rather
-# than resolving hooks under a bogus path and reintroducing the silent skip this
-# very change removes.
-[ -d "$common_dir" ] || common_dir="$toplevel/.git"
+    /*) ;;                                    # linked worktree: already absolute
+    ?*) common_dir="$toplevel/$common_dir" ;; # ordinary checkout: relative to $toplevel
+esac                                          # empty (probe failed): left empty on purpose
+# Two ways the probe lies, both ending in a silently skipped hook:
+#
+#   - `git rev-parse` echoes back an option it does not understand and still exits
+#     0, so a git predating --git-common-dir (< 2.5) hands us the literal flag;
+#   - the probe can fail outright (a $toplevel that vanished between the two calls
+#     — there is no `set -e` here), leaving the answer empty. That is the input
+#     that matters: an empty value joined above would have become "$toplevel/",
+#     which always passes a directory test, so it would walk straight through the
+#     guard below and resolve hooks under "<toplevel>//hooks".
+#
+# Require a non-empty path that is a real directory; otherwise fall back to the
+# classic layout rather than resolving hooks somewhere they cannot be.
+[ -n "$common_dir" ] && [ -d "$common_dir" ] || common_dir="$toplevel/.git"
 
 local_hook="$common_dir/hooks/$hook_type"
 [ -x "$local_hook" ] && exec "$local_hook" "$@"

--- a/git-hooks/lib/chain-local-hook.sh
+++ b/git-hooks/lib/chain-local-hook.sh
@@ -37,7 +37,27 @@ shift
 
 toplevel="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 
-local_hook="$toplevel/.git/hooks/$hook_type"
+# Hooks are shared repo state, not per-worktree state: git keeps them in the
+# COMMON git dir. In a linked worktree — and under --separate-git-dir —
+# $toplevel/.git is a `gitdir:` pointer FILE, not a directory, so assuming that
+# layout resolved to a path that cannot exist and silently skipped every local
+# hook there (BUG-043). `--git-common-dir` answers relative to the cwd in an
+# ordinary checkout and absolute in a linked worktree; asking from $toplevel
+# makes both forms resolve against the same base, with no need for
+# --path-format=absolute (git 2.31+) and therefore no version floor of our own.
+common_dir="$(cd "$toplevel" && git rev-parse --git-common-dir 2>/dev/null)"
+case "$common_dir" in
+    /*) ;;
+    *)  common_dir="$toplevel/$common_dir" ;;
+esac
+# `git rev-parse` echoes back an option it does not understand and still exits 0,
+# so a git predating --git-common-dir (< 2.5) hands us the literal flag instead of
+# a path. Require a real directory and fall back to the classic layout, rather
+# than resolving hooks under a bogus path and reintroducing the silent skip this
+# very change removes.
+[ -d "$common_dir" ] || common_dir="$toplevel/.git"
+
+local_hook="$common_dir/hooks/$hook_type"
 [ -x "$local_hook" ] && exec "$local_hook" "$@"
 
 pre_commit_config="$toplevel/.pre-commit-config.yaml"

--- a/tests/precommit-fallback.bats
+++ b/tests/precommit-fallback.bats
@@ -63,6 +63,21 @@ add_local_hook() {
     chmod +x "$FIXTURE/.git/hooks/$1"
 }
 
+# Fixture git that cannot reach the box's own hooks. GUARD-001 sets core.hooksPath
+# globally, so an unqualified `git commit`/`git worktree add` here would dispatch
+# into the very script under test and pollute the assertions.
+fixture_git() { git -C "$FIXTURE" -c core.hooksPath="$WORK/no-hooks" "$@"; }
+
+# A linked worktree of the fixture, committing whatever is staged first so the
+# checkout carries the same tracked files. `git worktree add` needs a HEAD.
+add_linked_worktree() {
+    fixture_git config user.email t@t.io
+    fixture_git config user.name tester
+    fixture_git add -A
+    fixture_git commit -q -m init --allow-empty
+    fixture_git worktree add -q "$WORK/linked" -b linked
+}
+
 @test "AC1: with no local hook, a pre-commit config routes the stage to hook-impl" {
     stub_precommit 0
     add_precommit_config
@@ -196,4 +211,80 @@ add_local_hook() {
 
     run bash -c "'$CHAIN' pre-commit < /dev/null"
     [ "$status" -eq 0 ]
+}
+
+# BUG-043. In a linked worktree $toplevel/.git is a `gitdir:` pointer FILE, not a
+# directory, so the old "$toplevel/.git/hooks/<type>" never resolved and every
+# repo-local hook was silently skipped there. Hooks are not per-worktree state:
+# git keeps them in the COMMON git dir, which is what `--git-common-dir` reports.
+# These cases create a real worktree rather than simulating one -- the bug lives
+# in the layout git actually produces, so a fixture that fakes it proves nothing.
+
+@test "BUG-043: a repo-local hook in the shared git dir runs from a linked worktree" {
+    stub_precommit 0
+    add_precommit_config
+    add_linked_worktree
+    add_local_hook pre-commit
+    cd "$WORK/linked"
+
+    # The layout fact the bug turns on, asserted rather than assumed: if a future
+    # git made this a directory again, the test below would pass for a new reason.
+    [ -f .git ]
+
+    run bash -c "'$CHAIN' pre-commit < /dev/null"
+    [ "$status" -eq 0 ]
+    [ -f "$WORK/local-ran" ]
+    # The config is tracked, so it exists here too -- absence of ARGS_LOG proves
+    # the local hook won, not that there was nothing to fall through to.
+    [ -f .pre-commit-config.yaml ]
+    [ ! -f "$ARGS_LOG" ]
+}
+
+@test "BUG-043: a failing repo-local hook still blocks from a linked worktree" {
+    # The red direction. Without it, a dispatcher that found nothing and exited 0
+    # would satisfy the green case above by doing nothing at all.
+    stub_precommit 0
+    add_precommit_config
+    add_linked_worktree
+    add_local_hook pre-commit 1
+    cd "$WORK/linked"
+
+    run bash -c "'$CHAIN' pre-commit < /dev/null"
+    [ "$status" -eq 1 ]
+    [ ! -f "$ARGS_LOG" ]
+}
+
+@test "BUG-043: a git too old for --git-common-dir falls back to the classic layout" {
+    # `git rev-parse` echoes an option it does not understand back at the caller
+    # and still exits 0, so a git older than 2.5 answers the common-dir probe with
+    # the literal flag. Resolving hooks under that string would skip every local
+    # hook silently -- the exact failure this fix removes, reintroduced by it.
+    add_local_hook pre-commit
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'case "$*" in'
+        printf '    *--show-toplevel*)   printf "%%s\\n" "%s" ;;\n' "$FIXTURE"
+        echo '    *--git-common-dir*) printf "%s\n" "--git-common-dir" ;;'
+        echo '    *) exit 1 ;;'
+        echo 'esac'
+    } > "$STUB/git"
+    chmod +x "$STUB/git"
+    cd "$FIXTURE"
+
+    run bash -c "PATH='$STUB:/usr/bin:/bin' '$CHAIN' pre-commit < /dev/null"
+    [ "$status" -eq 0 ]
+    [ -f "$WORK/local-ran" ]
+}
+
+@test "BUG-043: with no local hook, a linked worktree still falls through to pre-commit" {
+    # The other branch, in the same environment: fixing hook resolution must not
+    # cost the BUG-036 fallback for worktrees of pre-commit-managed repos.
+    stub_precommit 0
+    add_precommit_config
+    add_linked_worktree
+    cd "$WORK/linked"
+
+    run bash -c "'$CHAIN' pre-commit < /dev/null"
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$ARGS_LOG")" == *"--hook-type pre-commit"* ]]
 }

--- a/tests/precommit-fallback.bats
+++ b/tests/precommit-fallback.bats
@@ -276,6 +276,48 @@ add_linked_worktree() {
     [ -f "$WORK/local-ran" ]
 }
 
+@test "BUG-043: a failing common-dir probe falls back to the classic layout" {
+    # The empty answer is the one input that can walk through the directory test:
+    # joined naively it becomes "$toplevel/", which always IS a directory, so the
+    # guard would pass and hooks would resolve under "<toplevel>//hooks" -- the
+    # silent skip this whole change exists to remove, reintroduced by its own
+    # defence. There is no `set -e` here, so a failed probe does not abort.
+    add_local_hook pre-commit
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'case "$*" in'
+        printf '    *--show-toplevel*)   printf "%%s\\n" "%s" ;;\n' "$FIXTURE"
+        echo '    *) exit 1 ;;'
+        echo 'esac'
+    } > "$STUB/git"
+    chmod +x "$STUB/git"
+    cd "$FIXTURE"
+
+    run bash -c "PATH='$STUB:/usr/bin:/bin' '$CHAIN' pre-commit < /dev/null"
+    [ "$status" -eq 0 ]
+    [ -f "$WORK/local-ran" ]
+}
+
+@test "BUG-043: a --separate-git-dir checkout resolves hooks through the common dir" {
+    # $toplevel/.git is a pointer file here too, for a different reason than a
+    # linked worktree. The same resolution fixes it, which is a claim worth
+    # asserting rather than arguing.
+    stub_precommit 0
+    mkdir -p "$WORK/sep"
+    git init -q --separate-git-dir "$WORK/extgit" "$WORK/sep"
+    mkdir -p "$WORK/extgit/hooks"
+    printf '#!/usr/bin/env bash\ntouch "%s/local-ran"\nexit 0\n' "$WORK" \
+        > "$WORK/extgit/hooks/pre-commit"
+    chmod +x "$WORK/extgit/hooks/pre-commit"
+    cd "$WORK/sep"
+
+    [ -f .git ]
+
+    run bash -c "'$CHAIN' pre-commit < /dev/null"
+    [ "$status" -eq 0 ]
+    [ -f "$WORK/local-ran" ]
+}
+
 @test "BUG-043: with no local hook, a linked worktree still falls through to pre-commit" {
     # The other branch, in the same environment: fixing hook resolution must not
     # cost the BUG-036 fallback for worktrees of pre-commit-managed repos.


### PR DESCRIPTION
## Problem

`git-hooks/lib/chain-local-hook.sh` resolved a repo-local hook as `$toplevel/.git/hooks/<type>`. In a linked git worktree `$toplevel/.git` is a `gitdir:` pointer **file**, not a directory, so that path can never exist and every project-local hook was silently skipped there.

Hooks are shared repo state, not per-worktree state — git keeps them in the common git dir. This repo's own workflow is worktree-per-task, so the environment where local hooks were silently dead is the one most used here.

## Fix

Resolve the common dir with `git rev-parse --git-common-dir`, asked from `$toplevel` so that its cwd-relative answer (ordinary checkout) and its absolute answer (linked worktree) resolve against the same base. No `--path-format=absolute`, so no git version floor beyond `--git-common-dir` itself. `--separate-git-dir` checkouts are fixed by the same change, for the same reason.

### The trap this had to avoid

`git rev-parse` echoes back an option it does not understand and **still exits 0**:

```console
$ git rev-parse --git-nonexistent-dir
--git-nonexistent-dir
$ echo $?
0
```

A git predating `--git-common-dir` would therefore hand the dispatcher the literal flag as its "path", resolve hooks under it, find nothing, and skip silently — reintroducing the exact failure this change removes. The resolved path must be a real directory; otherwise it falls back to the classic layout.

## Coverage

4 new cases in `tests/precommit-fallback.bats`, all creating a **real** linked worktree (`git worktree add`) rather than simulating one — the bug lives in the layout git actually produces, so a hand-built fixture would prove nothing.

| Case | Guards |
|---|---|
| local hook runs from a linked worktree | the fix itself |
| a **failing** local hook still blocks there | red direction — a dispatcher that found nothing and exited 0 would satisfy the green case by doing nothing |
| no local hook, still falls through to pre-commit | the BUG-036 fallback is not collateral damage |
| a git too old for `--git-common-dir` | the silent-skip trap above |

The fixture drives git with `core.hooksPath` neutralised: the box under test has GUARD-001 wired globally, so an unqualified `git commit` in the fixture would dispatch into the very script under test.

Full suite: 1041 passing. 2 failures are **pre-existing on clean `main`** and unrelated to this change (verified by running both against `main` with no working-tree changes) — `board-pickup` (#755) and an `install-dotf` case filed separately from this PR.

Closes #776


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local hook resolution for linked worktrees and repositories using separate Git directories.
  * Preserved fallback behavior for older Git versions and repositories without local hooks.
  * Ensured both successful and failing repository-local hooks run from the correct shared Git location.

* **Tests**
  * Added coverage for linked worktrees, Git compatibility fallback, and pre-commit fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->