### PR TITLE
docs(agents): hand the PR over instead of watching CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,7 @@ Any of the five may be skipped, but only as a stated decision naming which one a
 ### Interaction Discipline
 
 - **Wait before acting** — don't explore/implement/launch until the prompt is finished. **Ask before exploring** a codebase; no unprompted exploration. **Hands off unless asked** — no terminal/Docker/tests unless requested; when the user says they'll handle it, give instructions only. **Never delete without confirmation** — no removing existing content (README links, doc sections, backlog items) without explicit approval.
+- **Hand the PR over; don't watch CI.** After opening a PR, report it and move to the next piece of work — never sit in a watch loop (`gh pr checks --watch`) waiting for checks. The human reviews the PR and reports a red build. Query the status **once** only when something actually depends on the result (a stacked branch, a follow-up commit). Watching burns wall-clock while the queue waits and tells the reviewer nothing they are not already looking at.
 
 ### Autonomy Boundaries
 


### PR DESCRIPTION
One bullet in `AGENTS.md` § Interaction Discipline.

Established by correction twice in one session: sitting in `gh pr checks --watch` after opening a PR burns wall-clock while the queue waits, and adds no information — the reviewer owns review and merge, so they own noticing a red build too. Status gets queried once, and only when something downstream actually depends on the result (a stacked branch, a follow-up commit).

It lands in `AGENTS.md` rather than in one agent's memory on purpose: a rule that only reaches Claude is exactly the gap this session spent its time closing. From here it reaches codex, copilot, pi and opencode through their instruction files as well.

Recorded locally as `feedback-hand-over-pr-dont-watch-ci`; this is the cross-agent half.