### PR TITLE
fix(spec): accept digit-bearing AREAs in feature-ids and reconcile the seven copies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,10 @@ archive a spec. Subcommands via `dotf spec …` (Go CLI, works in CI/Windows):
 `init` ("create/scaffold spec X"), `fill` ("write the proposal"), `archive`
 ("close spec X"). Specs live at `specs/<feature-id>/`, archived at
 `specs/archive/` (never deleted — audit trail). `<feature-id>`:
-`^[A-Z]+-\d+(-[a-z0-9-]+)?$` or `^\d{4}-\d{2}-\d{2}-[a-z0-9-]+$`.
+`^([A-Z]+[0-9]*-[0-9]+[a-z]?(-[a-z0-9-]+)?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+)$`
+— the AREA may carry digits (`ADR028-004`), the number an optional sub-id letter
+(`SDD-012b`). Verbatim copy of `idPattern` in `cli/internal/spec/spec.go`, held
+to it by `TestIDPatternProseMatchesCode`; do not reword it.
 
 **Skip SDD for**: typos, comment-only edits, mechanical refactors, bug fixes
 <20 lines with obvious cause, doc-only changes.

--- a/cli/internal/initrepo/templates/agents-spec-section.md
+++ b/cli/internal/initrepo/templates/agents-spec-section.md
@@ -43,6 +43,6 @@ Per-feature specs live at `specs/<feature-id>/` in this repo; archived at `specs
 
 **Skip SDD for**: typo fixes, comment-only edits, mechanical refactors, bug fixes <20 lines with obvious cause, doc-only changes.
 
-`<feature-id>` format: `^[A-Z]+-\d+(-[a-z0-9-]+)?$` (e.g., `AI-001-ollama-public`) or `^\d{4}-\d{2}-\d{2}-[a-z0-9-]+$` (e.g., `2026-05-13-cleanup`).
+`<feature-id>` format: `^([A-Z]+[0-9]*-[0-9]+[a-z]?(-[a-z0-9-]+)?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+)$` (e.g., `AI-001-ollama-public`, `ADR028-004`, `SDD-012b-guard`, `2026-05-13-cleanup`). This string is `idPattern` in dotfiles `cli/internal/spec/spec.go` verbatim; a drift test asserts every copy matches, so do not reword it.
 
 ## --- END SNIPPET ---

--- a/cli/internal/spec/drift_test.go
+++ b/cli/internal/spec/drift_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -45,6 +46,82 @@ func TestEmbeddedTemplatesMatchVault(t *testing.T) {
 				"Re-vendor: cp %s cli/internal/spec/templates/%s",
 				embedded, vaultName, filepath.Join(tmplDir, vaultName), embedded)
 		}
+	}
+}
+
+// TestIDPatternProseMatchesCode is the reconciliation guard for the feature-id
+// grammar. The rule was declared in six places and two had already drifted
+// silently: AGENTS.md and the agents-spec-section template both omitted the
+// `[a-z]?` sub-id letter, so they rejected SDD-012b-guard — an id the code
+// accepts and TestValidateID asserts. Nothing reconciled them, so they lied
+// until someone crossed both paths.
+//
+// The guard is a literal compare against idPattern.String(), not a parse of the
+// prose, which is why every copy must carry the Go string VERBATIM (the older
+// copies used \d where the code uses [0-9] — semantically equal, textually not).
+// The code is canonical because it is the enforcement point.
+//
+// In-repo copies are always checked. The vault copies skip when the vault is
+// absent (ADR-013), same rationale as TestEmbeddedTemplatesMatchVault above.
+// The enrich-us skill deliberately carries a SUBSET (no dated-slug alternative,
+// since a dated slug is not a backlog id) and is therefore not listed here.
+func TestIDPatternProseMatchesCode(t *testing.T) {
+	want := idPattern.String()
+
+	// RepoRoot must be given an ABSOLUTE path: it walks up with filepath.Dir,
+	// and filepath.Dir(".") is "." — so a relative start exits the loop on the
+	// first iteration and reports "not in a git repo" from inside one.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	root, err := RepoRoot(wd)
+	if err != nil {
+		t.Fatalf("locate repo root: %v", err)
+	}
+
+	check := func(label, path string) {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %s: %v", label, err)
+			return
+		}
+		if !strings.Contains(string(b), want) {
+			t.Errorf("%s does not carry the canonical feature-id grammar verbatim.\n"+
+				"want the exact string: %s\n"+
+				"fix: replace that file's regex with the string above — do not reword it",
+				label, want)
+		}
+	}
+
+	// The initrepo template is listed even though TestEmbeddedTemplatesMatchVault
+	// already pins it byte-for-byte to the vault: that guard SKIPS without the
+	// vault, so in CI the embedded copy would otherwise go unchecked. It is a
+	// repo file, so checking it offline closes that gap.
+	for _, rel := range []string{
+		"AGENTS.md",
+		filepath.Join("harness", "skills", "spec", "SKILL.md"),
+		filepath.Join("cli", "internal", "initrepo", "templates", "agents-spec-section.md"),
+	} {
+		check(rel, filepath.Join(root, rel))
+	}
+
+	vault := os.Getenv("VAULT_PATH")
+	if vault == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			vault = filepath.Join(home, "Projects", "knowledge")
+		}
+	}
+	metaDir := filepath.Join(vault, "00_meta")
+	if _, err := os.Stat(metaDir); err != nil {
+		t.Logf("vault absent (%s) — checked in-repo copies only (ADR-013)", metaDir)
+		return
+	}
+	for _, rel := range []string{
+		filepath.Join("skills", "spec", "SKILL.md"),
+		filepath.Join("templates", "agents-spec-section.md"),
+	} {
+		check("vault 00_meta/"+filepath.ToSlash(rel), filepath.Join(metaDir, rel))
 	}
 }
 

--- a/cli/internal/spec/spec.go
+++ b/cli/internal/spec/spec.go
@@ -25,9 +25,17 @@ var templateNames = []string{"proposal.md", "tasks.md", "verification.md"}
 //go:embed templates/proposal.md templates/tasks.md templates/verification.md
 var templatesFS embed.FS
 
-// idPattern mirrors init-spec.sh exactly: an AREA-NNN ticket with an optional
-// sub-id letter (SDD-012b) and optional slug, or a YYYY-MM-DD dated slug.
-var idPattern = regexp.MustCompile(`^([A-Z]+-[0-9]+[a-z]?(-[a-z0-9-]+)?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+)$`)
+// idPattern is the canonical feature-id grammar: an AREA-NNN ticket whose AREA
+// may carry digits (ADR028-004), with an optional sub-id letter (SDD-012b) and
+// optional slug, or a YYYY-MM-DD dated slug.
+//
+// This regex is the enforcement point, so it is the canonical form; the prose
+// copies in AGENTS.md and the spec SKILL are held to it verbatim by
+// TestIDPatternProseMatchesCode. Widening it is safe, narrowing it is not:
+// ValidateID is also the path-traversal guard for the specs/ directory (#362,
+// TestArchiveRejectsTraversalID), so any change must keep "/", "." and ".."
+// unmatched.
+var idPattern = regexp.MustCompile(`^([A-Z]+[0-9]*-[0-9]+[a-z]?(-[a-z0-9-]+)?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+)$`)
 
 // ValidateID returns an error naming the expected grammar if id is not a valid
 // feature-id.
@@ -35,13 +43,18 @@ func ValidateID(id string) error {
 	if !idPattern.MatchString(id) {
 		return fmt.Errorf(
 			"invalid feature-id: %s\n        expected: TICKET-NNN[letter][-slug] "+
-				"(e.g. AI-001-ollama-public, SDD-012b-guard) or YYYY-MM-DD-slug", id)
+				"(e.g. AI-001-ollama-public, SDD-012b-guard, ADR028-004) "+
+				"or YYYY-MM-DD-slug", id)
 	}
 	return nil
 }
 
 // RepoRoot walks up from start until it finds a directory containing .git
 // (a directory in a normal clone, a file in a git worktree — both are accepted).
+//
+// start MUST be absolute. The walk terminates on filepath.Dir(dir) == dir, and
+// filepath.Dir(".") is ".", so a relative start returns "not in a git repo" on
+// the first iteration even when the caller is inside one.
 func RepoRoot(start string) (string, error) {
 	dir := start
 	for {

--- a/cli/internal/spec/spec_test.go
+++ b/cli/internal/spec/spec_test.go
@@ -15,6 +15,9 @@ func TestValidateID(t *testing.T) {
 		"CLI-007-dot-spec-init",
 		"BUG-007", // ticket with no slug
 		"2026-05-13-foo",
+		"ADR028-004", // AREA carrying digits (the ADR028-* bitacora series)
+		"ADR028-004-classify-stateful-service-placement",
+		"ADR028-004b", // digits in AREA and a sub-id letter together
 	}
 	for _, id := range valid {
 		if err := ValidateID(id); err != nil {

--- a/harness/skills/enrich-us/SKILL.md
+++ b/harness/skills/enrich-us/SKILL.md
@@ -31,7 +31,7 @@ allowed-tools: [Bash, Read, Grep, mcp__hive__vault_query, mcp__hive__vault_searc
 
 Two modes, auto-detected:
 
-1. **Backlog-id mode.** Input matches `^[A-Z]+-\d+(-[a-z0-9-]+)?$` (e.g. `SDD-014`, `AI-001-ollama-public`). Resolve the original:
+1. **Backlog-id mode.** Input matches `^[A-Z]+[0-9]*-\d+[a-z]?(-[a-z0-9-]+)?$` (e.g. `SDD-014`, `AI-001-ollama-public`, `ADR028-004`). Deliberately a SUBSET of the spec `idPattern`: the AREA may carry digits and the number an optional sub-id letter, but the `YYYY-MM-DD-slug` alternative is excluded — a dated slug is not a backlog id, so it must not enter this mode. Resolve the original:
    - Read the GitHub issue via `gh issue view <id> --json title,body` (bitácora is the SSOT per ADR-018).
    - If not found, ask the user to paste the story.
 

--- a/harness/skills/spec/SKILL.md
+++ b/harness/skills/spec/SKILL.md
@@ -88,7 +88,7 @@ When unsure whether a change crosses the threshold, ASK rather than assume (`AGE
 
 **Steps:**
 
-1. **Validate id** matches `^[A-Z]+-\d+[a-z]?(-[a-z0-9-]+)?$` OR `^\d{4}-\d{2}-\d{2}-[a-z0-9-]+$`. Reject otherwise.
+1. **Validate id** matches `^([A-Z]+[0-9]*-[0-9]+[a-z]?(-[a-z0-9-]+)?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+)$`. Reject otherwise. The AREA may carry digits (`ADR028-004`), the ticket number an optional sub-id letter (`SDD-012b`). This string is `idPattern` in `cli/internal/spec/spec.go` **verbatim** — the Go regex is the enforcement point and therefore the canonical form; a drift test asserts the two match, so do not reword it.
 2. **No clobber:** fail if `$REPO_ROOT/specs/<feature-id>/` exists. Warn if `specs/archive/<feature-id>/` exists.
 3. **Work-gate pre-flight (mandatory):**
    - The gate is an OPEN GitHub issue on the repo (tracked in the bitácora Project). Verify via `gh issue view <number> --json state,title`: the issue must exist and be `OPEN`.


### PR DESCRIPTION
## Why

`/spec init ADR028-004` was refused: the feature-id grammar requires a pure-letter AREA, so `ADR028-004` — a legitimate id under the bitácora ID convention, and the fourth of a series whose first three are already filed as issues — could not have a spec. Latent since that series was minted, because none of its tickets had reached the spec stage.

Chasing the fix surfaced the larger problem: **the same rule was declared in seven places, and two had already drifted.**

## The seven copies

| Location | Before |
|---|---|
| `cli/internal/spec/spec.go` — `idPattern` | enforcement point; no digits in AREA |
| `AGENTS.md` | **drifted** — also missing `[a-z]?` |
| `harness/skills/spec/SKILL.md` | compiled record |
| `cli/internal/initrepo/templates/agents-spec-section.md` | **drifted** — same omission |
| vault `00_meta/skills/spec/SKILL.md` | prose SSOT |
| vault `00_meta/templates/agents-spec-section.md` | **drifted** — source of the `AGENTS.md` copy |
| vault `00_meta/skills/enrich-us/SKILL.md` | subset, for input dispatch |

The drift was not arbitrary. `agents-spec-section.md` is the template that seeds every repo's `AGENTS.md`, so the omission propagated from there — and fixing `AGENTS.md` alone would have been undone by the next repo bootstrap.

The drifted copies rejected `SDD-012b-guard`, an id the code accepts and `TestValidateID` asserts is valid. So the instructions every agent reads at session start contradicted the code that actually enforces the rule.

**The seventh copy was found by the existing drift guard, not by grep.** A repo-wide search for the pattern missed the embedded template in `cli/internal/initrepo/templates/`; `TestEmbeddedTemplatesMatchVault` caught it in half a second and printed the re-vendor command. That is the argument for the new test, demonstrated.

## What changed

- **Widened** `idPattern` to `^([A-Z]+[0-9]*-[0-9]+[a-z]?(-[a-z0-9-]+)?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+)$`.
- **Normalised all copies to `idPattern.String()` verbatim.** The prose previously used `\d` where the code uses `[0-9]` — semantically identical, textually not, which is why a literal-compare guard was impossible before. The code is canonical because it is the enforcement point.
- **Added `TestIDPatternProseMatchesCode`**: literal `strings.Contains` per file, following `TestEmbeddedTemplatesMatchVault`'s precedent. In-repo copies always checked; vault copies skip when the vault is absent (ADR-013). The initrepo template is listed even though the sibling guard already pins it byte-for-byte to the vault, because that guard skips without the vault and CI has none — so the embedded copy would otherwise go unchecked in CI.
- `enrich-us` keeps a **deliberate subset** — the AREA widening, but no dated-slug alternative, since a dated slug is not a backlog id and must not enter that mode. It is therefore not listed in the new guard.

## Safety

**Strictly widening — no previously valid id becomes invalid.** Verified by diffing old against new over the full `TestValidateID` corpus.

`ValidateID` is also the path-traversal guard for `specs/` (#362, `TestArchiveRejectsTraversalID`). The widened pattern was checked to still reject `../outside`, `../../etc`, `foo/bar`, `.` and `..` — `[A-Z]+[0-9]*` admits no path separator or dot. The comment on `idPattern` now records that widening is safe and narrowing is not, so the next editor knows the constraint without finding #362.

## Evidence

- `go test ./... -count=1` — all packages pass.
- `scripts/compile-harness.sh --check` (the CI gate) — "OK: no harness drift".
- `scripts/compile-harness.sh --refresh` — idempotent; the hand-maintained `AGENTS.md` line survives (it sits outside the managed marker region).
- Three negative controls, because a passing test proves nothing on its own:

| Control | Expected | Result |
|---|---|---|
| Break the `AGENTS.md` copy | FAIL | FAIL, naming the file and the exact wanted string |
| Point `VAULT_PATH` at a fake vault with a wrong regex | FAIL on both vault legs | FAIL on both |
| Point `VAULT_PATH` at a nonexistent dir | PASS, log the skip, still check in-repo | exactly that |

## Also fixed in passing

- The `idPattern` comment cited `init-spec.sh`, a script that no longer exists in the repo.
- `RepoRoot`'s docstring now records that `start` must be absolute: the walk terminates on `filepath.Dir(dir) == dir`, and `filepath.Dir(".")` is `"."`, so a relative start reports "not in a git repo" from inside one. Behaviour unchanged — this was hit while writing the new test.

## Notes for review

No gating issue: this is a defect fix under 20 lines of production change with an obvious cause, which the Skip-SDD list covers. The public-contract trigger is defused by the change being strictly widening.

The deploy to `$HOME` is deliberately **not** part of this PR. `compile-harness.sh --deploy` takes its source from whichever checkout the script lives in and has no branch guard, so it must run from the main checkout after merge — not from a feature worktree, which would publish unreviewed content to shared agent state.
