### PR TITLE
test(board-pickup): isolate the fixture from the machine global hooksPath

### DIFF
--- a/tests/board-pickup.bats
+++ b/tests/board-pickup.bats
@@ -43,6 +43,16 @@ EOF
     REPO="$TMP/repo"
     mkdir -p "$REPO"
     git -C "$REPO" init -q
+
+    # GUARD-001 wires core.hooksPath globally, so an unqualified `git checkout`
+    # in this fixture fires the machine's real post-checkout dispatcher — which
+    # backgrounds *this very helper* and appends its own line to $GHLOG. Every
+    # count assertion below would then measure the machine's hooks as well as the
+    # helper under test. Neutralising it in the fixture's own config (rather than
+    # per call, as tests/precommit-fallback.bats does) covers all 13 git
+    # invocations here and any added later.
+    mkdir -p "$TMP/no-hooks"
+    git -C "$REPO" config core.hooksPath "$TMP/no-hooks"
     git -C "$REPO" config user.email t@t
     git -C "$REPO" config user.name t
     git -C "$REPO" remote add origin "git@github.com:mlorentedev/dotfiles.git"
@@ -104,4 +114,18 @@ run_helper() { ( cd "$REPO" && bash "$HELPER" "$@" ); }
     run run_helper "" "" "1"
     [ "$status" -eq 0 ]
     [ "$(grep -c 'mlorentedev/knowledge 52' "$GHLOG")" -eq 1 ]
+}
+
+@test "fixture isolation: a checkout must not fire the machine's post-checkout dispatcher" {
+    # Guard for the isolation itself, not for the helper. Without the
+    # core.hooksPath neutralisation in setup(), the global GUARD-001 dispatcher
+    # runs the real post-checkout, which launches board-pickup.sh in the
+    # background -- so every count assertion in this file silently measures two
+    # runs. That is exactly how "assigns once, no redundant fallback" came to
+    # fail on a clean main while the helper itself was correct.
+    git -C "$REPO" checkout -q -b feat/77-x
+    # The dispatcher backgrounds the helper (`... &`), so an immediate check can
+    # pass on timing alone. Wait long enough that a leaked run would have landed.
+    sleep 1
+    [ ! -s "$GHLOG" ]
 }


### PR DESCRIPTION
Refs #755. Fixes the red case on `main`; does **not** close the issue — see below.

## What was actually wrong

`tests/board-pickup.bats` was not isolated from the machine it runs on. GUARD-001
wires `core.hooksPath` globally, so the fixture's `git checkout` fired the real
`post-checkout` dispatcher — which launches `board-pickup.sh` in the background:

```sh
"$DISPATCH_DIR/lib/board-pickup.sh" "$@" >/dev/null 2>&1 &
```

Every count assertion in the file was therefore measuring the machine's hooks plus
the helper under test. `assigns once, no redundant fallback` saw two log lines
because the helper genuinely ran twice — once from the dispatcher, once from
`run_helper`.

Reproduced by hand, with hooks neutralised:

```
log after checkout: 0 lines
log after helper:   1 line
    mlorentedev/knowledge 52
=> the helper on its own assigns exactly once
```

`tests/precommit-fallback.bats` already guards against this, per call:

> GUARD-001 sets core.hooksPath globally, so an unqualified `git commit` here would dispatch into the very script under test and pollute the assertions.

This file never got the same treatment.

## The fix

Neutralise in the fixture's own config rather than per call — it covers all 13 git
invocations and any added later, where a wrapper only covers the ones someone
remembers to route through it.

Plus a guard for the isolation itself: a bare checkout must leave `$GHLOG` empty.
It carries a `sleep` because the dispatcher backgrounds the helper, so an immediate
assertion can pass on timing alone rather than on isolation.

Verified by removing the neutralisation — cases 7 and 8 go red, green when
restored.

## Why this does not close #755

That issue describes a **product** bug: the helper assigning twice when the current
repo IS knowledge. What this PR shows is that the failing *test* was not evidence
of it — the helper assigns once under isolation, and the guard for that behaviour
is now green and trustworthy. Whether the original field report is already fixed or
lives on a path this fixture does not reach is for the issue owner to decide, so it
stays open with the correction recorded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability during board pickup setup by preventing unrelated checkout actions from running automatically.
  * Avoided unexpected entries in command logs during fixture preparation.

* **Tests**
  * Added regression coverage to verify checkout workflows complete without triggering unintended background actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->