### PR TITLE
fix(hooks): pin default_stages so a stage-agnostic hook runs once, not once per hook type

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,14 @@
 # Bypass (only with explicit user approval):
 #   SKIP=gitleaks git commit ...
 
+# Pin the stage — see the same block in cli/internal/initrepo/templates/. Only
+# `gitleaks` below declares no stage of its own, so this is what stops it running
+# once per dispatched hook type (it was firing twice on every commit here). Its
+# effective stage becomes pre-commit, which gates strictly earlier than pre-push:
+# secrets are blocked before they enter history rather than before they leave the
+# machine.
+default_stages: [pre-commit]
+
 repos:
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.1

--- a/cli/internal/initrepo/templates/pre-commit-config.yaml
+++ b/cli/internal/initrepo/templates/pre-commit-config.yaml
@@ -7,6 +7,16 @@
 # Bypass (only with explicit user approval):
 #   SKIP=gitleaks git commit ...
 
+# Pin the stage. A hook that declares no stages of its own defaults to EVERY
+# stage, which was harmless while .git/hooks/ held only what `pre-commit install`
+# wrote. GUARD-001 dispatches hooks machine-wide via core.hooksPath, so every hook
+# type git fires now reaches `pre-commit hook-impl` and a stage-agnostic hook runs
+# once per type — measured at 3 gitleaks runs per commit, plus one per checkout and
+# one per push. Results were correct; the work was triple. A hook that genuinely
+# needs another stage declares it explicitly and is unaffected: an explicit stage
+# beats this default.
+default_stages: [pre-commit]
+
 repos:
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.1


### PR DESCRIPTION
Reported from a parallel session working in `pdf-modifier-mcp`, verified
independently here before acting on it.

## The defect

A pre-commit hook that declares no `stages` of its own defaults to **every**
stage. That was harmless while `.git/hooks/` held only what `pre-commit install`
wrote. GUARD-001 dispatches hooks machine-wide via `core.hooksPath`, so every hook
type git fires now reaches `pre-commit hook-impl`, and a stage-agnostic hook runs
once per hook type.

Reproduced with a marker hook declaring no stages, invoking each dispatcher
directly:

```
pre-commit           -> ran
prepare-commit-msg   -> ran
commit-msg           -> ran
```

Correct results, multiplied work — plus one full suite per `git checkout` (the
dispatcher's `post-checkout`) and one per push.

## This repo was affected too

`gitleaks` is the only hook here without its own `stages`, and it was running
**twice on every commit**. That was visible in this session's own commit output
and went unrecognised:

```
Detect hardcoded secrets.................................................Passed
Detect hardcoded secrets.................................................Passed
Validate message format..................................................Passed
```

Measured on the commit that carries this fix: **1 invocation**.

## Two layers

| File | Effect |
|---|---|
| `cli/internal/initrepo/templates/pre-commit-config.yaml` | new repos scaffolded by `dotf init` stop inheriting it |
| `.pre-commit-config.yaml` | this repo stops its own duplicate runs |

Hooks with an explicit stage are unaffected — an explicit stage beats the default,
so `validate-commit-msg` (`[commit-msg]`), `dotfiles-test` (`[pre-commit]`) and
`sdd-spec-gate` (`[pre-push]`) keep firing exactly where they did.

One behavioural note worth stating: `gitleaks`' effective stage in this repo
becomes `pre-commit`, where before it also ran at `pre-push`. That gates strictly
**earlier** — secrets are blocked before entering history rather than before
leaving the machine — so it is a tightening, not a relaxation.

## Verification

`go test ./internal/initrepo/...` green; `install-precommit.bats`,
`precommit-fallback.bats` and `precommit-fallback-real.bats` all green.

## Not in scope

The reporting session also found that a `.gitleaks.toml` carrying `[allowlist]`
without `[extend] useDefault = true` **replaces** the built-in ruleset, so gitleaks
runs with zero rules and passes a planted PAT. That file is hand-written per repo
and `dotf init` does not emit one, so it is not a dotfiles concern today — worth
remembering if a `.gitleaks.toml` is ever added to the template.
