### PR TITLE
docs(dr): put the age-key restore commands in the disaster chain itself

### DIFF
--- a/docs/runbooks/guide-secrets-governance.md
+++ b/docs/runbooks/guide-secrets-governance.md
@@ -54,7 +54,18 @@ Scheduled (e.g. weekly) + before any big change:
 
 Lost Bitwarden access / new machine / account compromise (the OPS-001 #257 chain):
 
-1. Restore the **age key** from its offline backup → `~/.config/age/key.txt`.
+1. **Restore the age key from its offline backup** → `~/.config/age/key.txt`. Everything below decrypts with this key, so nothing else in the chain can start until it is in place. The authoritative offline copy is an encrypted USB (VeraCrypt); `lsblk` identifies the device, which is not stable across machines.
+
+   ```bash
+   sudo apt install age veracrypt            # a fresh machine has neither
+   veracrypt /dev/sdX1 /media/secrets        # prompts for the volume password
+   install -m 600 -D /media/secrets/key.txt ~/.config/age/key.txt
+   veracrypt -d /media/secrets               # unmount when done
+   ```
+
+   A USB written by `backup-secrets-to-usb.sh` also carries `ci-age-key.txt`, a standalone decrypt script and a `secrets/` mirror, so `cd /media/secrets && ./age-standalone.sh decrypt` recovers everything **without the repo**. A hand-copied USB holds `key.txt` alone — still enough for this chain, which is what matters here.
+
+   Creating and refreshing that USB lives in [`secrets-management.md` § Physical Backup](secrets-management.md#physical-backup-usb--veracrypt). That runbook carries an out-of-date banner scoped to its `env-mapping.conf` workflow; the VeraCrypt procedure is **not** part of what was retired and remains current under ADR-028, which keeps age as the DR floor.
 2. Clone the dotfiles repo.
 3. `age -d -i ~/.config/age/key.txt sensitive/dr/bitwarden-export.age > $TMPDIR/vault.json` (ephemeral / tmpfs) — `sensitive/dr/bitwarden-export.age` is the artifact `dotf secrets backup` produced.
 4. Stand up a fresh Bitwarden (or any manager) and **import** `vault.json` (`bw import bitwardenjson $TMPDIR/vault.json`); or read individual secrets for immediate needs.

--- a/docs/runbooks/secrets-management.md
+++ b/docs/runbooks/secrets-management.md
@@ -9,10 +9,17 @@ owner: manu
 
 # Secrets Management
 
-> ⚠️ **Out of date — pending rewrite ([#600](https://github.com/mlorentedev/dotfiles/issues/600)).**
+> ⚠️ **Partly out of date — pending rewrite ([#600](https://github.com/mlorentedev/dotfiles/issues/600)).**
 > The `sensitive/env-mapping.conf` workflow below was retired in #587. Secrets are now
 > mapped in **`secrets/registry.yaml`** (ADR-028) and accessed via `dotf secrets {run,show,render}`.
 > Treat the `env-mapping.conf` steps here as historical until this runbook is refreshed.
+>
+> **[§ Physical Backup (USB + VeraCrypt)](#physical-backup-usb--veracrypt) is NOT affected and is current.**
+> ADR-028 keeps age as the DR floor, so the encrypted-USB procedure still applies —
+> it is called from step 1 of the disaster chain in
+> [`guide-secrets-governance.md` § RECOVER](guide-secrets-governance.md#protocol--recover-disaster).
+> Said explicitly because a banner at the top of a document is read as covering all of it,
+> and this is the only place the physical procedure is written down.
 
 Complete guide for managing encrypted secrets in the dotfiles. Uses [age](https://github.com/FiloSottile/age) encryption with automatic environment variable loading.
 


### PR DESCRIPTION
Fixed directly rather than ticketed, at Manu's call — it is a disaster-recovery
gap, and those only matter on the day they cannot be scheduled.

## The gap

`guide-secrets-governance.md` § RECOVER opens the disaster chain with:

> 1. Restore the **age key** from its offline backup → `~/.config/age/key.txt`.

One sentence, no instructions — for the step every later step depends on. Nothing
in the chain decrypts without that key.

The actual procedure — VeraCrypt install, mount, device discovery, where the key
lands — existed in exactly one place: `secrets-management.md` § Physical Backup.
That runbook opens with **⚠️ Out of date — pending rewrite (#600)**.

The banner is scoped to the retired `env-mapping.conf` workflow and is accurate
about it. But a warning at the top of a document is read as covering the document,
so the only written copy of the physical restore procedure looked untrustworthy at
precisely the moment someone would be reaching for it — on a fresh machine, under
pressure, with no way to tell which half of the page still applied.

## What changed

**`guide-secrets-governance.md`** — step 1 now carries the commands inline, so the
emergency document is self-sufficient:

```bash
sudo apt install age veracrypt            # a fresh machine has neither
veracrypt /dev/sdX1 /media/secrets        # prompts for the volume password
install -m 600 -D /media/secrets/key.txt ~/.config/age/key.txt
veracrypt -d /media/secrets
```

`install -D` rather than `cp`, because `~/.config/age/` does not exist on a fresh
machine, and `-m 600` because a private key restored world-readable is its own
incident. It also distinguishes the two USB shapes: one written by
`backup-secrets-to-usb.sh` (carries `age-standalone.sh` and a `secrets/` mirror,
so it recovers everything **without the repo**) versus a hand-copied one holding
`key.txt` alone — still sufficient for this chain.

**`secrets-management.md`** — the banner now says "Partly out of date" and states
explicitly that § Physical Backup is not part of what was retired and remains
current under ADR-028, which keeps age as the DR floor.

## Verification

Both cross-links are anchors into the other file; the slugs were generated from
the exact heading text and checked against GitHub's rule
(`#physical-backup-usb--veracrypt`, `#protocol--recover-disaster` — both with the
double hyphen the removed `(`/`+`/`—` characters produce). A broken link in a
recovery runbook is worse than no link.

## Still open

#257 (OPS-001) — the full ordered DR chain as its own runbook — remains open. This
does not close it; it makes the step that had no instructions executable.

Context: prompted by Manu asking whether a VeraCrypt runbook existed. It did, in
the repo rather than the vault, and in the document that looked retired.
