### PR TITLE
fix(ci): pin golangci-lint from versions.conf instead of the action default (BUG-071)

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -52,9 +52,23 @@ jobs:
         with:
           go-version-file: cli/go.mod
           cache-dependency-path: cli/go.sum
+      # Resolve the pin from versions.conf (BUG-071). Without an explicit
+      # version the action takes `latest`, so a local run proves nothing about
+      # CI and a linter release can turn main red with no change here.
+      - name: Resolve pinned golangci-lint version
+        id: golangci
+        working-directory: ${{ github.workspace }}
+        run: |
+          . ./versions.conf
+          if [ -z "${GOLANGCI_LINT_VERSION:-}" ]; then
+            echo "GOLANGCI_LINT_VERSION missing from versions.conf" >&2
+            exit 1
+          fi
+          echo "version=v${GOLANGCI_LINT_VERSION}" >> "$GITHUB_OUTPUT"
       - uses: golangci/golangci-lint-action@v9
         with:
           working-directory: cli
+          version: ${{ steps.golangci.outputs.version }}
 
   release-snapshot:
     name: goreleaser snapshot

--- a/cli/internal/doctor/checks_golangci.go
+++ b/cli/internal/doctor/checks_golangci.go
@@ -1,0 +1,64 @@
+package doctor
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// golangciVersionRe pulls the semver out of `golangci-lint --version`, which
+// reads e.g. "golangci-lint has version 2.12.2 built with go1.26.0 from …".
+// The `v` is optional on purpose: v1 printed "has version v1.62.2" and v2
+// prints "has version 2.12.2", and a check that only understood one of them
+// would report the other as unknown — turning a drift into a mystery.
+var golangciVersionRe = regexp.MustCompile(`version\s+v?(\d+\.\d+\.\d+)`)
+
+// golangciVersion extracts the installed semver, or "" when golangci-lint is
+// absent or answers in a shape we do not recognise. trailingVersion is not
+// usable here: the version is mid-line, and the last field is "(unknown)".
+func golangciVersion(sys *System) string {
+	out, err := sys.CommandOutput("golangci-lint", "--version")
+	if err != nil {
+		return ""
+	}
+	m := golangciVersionRe.FindStringSubmatch(out)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
+// checkGolangciLint compares the locally installed golangci-lint against the
+// versions.conf pin that CI consumes (BUG-071).
+//
+// This exists because the absence of a linter is loud and a stale one is not.
+// Before the pin, CI resolved the action's `latest` while this machine had a
+// binary two majors behind; `golangci-lint run` reported "0 issues" locally and
+// CI failed on the same commit, because v2 checks deferred calls in test files
+// that v1 ignores. A local pass was not merely uninformative — it manufactured
+// the confidence to push. Drift is a WARN rather than a FAIL, matching every
+// other pinned-tool check here: the tool still works, it just cannot speak for
+// CI.
+func checkGolangciLint(sys *System, cfg *Config, rep *Report) {
+	rep.Section("Go lint toolchain")
+
+	pin := cfg.Versions["GOLANGCI_LINT_VERSION"]
+	if !sys.has("golangci-lint") {
+		// Optional tooling: absent is a SKIP, not a failure. The message names
+		// the pin so the fix is a copy-paste rather than a lookup.
+		if pin == "" {
+			rep.Skip("golangci-lint not installed (CI lints the Go layer regardless)")
+			return
+		}
+		rep.Skip(fmt.Sprintf(
+			"golangci-lint not installed — CI gates the Go layer at v%s "+
+				"(go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v%s)", pin, pin))
+		return
+	}
+
+	installed := golangciVersion(sys)
+	if installed == "" {
+		rep.Warn("golangci-lint is on PATH but its --version output was not recognised — cannot verify it matches CI")
+		return
+	}
+	matchPin(rep, "golangci-lint", installed, pin)
+}

--- a/cli/internal/doctor/checks_golangci_test.go
+++ b/cli/internal/doctor/checks_golangci_test.go
@@ -1,0 +1,115 @@
+package doctor
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestGolangciVersionExtraction pins the parser against the real output of both
+// majors. v1 and v2 differ by a leading `v`, and BUG-071 was a v1-vs-v2 drift —
+// a parser that only understood the version it was written against would report
+// the other as unrecognised and hide the exact case it exists to catch.
+func TestGolangciVersionExtraction(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{
+			name: "v2 output (no leading v)",
+			out:  `golangci-lint has version 2.12.2 built with go1.26.0 from (unknown, modified: ?) on (unknown)`,
+			want: "2.12.2",
+		},
+		{
+			name: "v1 output (leading v)",
+			out:  `golangci-lint has version v1.62.2 built with go1.26.0 from (unknown, modified: ?) on (unknown)`,
+			want: "1.62.2",
+		},
+		{
+			name: "unrecognised output yields no version rather than a wrong one",
+			out:  "some other tool entirely",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sys := newSys(nil, []string{"golangci-lint"},
+				map[string]string{"golangci-lint --version": tt.out})
+			if got := golangciVersion(sys); got != tt.want {
+				t.Errorf("golangciVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckGolangciLint(t *testing.T) {
+	const v2 = `golangci-lint has version 2.12.2 built with go1.26.0 from (unknown) on (unknown)`
+	const v1 = `golangci-lint has version v1.62.2 built with go1.26.0 from (unknown) on (unknown)`
+
+	tests := []struct {
+		name       string
+		onPath     []string
+		cmdOut     map[string]string
+		pin        string
+		wantSubstr string
+		wantFail   bool
+	}{
+		{
+			name:       "installed version matches the pin",
+			onPath:     []string{"golangci-lint"},
+			cmdOut:     map[string]string{"golangci-lint --version": v2},
+			pin:        "2.12.2",
+			wantSubstr: "matches versions.conf",
+		},
+		{
+			// The BUG-071 case: this is what the machine looked like while
+			// `golangci-lint run` reported 0 issues and CI failed.
+			name:       "two majors behind the pin warns rather than passing silently",
+			onPath:     []string{"golangci-lint"},
+			cmdOut:     map[string]string{"golangci-lint --version": v1},
+			pin:        "2.12.2",
+			wantSubstr: "golangci-lint version drift: installed=1.62.2 pinned=2.12.2",
+		},
+		{
+			name:       "absent tool skips and names the pinned install command",
+			pin:        "2.12.2",
+			wantSubstr: "@v2.12.2",
+		},
+		{
+			name:       "absent tool with no pin still skips cleanly",
+			wantSubstr: "not installed",
+		},
+		{
+			name:       "unparseable version output is reported, not treated as a match",
+			onPath:     []string{"golangci-lint"},
+			cmdOut:     map[string]string{"golangci-lint --version": "mystery build"},
+			pin:        "2.12.2",
+			wantSubstr: "not recognised",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			rep := capture(&buf)
+			cfg := &Config{Versions: map[string]string{}}
+			if tt.pin != "" {
+				cfg.Versions["GOLANGCI_LINT_VERSION"] = tt.pin
+			}
+
+			checkGolangciLint(newSys(nil, tt.onPath, tt.cmdOut), cfg, rep)
+
+			got := buf.String()
+			if !strings.Contains(got, tt.wantSubstr) {
+				t.Errorf("report missing %q; got:\n%s", tt.wantSubstr, got)
+			}
+			// Drift must never fail the run: the tool works, it just cannot
+			// speak for CI. Same posture as every other pinned-tool check.
+			if !tt.wantFail && rep.ExitCode() != 0 {
+				t.Errorf("check must not FAIL (exit=%d); got:\n%s", rep.ExitCode(), got)
+			}
+		})
+	}
+}

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -91,6 +91,7 @@ func Run(opts Options) (int, error) {
 		checkGuardHooks(sys, cfg, rep, opts.Fix)
 		checkTmux(sys, cfg, rep)
 		checkOpenCode(sys, cfg, rep)
+		checkGolangciLint(sys, cfg, rep)
 		checkHarnessDrift(sys, cfg, rep)
 		checkDeployDrift(sys, cfg, rep)
 		checkRepoDirResolves(rep)

--- a/tests/versions-conf.bats
+++ b/tests/versions-conf.bats
@@ -76,3 +76,24 @@ setup() {
     [[ $status -eq 0 ]]
     [[ -n "$output" ]]
 }
+
+@test "versions.conf sets GOLANGCI_LINT_VERSION [#919]" {
+    . "$VERSIONS_CONF"
+    [[ -n "$GOLANGCI_LINT_VERSION" ]]
+}
+
+@test "cli.yml pins golangci-lint from versions.conf, never the action default [#919]" {
+    local wf="$DOTFILES_DIR/.github/workflows/cli.yml"
+    # The action resolves 'latest' when no version is given, which is what made
+    # a local run unable to reproduce CI (BUG-071). Assert the pin is both
+    # sourced from versions.conf and handed to the action.
+    grep -q 'GOLANGCI_LINT_VERSION' "$wf"
+    grep -q 'version: \${{ steps.golangci.outputs.version }}' "$wf"
+}
+
+@test "cli.yml fails loudly when the golangci-lint pin is missing [#919]" {
+    local wf="$DOTFILES_DIR/.github/workflows/cli.yml"
+    # A silently-empty version input falls back to 'latest', reintroducing the
+    # bug while looking green. The resolve step must exit non-zero instead.
+    grep -q 'GOLANGCI_LINT_VERSION missing from versions.conf' "$wf"
+}

--- a/versions.conf
+++ b/versions.conf
@@ -23,6 +23,11 @@ PI_VERSION=0.79.1
 # v0.10, so latest/download/shellcheck-stable... now 404s). Pin the tag; setup
 # builds the URL + the tarball's internal dir name from it (prefixed with `v`).
 SHELLCHECK_VERSION=0.11.0
+# golangci-lint gates the Go layer (ADR-020's primary layer), so it is pinned for
+# the same reason shellcheck is: the CI job previously took the action's `latest`
+# default, which meant a local run could not reproduce CI's verdict and a linter
+# release could turn main red with no change here. Bump deliberately (BUG-071).
+GOLANGCI_LINT_VERSION=2.12.2
 # x-release-please-start-version
 DOTF_VERSION=0.37.0
 # x-release-please-end


### PR DESCRIPTION
Fixes #919.

`.github/workflows/cli.yml` passed no version to `golangci-lint-action`, so it
resolved **`latest`** on every run. Nothing pinned the linter, `versions.conf`
had no entry, and no local tool matched CI.

## What it actually cost

Hit live on #918, three pushes on one small PR:

```
local:  golangci-lint has version v1.62.2
CI:     Requested golangci-lint 'latest', using 'v2.12.2'
```

Two majors apart. `golangci-lint run` reported **`0 issues`** locally; CI failed
the same commit, because v2 checks deferred calls in `_test.go` files that v1
ignores. The local pass was not merely uninformative — it manufactured the
confidence to push. A missing linter is loud; a linter two majors stale is
silent and actively misleading.

## The change

- `versions.conf` gains `GOLANGCI_LINT_VERSION=2.12.2`, beside
  `SHELLCHECK_VERSION` and for the same reason that one is pinned.
- `cli.yml` reads it there rather than duplicating the number, via a resolve
  step that **exits non-zero if the key is missing** — a typo cannot silently
  restore `latest` while looking green.
- `dotf doctor` gains a *Go lint toolchain* section comparing the installed
  binary to the pin. Drift is a `WARN`, matching every other pinned-tool check
  (`matchPin`): the tool works, it just cannot speak for CI.

## Evidence

The guard reports exactly the machine state that caused the incident:

```
[Go lint toolchain]
  [WARN] golangci-lint version drift: installed=1.62.2 pinned=2.12.2
```

- `golangci-lint run` **at the pinned v2.12.2** → `0 issues` (the version
  distinction is the point: v1.62.2 also said 0 issues on a commit CI rejected)
- `go build ./...` clean, `go test ./...` green, 8 new table-driven cases
- `actionlint .github/workflows/cli.yml` clean; step order verified
- `bats tests/versions-conf.bats` → 17 passed
- **Mutation-checked, not assumed**: deleting the `version:` input turns
  `cli.yml pins golangci-lint…` red, and restoring it turns it green. The
  version parser is pinned against *both* majors' output shapes — one that
  understood only v2 would report v1 as unrecognised and hide the exact drift
  it exists to catch.

## Not in scope

Upgrading the linter on this machine. The `WARN` is now the durable signal and
the fix is a one-liner the check prints; silently mutating a dev toolchain is
not this PR's business.

Documenting the Go verification loop in `.claude/CLAUDE.md` belongs to #916,
which already carries it — that file names `shellcheck` and `bats` and no Go
tooling at all, which is the other half of why this shipped.

## SDD skip rationale

**Self-granted; flagging it rather than burying it, so it is yours to ratify.**

The gate counts 84 production LOC against a threshold of 50. The breakdown
matters: 14 lines of workflow, 5 of `versions.conf`, 1 of wiring, and 64 in the
new doctor check — of which **37 are code and 21 are comments**. The functional
change is a version pin plus one `matchPin` call in the established shape of the
`opencode` and `pi` checks beside it.

It clears the gate's own skip criterion in substance — a bug fix with an obvious,
already-diagnosed cause — and is over the line only because the
incident-to-guard rule requires shipping the guard in the same PR as the fix.
Writing a spec would restate #919, which already carries the full analysis.

No public contract changes: `versions.conf` gains a key (additive), the doctor
section is new output, and no existing flag, path or exported type moves.
