### PR TITLE
docs(agents): make ticket-ID allocation race-safe across parallel sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,12 @@ Any of the five may be skipped, but only as a stated decision naming which one a
 
 - **Escalate, don't grind.** When autonomous (unattended or fan-out), stop and surface the moment the **same failure repeats** (≥2 tries, no new info), a **taste/ownership decision** appears (naming, scope, UX, a trade-off the user should own), or the **diff exceeds the ~300 LOC atomic-PR cap**. Silently grinding, or making an owner's call unasked, is the failure — escalation is not. (`docs/adr/adr-017-alignment-audit-karpathy-anthropic.md`.)
 
+### Parallel Sessions
+
+- **Allocate ticket IDs from a live query, never from a cached scan.** Several sessions can be open on the same repo at once, so the highest `AREA-NNN` you saw earlier in the session is a stale reading by the time you file. Re-query immediately before creating the issue. (2026-08-08: a scan showed `HARNESS` max `059`; minutes later a concurrent session had taken `060` and `061`, and only a peer's warning stopped a duplicate ID being filed. A duplicate ID is not rejected by anything — the board carries both silently.)
+- **A peer agent's report is a lead, not a fact.** Verify identifiers, counts and states a peer hands you against the source before acting on them — it is cheap to confirm and expensive to propagate. The same applies in reverse: when you tell a peer a number, say where you read it.
+- **Do not resume a long-idle session to deliver a message.** Waking a session that has been dormant for weeks restarts it on stale context. Prefer a durable artifact — an issue, a comment on the work itself — that reaches whoever picks the work up next, whether or not you ever identify them.
+
 ### Change Management & Engineering
 
 - **Read before writing** — read existing code/changelogs/docs first; never assume. **One issue at a time** for CI/lint fixes (confirm each passes). **Backward compatibility** on multi-file refactors (open/closed; run all tests). **TDD** — failing test first, then the fix.


### PR DESCRIPTION
Adds a `### Parallel Sessions` subsection to `AGENTS.md` under `## Operational Rules (from past corrections)`, between `Autonomy Boundaries` and `Change Management & Engineering`.

## Why

Three sessions were open on this repo on 2026-08-08. One of them (working from kubelab, filing the vault-health findings) scanned for the highest `HARNESS-NNN`, got `059`, and prepared to file `HARNESS-060`. By the time it filed, a concurrent session had already taken `060` (#836) and `061` (#852). The duplicate was avoided only because that peer volunteered the collision in a message — nothing in the tooling would have rejected it, and the board would have carried two `HARNESS-060`s silently.

That is a race with no guard, in a workflow where concurrent sessions are now normal rather than exceptional.

## What it says

Three rules, all drawn from that incident:

1. **Allocate IDs from a live query, not a cached scan** — re-query immediately before filing.
2. **A peer agent's report is a lead, not a fact** — verify identifiers, counts and states against the source before acting; and when you hand a peer a number, say where you read it. (The peer's numbers were correct here; they were verified before use, which is the behaviour being written down.)
3. **Do not resume a long-idle session to deliver a message** — waking a dormant session restarts it on stale context. A durable artifact reaches whoever picks the work up next, whether or not you ever identify them. In the same session a warning needed to reach an unidentified dotfiles worker; the answer was to file #856, not to wake a session that had been idle 268 days.

## Notes for review

- **The generated block is untouched.** `### Overrides of Harness Defaults` is HARNESS-generated; the diff adds only above `### Change Management & Engineering` and does not enter the markers. Verified: zero marker lines in the diff.
- **A new subsection is a judgement call.** The rules could have gone as bullets under `Change Management & Engineering`, but only the first is really change mechanics — the other two are about trusting and addressing other agents, which `AGENTS.md` had no home for. Happy to fold them in instead if you'd rather not grow the section list.
- Docs only, 6 lines added, no behaviour change. Written from a worktree off `main`.

## Related

- #836, #852 — the two IDs that were taken mid-flight.
- #855, #856 — the tickets that came out of the same audit, filed with the corrected number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for handling parallel sessions, including verifying shared information, using current ticket details, and preserving durable work artifacts.
  * No changes were made to user-facing functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->