### PR TITLE
docs(adr): hold ADR-032's enforced record behind the HARNESS-065 audit

### DIFF
--- a/docs/adr/adr-032-cross-harness-agent-orchestration.md
+++ b/docs/adr/adr-032-cross-harness-agent-orchestration.md
@@ -399,7 +399,24 @@ Inside epic #558, in this order:
    claim, not a property. Needs its own ticket under #558.
 2. **#563** — Copilot promoted to `agent-md`; the pi adapter; #895 folded in as its empirical input.
 3. **#562** — the roster, now carrying `surface` and `delegates_to`.
-4. **`enforced/orchestration.md`** + dispatch hooks (#561).
+4. **`enforced/orchestration.md`** + dispatch hooks (#561). **Held behind #881.** That issue's
+   audit found the `harness/enforced/` layer carries six rule ids and not one skill, and set a
+   hold: do not add enforcement layers until the first one has been exercised end to end.
+   Orchestration would be the seventh id, so it inherits the hold. As of 2026-08-09 the gate
+   #881 waits on has still produced **no** `review.md` artifact, so the hold is live — the
+   tickets closing (#875, #879) is not the same as the mechanism running.
+
+   The record is also **written pointer-shaped** (~500 characters: the trigger, the two hard
+   boundaries, and a link to the `dispatching-parallel-agents` skill for the detail), because the
+   injected set is 2,532 characters against a GOV-004 (#673) target of ~9,000 for the whole
+   `AGENTS.md` — 28% already, and 41% with a `definition-of-done`-sized addition. The character
+   budget proposed to bound that is folded into #881 rather than tracked here, since it is the
+   same governance question from the cost side.
+
+   Nothing else in this ADR depends on step 4: levels 1 and 2, the maps and the schema all ship
+   without it. What is lost while it is held is only the *default-on* property (C3) — the
+   capability works, it just has to be asked for. That is the honest trade, and it is preferable
+   to shipping a seventh record onto a layer with no evidence it changes behaviour.
 5. **#462** is reprioritized from optional to prerequisite for the Orca backend, with **#649**
    (installer must handle `.deb` / AppImage / installers, not just binaries) and **#899** (the CLI
    wrapper is broken outside Orca's own terminals) as named blockers.


### PR DESCRIPTION
Follow-up to #901, which merged while this was being written.

**#881 (HARNESS-065) does not merely overlap with ADR-032 step 4 — it forbids it for now.** Its audit of the five enforcement layers set an explicit hold: *"Building a second and third enforcement layer before the first has been exercised end-to-end would reproduce the exact failure this whole line of work exists to correct — shipping correct mechanisms that never run."*

`harness/enforced/orchestration.md` would be the **seventh id** on that layer. It inherits the hold.

## The hold is live, despite appearances

| Signal | State |
|---|---|
| #875 (CLI-034, the gate) | closed 2026-08-09 |
| #879 (HARNESS-064, its trigger) | closed 2026-08-10 |
| `find specs -name review.md` | **empty — the gate has never produced an artifact** |

Both tickets closing reads as the hold being satisfied. It is not: the condition asks for evidence that the enforced-region shape *changes behaviour*, and a closed ticket is not an exercised mechanism. Worth recording that today's own spec abandonment (#900) went through `--force-without-review` — legitimate, since AGENTS-001 was never implemented, but one more pass where the gate did not run.

## What the hold costs

Nothing else in ADR-032 depends on step 4. Levels 1 and 2, the maps and the schema all ship without it. What is deferred is the **default-on** property (C3) alone: the capability works, it just has to be asked for. That is a better trade than a seventh record on a layer with no evidence behind it.

## Also recorded: why the record is pointer-shaped when it does ship

Measured while answering "does this fit?":

| | chars |
|---|---|
| `AGENTS.md` today | 26,260 (~490 lines) |
| GOV-004 (#673) target | ~150 lines ≈ 9,000 |
| Injected `enforced` set (5 of 6) | 2,532 — 9.6% today, **28% of a dieted file** |
| With a `definition-of-done`-sized 7th | 3,721 — **41% of a dieted file** |

So the record is specified at ~500 characters — trigger, the two hard boundaries, and a link to the `dispatching-parallel-agents` skill for the detail. The character budget that would bound the layer as a whole is folded into #881 (comment there) rather than tracked here: that issue already owns what earns a place on the layer, and size is the same question from the cost side. Per #852, the two gates are distinct — a character budget bounds cost, not effectiveness.

Docs-only; no production LOC.