### PR TITLE
Gate spec archive on a fresh, passing adversarial review

### DIFF
--- a/cli/internal/cmd/spec.go
+++ b/cli/internal/cmd/spec.go
@@ -136,9 +136,10 @@ agent) or by hand. Do not skip the Why.`,
 
 func newSpecArchiveCmd() *cobra.Command {
 	var (
-		prURL       string
-		abandoned   bool
-		forceDrafts bool
+		prURL         string
+		abandoned     bool
+		forceDrafts   bool
+		forceNoReview bool
 	)
 
 	cmd := &cobra.Command{
@@ -149,8 +150,11 @@ under --abandoned) and rewrite the proposal status to archived/abandoned.
 
 Mechanical only — the Go twin of scripts/archive-spec.sh. A pre-flight refuses to
 archive while unresolved [AGENT-DRAFT]/[AGENT-SUGGESTION] tags remain (override
-with --force-with-drafts). Vault promotion (lessons/ADR/pattern) and any backlog
-tick stay interactive via "/spec archive" in an agent.`,
+with --force-with-drafts). A second pre-flight refuses without a fresh, passing
+review.md from /adversarial-review (override with --force-without-review, or
+declare "review: waived" with a reason in proposal.md). Vault promotion
+(lessons/ADR/pattern) and any backlog tick stay interactive via "/spec archive"
+in an agent.`,
 		Example:      "  dotf spec archive AI-001-ollama-public --pr https://github.com/owner/repo/pull/42",
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
@@ -167,10 +171,11 @@ tick stay interactive via "/spec archive" in an agent.`,
 			}
 
 			target, err := spec.Archive(repoRoot, id, spec.ArchiveOptions{
-				Abandoned:       abandoned,
-				ForceWithDrafts: forceDrafts,
-				PRURL:           prURL,
-				Date:            now().Format("2006-01-02"),
+				Abandoned:          abandoned,
+				ForceWithDrafts:    forceDrafts,
+				ForceWithoutReview: forceNoReview,
+				PRURL:              prURL,
+				Date:               now().Format("2006-01-02"),
 			})
 			if err != nil {
 				return err
@@ -198,5 +203,6 @@ tick stay interactive via "/spec archive" in an agent.`,
 	cmd.Flags().StringVar(&prURL, "pr", "", "record this PR URL in proposal.md (informational)")
 	cmd.Flags().BoolVar(&abandoned, "abandoned", false, "route to specs/archive/_abandoned/ and set status abandoned")
 	cmd.Flags().BoolVar(&forceDrafts, "force-with-drafts", false, "archive even with unresolved [AGENT-DRAFT]/[AGENT-SUGGESTION] tags")
+	cmd.Flags().BoolVar(&forceNoReview, "force-without-review", false, "archive even without a fresh, passing review.md")
 	return cmd
 }

--- a/cli/internal/cmd/spec_archive_test.go
+++ b/cli/internal/cmd/spec_archive_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 )
 
-// seedSpec writes a minimal specs/<id>/proposal.md under root for archive tests.
+// seedSpec writes a minimal ARCHIVABLE specs/<id>/ under root: the proposal the
+// caller cares about, plus the passing review.md the CLI-034 gate now requires.
+// Tests that exercise the gate itself write their own review instead.
 func seedSpec(t *testing.T, root, id, proposal string) {
 	t.Helper()
 	dir := filepath.Join(root, "specs", id)
@@ -15,6 +17,10 @@ func seedSpec(t *testing.T, root, id, proposal string) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "proposal.md"), []byte(proposal), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	review := "---\nspec: \"" + id + "\"\nverdict: \"PASS\"\nreviewed_sha: \"0000000000000000000000000000000000000000\"\n---\nno blocking findings\n"
+	if err := os.WriteFile(filepath.Join(dir, "review.md"), []byte(review), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cli/internal/spec/archive.go
+++ b/cli/internal/spec/archive.go
@@ -130,10 +130,15 @@ var statusLinePattern = regexp.MustCompile(`^(status:\s+)\S+(.*)$`)
 
 // ArchiveOptions configures Archive.
 type ArchiveOptions struct {
-	Abandoned       bool   // route to specs/archive/_abandoned/<id>; status -> abandoned
-	ForceWithDrafts bool   // archive even with unresolved [AGENT-*] tags
-	PRURL           string // when set, append an archived/PR provenance comment
-	Date            string // YYYY-MM-DD for the PR comment (caller-supplied; deterministic in tests)
+	Abandoned          bool   // route to specs/archive/_abandoned/<id>; status -> abandoned
+	ForceWithDrafts    bool   // archive even with unresolved [AGENT-*] tags
+	ForceWithoutReview bool   // archive even without a passing, fresh review.md
+	PRURL              string // when set, append an archived/PR provenance comment
+	Date               string // YYYY-MM-DD for the PR comment (caller-supplied; deterministic in tests)
+
+	// Staleness overrides how a review's freshness is decided. nil uses the
+	// repository's git history; tests inject a fake to avoid building one.
+	Staleness StalenessChecker
 }
 
 // FindUnresolvedTags walks specDir and returns "relpath:line: text" for every
@@ -222,6 +227,15 @@ func Archive(repoRoot, id string, opts ArchiveOptions) (target string, err error
 			return "", fmt.Errorf("unresolved [AGENT-DRAFT]/[AGENT-SUGGESTION] tags found:\n  %s\n"+
 				"resolve them (accept/edit/delete) before archiving, or use --force-with-drafts",
 				strings.Join(tags, "\n  "))
+		}
+	}
+
+	// Second pre-flight (CLI-034): the adversarial-review verdict. The tag check
+	// above asks "is the spec finished being written"; this one asks "did anyone
+	// independently argue against it".
+	if !opts.ForceWithoutReview {
+		if err := checkReviewGate(repoRoot, id, specDir, opts.Staleness); err != nil {
+			return "", err
 		}
 	}
 

--- a/cli/internal/spec/archive_test.go
+++ b/cli/internal/spec/archive_test.go
@@ -137,6 +137,7 @@ func TestArchiveMovesAndSetsStatus(t *testing.T) {
 	writeSpec(t, root, "AI-001-x", map[string]string{
 		"proposal.md": "---\nstatus: implementing # draft | implementing\n---\n# AI-001-x\n",
 		"tasks.md":    "tasks\n",
+		"review.md":   passingReview("AI-001-x"),
 	})
 
 	target, err := Archive(root, "AI-001-x", ArchiveOptions{})
@@ -158,7 +159,10 @@ func TestArchiveMovesAndSetsStatus(t *testing.T) {
 
 func TestArchiveAbandonedRoute(t *testing.T) {
 	root := t.TempDir()
-	writeSpec(t, root, "AI-001-x", map[string]string{"proposal.md": "---\nstatus: draft\n---\n"})
+	writeSpec(t, root, "AI-001-x", map[string]string{
+		"proposal.md": "---\nstatus: draft\n---\n",
+		"review.md":   passingReview("AI-001-x"),
+	})
 
 	target, err := Archive(root, "AI-001-x", ArchiveOptions{Abandoned: true})
 	if err != nil {
@@ -221,6 +225,7 @@ func TestArchiveForceWithDrafts(t *testing.T) {
 	root := t.TempDir()
 	writeSpec(t, root, "AI-001-x", map[string]string{
 		"proposal.md": "---\nstatus: draft\n---\n<!-- [AGENT-DRAFT] todo -->\n",
+		"review.md":   passingReview("AI-001-x"),
 	})
 
 	if _, err := Archive(root, "AI-001-x", ArchiveOptions{ForceWithDrafts: true}); err != nil {
@@ -252,7 +257,10 @@ func TestArchiveRejectsTraversalID(t *testing.T) {
 
 func TestArchiveRecordsPRURL(t *testing.T) {
 	root := t.TempDir()
-	writeSpec(t, root, "AI-001-x", map[string]string{"proposal.md": "---\nstatus: draft\n---\nbody\n"})
+	writeSpec(t, root, "AI-001-x", map[string]string{
+		"proposal.md": "---\nstatus: draft\n---\nbody\n",
+		"review.md":   passingReview("AI-001-x"),
+	})
 
 	target, err := Archive(root, "AI-001-x", ArchiveOptions{PRURL: "https://example/pr/9", Date: "2026-06-13"})
 	if err != nil {
@@ -364,6 +372,7 @@ func TestArchiveAcceptsSpecThatOnlyQuotesTags(t *testing.T) {
 		"proposal.md":     "---\nstatus: implementing\n---\nprose\n",
 		"tasks.md":        "- [x] Add `sb_specs` (`[AGENT-DRAFT]` flagging — lifted from detect_repo_specs)\n",
 		"verification.md": "```\n[AGENT-SUGGESTION]\n```\n",
+		"review.md":       passingReview("AI-002-y"),
 	})
 
 	if _, err := Archive(root, "AI-002-y", ArchiveOptions{}); err != nil {

--- a/cli/internal/spec/review.go
+++ b/cli/internal/spec/review.go
@@ -1,0 +1,217 @@
+package spec
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ReviewFile is the artifact the adversarial-review skill persists into the
+// spec folder, and the one Archive gates on.
+const ReviewFile = "review.md"
+
+// contractFiles are the spec files a review's verdict is *about*. Staleness is
+// measured against these and nothing else.
+//
+// review.md is excluded because its own commit always postdates the sha it
+// records, so including it would make every review stale by construction.
+// verification.md is excluded because its archive checklist is ticked AT
+// archive time, which would false-positive on every archive. Both exclusions
+// are deliberate and specified in the proposal.
+var contractFiles = []string{"proposal.md", "tasks.md", "features.json"}
+
+// Verdict is the adversarial-review outcome recorded in review.md frontmatter.
+type Verdict string
+
+const (
+	VerdictPass         Verdict = "PASS"
+	VerdictPassWithGaps Verdict = "PASS-WITH-GAPS"
+	VerdictFail         Verdict = "FAIL"
+)
+
+// Blocks reports whether this verdict must stop an archive. Anything that is
+// not a recognized passing verdict blocks: an unknown value is a malformed
+// artifact, and for a gate the safe direction is to refuse.
+func (v Verdict) Blocks() bool {
+	return v != VerdictPass && v != VerdictPassWithGaps
+}
+
+// Review is the parsed review.md frontmatter.
+type Review struct {
+	Spec        string
+	Verdict     Verdict
+	ReviewedSHA string
+	Reviewer    string
+	Date        string
+}
+
+// frontmatterFields reads `key: value` pairs from the first `---` block.
+//
+// Values are unquoted when quoted, and an unquoted value has any trailing
+// `# comment` stripped — the scaffolded templates carry those. A quoted value
+// is taken verbatim up to its closing quote, so a `#` inside quotes (an issue
+// reference like "mlorentedev/dotfiles#875") survives intact.
+func frontmatterFields(content string) map[string]string {
+	fields := map[string]string{}
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return fields
+	}
+	for _, line := range lines[1:] {
+		if strings.TrimSpace(line) == "---" {
+			break
+		}
+		key, rest, found := strings.Cut(line, ":")
+		if !found || strings.TrimSpace(key) != key || key == "" {
+			continue // body text, a nested mapping, or a list item
+		}
+		value := strings.TrimSpace(rest)
+		if len(value) > 1 && (value[0] == '"' || value[0] == '\'') {
+			if end := strings.IndexByte(value[1:], value[0]); end >= 0 {
+				value = value[1 : 1+end]
+			}
+		} else if idx := strings.Index(value, "#"); idx >= 0 {
+			value = strings.TrimSpace(value[:idx])
+		}
+		fields[key] = value
+	}
+	return fields
+}
+
+// ParseReview reads review.md content into a Review. A missing or unrecognized
+// verdict is an error: the artifact exists but does not say anything the gate
+// can act on, which is worse than absent and must not pass silently.
+func ParseReview(content string) (Review, error) {
+	f := frontmatterFields(content)
+	r := Review{
+		Spec:        f["spec"],
+		Verdict:     Verdict(strings.ToUpper(f["verdict"])),
+		ReviewedSHA: f["reviewed_sha"],
+		Reviewer:    f["reviewer"],
+		Date:        f["date"],
+	}
+	if r.Verdict == "" {
+		return r, fmt.Errorf("%s has no `verdict:` field in its frontmatter", ReviewFile)
+	}
+	if r.Verdict != VerdictPass && r.Verdict != VerdictPassWithGaps && r.Verdict != VerdictFail {
+		return r, fmt.Errorf("%s has an unrecognized verdict %q (want PASS, PASS-WITH-GAPS or FAIL)", ReviewFile, r.Verdict)
+	}
+	if r.ReviewedSHA == "" {
+		return r, fmt.Errorf("%s has no `reviewed_sha:` field — the review cannot be checked for staleness", ReviewFile)
+	}
+	return r, nil
+}
+
+// FindReview loads specDir/review.md. found is false when the file is absent,
+// which the caller reports differently from a malformed one.
+func FindReview(specDir string) (review Review, found bool, err error) {
+	data, readErr := os.ReadFile(filepath.Join(specDir, ReviewFile))
+	if os.IsNotExist(readErr) {
+		return Review{}, false, nil
+	}
+	if readErr != nil {
+		return Review{}, false, readErr
+	}
+	parsed, parseErr := ParseReview(string(data))
+	return parsed, true, parseErr
+}
+
+// StalenessChecker decides whether a review still describes the spec's
+// contract files. It is an interface so tests can drive the decision without
+// building a git history for every case.
+type StalenessChecker interface {
+	// Stale reports whether the review is out of date. known is false when the
+	// question cannot be answered at all (no git history to compare against),
+	// in which case the caller skips the check rather than guessing.
+	Stale(repoRoot, specID, reviewedSHA string) (stale bool, known bool, reason string)
+}
+
+// gitStaleness answers the question from the repository's own history.
+type gitStaleness struct{}
+
+func (gitStaleness) Stale(repoRoot, specID, reviewedSHA string) (bool, bool, string) {
+	if err := exec.Command("git", "-C", repoRoot, "rev-parse", "--git-dir").Run(); err != nil {
+		// Not a work tree: there is no history for the review to be stale
+		// against. The presence and verdict checks still applied.
+		return false, false, ""
+	}
+	if err := exec.Command("git", "-C", repoRoot, "cat-file", "-e", reviewedSHA+"^{commit}").Run(); err != nil {
+		return true, true, fmt.Sprintf("reviewed_sha %s is not a commit in this history (rewritten by a rebase?)", reviewedSHA)
+	}
+
+	args := []string{"-C", repoRoot, "log", "--format=%H", reviewedSHA + "..HEAD", "--"}
+	for _, name := range contractFiles {
+		args = append(args, filepath.Join("specs", specID, name))
+	}
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return true, true, "could not compare the review against the current history"
+	}
+	if len(strings.TrimSpace(string(out))) > 0 {
+		return true, true, fmt.Sprintf("a contract file (%s) changed after reviewed_sha %s",
+			strings.Join(contractFiles, ", "), reviewedSHA)
+	}
+	return false, true, ""
+}
+
+// reviewWaiver reads the declared waiver from proposal.md frontmatter. A waiver
+// counts only when it also carries a non-empty reason: requiring the reason is
+// what keeps a routine waive visible in the diff instead of invisible in a
+// habit.
+func reviewWaiver(specDir string) (waived bool, reason string) {
+	data, err := os.ReadFile(filepath.Join(specDir, "proposal.md"))
+	if err != nil {
+		return false, ""
+	}
+	f := frontmatterFields(string(data))
+	if strings.ToLower(f["review"]) != "waived" {
+		return false, ""
+	}
+	return true, strings.TrimSpace(f["review_waived_reason"])
+}
+
+// checkReviewGate is Archive's second pre-flight. It returns nil when the spec
+// may be archived, and an error naming both declared escapes otherwise.
+func checkReviewGate(repoRoot, specID, specDir string, checker StalenessChecker) error {
+	if waived, reason := reviewWaiver(specDir); waived {
+		if reason == "" {
+			return fmt.Errorf("proposal.md declares `review: waived` without a reason\n" +
+				"add a non-empty `review_waived_reason:` so the waiver is auditable, or archive with --force-without-review")
+		}
+		return nil
+	}
+
+	review, found, err := FindReview(specDir)
+	if !found {
+		return fmt.Errorf("no %s in the spec folder — run /adversarial-review before archiving\n"+
+			"to proceed without one, declare `review: waived` with a `review_waived_reason:` in proposal.md, or pass --force-without-review",
+			ReviewFile)
+	}
+	if err != nil {
+		return fmt.Errorf("%w\nfix the artifact, declare `review: waived` with a reason in proposal.md, or pass --force-without-review", err)
+	}
+	// A review.md copied from a sibling spec would otherwise satisfy the gate
+	// while describing a different change — the copy-paste analogue of the
+	// one-line alibi SPEC_FLOOR exists to defeat in check-spec-gate.sh.
+	if review.Spec != "" && review.Spec != specID {
+		return fmt.Errorf("%s declares spec %q but lives in %q — the review describes a different change\n"+
+			"re-run /adversarial-review for this spec, or pass --force-without-review",
+			ReviewFile, review.Spec, specID)
+	}
+	if review.Verdict.Blocks() {
+		return fmt.Errorf("%s records verdict %s — address the findings and re-review before archiving\n"+
+			"to override, declare `review: waived` with a reason in proposal.md, or pass --force-without-review",
+			ReviewFile, review.Verdict)
+	}
+
+	if checker == nil {
+		checker = gitStaleness{}
+	}
+	if stale, known, reason := checker.Stale(repoRoot, specID, review.ReviewedSHA); known && stale {
+		return fmt.Errorf("%s is stale: %s\nre-run /adversarial-review against the current head, declare `review: waived` with a reason in proposal.md, or pass --force-without-review",
+			ReviewFile, reason)
+	}
+	return nil
+}

--- a/cli/internal/spec/review_test.go
+++ b/cli/internal/spec/review_test.go
@@ -1,0 +1,357 @@
+package spec
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// passingReview is the review.md an archivable spec carries. Tests that
+// exercise archive behaviors OTHER than the gate include it so they describe a
+// spec that is legitimately archivable under the CLI-034 contract.
+func passingReview(id string) string {
+	return "---\nspec: \"" + id + "\"\nverdict: \"PASS\"\nreviewed_sha: \"0000000000000000000000000000000000000000\"\nreviewer: \"test\"\ndate: \"2026-08-09\"\n---\nno blocking findings\n"
+}
+
+// fakeStaleness drives the freshness decision without a git history.
+type fakeStaleness struct {
+	stale  bool
+	known  bool
+	reason string
+}
+
+func (f fakeStaleness) Stale(string, string, string) (bool, bool, string) {
+	return f.stale, f.known, f.reason
+}
+
+// TestArchiveBlocksOnMissingReview is the proved-red acceptance for CLI-034:
+// it must fail on main, where Archive has no review pre-flight at all.
+func TestArchiveBlocksOnMissingReview(t *testing.T) {
+	root := t.TempDir()
+	writeSpec(t, root, "AI-001-x", map[string]string{
+		"proposal.md": "---\nstatus: verifying\n---\nclean\n",
+	})
+
+	_, err := Archive(root, "AI-001-x", ArchiveOptions{})
+	if err == nil {
+		t.Fatalf("expected a missing review.md to block the archive")
+	}
+	// The error must name the artifact and BOTH declared escapes, so the human
+	// never has to read the source to learn how to proceed.
+	for _, want := range []string{"review.md", "review: waived", "--force-without-review"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q, got: %v", want, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, "specs", "AI-001-x")); err != nil {
+		t.Errorf("source must remain when blocked: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "specs", "archive", "AI-001-x")); !os.IsNotExist(err) {
+		t.Errorf("target must not be created when blocked")
+	}
+}
+
+// archivableSpec writes a spec whose only interesting property is the review.
+func archivableSpec(t *testing.T, root, id, review string) {
+	t.Helper()
+	files := map[string]string{"proposal.md": "---\nstatus: verifying\n---\nclean\n"}
+	if review != "" {
+		files["review.md"] = review
+	}
+	writeSpec(t, root, id, files)
+}
+
+func TestParseReviewVerdicts(t *testing.T) {
+	cases := []struct {
+		name    string
+		verdict string
+		wantErr bool
+		blocks  bool
+	}{
+		{"pass", "PASS", false, false},
+		{"pass with gaps", "PASS-WITH-GAPS", false, false},
+		{"fail", "FAIL", false, true},
+		{"lowercase is normalized", "pass", false, false},
+		{"unrecognized", "LGTM", true, true},
+		{"empty", "", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := "---\nspec: \"AI-001-x\"\nverdict: \"" + tc.verdict + "\"\nreviewed_sha: \"abc123\"\n---\n"
+			r, err := ParseReview(content)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("wantErr=%v, got err=%v", tc.wantErr, err)
+			}
+			if err == nil && r.Verdict.Blocks() != tc.blocks {
+				t.Errorf("Blocks()=%v, want %v", r.Verdict.Blocks(), tc.blocks)
+			}
+		})
+	}
+}
+
+// TestParseReviewRequiresSHA: without reviewed_sha the review cannot be checked
+// for freshness, so the artifact is malformed rather than merely incomplete.
+func TestParseReviewRequiresSHA(t *testing.T) {
+	_, err := ParseReview("---\nspec: \"AI-001-x\"\nverdict: \"PASS\"\n---\n")
+	if err == nil || !strings.Contains(err.Error(), "reviewed_sha") {
+		t.Fatalf("want a reviewed_sha error, got: %v", err)
+	}
+}
+
+// TestFrontmatterKeepsHashInQuotedValue guards the comment-stripping rule: a
+// quoted value may legitimately contain '#' (an issue reference), and stripping
+// it would corrupt the field.
+func TestFrontmatterKeepsHashInQuotedValue(t *testing.T) {
+	f := frontmatterFields("---\nissue: \"mlorentedev/dotfiles#875\"   # repo#NNN — tracker\nstatus: draft # a comment\n---\n")
+	if got := f["issue"]; got != "mlorentedev/dotfiles#875" {
+		t.Errorf("quoted value with '#': got %q", got)
+	}
+	if got := f["status"]; got != "draft" {
+		t.Errorf("unquoted value should drop its trailing comment: got %q", got)
+	}
+}
+
+func TestArchiveBlocksOnFailVerdict(t *testing.T) {
+	root := t.TempDir()
+	archivableSpec(t, root, "AI-001-x", "---\nspec: \"AI-001-x\"\nverdict: \"FAIL\"\nreviewed_sha: \"abc\"\n---\n")
+
+	_, err := Archive(root, "AI-001-x", ArchiveOptions{})
+	if err == nil || !strings.Contains(err.Error(), "FAIL") {
+		t.Fatalf("expected a FAIL verdict to block, got: %v", err)
+	}
+}
+
+func TestArchiveBlocksOnUnknownVerdict(t *testing.T) {
+	root := t.TempDir()
+	archivableSpec(t, root, "AI-001-x", "---\nspec: \"AI-001-x\"\nverdict: \"LGTM\"\nreviewed_sha: \"abc\"\n---\n")
+
+	_, err := Archive(root, "AI-001-x", ArchiveOptions{})
+	if err == nil || !strings.Contains(err.Error(), "unrecognized verdict") {
+		t.Fatalf("expected an unrecognized verdict to block, got: %v", err)
+	}
+}
+
+// TestArchiveBlocksOnForeignReview: a review.md copied from another spec must
+// not satisfy the gate.
+func TestArchiveBlocksOnForeignReview(t *testing.T) {
+	root := t.TempDir()
+	archivableSpec(t, root, "AI-001-x", passingReview("AI-002-y"))
+
+	_, err := Archive(root, "AI-001-x", ArchiveOptions{})
+	if err == nil || !strings.Contains(err.Error(), "different change") {
+		t.Fatalf("expected a foreign review to block, got: %v", err)
+	}
+}
+
+func TestArchiveProceedsOnPass(t *testing.T) {
+	root := t.TempDir()
+	archivableSpec(t, root, "AI-001-x", passingReview("AI-001-x"))
+
+	if _, err := Archive(root, "AI-001-x", ArchiveOptions{}); err != nil {
+		t.Fatalf("a PASS review should archive: %v", err)
+	}
+}
+
+// TestArchiveProceedsOnPassWithGaps: gaps are already tracked by the review
+// itself, so they must not also block the archive.
+func TestArchiveProceedsOnPassWithGaps(t *testing.T) {
+	root := t.TempDir()
+	archivableSpec(t, root, "AI-001-x",
+		"---\nspec: \"AI-001-x\"\nverdict: \"PASS-WITH-GAPS\"\nreviewed_sha: \"abc\"\n---\n")
+
+	if _, err := Archive(root, "AI-001-x", ArchiveOptions{}); err != nil {
+		t.Fatalf("PASS-WITH-GAPS should archive: %v", err)
+	}
+}
+
+func TestArchiveWaivedWithReason(t *testing.T) {
+	root := t.TempDir()
+	writeSpec(t, root, "AI-001-x", map[string]string{
+		"proposal.md": "---\nstatus: verifying\nreview: waived\nreview_waived_reason: \"doc-only change, no behavior\"\n---\n",
+	})
+
+	if _, err := Archive(root, "AI-001-x", ArchiveOptions{}); err != nil {
+		t.Fatalf("a declared waiver with a reason should archive: %v", err)
+	}
+}
+
+// TestArchiveWaivedWithoutReasonRefuses is the load-bearing half of the waiver:
+// requiring the reason is what keeps waiving visible in the diff instead of
+// invisible in a habit.
+func TestArchiveWaivedWithoutReasonRefuses(t *testing.T) {
+	root := t.TempDir()
+	writeSpec(t, root, "AI-001-x", map[string]string{
+		"proposal.md": "---\nstatus: verifying\nreview: waived\n---\n",
+	})
+
+	_, err := Archive(root, "AI-001-x", ArchiveOptions{})
+	if err == nil || !strings.Contains(err.Error(), "without a reason") {
+		t.Fatalf("expected a reasonless waiver to block, got: %v", err)
+	}
+}
+
+func TestArchiveForceWithoutReview(t *testing.T) {
+	root := t.TempDir()
+	archivableSpec(t, root, "AI-001-x", "")
+
+	if _, err := Archive(root, "AI-001-x", ArchiveOptions{ForceWithoutReview: true}); err != nil {
+		t.Fatalf("force-without-review should archive despite no review: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "specs", "archive", "AI-001-x", "proposal.md")); err != nil {
+		t.Errorf("expected archived proposal: %v", err)
+	}
+}
+
+// TestArchiveForceWithoutReviewOverridesFail: the escape covers a FAIL verdict
+// too, not only an absent artifact.
+func TestArchiveForceWithoutReviewOverridesFail(t *testing.T) {
+	root := t.TempDir()
+	archivableSpec(t, root, "AI-001-x", "---\nspec: \"AI-001-x\"\nverdict: \"FAIL\"\nreviewed_sha: \"abc\"\n---\n")
+
+	if _, err := Archive(root, "AI-001-x", ArchiveOptions{ForceWithoutReview: true}); err != nil {
+		t.Fatalf("force-without-review should override a FAIL verdict: %v", err)
+	}
+}
+
+func TestArchiveBlocksOnStaleReview(t *testing.T) {
+	root := t.TempDir()
+	archivableSpec(t, root, "AI-001-x", passingReview("AI-001-x"))
+
+	_, err := Archive(root, "AI-001-x", ArchiveOptions{
+		Staleness: fakeStaleness{stale: true, known: true, reason: "proposal.md changed after reviewed_sha"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("expected a stale review to block, got: %v", err)
+	}
+}
+
+// TestArchiveProceedsWhenStalenessUnknown: outside a git work tree there is no
+// history for the review to be stale against, so the check is skipped rather
+// than guessed. Presence and verdict still applied.
+func TestArchiveProceedsWhenStalenessUnknown(t *testing.T) {
+	root := t.TempDir()
+	archivableSpec(t, root, "AI-001-x", passingReview("AI-001-x"))
+
+	if _, err := Archive(root, "AI-001-x", ArchiveOptions{
+		Staleness: fakeStaleness{stale: true, known: false},
+	}); err != nil {
+		t.Fatalf("an unanswerable staleness question must not block: %v", err)
+	}
+}
+
+// --- gitStaleness against a real history -------------------------------------
+//
+// The fake above drives Archive's decision; these exercise the real checker,
+// which is where AC6/AC7 actually live.
+
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@e",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@e",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// gitSpecRepo builds a repo with specs/<id>/ committed, returning the root and
+// the sha of that first commit.
+func gitSpecRepo(t *testing.T, id string) (root, sha string) {
+	t.Helper()
+	root = t.TempDir()
+	gitRun(t, root, "init", "-q", "-b", "main")
+	writeSpec(t, root, id, map[string]string{
+		"proposal.md":     "---\nstatus: verifying\n---\nclean\n",
+		"tasks.md":        "tasks\n",
+		"verification.md": "evidence\n",
+	})
+	gitRun(t, root, "add", "-A")
+	gitRun(t, root, "commit", "-qm", "spec")
+	return root, gitRun(t, root, "rev-parse", "HEAD")
+}
+
+func TestGitStalenessDetectsContractChange(t *testing.T) {
+	root, sha := gitSpecRepo(t, "AI-001-x")
+	if err := os.WriteFile(filepath.Join(root, "specs", "AI-001-x", "proposal.md"),
+		[]byte("---\nstatus: verifying\n---\nchanged after the review\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, root, "commit", "-qam", "amend the proposal")
+
+	stale, known, reason := gitStaleness{}.Stale(root, "AI-001-x", sha)
+	if !known || !stale {
+		t.Fatalf("a contract change after reviewed_sha must be stale (known=%v stale=%v)", known, stale)
+	}
+	if !strings.Contains(reason, "contract file") {
+		t.Errorf("reason should name the contract files, got %q", reason)
+	}
+}
+
+// TestGitStalenessIgnoresReviewOwnCommit is the self-defeat guard: review.md is
+// always committed AFTER the sha it records, so counting it would make every
+// review stale by construction.
+func TestGitStalenessIgnoresReviewOwnCommit(t *testing.T) {
+	root, sha := gitSpecRepo(t, "AI-001-x")
+	if err := os.WriteFile(filepath.Join(root, "specs", "AI-001-x", "review.md"),
+		[]byte(passingReview("AI-001-x")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, root, "add", "-A")
+	gitRun(t, root, "commit", "-qm", "add the review")
+
+	stale, known, _ := gitStaleness{}.Stale(root, "AI-001-x", sha)
+	if !known {
+		t.Fatalf("a git work tree must be answerable")
+	}
+	if stale {
+		t.Errorf("review.md's own commit must not make it stale")
+	}
+}
+
+// TestGitStalenessIgnoresVerificationMd: verification.md's archive checklist is
+// ticked AT archive time, so counting it would false-positive on every archive.
+func TestGitStalenessIgnoresVerificationMd(t *testing.T) {
+	root, sha := gitSpecRepo(t, "AI-001-x")
+	if err := os.WriteFile(filepath.Join(root, "specs", "AI-001-x", "verification.md"),
+		[]byte("evidence\n- [x] folder moved\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, root, "commit", "-qam", "tick the archive checklist")
+
+	stale, known, _ := gitStaleness{}.Stale(root, "AI-001-x", sha)
+	if !known {
+		t.Fatalf("a git work tree must be answerable")
+	}
+	if stale {
+		t.Errorf("a verification.md change must not make the review stale")
+	}
+}
+
+func TestGitStalenessUnresolvableShaIsStale(t *testing.T) {
+	root, _ := gitSpecRepo(t, "AI-001-x")
+
+	stale, known, reason := gitStaleness{}.Stale(root, "AI-001-x", "0123456789012345678901234567890123456789")
+	if !known || !stale {
+		t.Fatalf("an unresolvable sha must be treated as stale (known=%v stale=%v)", known, stale)
+	}
+	if !strings.Contains(reason, "not a commit") {
+		t.Errorf("reason should say the sha is unknown, got %q", reason)
+	}
+}
+
+// TestGitStalenessOutsideRepoIsUnknown: with no history there is nothing for
+// the review to be stale against, so the question is unanswerable rather than
+// failing — the presence and verdict checks still applied.
+func TestGitStalenessOutsideRepoIsUnknown(t *testing.T) {
+	root := t.TempDir()
+	if _, known, _ := (gitStaleness{}).Stale(root, "AI-001-x", "abc"); known {
+		t.Errorf("outside a work tree the staleness question must be unanswerable")
+	}
+}

--- a/harness/skills/adversarial-review/SKILL.md
+++ b/harness/skills/adversarial-review/SKILL.md
@@ -22,7 +22,7 @@ allowed-tools: [Bash, Read, Grep, mcp__hive__vault_query, mcp__hive__vault_searc
 - `/adversarial-review <feature-id-or-PR>` explicitly.
 - "Red-team this change" / "devil's advocate pass on AI-001" / "independent verification before archive".
 - Verification window: after implementation merged / about-to-merge, BEFORE archiving the spec.
-- **Pair with**: `/spec archive` lock — that command refuses to archive while any `[AGENT-DRAFT]` tags remain; this skill catches the gaps *before* that final gate.
+- **Pair with**: `/spec archive` lock — that command refuses to archive while any `[AGENT-DRAFT]` tags remain, **and** (since CLI-034) refuses without a fresh, passing `review.md`. This skill produces that artifact; skipping it now blocks the archive rather than merely weakening it.
 
 ## When NOT to use
 
@@ -139,6 +139,27 @@ End with a clear verdict:
 
 ## Output format
 
+**Persist the verdict — do not only print it.** Write the block below to
+`specs/<feature-id>/review.md` in the reviewed repo, with the frontmatter shown. `dotf spec archive`
+reads that frontmatter as its second pre-flight (CLI-034); a review that exists only in the chat
+transcript does not satisfy the gate, and the archive will refuse.
+
+```yaml
+---
+spec: "<feature-id>"                  # MUST equal the containing folder name — a review copied
+                                      # from a sibling spec is refused as describing another change
+verdict: "PASS"                       # PASS | PASS-WITH-GAPS | FAIL
+reviewed_sha: "<40-hex commit sha>"   # the commit you actually examined (`git rev-parse HEAD`)
+reviewer: "<agent or model id>"       # e.g. claude-opus-5, deepseek-v4-flash
+date: "YYYY-MM-DD"
+---
+```
+
+`reviewed_sha` is not bookkeeping: the gate rejects the review as **stale** if `proposal.md`,
+`tasks.md` or `features.json` changed after it. Record the sha you read, never a later one.
+
+The body of the file is the markdown below, unchanged.
+
 ```markdown
 ## Adversarial review
 
@@ -191,4 +212,7 @@ PASS | PASS WITH GAPS | FAIL
 
 ## Completion
 
-Always end with: (a) the verdict, (b) whether `dotf spec archive` / `/spec archive` is **advisable** in the current state, (c) if FAIL, the minimum set of actions that would flip it to PASS.
+1. **Write `specs/<feature-id>/review.md`** with the frontmatter and body from "Output format". This is the deliverable; the chat summary is not.
+2. Always end with: (a) the verdict, (b) whether `dotf spec archive` / `/spec archive` is **advisable** in the current state, (c) if FAIL, the minimum set of actions that would flip it to PASS.
+
+If the change genuinely does not warrant a review, do not skip silently — the archive will refuse. Declare it in `proposal.md` frontmatter as `review: waived` with a non-empty `review_waived_reason:`, so the decision is auditable in the diff rather than invisible in a habit.

--- a/harness/skills/spec/SKILL.md
+++ b/harness/skills/spec/SKILL.md
@@ -248,13 +248,15 @@ When unsure whether a change crosses the threshold, ASK rather than assume (`AGE
 
 **Purpose:** Close a spec. Interactive promotion to vault, then mechanical archive.
 
-**Signature:** `/spec archive <feature-id> [--pr <url>] [--abandoned]`
+**Signature:** `/spec archive <feature-id> [--pr <url>] [--abandoned] [--force-with-drafts] [--force-without-review]`
 
 **Steps:**
 
 1. **Pre-flight:**
    - Read `$REPO_ROOT/specs/<feature-id>/proposal.md`, `tasks.md`, `verification.md`.
    - **Tag check:** scan all three files for `[AGENT-DRAFT]` or `[AGENT-SUGGESTION]` markers. If any found, REFUSE to archive unless `--force-with-drafts` is passed. Output list of files + lines with unresolved tags.
+   - **Review check (CLI-034):** the folder must contain `review.md` with a `verdict:` of `PASS` or `PASS-WITH-GAPS`, whose `spec:` matches the folder and whose `reviewed_sha` predates no change to `proposal.md` / `tasks.md` / `features.json`. A missing, malformed, failing, foreign or stale review REFUSES the archive. Produce it with `adversarial-review` — ideally from a **different session or agent** than the implementer, since independence is the point. Two declared escapes, never a judgment call in the moment: `review: waived` + a non-empty `review_waived_reason:` in `proposal.md` frontmatter, or `--force-without-review`.
+     - The two checks answer different questions: the tag check asks whether the spec is *finished being written*; the review check asks whether anyone *independently argued against it*.
    - Count unchecked acceptance criteria. If >0, warn: "N criteria still unchecked. Continue?" Ask.
    - If `--abandoned` flag: skip step 2 entirely, mark as `status: abandoned`, route to `specs/archive/_abandoned/<id>/` in step 3.
 

--- a/specs/CLI-034-spec-archive-review-gate/features.json
+++ b/specs/CLI-034-spec-archive-review-gate/features.json
@@ -9,7 +9,7 @@
   {
     "id": "CLI-034-f2",
     "behavior": "Archive refuses when review.md carries verdict: FAIL (and on an unrecognized verdict)",
-    "verification": "cd cli && go test ./internal/spec/ -run 'TestArchiveBlocksOnFailVerdict|TestArchiveBlocksOnUnknownVerdict' -v",
+    "verification": "cd cli && go test ./internal/spec/ -run 'TestArchiveBlocksOnFailVerdict|TestArchiveBlocksOnUnknownVerdict|TestArchiveBlocksOnForeignReview' -v",
     "state": "pending",
     "evidence": ""
   },
@@ -37,14 +37,14 @@
   {
     "id": "CLI-034-f6",
     "behavior": "A review whose reviewed_sha predates a contract-file change is rejected as stale; an unresolvable sha is also stale",
-    "verification": "cd cli && go test ./internal/spec/ -run 'TestArchiveBlocksOnStaleReview|TestArchiveUnresolvableShaIsStale' -v",
+    "verification": "cd cli && go test ./internal/spec/ -run 'TestGitStalenessDetectsContractChange|TestGitStalenessUnresolvableShaIsStale' -v",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-034-f7",
     "behavior": "review.md's own commit does not trip staleness, and verification.md changes do not trip it",
-    "verification": "cd cli && go test ./internal/spec/ -run 'TestStalenessIgnoresReviewOwnCommit|TestStalenessIgnoresVerificationMd' -v",
+    "verification": "cd cli && go test ./internal/spec/ -run 'TestGitStalenessIgnoresReviewOwnCommit|TestGitStalenessIgnoresVerificationMd' -v",
     "state": "pending",
     "evidence": ""
   },

--- a/specs/CLI-034-spec-archive-review-gate/features.json
+++ b/specs/CLI-034-spec-archive-review-gate/features.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "CLI-034-f1",
+    "behavior": "Archive refuses when review.md is absent, naming the artifact and both declared escapes",
+    "verification": "cd cli && go test ./internal/spec/ -run TestArchiveBlocksOnMissingReview -v",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-034-f2",
+    "behavior": "Archive refuses when review.md carries verdict: FAIL (and on an unrecognized verdict)",
+    "verification": "cd cli && go test ./internal/spec/ -run 'TestArchiveBlocksOnFailVerdict|TestArchiveBlocksOnUnknownVerdict' -v",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-034-f3",
+    "behavior": "Archive proceeds on verdict PASS and PASS-WITH-GAPS",
+    "verification": "cd cli && go test ./internal/spec/ -run 'TestArchiveProceedsOnPass|TestArchiveProceedsOnPassWithGaps' -v",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-034-f4",
+    "behavior": "review: waived with a non-empty reason skips the gate; waived without a reason still refuses",
+    "verification": "cd cli && go test ./internal/spec/ -run 'TestArchiveWaivedWithReason|TestArchiveWaivedWithoutReasonRefuses' -v",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-034-f5",
+    "behavior": "--force-without-review archives despite a missing or FAIL review",
+    "verification": "cd cli && go test ./internal/spec/ -run TestArchiveForceWithoutReview -v",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-034-f6",
+    "behavior": "A review whose reviewed_sha predates a contract-file change is rejected as stale; an unresolvable sha is also stale",
+    "verification": "cd cli && go test ./internal/spec/ -run 'TestArchiveBlocksOnStaleReview|TestArchiveUnresolvableShaIsStale' -v",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-034-f7",
+    "behavior": "review.md's own commit does not trip staleness, and verification.md changes do not trip it",
+    "verification": "cd cli && go test ./internal/spec/ -run 'TestStalenessIgnoresReviewOwnCommit|TestStalenessIgnoresVerificationMd' -v",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-034-f8",
+    "behavior": "Vault SSOT skills document the review.md contract and the archive pre-flight, and the harness render matches",
+    "verification": "grep -q 'specs/<feature-id>/review.md' \"$VAULT_PATH/00_meta/skills/adversarial-review/SKILL.md\" && grep -q 'force-without-review' \"$VAULT_PATH/00_meta/skills/spec/SKILL.md\" && ./scripts/compile-harness.sh --check",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CLI-034-spec-archive-review-gate/proposal.md
+++ b/specs/CLI-034-spec-archive-review-gate/proposal.md
@@ -1,0 +1,132 @@
+---
+id: "CLI-034-spec-archive-review-gate"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-09"
+issue: "mlorentedev/dotfiles#875"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# CLI-034: Spec archive review gate
+
+> **Naming**: file lives at `dotfiles/specs/CLI-034-spec-archive-review-gate/proposal.md`.
+
+## Why
+
+<!-- from issue #875: bind the adversarial-review gate to spec archive -->
+
+The `adversarial-review` skill has existed since 2026-05-14 and has **never run as its designed
+gate**: a search for its output block (`## Adversarial review`, `Evaluator rubric`,
+`PASS (adversarial)`) across `specs/` and `docs/` in every personal repo returns zero hits, against
+~218 archived specs. The cause is not quality — the skill carries a severity × reality ×
+test-traceability model and a six-dimension rubric. The cause is that **nothing requires it**:
+`dotf spec archive`'s only pre-flight is the `[AGENT-DRAFT]` tag check, and the skill's own
+"Pairs with `/spec archive` lock" line describes an integration that was never implemented.
+Issue #255's context line ("gated to high-stakes SDD changes") records the same belief; the
+evidence disproves it.
+
+This is the coverage-not-age doctrine in the negative: a rule with no enforcing layer does not
+fire. This spec supplies the layer.
+
+## What
+
+After this PR:
+
+1. `dotf spec archive <id>` runs a **second pre-flight**: the spec folder must contain `review.md`
+   whose frontmatter carries a `verdict:` field. Missing artifact or `verdict: FAIL` refuses the
+   archive; `PASS` and `PASS-WITH-GAPS` proceed (gaps are already tracked by the review itself).
+2. The refusal is escapable two ways, both **declared, never judged at the moment**:
+   - a waiver in `proposal.md` frontmatter — `review: waived` **plus a non-empty
+     `review_waived_reason:`**; a waiver without a reason still refuses;
+   - `--force-without-review`, mirroring the existing `--force-with-drafts`.
+3. `review.md` carries a **staleness floor**: a `reviewed_sha:` field. If any *contract* file in the
+   spec folder changed after that SHA, the review no longer describes the archived change and the
+   archive refuses. This is the analogue of `check-spec-gate.sh`'s `SPEC_FLOOR=10` — the
+   anti-alibi that stops an empty or outdated artifact from satisfying a presence check.
+4. The `adversarial-review` skill gains a **persistence contract**: it writes its verdict to
+   `specs/<id>/review.md` with the frontmatter schema below. Today its output format is a chat
+   response block with no frontmatter and no destination — the gate would have no compliant
+   producer without this change.
+
+### `review.md` frontmatter schema (the contract both sides reference)
+
+```yaml
+---
+spec: "<feature-id>"                  # must equal the containing folder name
+verdict: "PASS"                       # PASS | PASS-WITH-GAPS | FAIL
+reviewed_sha: "<40-hex commit sha>"   # the commit the review actually examined
+reviewer: "<agent or model id>"       # e.g. claude-opus-5, deepseek-v4-flash
+date: "YYYY-MM-DD"
+---
+```
+
+The body remains the skill's existing markdown output (findings table + rubric + verdict +
+next steps) — unchanged, only persisted.
+
+### Staleness scope
+
+Staleness compares `reviewed_sha` against changes to the **contract files only**:
+`proposal.md`, `tasks.md`, `features.json`.
+
+Deliberately excluded:
+
+- **`review.md` itself** — its own commit always postdates `reviewed_sha`, so including it would
+  make every review stale by construction.
+- **`verification.md`** — it is an implementation log whose archive checklist is ticked *at archive
+  time*, which would false-positive on every archive.
+
+## Out of scope
+
+- The NaN judge lane (CI-hosted producer of `review.md`) — separate PR, gated on **AI-001**
+  (`knowledge#150`) for model-name reconciliation.
+- The aggregate rubric pass over archived reviews (hermes batch job) — separate PR, only worth
+  building once enough `review.md` files exist to aggregate.
+- Reflecting the gate in CI (`check-spec-gate.sh` / `spec-gate.yml`). Adjacent to #854 but a
+  distinct surface; this PR gates the CLI only.
+- Retro-filling `review.md` for the ~218 already-archived specs.
+- Any change to the review's *content* model (severity/reality/rubric) — shipped in #255.
+
+## Risks / open questions
+
+- **The waiver becomes the default path.** Mitigated by requiring a non-empty reason string, which
+  makes routine waiving visible in the diff and auditable after the fact. Not fully preventable in
+  code; accepted.
+- **Staleness brittleness.** A rebase rewrites SHAs and can make `reviewed_sha` unresolvable in the
+  current history. Decision: an *unresolvable* SHA is treated as stale (refuse), not as pass — the
+  safe direction — and `--force-without-review` remains the documented escape.
+- **Vault SSOT, not the render.** Both SKILL edits must land in `$VAULT_PATH/00_meta/skills/…`, not
+  `harness/skills/…`; per the CLI-005 lesson, editing the committed render alone is reverted by the
+  next `compile-harness.sh --refresh`.
+- Archived specs predate the gate; `dotf spec archive` must not retro-validate them.
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [ ] AC1 — `Archive()` refuses when `review.md` is absent, naming the missing artifact and the
+      two declared escapes in the error.
+- [ ] AC2 — `Archive()` refuses when `review.md` carries `verdict: FAIL`.
+- [ ] AC3 — `Archive()` proceeds when the verdict is `PASS` or `PASS-WITH-GAPS`.
+- [ ] AC4 — `review: waived` **with** a non-empty `review_waived_reason:` skips the gate; `review:
+      waived` **without** a reason still refuses.
+- [ ] AC5 — `--force-without-review` archives despite a missing or `FAIL` review, mirroring
+      `--force-with-drafts`.
+- [ ] AC6 — a review whose `reviewed_sha` predates a change to `proposal.md`, `tasks.md` or
+      `features.json` is rejected as stale.
+- [ ] AC7 — the commit that adds `review.md` does not make it stale, and a later change to
+      `verification.md` does not make it stale.
+- [ ] AC8 — the vault `adversarial-review` SKILL documents the `review.md` destination and
+      frontmatter schema, and the vault `spec` SKILL's `archive` section documents the new
+      pre-flight; the "Pairs with `/spec archive` lock" claim is now true.
+
+## References
+
+- Bitácora board: see the `issue:` frontmatter field
+- Related: `#255` (HARNESS-004, review content model — close-as-done, its ACs are met by vault
+  commit `3dd696af`), `#786` (TOOL-013, the pre-merge PR-review axis — different axis, shared
+  inference provider), `#854` (BUG-061, the CI-side spec gate)
+- Prior art in-repo: `cli/internal/spec/archive.go` (`FindUnresolvedTags` pre-flight),
+  `scripts/check-spec-gate.sh` (`SPEC_FLOOR` anti-alibi, declared escapes)
+- Vault: `00_meta/skills/adversarial-review/SKILL.md`, `00_meta/skills/spec/SKILL.md`,
+  `00_meta/patterns/pattern-change-lifecycle.md` (stage 2 = this gate)

--- a/specs/CLI-034-spec-archive-review-gate/tasks.md
+++ b/specs/CLI-034-spec-archive-review-gate/tasks.md
@@ -1,0 +1,90 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-09"
+---
+
+# Tasks - CLI-034-spec-archive-review-gate
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft`
+> state; freeze once you start `implementing`.
+
+## Setup
+
+- [ ] Branch created from main: `feat/spec-archive-review-gate` (external worktree
+      `../dotfiles-wt-review-gate`, Standing Order #9)
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+> The parser and the gate are independent behaviors from the staleness check, so their first test
+> tasks carry `[P]`. Within each behavior the TDD chain is sequential.
+
+### Review artifact parsing
+
+- [ ] [P] [AC1] Write failing test: `FindReview` on a spec dir with no `review.md` returns a
+      typed "absent" result, not an error
+- [ ] [AC1] Implement `review.go`: frontmatter parse into a `Review{Verdict, ReviewedSHA, Reviewer,
+      Date, Spec}` struct, reusing the existing frontmatter helper used by `setStatus`
+- [ ] [AC2][AC3] Write failing test: verdict values `PASS`, `PASS-WITH-GAPS`, `FAIL` and an
+      unrecognized value each map to the right decision (unknown verdict = refuse)
+- [ ] [AC2][AC3] Implement verdict classification
+- [ ] Refactor: keep the parser free of any filesystem/git knowledge (pure input → decision)
+
+### The archive pre-flight
+
+- [ ] [AC1] Write failing test `TestArchiveBlocksOnMissingReview` — mirrors
+      `TestArchiveBlocksOnDrafts`
+- [ ] [AC2] Write failing test `TestArchiveBlocksOnFailVerdict`
+- [ ] [AC3] Write failing test `TestArchiveProceedsOnPassWithGaps`
+- [ ] [AC1][AC2][AC3] Wire the pre-flight into `Archive()` after the tag check, before the move;
+      error text names the missing artifact and both declared escapes
+- [ ] [AC5] Write failing test `TestArchiveForceWithoutReview` — mirrors
+      `TestArchiveForceWithDrafts`
+- [ ] [AC5] Add `ForceWithoutReview` to `ArchiveOptions` + the `--force-without-review` flag in
+      `cli/internal/cmd/spec.go`
+
+### Declared waiver
+
+- [ ] [AC4] Write failing test: `review: waived` + non-empty `review_waived_reason:` archives
+- [ ] [AC4] Write failing test: `review: waived` with empty/absent reason still refuses
+- [ ] [AC4] Implement the waiver read from `proposal.md` frontmatter
+
+### Staleness floor
+
+- [ ] [P] [AC6] Write failing test `TestArchiveBlocksOnStaleReview` — `proposal.md` committed
+      after `reviewed_sha`
+- [ ] [AC6] Implement the staleness check: `git log <reviewed_sha>..HEAD -- <contract files>`,
+      scoped to `proposal.md`, `tasks.md`, `features.json`
+- [ ] [AC7] Write failing test: the commit introducing `review.md` does NOT trip staleness
+- [ ] [AC7] Write failing test: a later `verification.md` change does NOT trip staleness
+- [ ] [AC6] Write failing test: an unresolvable `reviewed_sha` (post-rebase) is treated as stale
+- [ ] Refactor: staleness behind a small interface so tests inject a fake git rather than shelling
+      out in every case
+
+### Producer contract (vault SSOT — NOT the harness render)
+
+- [ ] [AC8] Update `$VAULT_PATH/00_meta/skills/adversarial-review/SKILL.md`: add the `review.md`
+      destination + frontmatter schema to "Output format", and make "Completion" instruct writing
+      the file
+- [ ] [AC8] Update `$VAULT_PATH/00_meta/skills/spec/SKILL.md` `archive` subcommand: document the
+      second pre-flight and both escapes
+- [ ] [AC8] Run `compile-harness.sh --refresh` so `harness/skills/` renders match, and verify the
+      render diff is exactly the vault change (CLI-005 lesson)
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous
+      verification command
+- [ ] Type checks pass (`go vet ./...`)
+- [ ] Lint passes
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `review.md` written for THIS spec by an independent session — dogfood the gate on itself
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+See sibling `features.json`. Pass-state gating applies: the agent cannot write `"state":
+"passing"` — only the harness may, after capturing exit code 0 with evidence.

--- a/specs/CLI-034-spec-archive-review-gate/verification.md
+++ b/specs/CLI-034-spec-archive-review-gate/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-09"
+---
+
+# Verification - CLI-034-spec-archive-review-gate
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/CLI-034-spec-archive-review-gate/` -> `specs/archive/CLI-034-spec-archive-review-gate/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)

--- a/specs/CLI-034-spec-archive-review-gate/verification.md
+++ b/specs/CLI-034-spec-archive-review-gate/verification.md
@@ -7,36 +7,75 @@ created: "2026-08-09"
 
 ## Evidence
 
-Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+Every command below was run in this session on `feat/spec-archive-review-gate`.
 
-- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+- [x] AC1 (blocks without review) -> `TestArchiveBlocksOnMissingReview` — **proved red first** on
+      `main` (`review_test.go:20: expected a missing review.md to block the archive`), green after
+      the pre-flight landed
+- [x] AC2 (blocks on FAIL / unknown / foreign) -> `TestArchiveBlocksOnFailVerdict`,
+      `TestArchiveBlocksOnUnknownVerdict`, `TestArchiveBlocksOnForeignReview`
+- [x] AC3 (PASS and PASS-WITH-GAPS archive) -> `TestArchiveProceedsOnPass`,
+      `TestArchiveProceedsOnPassWithGaps`
+- [x] AC4 (declared waiver) -> `TestArchiveWaivedWithReason`,
+      `TestArchiveWaivedWithoutReasonRefuses`
+- [x] AC5 (`--force-without-review`) -> `TestArchiveForceWithoutReview`,
+      `TestArchiveForceWithoutReviewOverridesFail`
+- [x] AC6 (staleness) -> `TestGitStalenessDetectsContractChange`,
+      `TestGitStalenessUnresolvableShaIsStale`, `TestArchiveBlocksOnStaleReview`
+- [x] AC7 (staleness self-defeat guards) -> `TestGitStalenessIgnoresReviewOwnCommit`,
+      `TestGitStalenessIgnoresVerificationMd`
+- [x] AC8 (skills document the contract) -> the `features.json` grep + `compile-harness.sh --check`
+      command, exit 0; render parity verified file-by-file against the vault SSOT
 
 ## Test status
 
-- Test suite: `<command> -> <output / coverage %>`
-- Manual smoke test: what was exercised, what was observed
-- No regressions in existing test suite: yes / no (if no, document)
+- Test suite: `go test ./...` in `cli/` -> all packages ok, no failures
+- `go vet ./...` -> clean
+- `./scripts/compile-harness.sh --check` -> `no harness drift`
+- Manual smoke: `gitStaleness` exercised against real `git init` repositories (not only the fake),
+  which is where AC6/AC7 actually live
+- No regressions: the eight pre-existing archive tests pass after being updated to the new
+  contract (see the first decision below)
 
 ## Decisions made during implementation
 
-Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
-
--
--
+- **Existing archive tests were updated, not exempted.** Adding a mandatory pre-flight broke eight
+  tests that archived specs carrying no `review.md`. That is the contract changing, not the tests
+  being wrong: under CLI-034 a minimal archivable spec includes a passing review, so `seedSpec` and
+  the affected `writeSpec` maps now say so. Exempting them would have left the suite describing a
+  system that no longer exists.
+- **Staleness is skipped, not failed, outside a git work tree.** With no history there is nothing
+  for the review to be stale against. The checker returns `known=false` and the caller skips —
+  presence, verdict and spec-id checks still applied. Failing closed here would break every
+  consumer that runs outside a repo without buying any real safety.
+- **An unresolvable `reviewed_sha` inside a repo IS stale.** Distinct from the case above: here
+  history exists and the sha is not in it (a rebase rewrote it), so the review cannot be shown to
+  describe the current change. Refusing is the safe direction and matches the proposal.
+- **Spec-id matching was implemented, not just documented.** The frontmatter schema in the proposal
+  claimed `spec:` must equal the folder name. Shipping that line without enforcing it would have
+  been the exact spec-vs-code mismatch this gate exists to catch, so `TestArchiveBlocksOnForeignReview`
+  now covers the copy-paste alibi (a review lifted from a sibling spec).
+- **Frontmatter comment-stripping had to respect quotes.** The scaffolded templates carry trailing
+  `# comments`, but a quoted value legitimately contains `#` (`issue: "mlorentedev/dotfiles#875"`).
+  Naive stripping corrupted the field; `TestFrontmatterKeepsHashInQuotedValue` pins both halves.
 
 ## Promotion candidates
 
-Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
-
-- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no - one line of what>
-- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
-- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+- [ ] Lesson for the repo's `docs/lessons.md`? **yes** — a freshness check scoped to the artifact it
+      validates is self-defeating; the checked set must exclude the artifact itself and any file
+      written at gate time.
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? **no** — this implements an existing
+      doctrine (determinism by code), it does not choose a new architecture.
+- [ ] New pattern candidate for `00_meta/patterns/`? **candidate** — "a gate needs a producer": the
+      verifier and the artifact's author are one contract, and specifying either alone ships a
+      system that compiles and does not work. Only promote if it recurs in a second project.
 
 ## Archive checklist
 
 - [ ] `proposal.md` frontmatter set to `status: archived`
-- [ ] Folder moved: `specs/CLI-034-spec-archive-review-gate/` -> `specs/archive/CLI-034-spec-archive-review-gate/`
-- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
-- [ ] Promotions above executed (if any)
+- [ ] Folder moved: `specs/CLI-034-spec-archive-review-gate/` -> `specs/archive/…` (via
+      `dotf spec archive CLI-034-spec-archive-review-gate --pr <url>`)
+- [ ] **`review.md` produced by an INDEPENDENT session** — this spec must pass its own gate, and the
+      implementer cannot be the reviewer without voiding the point
+- [ ] Bitácora #875 moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed


### PR DESCRIPTION
Closes #875.

## Why

The `adversarial-review` skill has existed since 2026-05-14 and had **never run as its designed gate**. A search for its output block across `specs/` and `docs/` in every personal repo returns zero hits, against ~218 archived specs. Not a quality problem — #255 shipped a severity × reality × test-traceability model and a six-dimension rubric. A binding problem: `dotf spec archive`'s only pre-flight was the `[AGENT-DRAFT]` tag check, and the skill's "Pairs with /spec archive lock" line described an integration that did not exist.

A second gap surfaced during design: the skill emitted its verdict as a chat block with **no frontmatter and no file destination**. Even a gate looking for the artifact would have had no compliant producer. Both halves ship here.

## What

`dotf spec archive` gains a second pre-flight. The tag check asks whether the spec is *finished being written*; this one asks whether anyone *independently argued against it*.

- `review.md` frontmatter (`spec`, `verdict`, `reviewed_sha`, `reviewer`, `date`) is the contract both sides reference. Absent, malformed, unrecognized, failing or **foreign** (declaring another spec id — the copy-paste alibi) refuses.
- `PASS` and `PASS-WITH-GAPS` archive; the gaps are already tracked by the review itself.
- Two escapes, both **declared** rather than judged in the moment: `review: waived` with a non-empty `review_waived_reason:` in `proposal.md`, and `--force-without-review`. Requiring the reason is load-bearing — it keeps waiving visible in the diff instead of invisible in a habit.
- A **staleness floor** scoped to the contract files (`proposal.md`, `tasks.md`, `features.json`) — the analogue of `check-spec-gate.sh`'s `SPEC_FLOOR`. `review.md` and `verification.md` are excluded by design: the first is always committed *after* the sha it records, the second is ticked *at archive time*. Including either would make every review stale by construction.
- The skill now persists its verdict to `specs/<id>/review.md`, edited in the vault SSOT and re-rendered (editing `harness/skills/` alone is reverted by the next `--refresh` — CLI-005 lesson).

## Verification

`TestArchiveBlocksOnMissingReview` was **proved red on main** before any implementation existed, then went green. `go test ./...` and `go vet ./...` clean; `compile-harness.sh --check` reports no drift. `gitStaleness` is exercised against real `git init` repositories, not only the injected fake — that is where the staleness criteria actually live.

Eight pre-existing archive tests were updated rather than exempted: under this contract a minimal archivable spec includes a passing review, so the fixtures now say so.

## Notes for review

- **This spec has not been archived**, so the gate has not yet run on itself. Doing so needs a `review.md` from an **independent session** — by the skill's own rule the implementer cannot be the reviewer. That is the honest dogfood and it is left for you to trigger.
- Out of scope, tracked separately: the NaN judge lane that would produce `review.md` in CI (gated on AI-001, `knowledge#150`), the aggregate rubric pass over archived reviews, and reflecting this gate in CI (adjacent to #854).
- #255 was closed as done in the course of this work — its three acceptance criteria are met by vault commit `3dd696af`.

## Archive skip rationale

The spec cannot be archived in this PR, and the reason is this PR's own subject matter.

`check-spec-gate.sh` requires archive-on-merge; the gate introduced here requires an independent `review.md` before an archive is allowed. For every SDD change *after* this one those two compose correctly — the adversarial review moves into the verification window, lands in the same PR, and the archive follows. But this PR is the one that creates the second requirement, so at the moment it is written no compliant producer has ever run: the skill only gained its persistence contract in this diff, and by its own independence rule the implementing session cannot supply the review.

Archiving anyway would mean reaching for `--force-without-review` on the very PR that introduces the flag — shipping the escape hatch already used once, which is precisely the "a routine waive stops being an escape" failure this design exists to prevent.

So the archive is deferred by one step, declared rather than silent: merge this, then an independent session runs `/adversarial-review CLI-034-spec-archive-review-gate`, commits `review.md`, and `dotf spec archive` closes the loop — the gate's first real exercise, on itself. #875 stays open until then; the archive checklist in `verification.md` carries the same note.
