### PR TITLE
docs(claude): correct the repo instructions and guard against them rotting (DOCS-013)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,17 +26,34 @@ All shell scripts MUST work in **both bash and zsh**. Before modifying any `.sh`
 
 ## Verification Commands
 
-Run these before claiming any shell script change is complete:
+Two layers, two loops (ADR-020). Run the one you touched — and note the Go
+layer is the primary one, so "I ran shellcheck" is not verification of a `cli/`
+change.
 
 ```bash
-# Lint all scripts
+# --- Shell layer ---
 ~/.local/bin/shellcheck scripts/*.sh setup-linux.sh
-
-# Run full test suite (147 tests, bash+zsh)
-~/.local/bin/bats tests/*.bats
-
-# Syntax check
+~/.local/bin/bats tests/*.bats                        # ~1200 tests, bash+zsh
 for f in scripts/*.sh setup-linux.sh; do bash -n "$f"; done
+
+# --- Go layer (cli/) ---
+cd cli
+go build ./... && go vet ./... && go test ./...
+golangci-lint run
+```
+
+**Use the pinned linter, not whatever is installed.** CI resolves
+`GOLANGCI_LINT_VERSION` from `versions.conf`; a local binary on a different
+major reports "0 issues" on code CI rejects (BUG-071). `dotf doctor` reports
+the drift under *Go lint toolchain*; install the pin with:
+
+```bash
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(. versions.conf; echo "$GOLANGCI_LINT_VERSION")
+```
+
+```bash
+# --- Post-setup verification (both layers) ---
+dotf doctor
 ```
 
 ## Key Files
@@ -45,33 +62,49 @@ for f in scripts/*.sh setup-linux.sh; do bash -n "$f"; done
 |---|---|---|
 | `versions.conf` | Central version manifest | Single source of truth for tool versions |
 | `scripts/utils.sh` | Foundation library | Sourced by ALL other scripts |
-| `scripts/healthcheck.sh` | Post-setup verification | 6-section tool/version/symlink checks |
-| `scripts/load-secrets.sh` | Secrets loader | Sourced in `.zshrc`/`.bashrc` at login |
-| `sensitive/env-mapping.conf` | Secret-to-env mapping | Maps `.secret.age` files to env vars |
+| `cli/` | `dotf` Go CLI — the primary user-facing tool | `doctor`, `env`, `secrets`, `spec`, `init`, `mem`, `tools`, `vault`. Absorbs `.sh`/`.ps1` twins on contact (ADR-020) |
+| `secrets/registry.yaml` | Secret mapping SSOT (ADR-028) | Replaced the retired sensitive/env-mapping.conf |
 | `setup-linux.sh` | Linux bootstrap | Installs tools, deploys configs, registers MCP servers |
 | `setup-windows.ps1` | Windows bootstrap | PowerShell equivalent (copies instead of symlinks) |
 | `ai/claude/CLAUDE.md` | Master Claude instructions | Deployed to `~/.claude/CLAUDE.md` by setup |
-| `ai/skills/*/SKILL.md` | Claude skills (20 total) | Deployed to `~/.claude/skills/` |
-| `scripts/claude-session-start.sh` | SessionStart hook | Injects vault health + knowledge staleness into Claude context |
+| `harness/skills/*/SKILL.md` | Committed skill records (37) | Rendered from the vault by `compile-harness.sh --refresh`; deployed to each agent by `--deploy`. **Generated — edit the vault source, not these** |
+| `harness/manifest.json` | Harness engine manifest | Which enforced regions inject where, and which agents receive skills |
+| `scripts/compile-harness.sh` | Harness engine | `--refresh` (vault → records), `--deploy` (records → agent dirs), `--check` (offline drift) |
 | `scripts/vault.sh` | Vault tooling dispatcher (REFACTOR-005) | `vault {health, maintenance, check-escapes}` — single discoverable entry point; each subcommand still runnable standalone |
 | `scripts/vault-health.sh` | Obsidian vault health check | Checks plugin status, pending tasks, etc. Also runnable via `vault health`. |
 | `scripts/obs-cli.sh` | Obsidian CLI wrapper (Linux) | --no-sandbox, default vault, GUI check |
 | `scripts/obs-cli.ps1` | Obsidian CLI wrapper (Windows) | Default vault, GUI check |
 | `scripts/knowledge-crystallize.sh` | AI knowledge maintenance | Updates MEMORY.md dates, checks health, prints crystallization checklist |
-| `ai/aider/aider.conf.yml` | Aider global config | Deployed to `~/.aider.conf.yml` — 3 tiers via OpenRouter |
-| `ai/aider/aider.model.settings.yml` | Aider model settings | Deployed to `~/.aider.model.settings.yml` |
-| `.zsh/aliases.zsh` | Shell aliases | Includes `oc` for opencode, `ai`/`aic`/`aia` for aider (legacy, sunset PR2), `tx`/`txl`/`txa`/`txk` for tmux |
+| `scripts/check-doc-paths.sh` | Doc-path guard (#916) | Fails when an instruction file names a repo path that no longer exists |
+| `.zsh/aliases.zsh` | Shell aliases | Includes `oc` for opencode, `qq` for one-shot questions, `tx`/`txl`/`txa`/`txk` for tmux |
 | `ai/opencode/opencode.jsonc` | OpenCode config | Provider `opencode-go` (Go subscription, catalog-restricted) + `openrouter` + MCP mirror. Deployed to `~/.config/opencode/`. |
 | `AGENTS.md` (root) | Cross-agent SSOT | Canonical system prompt read by OpenCode (natively) and Claude (via this file's pointer). Per-agent files in `ai/<agent>/` and `.github/` delegate here. |
 | `tmux.conf` | tmux configuration (Linux only) | Deployed via symlink to `~/.tmux.conf` by `setup-linux.sh` |
 
-## Secrets System
+> **Editing this file: a backticked repo path is a live claim.**
+> `scripts/check-doc-paths.sh` fails CI when one does not resolve — that is how
+> this file came to name seven files that no longer existed (#916). To mention a
+> path that is gone ("the old loader lived at scripts/load-secrets.sh"), write it
+> in plain text, not backticks.
 
-- Encryption: [age](https://github.com/FiloSottile/age) with key at `~/.config/age/key.txt`
-- Encrypted files: `sensitive/*.secret.age`
-- Mapping: `sensitive/env-mapping.conf` maps filenames to environment variable names
-- Loader: `scripts/load-secrets.sh` decrypts and exports at shell startup
-- Add a secret: encrypt with `age -r $(age-keygen -y ~/.config/age/key.txt)`, add mapping to `env-mapping.conf`
+## Secrets System (ADR-028)
+
+Two tiers, and the shape matters: **secrets are never exported into the ambient
+shell.** They are injected into one child process on demand. The older model —
+a login-time loader that decrypted everything into the environment — is retired,
+along with the scripts/load-secrets.sh loader and the sensitive/env-mapping.conf
+mapping file.
+
+- **SSOT:** Bitwarden. **DR floor:** [age](https://github.com/FiloSottile/age)-encrypted copies under `sensitive/*.secret.age`, key at `~/.config/age/key.txt`.
+- **Mapping SSOT:** `secrets/registry.yaml`.
+- **Facade:** `dotf secrets` — `run` (inject into a child process only), `show`,
+  `ls`, `verify`, `set`, `render`, `migrate`, `sync`, `backup`.
+
+```bash
+dotf secrets ls                     # inventory: ids, plane, exposed vars (no values)
+dotf secrets verify                 # resolve everything, report OK/MISSING/FAILED
+dotf secrets run -- ./deploy.sh     # the only sanctioned way to hand a secret to a process
+```
 
 ## Common Workflows
 
@@ -81,37 +114,40 @@ for f in scripts/*.sh setup-linux.sh; do bash -n "$f"; done
 3. Follow the prohibited patterns table above
 4. Run `shellcheck` and `bats` before committing
 
-### Adding a new secret
-1. Create `sensitive/KEYNAME.secret.age` with age encryption
-2. Add mapping line to `sensitive/env-mapping.conf`
-3. Test with `. scripts/load-secrets.sh && echo $VAR_NAME`
+### Adding a new secret (ADR-028)
+1. Add its entry to `secrets/registry.yaml` (the mapping SSOT — id, plane, exposed vars)
+2. Write the value: `dotf secrets set <id>` (reads stdin or prompts hidden; idempotent)
+3. Verify without printing it: `dotf secrets verify`
+4. Consume it: `dotf secrets run -- <cmd>` — never by exporting into your shell
 
-### Adding a file secret
-1. Run `secrets_add_file VAR_NAME filename dest_path` (e.g. `secrets_add_file KUBECONFIG kubelab.kubeconfig ~/.kube/kubelab.config`)
-2. It will prompt for the source file path, encrypt it, and add `@VAR=filename>dest` to `env-mapping.conf`
-3. Or manually: encrypt with age, add `@VAR=filename>~/.kube/dest.config` to `env-mapping.conf`
-4. Test with `secrets_refresh && echo $VAR_NAME` (should point to deployed file path)
+Run `dotf secrets <sub> --help` for the exact flags; do not reconstruct the old
+`env-mapping.conf` syntax, which no longer exists.
 
 ### Updating a tool version
 1. Edit `versions.conf` at repo root — change `TOOL_VERSION=X.Y.Z`
 2. Verify syntax: `bash -n versions.conf && zsh -n versions.conf`
 3. Run `~/.local/bin/bats tests/versions-conf.bats` to validate format
 4. The new version propagates automatically to `.zshrc`/`.bashrc` via `${VAR:-fallback}` on next shell reload
-5. Run `./scripts/healthcheck.sh` to verify the versioned directory exists at `~/Applications/tool-X.Y.Z`
+5. Run `dotf doctor` to verify the versioned directory exists at `~/Applications/tool-X.Y.Z`
 
 ### Adding a new versioned tool
 1. Add `NEWTOOL_VERSION=X.Y.Z` to `versions.conf`
 2. Add `export NEWTOOL_HOME="$APPS_HOME/newtool-${NEWTOOL_VERSION:-X.Y.Z}"` to both `.zshrc` and `.bashrc`
 3. Add `export PATH="$NEWTOOL_HOME/bin:$PATH"` in both RC files (if the tool has binaries)
-4. Add version check to `scripts/healthcheck.sh` (sections 2, 3, and 5)
-5. Run tests: `~/.local/bin/bats tests/versions-conf.bats tests/healthcheck.bats`
+4. Add the version check to `cli/internal/doctor/` — `versionMatches` for a
+   versioned `$APPS_HOME` dir, or `matchPin` against the live binary for tools
+   installed elsewhere (see `checks_golangci.go` for the latter shape)
+5. Run tests: `~/.local/bin/bats tests/versions-conf.bats` and `cd cli && go test ./internal/doctor/`
 
 ### Running the health check
 ```bash
-./scripts/healthcheck.sh     # Full post-setup verification
-# Checks: core tools, versioned paths, version match, symlinks, env vars, optional tools
+dotf doctor          # Full post-setup verification
+dotf doctor --fix    # Repair what is safely repairable (junctions, hooks paths)
 # Exit 0 = all pass, Exit 1 = failures detected
 ```
+
+> The `healthcheck.sh` / `doctor.sh` twins were retired into this command
+> (ADR-020 strangler-fig). If something tells you to run them, it is stale.
 
 ### Diagnosing shell startup time (when zsh/bash feels slow)
 ```bash
@@ -140,7 +176,8 @@ Alias to `scripts/shell-profile.sh`. Diagnostic tool — use when interactive sh
 ./scripts/knowledge-crystallize.sh ~/Projects/kubelab
 ```
 
-See vault runbook: `~/Projects/knowledge/10_projects/dotfiles/40-runbooks/guide-knowledge-distillation.md`
+See vault runbook: `$VAULT_PATH/10_projects/dotfiles/40-runbooks/guide-knowledge-distillation.md`
+(resolve `$VAULT_PATH` via `dotf env path VAULT_PATH` — never hardcode the literal, per ADR-025)
 
 ### Using opencode (AI coding agent — primary daily after PR2)
 ```bash
@@ -151,20 +188,9 @@ qq "tu pregunta"      # one-shot quick-question via opencode-go/qwen3.6-plus (ba
 - `qq` wrapper pinned to `opencode-go/qwen3.6-plus` (multilingual, fast, never-rate-limited). One-shot: each call is a fresh session. Defined in `.zsh/aliases.zsh`, `.bashrc`, and `powershell/profile.ps1`. Cross-platform name is `qq` (not `??`) because PowerShell 7+ reserves `??` as null-coalescing operator.
 - Frontier on-demand: provider `openrouter` (consumes existing `OPENROUTER_API_KEY` $5 credit).
 - First-time setup: launch `oc`, run `/connect` → select **OpenCode Go**, paste API key from opencode.ai/zen.
-- 3-layer PAYG guardrail: (1) `opencode.jsonc` lists only Go models, (2) Zen workspace cap $0, (3) no payment method for PAYG. Runbook: `~/Projects/knowledge/10_projects/dotfiles/40-runbooks/guide-opencode-go-setup.md`.
+- 3-layer PAYG guardrail: (1) `opencode.jsonc` lists only Go models, (2) Zen workspace cap $0, (3) no payment method for PAYG. Runbook: `$VAULT_PATH/10_projects/dotfiles/40-runbooks/guide-opencode-go-setup.md`.
 - Config: `ai/opencode/opencode.jsonc` → `~/.config/opencode/opencode.jsonc` (deployed by `setup-linux.sh`).
 - ⚠ Coexistence constraint: don't run `oc` and `claude` in parallel on the same repo until hive MCP adds a lock-file to its auto-commit.
-
-### Using aider (legacy — sunset in PR2)
-```bash
-ai                    # daily — DeepSeek V3.2 ($0.25/$0.40 per M tokens)
-aic                   # coding — Qwen3 Coder ($0.12/$0.75 per M tokens)
-aia                   # architecture — DeepSeek Speciale + architect mode ($0.40/$1.20 per M tokens)
-```
-- Budget target: ~$2/month at heavy use (60 interactions/day)
-- Requires: `uv`, Python 3.12 (audioop removed in 3.13), `OPENROUTER_API_KEY`
-- To change models: edit `ai/aider/aider.conf.yml` + `.zsh/aliases.zsh`, re-run setup
-- **Replaced by opencode in PR2.** Kept here during PR1 coexistence (see spec `specs/AI-011-opencode-bootstrap/`).
 
 ### Modifying setup scripts
 1. Edit both `setup-linux.sh` AND `setup-windows.ps1` if the change is cross-platform
@@ -180,7 +206,10 @@ After modifying ANY shell script:
 
 After completing a session:
 - If new patterns were learned, suggest updating this CLAUDE.md
-- If mistakes were corrected, update vault `~/Projects/knowledge/10_projects/dotfiles/lessons.md`
+- If mistakes were corrected, write the lesson to this repo's `docs/lessons.md`.
+  **Not the vault** — project lessons are build/operate knowledge and live in
+  the repo (Standing Order #2, `pattern-knowledge-placement`). Only
+  cross-project insight goes to `00_meta/` in the store.
 
 <claude-mem-context>
 # Recent Activity

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ admin needed; some changes show after an Explorer restart.
 ├── cli/                        # `dotf` Go CLI (doctor, init, env, spec) — primary user-facing tool
 ├── scripts/                    # Shell utilities (NOT on PATH — see Human entrypoints below)
 │   ├── utils.sh                # Shared function library (sourced by other scripts)
-│   ├── load-secrets.sh / .ps1  # Secrets → env vars (sourced at login)
 │   ├── vault.sh                # Vault tooling dispatcher
 │   └── …                       # ~50 scripts total (hooks, CI helpers, secret tools)
 ├── sensitive/                  # Encrypted secrets
@@ -93,7 +92,7 @@ scripts that a human ever runs directly — everything else is a library, hook, 
 | `vault <subcommand>` | `scripts/vault.sh` | Vault tooling: `vault health`, `vault maintenance`, `vault check-escapes` |
 | `profile-shell` | `scripts/shell-profile.sh` | Measure shell startup time (zsh/bash, --detail for per-function) |
 | `obs` | `scripts/obs-cli.sh` | Open Obsidian vault (Linux, --no-sandbox, GUI check) |
-| `. scripts/load-secrets.sh` | `scripts/load-secrets.sh` | Decrypt age secrets → env vars (auto-sourced at login; manual when adding a new secret) |
+| `dotf secrets run -- <cmd>` | `dotf` CLI | Inject mapped secrets into one child process only, never the ambient shell (ADR-028). `show`/`ls`/`verify` for single values, inventory and health |
 
 ## Key Commands
 

--- a/scripts/check-doc-paths.sh
+++ b/scripts/check-doc-paths.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+# check-doc-paths.sh: fail when an instruction file names a repo path that does
+# not exist.
+#
+# Agent instruction files (.claude/CLAUDE.md, AGENTS.md, …) are read as fact.
+# When a script is retired into `dotf` or a config is replaced by a new model,
+# the file that told agents to run it keeps saying so and nothing complains:
+# the repo checks content sync, markdown corruption and harness drift, but
+# nothing checks that a path named in prose still resolves.
+#
+# Not hypothetical (#916): `.claude/CLAUDE.md` was committed by #907 while
+# naming seven files that no longer existed, and two sessions in two days
+# followed one of them — `./scripts/healthcheck.sh`, long retired into
+# `dotf doctor`.
+#
+# ## What counts as a repo path
+#
+# Deliberately conservative, because a guard with false positives gets
+# bypassed and then protects nothing. A backticked token is checked only when:
+#
+#   - it contains no whitespace, shell metacharacters or <placeholder> markers;
+#   - it is repo-relative (no leading /, ~, $ or -) and not a URL;
+#   - AND EITHER its first segment is a real top-level entry of this repo
+#     (computed from disk, so the rule needs no maintenance), OR it is a bare
+#     filename with a known extension, matched against the git index by
+#     basename so prose like `utils.sh` resolves to scripts/utils.sh.
+#
+# Everything else — model ids like `opencode-go/qwen3.6-plus`, command
+# fragments, vault paths, deployed ~/ locations — is ignored by construction
+# rather than by an exclusion list that would rot the same way the docs did.
+#
+# ## Convention this implies
+#
+# A backticked repo path is a LIVE claim. To name a path that no longer exists
+# — "the old loader lived at scripts/load-secrets.sh" — write it in plain text.
+# That keeps the invariant simple enough to state in one line, and needs no
+# per-file exception list.
+#
+# It also means this guard is for INSTRUCTION files (things agents act on), not
+# for historical ones. docs/lessons.md legitimately names retired scripts in its
+# incident write-ups; running this against it would report a dozen "failures"
+# that are all correct as history. Keep the target list to files that tell
+# someone what to do.
+#
+# Usage:
+#   check-doc-paths.sh <file>...
+#
+# Exit:
+#   0  every referenced path resolves
+#   1  one or more referenced paths are missing
+#   2  usage error / unreadable file
+
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+    cat >&2 <<'EOF'
+Usage: check-doc-paths.sh <file>...
+  Verifies that every repo-relative path named in backticks inside <file>
+  exists on disk. Paths resolve against the repo root (the parent of the
+  directory holding this script).
+EOF
+    exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+KNOWN_EXT='\.(sh|ps1|zsh|bats|conf|md|json|jsonc|ya?ml|toml)$'
+
+# Top-level entries of this repo, one per line. Computed rather than listed:
+# a new top-level directory is covered the day it is created.
+TOP_LEVEL="$(ls -A "$REPO_ROOT")"
+
+# True when the token's first path segment is a real top-level repo entry.
+is_repo_rooted() {
+    _first="${1%%/*}"
+    # .git is a top-level entry but its internals are not repo content — docs
+    # mention `.git/info/exclude` as a concept, not as a tracked file.
+    [ "$_first" = ".git" ] && return 1
+    printf '%s\n' "$TOP_LEVEL" | grep -qxF "$_first"
+}
+
+missing_total=0
+
+for target in "$@"; do
+    if [ ! -f "$target" ]; then
+        printf 'check-doc-paths: not a file: %s\n' "$target" >&2
+        exit 2
+    fi
+
+    missing_in_file=0
+    # shellcheck disable=SC2016  # the backtick pattern is literal by design
+    tokens="$(grep -o '`[^`[:space:]]*`' "$target" | tr -d '\140' | sort -u || true)"
+
+    while IFS= read -r token; do
+        [ -n "$token" ] || continue
+
+        # Absolute, home-relative, variable-rooted, flag-like, or a URL.
+        case "$token" in
+            /*|'~'*|'$'*|-*|*://*) continue ;;
+        esac
+
+        # Shell metacharacters, assignments, or <placeholder> markers mean this
+        # is a command fragment or a template, not a path on disk.
+        case "$token" in
+            *'<'*|*'>'*|*'&'*|*'|'*|*';'*|*'='*|*'@'*|*'('*|*')'*) continue ;;
+        esac
+
+        # An ALL-CAPS segment is usually a stand-in the reader substitutes
+        # (`sensitive/KEYNAME.secret.age`). But plenty of real files are
+        # ALL-CAPS — SKILL.md, AGENTS.md, MEMORY.md, README.md — so the
+        # placeholder reading only applies when the token does NOT end in a
+        # known extension. Without that second condition this rule silently
+        # skipped `ai/skills/*/SKILL.md`, a genuinely dead reference.
+        if printf '%s\n' "$token" | grep -qE '(^|/)[A-Z][A-Z0-9_]+(\.|/|$)' &&
+            ! printf '%s' "$token" | grep -qE "$KNOWN_EXT"; then
+            continue
+        fi
+
+        token="${token#./}"
+
+        # Only rooted paths are checked. A bare filename is deliberately
+        # ignored: prose names plenty of files that live elsewhere by design —
+        # vault patterns (`pattern-language-standards.md`), per-machine config
+        # (`machine.json`), spec artifacts (`review.md`), even files named only
+        # to forbid them (`TODO.md`). Resolving those by basename produced a
+        # dozen false alarms on AGENTS.md, and a guard that cries wolf is a
+        # guard someone deletes.
+        printf '%s' "$token" | grep -q '/' || continue
+        is_repo_rooted "$token" || continue
+
+        case "$token" in
+            *'*'*)
+                # A glob must match at least one path. Expanded under bash -c
+                # with nullglob so an unmatched pattern yields nothing rather
+                # than the literal pattern — and, under zsh's default NOMATCH,
+                # rather than aborting the whole command.
+                matches="$(bash -c 'shopt -s nullglob; cd "$1" || exit 0; set -- $2; printf "%s\n" "$@"' _ "$REPO_ROOT" "$token" | grep -c . || true)"
+                if [ "$matches" -eq 0 ]; then
+                    printf '%s: glob matches nothing: %s\n' "$target" "$token" >&2
+                    missing_in_file=$((missing_in_file + 1))
+                fi
+                ;;
+            *)
+                if [ ! -e "$REPO_ROOT/$token" ]; then
+                    printf '%s: referenced path does not exist: %s\n' "$target" "$token" >&2
+                    missing_in_file=$((missing_in_file + 1))
+                fi
+                ;;
+        esac
+    done <<TOKENS
+$tokens
+TOKENS
+
+    if [ "$missing_in_file" -eq 0 ]; then
+        printf 'check-doc-paths: OK %s\n' "$target"
+    else
+        printf 'check-doc-paths: %s missing path(s) in %s\n' "$missing_in_file" "$target" >&2
+        missing_total=$((missing_total + missing_in_file))
+    fi
+done
+
+if [ "$missing_total" -ne 0 ]; then
+    printf '\ncheck-doc-paths: %s referenced path(s) do not exist.\n' "$missing_total" >&2
+    printf 'Either the path moved (update the doc) or the doc is stale (drop the claim).\n' >&2
+    exit 1
+fi
+
+exit 0

--- a/specs/DOCS-013-doc-path-guard/proposal.md
+++ b/specs/DOCS-013-doc-path-guard/proposal.md
@@ -1,0 +1,91 @@
+---
+id: "DOCS-013-doc-path-guard"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-08-11"
+issue: "mlorentedev/dotfiles#916"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# DOCS-013-doc-path-guard
+
+## Why
+
+`.claude/CLAUDE.md` was gitignored until #907 tracked it so its mandatory shell
+rules would stop being per-machine and invisible. Tracking made the file
+authoritative for every agent that opens this repo; it did not make it true. On
+the day it landed it named seven files that no longer exist, and two sessions in
+two days acted on one of them — `./scripts/healthcheck.sh`, retired into
+`dotf doctor` — before noticing. The repo has guards for content sync
+(`docs-drift.bats`), markdown corruption (`check-md-escapes.sh`) and harness
+drift (`compile-harness.sh --check`), and none that asks whether a path named in
+prose still resolves.
+
+## What
+
+Two things, and the second is why this is a spec rather than a doc edit.
+
+1. **The instructions match reality.** Dead Key Files rows dropped or
+   repointed; the Secrets System section describes ADR-028 (child-process
+   injection via `dotf secrets`) instead of the retired login-time loader it was
+   written to abolish; Verification Commands names the Go layer and the pinned
+   linter; health-check recipes point at `dotf doctor`; hardcoded
+   `~/Projects/knowledge` literals become `$VAULT_PATH` per ADR-025; the lessons
+   pointer moves from the vault to `docs/lessons.md` per Standing Order #2.
+
+2. **A convention, enforced.** `scripts/check-doc-paths.sh` establishes that
+   **a backticked repo path in an instruction file is a live claim**, and fails
+   CI when one does not resolve. Naming a retired path is still allowed — in
+   plain text, not backticks. That single rule is what makes the guard
+   maintainable without a per-file exception list.
+
+## Out of scope
+
+- The dead `<claude-mem-context>` block at the end of `.claude/CLAUDE.md` —
+  #832 (MEMORY-005) owns claude-mem's retirement.
+- `docs/lessons.md` and other historical records. They name retired scripts on
+  purpose; running the guard against them would report a dozen "failures" that
+  are all correct as history. The guard is for files that tell someone what to
+  do.
+- Broadening the guard to link-checking (URLs, anchors) or to the vault.
+
+## Acceptance
+
+- [x] Every repo path named in `.claude/CLAUDE.md` resolves
+- [x] Secrets documentation describes the ADR-028 model, with no reference to
+      `env-mapping.conf` syntax as if it were live
+- [x] Verification Commands covers the Go layer, naming the pinned
+      `GOLANGCI_LINT_VERSION` and why an unpinned local run proves nothing
+- [x] No hardcoded vault literal remains in the file
+- [x] `scripts/check-doc-paths.sh` exits 0 on all six instruction files and 1 on
+      a seeded dead path
+- [x] The guard produces **zero** false positives on `AGENTS.md`, the largest
+      instruction file
+- [x] A bats suite pins both the catching and the not-crying-wolf behaviour
+
+## Risks
+
+**A guard with false positives is worse than none** — it gets bypassed, and then
+the real regression sails through. Mitigated by making the matcher conservative
+by construction (only backticked, repo-rooted tokens whose first segment is a
+real top-level entry, computed from disk) rather than by an exclusion list that
+would rot exactly as the docs did. Measured: an earlier revision produced 13
+false positives on `AGENTS.md`; the shipped one produces zero.
+
+**A guard with false negatives is a placebo.** Found one while building it: an
+ALL-CAPS "placeholder" rule swallowed `SKILL.md` and so skipped the dead
+`ai/skills/*/SKILL.md` glob the guard existed to catch. Both that case and the
+false-positive cases are pinned as tests, so the next tightening cannot silently
+re-open either.
+
+## Alternatives rejected
+
+- **Fix the docs, no guard.** This is the second time this file class has misled
+  a session; the incident-to-guard rule exists for exactly this repetition.
+- **Resolve bare filenames by basename.** Would catch a few more stale mentions,
+  but flagged vault patterns, `machine.json` and `review.md` on `AGENTS.md` —
+  files that legitimately live elsewhere. Rejected on the false-positive risk
+  above.
+- **A per-file exclusion list.** Rots the same way the docs rot, and hides the
+  rule it is meant to express.

--- a/specs/DOCS-013-doc-path-guard/tasks.md
+++ b/specs/DOCS-013-doc-path-guard/tasks.md
@@ -1,0 +1,66 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-11"
+---
+
+# Tasks - DOCS-013-doc-path-guard
+
+> TDD order. One task = one focused commit. Tick as you go.
+>
+> Written after the fact, honestly: the work was done in one pass on
+> `fix/claude-md-staleness` before the spec-gate flagged it at 293 production
+> LOC. The order below is the order it actually happened — the guard first,
+> run against the unfixed file, then the corrections until it went green. The
+> spec is retrofitted; the sequence is not invented.
+
+## Setup
+
+- [x] Branch (worktree) created from main: `fix/claude-md-staleness`
+- [x] `proposal.md` complete; acceptance criteria testable
+- [x] Work-gate: issue #916 open and linked
+
+## Implementation
+
+- [x] `scripts/check-doc-paths.sh`: extract backticked tokens, filter to
+      repo-rooted paths, assert each resolves. Run against the **unfixed**
+      `.claude/CLAUDE.md` first — 8 genuine findings. [AC5]
+- [x] Tighten the matcher after the first revision flagged 26 tokens including
+      `&>/dev/null`, `ai/<agent>/` and the model id `opencode-go/qwen3.6-plus`.
+      First segment must be a real top-level repo entry, computed from disk. [AC6]
+- [x] Control-run on `AGENTS.md`: 13 false positives from resolving bare
+      filenames by basename (vault patterns, `machine.json`, `review.md`).
+      Drop bare-filename resolution entirely. `AGENTS.md` now clean. [AC6]
+- [x] Fix the false negative found by the control run: the ALL-CAPS placeholder
+      rule swallowed `SKILL.md`, hiding the dead `ai/skills/*/SKILL.md` glob.
+      Placeholder reading now applies only when the token lacks a known
+      extension. [AC5]
+- [x] `tests/check-doc-paths.bats`: 8 cases — catches a dead path, catches an
+      empty glob, accepts a live path, ignores nine pathish non-paths, keeps
+      ALL-CAPS-with-extension checked, usage error, and applies the guard to all
+      six instruction files. [AC5][AC6][AC7]
+- [x] `.claude/CLAUDE.md` Key Files: drop/repoint dead rows, add `cli/`,
+      `secrets/registry.yaml`, harness engine + manifest. [AC1]
+- [x] `.claude/CLAUDE.md` Secrets System + "adding a secret" → ADR-028. [AC2]
+- [x] `.claude/CLAUDE.md` Verification Commands → both layers, pinned linter,
+      corrected test count. [AC3]
+- [x] Health-check recipes → `dotf doctor`, with a self-refuting note that the
+      twins are retired. [AC1]
+- [x] Vault literals → `$VAULT_PATH` (ADR-025). [AC4]
+- [x] Lessons pointer → `docs/lessons.md` (Standing Order #2). [AC1]
+- [x] Remove the aider section (sunset by opencode). [AC1]
+- [x] `README.md`: same dead `load-secrets.sh` entrypoint in the tree and the
+      human-entrypoints table → `dotf secrets`. [AC5]
+- [x] Convention documented in the script header: a backticked repo path is a
+      live claim; name retired paths in plain text.
+
+## Verification
+
+- [x] `shellcheck` clean; `bash -n` + `zsh -n`; guard executed under zsh
+- [x] `bats tests/check-doc-paths.bats` → 8/8
+- [x] Guard clean on all six instruction files
+- [x] Full bats suite for regressions
+- [x] `check-bats-names.sh` clean
+
+## Out
+
+- [ ] `<claude-mem-context>` block — #832 owns it, deliberately untouched

--- a/specs/DOCS-013-doc-path-guard/verification.md
+++ b/specs/DOCS-013-doc-path-guard/verification.md
@@ -7,36 +7,64 @@ created: "2026-08-11"
 
 ## Evidence
 
-Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
-
-- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+| AC | Claim | Proof |
+|---|---|---|
+| 1 | Every repo path in `.claude/CLAUDE.md` resolves | `./scripts/check-doc-paths.sh .claude/CLAUDE.md` → `OK`. Before the change the same command reported **8** dead paths |
+| 2 | Secrets docs describe ADR-028 | `grep -n env-mapping .claude/CLAUDE.md` → only plain-text mentions naming it as retired; the two "adding a secret" recipes now use `dotf secrets set/verify/run` |
+| 3 | Verification Commands covers the Go layer | New *Go layer* block: `go build/vet/test` + `golangci-lint run`, with the `GOLANGCI_LINT_VERSION` pin and the reason an unpinned local run proves nothing (BUG-071) |
+| 4 | No hardcoded vault literal | `grep -n 'Projects/knowledge' .claude/CLAUDE.md` → no matches; three occurrences replaced with `$VAULT_PATH` |
+| 5 | Guard catches, on real and seeded inputs | `tests/check-doc-paths.bats` cases 3 (dead path), 4 (empty glob), 7 (ALL-CAPS with extension); README's dead `load-secrets.sh` was found by the guard, not by reading |
+| 6 | Zero false positives on `AGENTS.md` | `./scripts/check-doc-paths.sh AGENTS.md` → `OK`. An earlier revision reported **13** on the same file; case 6 pins nine of the token shapes that caused them |
+| 7 | Suite pins both behaviours | `bats tests/check-doc-paths.bats` → **8/8** |
 
 ## Test status
 
-- Test suite: `<command> -> <output / coverage %>`
-- Manual smoke test: what was exercised, what was observed
-- No regressions in existing test suite: yes / no (if no, document)
+- `bats tests/check-doc-paths.bats` → **8 passed, 0 failed** (re-run against the
+  final tree after the last edit, not an earlier state).
+- `bats tests/*.bats` → **1205 passed, 1 failed** of 1206.
+  The one failure is `not ok 402 converges over a running dotf: a live binary in
+  dest is replaced, not refused` — **#807 (BUG-054)**, pre-existing and
+  unrelated. Reproduced this session on clean `main` @ `a3f9a10` with no
+  working-tree changes, same `coreutils: unknown program 'dotf'` cause.
+- `shellcheck scripts/check-doc-paths.sh` → clean.
+- `bash -n` and `zsh -n` on the new script → clean; the script was also
+  **executed** under `zsh -c`, not merely parsed, because the failure class this
+  repo keeps hitting is a construct that runs and answers wrongly rather than
+  erroring (`docs/lessons.md`, 2026-08-09).
+- `./scripts/check-bats-names.sh tests/` → OK, 82 files.
+- `./scripts/check-spec-gate.sh --explain` → `Spec folder touched: yes`,
+  active-spec LOC 199 (floor 10).
+- Guard clean on all six instruction files: `.claude/CLAUDE.md`, `AGENTS.md`,
+  `README.md`, `ai/claude/CLAUDE.md`, `ai/copilot/copilot-instructions.md`,
+  `.github/copilot-instructions.md`.
 
-## Decisions made during implementation
+## What was found while verifying
 
-Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+Two defects in the guard itself, both caught by running it rather than
+reasoning about it, and both now pinned as tests:
 
--
--
+1. **False positives (26, then 13).** The first revision flagged `&>/dev/null`,
+   `ai/<agent>/`, the model id `opencode-go/qwen3.6-plus` and more. The control
+   run on `AGENTS.md` — a file with no staleness — was what exposed the scale.
+2. **A false negative.** The ALL-CAPS placeholder rule intended for
+   `sensitive/KEYNAME.secret.age` also swallowed `SKILL.md`, so the guard
+   silently skipped `ai/skills/*/SKILL.md`, a genuinely dead glob it existed to
+   catch. Fixed by applying the placeholder reading only when the token lacks a
+   known extension.
 
-## Promotion candidates
+The second is the one worth remembering: a guard that under-reports looks
+identical to a clean repo.
 
-Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+## Not verified
 
-- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no - one line of what>
-- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
-- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+- **Deployment.** This change is repo-side only; `.claude/CLAUDE.md` is read
+  from the checkout, so no deploy step applies. `README.md` is not deployed.
+- **Windows.** The guard is bash and runs in the Linux `test` job. It is not
+  wired into any PowerShell path, and nothing on Windows consumes it.
 
-## Archive checklist
+## Sign-off
 
-- [ ] `proposal.md` frontmatter set to `status: archived`
-- [ ] Folder moved: `specs/DOCS-013-doc-path-guard/` -> `specs/archive/DOCS-013-doc-path-guard/`
-- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
-- [ ] Promotions above executed (if any)
+- [ ] Independent `/adversarial-review` — **owed, not performed.** This session
+      implemented the change and therefore cannot review it. `dotf spec archive`
+      refuses without a fresh passing `review.md`, so this must be supplied by
+      another session before the spec can be archived.

--- a/specs/DOCS-013-doc-path-guard/verification.md
+++ b/specs/DOCS-013-doc-path-guard/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-11"
+---
+
+# Verification - DOCS-013-doc-path-guard
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/DOCS-013-doc-path-guard/` -> `specs/archive/DOCS-013-doc-path-guard/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)

--- a/tests/check-doc-paths.bats
+++ b/tests/check-doc-paths.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+# Guard for #916: an instruction file must not name a repo path that is gone.
+#
+# #907 committed .claude/CLAUDE.md while it named seven files that no longer
+# existed, and two sessions in two days acted on one of them. Nothing in the
+# repo checked it: docs-drift.bats checks content sync between two copies,
+# check-md-escapes.sh checks corruption, compile-harness --check checks harness
+# drift. None of them ask whether a path in prose still resolves.
+
+setup() {
+    DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    GUARD="$DOTFILES_DIR/scripts/check-doc-paths.sh"
+    SCRATCH="$BATS_TMPDIR/check-doc-paths"
+    mkdir -p "$SCRATCH"
+}
+
+teardown() {
+    rm -rf "$SCRATCH"
+}
+
+# The files this guard governs: those that tell an agent what to do. Historical
+# records (docs/lessons.md) are deliberately absent — they name retired scripts
+# on purpose, and that is correct.
+instruction_files() {
+    printf '%s\n' \
+        ".claude/CLAUDE.md" \
+        "AGENTS.md" \
+        "README.md" \
+        "ai/claude/CLAUDE.md" \
+        "ai/copilot/copilot-instructions.md" \
+        ".github/copilot-instructions.md"
+}
+
+@test "check-doc-paths.sh exists and is executable" {
+    [ -x "$GUARD" ]
+}
+
+@test "check-doc-paths: every instruction file's repo paths resolve [#916]" {
+    local failed=0 f
+    while IFS= read -r f; do
+        [ -f "$DOTFILES_DIR/$f" ] || continue
+        if ! (cd "$DOTFILES_DIR" && "$GUARD" "$f"); then
+            failed=$((failed + 1))
+        fi
+    done < <(instruction_files)
+    [ "$failed" -eq 0 ]
+}
+
+@test "check-doc-paths: catches a path that does not exist [#916]" {
+    printf 'See `scripts/definitely-not-here.sh` for details.\n' > "$SCRATCH/doc.md"
+    run "$GUARD" "$SCRATCH/doc.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"definitely-not-here.sh"* ]]
+}
+
+@test "check-doc-paths: catches a glob that matches nothing [#916]" {
+    printf 'Skills live in `ai/skills/*/SKILL.md` today.\n' > "$SCRATCH/doc.md"
+    run "$GUARD" "$SCRATCH/doc.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"matches nothing"* ]]
+}
+
+@test "check-doc-paths: accepts a path that exists [#916]" {
+    printf 'The library is `scripts/utils.sh` and the manifest `versions.conf`.\n' > "$SCRATCH/doc.md"
+    run "$GUARD" "$SCRATCH/doc.md"
+    [ "$status" -eq 0 ]
+}
+
+# The false-positive cases below are the reason this guard is usable at all. An
+# earlier revision flagged all of them, which on AGENTS.md meant 13 bogus
+# failures — and a guard that cries wolf gets deleted rather than obeyed.
+@test "check-doc-paths: ignores non-path tokens that merely look pathish [#916]" {
+    {
+        printf 'Model `opencode-go/qwen3.6-plus` is pinned.\n'
+        printf 'Never use `&>/dev/null` in a script.\n'
+        printf 'Per-agent files live in `ai/<agent>/` directories.\n'
+        printf 'Encrypt to `sensitive/KEYNAME.secret.age`.\n'
+        printf 'Deployed to `~/.claude/skills/` at setup.\n'
+        printf 'Resolve via `$VAULT_PATH/00_meta/patterns/x.md`.\n'
+        printf 'Any `.sh` file must run under both shells.\n'
+        printf 'The store index is `_index.md` over there.\n'
+        printf 'See `https://example.com/a/b.md` for context.\n'
+    } > "$SCRATCH/doc.md"
+    run "$GUARD" "$SCRATCH/doc.md"
+    [ "$status" -eq 0 ]
+}
+
+@test "check-doc-paths: an ALL-CAPS filename with a known extension is still checked [#916]" {
+    # SKILL.md / AGENTS.md / MEMORY.md are real files, not placeholders. An
+    # earlier revision skipped every ALL-CAPS segment and so silently ignored
+    # the dead `ai/skills/*/SKILL.md` reference it was written to catch.
+    printf 'Records live at `harness/skills/nope-not-real/SKILL.md`.\n' > "$SCRATCH/doc.md"
+    run "$GUARD" "$SCRATCH/doc.md"
+    [ "$status" -eq 1 ]
+}
+
+@test "check-doc-paths: usage error without arguments [#916]" {
+    run "$GUARD"
+    [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
Fixes #916. Spec: `specs/DOCS-013-doc-path-guard/`.

`.claude/CLAUDE.md` was gitignored until #907 tracked it, so its mandatory shell
rules would stop being per-machine and invisible. Tracking made it authoritative
for every agent that opens this repo. It did not make it true — on the day it
landed it named **seven files that no longer existed**, and two sessions in two
days acted on one of them: `./scripts/healthcheck.sh`, retired into `dotf doctor`
by the ADR-020 strangler-fig.

## Corrected

- **Key Files** — dead rows dropped or repointed (healthcheck.sh,
  load-secrets.sh, env-mapping.conf, claude-session-start.sh, both aider
  configs, and ai/skills/* which moved to `harness/skills/`). Added what an
  agent needs today: `cli/`, `secrets/registry.yaml`, the harness engine and its
  manifest.
- **Secrets System** — described the ADR-028 model it has been on for months.
  The old text taught a login-time loader exporting every secret into the shell,
  *the exact model that ADR was written to abolish*, and both "adding a secret"
  recipes walked through a file that is gone.
- **Verification Commands** — named the Go layer at all. It listed `shellcheck`
  and `bats` and nothing for `cli/`, which is how BUG-071 shipped unlinted. Now
  it names the pinned `golangci-lint` and why an unpinned local run proves
  nothing. Test count corrected 147 → ~1200. (This closes the follow-up I added
  to #916 earlier.)
- **Health-check recipes** → `dotf doctor`, with a line stating the twins are
  retired, so the next stale mention refutes itself.
- **Vault paths** — three `~/Projects/knowledge` literals → `$VAULT_PATH`. The
  file that forbids hardcoded literals contained three of them (ADR-025, #463).
- **Lessons placement** — it said to write project lessons to the vault, which
  contradicts Standing Order #2. Now `docs/lessons.md`.
- **aider section** removed; sunset by opencode.
- **README** carried the same dead `load-secrets.sh` entrypoint in its tree and
  its human-entrypoints table → `dotf secrets`. Found by the guard, not by
  reading.

## The guard

`scripts/check-doc-paths.sh` makes **a backticked repo path a live claim** and
fails when one does not resolve. Naming a retired path stays legal — in plain
text. That one rule is what lets the guard work without a per-file exception
list that would rot exactly as the docs did.

Deliberately conservative: only backticked, repo-rooted tokens whose first
segment is a real top-level entry, computed from disk so a new directory is
covered the day it is created.

**Two defects in the guard itself, both found by running it, both now tests:**

1. **False positives.** First revision: 26 findings including `&>/dev/null`,
   `ai/<agent>/` and the model id `opencode-go/qwen3.6-plus`. The control run on
   `AGENTS.md` — a file with no staleness — is what exposed the scale: **13**
   bogus failures. Now **zero**. A guard that cries wolf is one somebody deletes.
2. **A false negative, which is worse.** The ALL-CAPS placeholder rule meant for
   `sensitive/KEYNAME.secret.age` also swallowed `SKILL.md`, so the guard
   silently skipped `ai/skills/*/SKILL.md` — a genuinely dead glob it existed to
   catch. A guard that under-reports looks identical to a clean repo.

## Evidence

- `bats tests/check-doc-paths.bats` → **8/8**, re-run against the final tree
- `bats tests/*.bats` → **1205 passed, 1 failed** of 1206. The failure is
  `converges over a running dotf` = **#807**, pre-existing; reproduced this
  session on clean `main` @ `a3f9a10`, same `coreutils: unknown program 'dotf'`
- Guard clean on all six instruction files
- `shellcheck` clean; `bash -n` + `zsh -n`; and the script **executed** under
  `zsh -c`, not merely parsed — this repo's recurring failure class is a
  construct that runs and answers wrongly rather than erroring
- `check-bats-names.sh` → OK, 82 files
- `check-spec-gate.sh --explain` → `Spec folder touched: yes`; **pushed without
  `--no-verify`**, unlike #920

## Notes

- The dead `<claude-mem-context>` block at the end of the file is **deliberately
  untouched** — #832 owns claude-mem's retirement, and folding it in here would
  widen the change past its spec.
- `docs/lessons.md` is deliberately **not** governed by the guard: its incident
  write-ups name retired scripts on purpose, and that is correct as history. The
  guard is for files that tell someone what to do. Documented in the script
  header and in the spec's "Out of scope".

## Adversarial review — proposed, and it matters more than usual

Per the AGENTS.md proactive rule, I'm proposing `/adversarial-review
DOCS-013-doc-path-guard` and **cannot supply it myself** — this session wrote
the change, and a reviewer who inherits the implementer's frame produces a
cosmetic review.

Concretely: `dotf spec archive` refuses without a fresh passing `review.md`, so
skipping it blocks the archive rather than merely weakening it.

Worth knowing before you decide who reviews it: `find specs -name review.md` is
**empty** — the CLI-034 gate (#875) has never produced an artifact, which is
precisely the evidence #881's hold is waiting on, which is what currently blocks
#833. A `review.md` here would be the first one the gate has ever produced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a documentation path checker that detects missing repository references in instruction files.
  * Added scoped secret injection through `dotf secrets run -- <cmd>`.
  * Added commands and guidance for inspecting secrets and validating documentation paths.

* **Documentation**
  * Updated the README and project guidance for current CLI, secret-management, tooling, and runbook workflows.
  * Added specification, task, and verification records for documentation path validation.

* **Tests**
  * Added coverage for valid paths, missing paths, false positives, globs, permissions, and usage errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->