### PR TITLE
chore(hooks): run check-bats-names.sh at pre-commit (#925)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,19 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
 
+      # #925: scripts/test.sh (above) is a legacy smoke suite that never ran
+      # bats and never ran this script. An em-dash in a new @test name
+      # (bats silently drops such a test, CURATOR-001/#615) shipped past a
+      # local commit ("dotfiles-test: Passed") and was only caught by a
+      # fresh adversarial-review subagent running check-bats-names.sh
+      # directly — a full review round burned on a one-character defect.
+      - id: check-bats-names
+        name: Check bats @test names (non-ASCII / duplicates)
+        entry: ./scripts/check-bats-names.sh tests/
+        language: script
+        pass_filenames: false
+        stages: [pre-commit]
+
       - id: sdd-spec-gate
         name: SDD spec-gate (Tier 4)
         entry: ./scripts/check-spec-gate.sh

--- a/tests/install-precommit.bats
+++ b/tests/install-precommit.bats
@@ -44,3 +44,20 @@ setup() {
     grep -A1 'sdd-spec-gate' "$DOTFILES_DIR/.pre-commit-config.yaml" | grep -q 'spec-gate'
     grep -B1 'pre-push' "$DOTFILES_DIR/.pre-commit-config.yaml" | grep -q 'sdd-spec-gate\|stages'
 }
+
+@test ".pre-commit-config.yaml declares check-bats-names at pre-commit stage [#925]" {
+    # scripts/test.sh (the dotfiles-test hook) never ran bats or this script —
+    # a non-ASCII @test name shipped past local pre-commit and was only
+    # caught by a full adversarial-review round. This hook is the guard.
+    grep -q 'check-bats-names' "$DOTFILES_DIR/.pre-commit-config.yaml"
+    grep -A2 'id: check-bats-names' "$DOTFILES_DIR/.pre-commit-config.yaml" | grep -q 'check-bats-names.sh'
+    grep -A5 'id: check-bats-names' "$DOTFILES_DIR/.pre-commit-config.yaml" | grep -q 'pre-commit'
+}
+
+@test "check-bats-names.sh exits 0 on this repo's own tests/ tree [#925]" {
+    # The hook is only a guard if it actually passes on a clean tree — pins
+    # that invariant so a future non-ASCII @test name is caught here, not
+    # three rounds of review later.
+    run "$SCRIPTS_DIR/check-bats-names.sh" "$DOTFILES_DIR/tests/"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #925.

## Problem

`scripts/test.sh` (the existing `dotfiles-test` pre-commit hook) is a legacy smoke suite — it never runs bats, and never ran `check-bats-names.sh`. During HARNESS-069 (#917), a new bats `@test` name with a literal em-dash instead of a hyphen passed local pre-commit clean (`dotfiles-test: Passed`), and was only caught by a fresh adversarial-review subagent running `check-bats-names.sh` directly — a full review round spent finding a one-character, deterministically-catchable defect.

## Change

Adds a `check-bats-names` local hook to `.pre-commit-config.yaml`, running `./scripts/check-bats-names.sh tests/` at the `pre-commit` stage. `cli/internal/initrepo/templates/pre-commit-config.yaml` (the generic template `dotf init` scaffolds into *other* repos) is deliberately untouched — it has no `tests/*.bats` tree to check, so adding this hook there would just fail on every fresh init.

## Evidence

- `bats tests/install-precommit.bats` → 9/9, including two new cases pinning the hook's presence/stage and that `check-bats-names.sh` is itself clean on this repo's `tests/`
- Mutation-verified live with `pre-commit`: staged a bats file with a literal em-dash in a `@test` name, `pre-commit run check-bats-names --files ...` failed with the exact expected message; removed the probe, reran clean
- This PR's own commits exercised the new hook for real (`Check bats @test names ... Passed` in the commit output above)

Under the spec-gate LOC threshold (30 lines total, 13 production) — no `specs/` folder, cause is small and obvious (this exact incident, same day).