### PR TITLE
chore(spec): archive MEMORY-006

### DIFF
--- a/specs/archive/MEMORY-006-unwrap-yaml-memory/proposal.md
+++ b/specs/archive/MEMORY-006-unwrap-yaml-memory/proposal.md
@@ -1,7 +1,7 @@
 ---
 id: "MEMORY-006-unwrap-yaml-memory"
 type: spec
-status: draft # draft | implementing | verifying | archived
+status: archived # draft | implementing | verifying | archived
 created: "2026-08-09"
 issue: "mlorentedev/dotfiles#864"
 tags: [spec, proposal]

--- a/specs/archive/MEMORY-006-unwrap-yaml-memory/tasks.md
+++ b/specs/archive/MEMORY-006-unwrap-yaml-memory/tasks.md
@@ -61,8 +61,8 @@ before the transform exists.
 - [x] Lesson in `docs/lessons.md`.
 - [x] File what was found along the way rather than mentioning it — **#865**
       (the wrap also truncated content).
-- [ ] PR #866 merged, CI green.
-- [ ] `dotf spec archive MEMORY-006-unwrap-yaml-memory`, #864 closed.
+- [x] PR #866 merged (`13a8b6d`), CI green.
+- [x] `dotf spec archive MEMORY-006-unwrap-yaml-memory`, #864 closed.
 
 ## Counts, stated once so they stay consistent
 

--- a/specs/archive/MEMORY-006-unwrap-yaml-memory/verification.md
+++ b/specs/archive/MEMORY-006-unwrap-yaml-memory/verification.md
@@ -213,10 +213,12 @@ CLEAN
 
 ## Archive checklist
 
-- [ ] `proposal.md` frontmatter set to `status: archived`
-- [ ] Folder moved to `specs/archive/MEMORY-006-unwrap-yaml-memory/`
-- [ ] Bitácora ticket closed with PR link (ADR-018)
+- [x] `proposal.md` frontmatter set to `status: archived`
+- [x] Folder moved to `specs/archive/MEMORY-006-unwrap-yaml-memory/`
+- [x] Bitácora ticket closed with PR link (ADR-018)
 
-> **Not archived by this PR yet.** The migration has been proven in a sandbox but
-> not run against live memory — that write is Manu's call, per this spec's own
-> acceptance. The PR carries `Refs #864`.
+> **PR #866 merged as `13a8b6d`.** The migration ran against live memory after
+> the dry-run diff was reviewed and approved; the migrated files are vault commit
+> `9f73dfc4`. #866 deliberately carried `Refs #864` rather than a closing keyword
+> — the ticket closes with this archive PR, which is the archive-on-merge
+> sequence the gate expects.


### PR DESCRIPTION
Archives `MEMORY-006-unwrap-yaml-memory` now that the work has shipped and run.

## What landed

- **#866** merged as `13a8b6d` — a `dotf doctor` check that detects a
  YAML-wrapped `MEMORY.md` and migrates it back to plain markdown under `--fix`.
- **The migration ran** against live memory after its dry-run diff was reviewed:
  16 distinct files, vault commit `9f73dfc4`.
- **Verified by effect**, not inspection: crystallize now succeeds where it
  refused, and the HARNESS-029 invariant survives the stamp.

## Why this is a separate PR

#866 deliberately carried `Refs #864` instead of a closing keyword, because at
that point the ticket was not finished — the live migration had not run and the
spec was still active. Archiving in the same act as closing the ticket is the
sequence the archive-on-merge gate expects, so it lands here.

## Findings filed rather than mentioned

- **#865** — the 2026-05-26 wrap did not only change shape, it **truncated
  content**: the trailing `# currentDate` section from most files, 169 lines from
  one work project, and **mid-line** in two more (one kept 1 byte of 18, another
  1 byte of 61). Recoverable from `1c216229^`, but per-file surgery rather than a
  concatenation.
- **#857** stays open pending its acceptance criteria being amended — they still
  describe the withdrawn plan of teaching crystallize to edit the wrapped shape.
  That is an owner decision, flagged on the issue rather than rewritten.

Closes #864
