### PR TITLE
fix(vault): drop the redundant --vault flag from vault-health.sh (#891)

### DIFF
--- a/scripts/vault-health.sh
+++ b/scripts/vault-health.sh
@@ -128,10 +128,10 @@ fi
 # ==================================================
 section "3/7" "Orphans & Dead-Ends"
 
-ORPHAN_OUTPUT=$(obsidian_cmd orphans --vault "$VAULT_NAME" 2>/dev/null || true)
+ORPHAN_OUTPUT=$(obsidian_cmd orphans 2>/dev/null || true)
 ORPHAN_COUNT=$(echo "$ORPHAN_OUTPUT" | grep -c '[^[:space:]]') || ORPHAN_COUNT=0
 
-DEADEND_OUTPUT=$(obsidian_cmd dead-ends --vault "$VAULT_NAME" 2>/dev/null || true)
+DEADEND_OUTPUT=$(obsidian_cmd dead-ends 2>/dev/null || true)
 DEADEND_COUNT=$(echo "$DEADEND_OUTPUT" | grep -c '[^[:space:]]') || DEADEND_COUNT=0
 
 if [ "$TOTAL_FILES" -gt 0 ]; then
@@ -171,7 +171,7 @@ fi
 # ==================================================
 section "4/7" "Unresolved Links"
 
-UNRESOLVED_OUTPUT=$(obsidian_cmd unresolved --vault "$VAULT_NAME" 2>/dev/null || true)
+UNRESOLVED_OUTPUT=$(obsidian_cmd unresolved 2>/dev/null || true)
 UNRESOLVED_COUNT=$(echo "$UNRESOLVED_OUTPUT" | grep -c '[^[:space:]]') || UNRESOLVED_COUNT=0
 
 if [ "$UNRESOLVED_COUNT" -eq 0 ]; then
@@ -221,7 +221,7 @@ fi
 # ==================================================
 section "6/7" "Tag Hygiene"
 
-TAG_OUTPUT=$(obsidian_cmd tags --vault "$VAULT_NAME" 2>/dev/null || true)
+TAG_OUTPUT=$(obsidian_cmd tags 2>/dev/null || true)
 TAG_COUNT=$(echo "$TAG_OUTPUT" | grep -c '[^[:space:]]') || TAG_COUNT=0
 info "Total unique tags: $TAG_COUNT"
 

--- a/tests/golden/vault-health/ORACLE
+++ b/tests/golden/vault-health/ORACLE
@@ -4,9 +4,9 @@
 # suite when the working tree drifts from these, so a recapture is always
 # a deliberate, reviewable act.
 #
-# Captured at git revision 8ad7e2f (informational only - never assert on it,
+# Captured at git revision 147e4ed (informational only - never assert on it,
 # CI checks out shallow and rebases change it for free).
 
-c8b840b8dfdae2ec2af17859cc1c32501c13340872bf3702c2602154763679ee  scripts/vault-health.sh
+578e90f784d5a526b9d39aedd208f396df632bfec77652a91021d257b0f4078e  scripts/vault-health.sh
 5bdb882ab09463774c94c52d31374263939104f83e04a4981ff13f2067c8b4c7  scripts/check-backlog-integrity.sh
 9e821023adc69de7a37301ef9852a110323865868c46ff634f4fa135175740f9  scripts/check-backlog-merged.sh

--- a/tests/golden/vault-health/cases/all-pass/expected/obsidian-argv
+++ b/tests/golden/vault-health/cases/all-pass/expected/obsidian-argv
@@ -1,5 +1,5 @@
 --no-sandbox vault --vault knowledge
---no-sandbox orphans --vault knowledge --vault knowledge
---no-sandbox dead-ends --vault knowledge --vault knowledge
---no-sandbox unresolved --vault knowledge --vault knowledge
---no-sandbox tags --vault knowledge --vault knowledge
+--no-sandbox orphans --vault knowledge
+--no-sandbox dead-ends --vault knowledge
+--no-sandbox unresolved --vault knowledge
+--no-sandbox tags --vault knowledge

--- a/tests/golden/vault-health/cases/backlog-drift/expected/obsidian-argv
+++ b/tests/golden/vault-health/cases/backlog-drift/expected/obsidian-argv
@@ -1,5 +1,5 @@
 --no-sandbox vault --vault knowledge
---no-sandbox orphans --vault knowledge --vault knowledge
---no-sandbox dead-ends --vault knowledge --vault knowledge
---no-sandbox unresolved --vault knowledge --vault knowledge
---no-sandbox tags --vault knowledge --vault knowledge
+--no-sandbox orphans --vault knowledge
+--no-sandbox dead-ends --vault knowledge
+--no-sandbox unresolved --vault knowledge
+--no-sandbox tags --vault knowledge

--- a/tests/golden/vault-health/cases/frontmatter-boundary/expected/obsidian-argv
+++ b/tests/golden/vault-health/cases/frontmatter-boundary/expected/obsidian-argv
@@ -1,5 +1,5 @@
 --no-sandbox vault --vault knowledge
---no-sandbox orphans --vault knowledge --vault knowledge
---no-sandbox dead-ends --vault knowledge --vault knowledge
---no-sandbox unresolved --vault knowledge --vault knowledge
---no-sandbox tags --vault knowledge --vault knowledge
+--no-sandbox orphans --vault knowledge
+--no-sandbox dead-ends --vault knowledge
+--no-sandbox unresolved --vault knowledge
+--no-sandbox tags --vault knowledge

--- a/tests/golden/vault-health/cases/frontmatter-tiers/expected/obsidian-argv
+++ b/tests/golden/vault-health/cases/frontmatter-tiers/expected/obsidian-argv
@@ -1,5 +1,5 @@
 --no-sandbox vault --vault knowledge
---no-sandbox orphans --vault knowledge --vault knowledge
---no-sandbox dead-ends --vault knowledge --vault knowledge
---no-sandbox unresolved --vault knowledge --vault knowledge
---no-sandbox tags --vault knowledge --vault knowledge
+--no-sandbox orphans --vault knowledge
+--no-sandbox dead-ends --vault knowledge
+--no-sandbox unresolved --vault knowledge
+--no-sandbox tags --vault knowledge

--- a/tests/golden/vault-health/cases/missing-vault-dir/expected/obsidian-argv
+++ b/tests/golden/vault-health/cases/missing-vault-dir/expected/obsidian-argv
@@ -1,5 +1,5 @@
 --no-sandbox vault --vault knowledge
---no-sandbox orphans --vault knowledge --vault knowledge
---no-sandbox dead-ends --vault knowledge --vault knowledge
---no-sandbox unresolved --vault knowledge --vault knowledge
---no-sandbox tags --vault knowledge --vault knowledge
+--no-sandbox orphans --vault knowledge
+--no-sandbox dead-ends --vault knowledge
+--no-sandbox unresolved --vault knowledge
+--no-sandbox tags --vault knowledge

--- a/tests/golden/vault-health/cases/orphans-boundary/expected/obsidian-argv
+++ b/tests/golden/vault-health/cases/orphans-boundary/expected/obsidian-argv
@@ -1,5 +1,5 @@
 --no-sandbox vault --vault knowledge
---no-sandbox orphans --vault knowledge --vault knowledge
---no-sandbox dead-ends --vault knowledge --vault knowledge
---no-sandbox unresolved --vault knowledge --vault knowledge
---no-sandbox tags --vault knowledge --vault knowledge
+--no-sandbox orphans --vault knowledge
+--no-sandbox dead-ends --vault knowledge
+--no-sandbox unresolved --vault knowledge
+--no-sandbox tags --vault knowledge

--- a/tests/golden/vault-health/cases/orphans-fail/expected/obsidian-argv
+++ b/tests/golden/vault-health/cases/orphans-fail/expected/obsidian-argv
@@ -1,5 +1,5 @@
 --no-sandbox vault --vault knowledge
---no-sandbox orphans --vault knowledge --vault knowledge
---no-sandbox dead-ends --vault knowledge --vault knowledge
---no-sandbox unresolved --vault knowledge --vault knowledge
---no-sandbox tags --vault knowledge --vault knowledge
+--no-sandbox orphans --vault knowledge
+--no-sandbox dead-ends --vault knowledge
+--no-sandbox unresolved --vault knowledge
+--no-sandbox tags --vault knowledge

--- a/tests/golden/vault-health/cases/orphans-warn/expected/obsidian-argv
+++ b/tests/golden/vault-health/cases/orphans-warn/expected/obsidian-argv
@@ -1,5 +1,5 @@
 --no-sandbox vault --vault knowledge
---no-sandbox orphans --vault knowledge --vault knowledge
---no-sandbox dead-ends --vault knowledge --vault knowledge
---no-sandbox unresolved --vault knowledge --vault knowledge
---no-sandbox tags --vault knowledge --vault knowledge
+--no-sandbox orphans --vault knowledge
+--no-sandbox dead-ends --vault knowledge
+--no-sandbox unresolved --vault knowledge
+--no-sandbox tags --vault knowledge

--- a/tests/golden/vault-health/cases/unresolved-boundary/expected/obsidian-argv
+++ b/tests/golden/vault-health/cases/unresolved-boundary/expected/obsidian-argv
@@ -1,5 +1,5 @@
 --no-sandbox vault --vault knowledge
---no-sandbox orphans --vault knowledge --vault knowledge
---no-sandbox dead-ends --vault knowledge --vault knowledge
---no-sandbox unresolved --vault knowledge --vault knowledge
---no-sandbox tags --vault knowledge --vault knowledge
+--no-sandbox orphans --vault knowledge
+--no-sandbox dead-ends --vault knowledge
+--no-sandbox unresolved --vault knowledge
+--no-sandbox tags --vault knowledge

--- a/tests/golden/vault-health/cases/unresolved-fail/expected/obsidian-argv
+++ b/tests/golden/vault-health/cases/unresolved-fail/expected/obsidian-argv
@@ -1,5 +1,5 @@
 --no-sandbox vault --vault knowledge
---no-sandbox orphans --vault knowledge --vault knowledge
---no-sandbox dead-ends --vault knowledge --vault knowledge
---no-sandbox unresolved --vault knowledge --vault knowledge
---no-sandbox tags --vault knowledge --vault knowledge
+--no-sandbox orphans --vault knowledge
+--no-sandbox dead-ends --vault knowledge
+--no-sandbox unresolved --vault knowledge
+--no-sandbox tags --vault knowledge

--- a/tests/golden/vault-health/cases/unresolved-warn/expected/obsidian-argv
+++ b/tests/golden/vault-health/cases/unresolved-warn/expected/obsidian-argv
@@ -1,5 +1,5 @@
 --no-sandbox vault --vault knowledge
---no-sandbox orphans --vault knowledge --vault knowledge
---no-sandbox dead-ends --vault knowledge --vault knowledge
---no-sandbox unresolved --vault knowledge --vault knowledge
---no-sandbox tags --vault knowledge --vault knowledge
+--no-sandbox orphans --vault knowledge
+--no-sandbox dead-ends --vault knowledge
+--no-sandbox unresolved --vault knowledge
+--no-sandbox tags --vault knowledge

--- a/tests/golden/vault-health/cases/verbose/expected/obsidian-argv
+++ b/tests/golden/vault-health/cases/verbose/expected/obsidian-argv
@@ -1,5 +1,5 @@
 --no-sandbox vault --vault knowledge
---no-sandbox orphans --vault knowledge --vault knowledge
---no-sandbox dead-ends --vault knowledge --vault knowledge
---no-sandbox unresolved --vault knowledge --vault knowledge
---no-sandbox tags --vault knowledge --vault knowledge
+--no-sandbox orphans --vault knowledge
+--no-sandbox dead-ends --vault knowledge
+--no-sandbox unresolved --vault knowledge
+--no-sandbox tags --vault knowledge

--- a/tests/golden/vault-health/cases/worktree-clean/expected/obsidian-argv
+++ b/tests/golden/vault-health/cases/worktree-clean/expected/obsidian-argv
@@ -1,5 +1,5 @@
 --no-sandbox vault --vault knowledge
---no-sandbox orphans --vault knowledge --vault knowledge
---no-sandbox dead-ends --vault knowledge --vault knowledge
---no-sandbox unresolved --vault knowledge --vault knowledge
---no-sandbox tags --vault knowledge --vault knowledge
+--no-sandbox orphans --vault knowledge
+--no-sandbox dead-ends --vault knowledge
+--no-sandbox unresolved --vault knowledge
+--no-sandbox tags --vault knowledge

--- a/tests/golden/vault-health/cases/worktree-deleted/expected/obsidian-argv
+++ b/tests/golden/vault-health/cases/worktree-deleted/expected/obsidian-argv
@@ -1,5 +1,5 @@
 --no-sandbox vault --vault knowledge
---no-sandbox orphans --vault knowledge --vault knowledge
---no-sandbox dead-ends --vault knowledge --vault knowledge
---no-sandbox unresolved --vault knowledge --vault knowledge
---no-sandbox tags --vault knowledge --vault knowledge
+--no-sandbox orphans --vault knowledge
+--no-sandbox dead-ends --vault knowledge
+--no-sandbox unresolved --vault knowledge
+--no-sandbox tags --vault knowledge

--- a/tests/vault-health-golden.bats
+++ b/tests/vault-health-golden.bats
@@ -11,12 +11,17 @@
 # stdout stayed identical, and every stdout-only assertion would still pass. The
 # argv log is therefore a compared artefact, not a debugging aid.
 #
-# One oracle DEFECT is captured faithfully and ticketed separately, per the
+# One oracle DEFECT was captured faithfully rather than fixed silently, per the
 # CLI-021 proposal — a port that "improves while translating" cannot be
-# characterization-tested:
+# characterization-tested — and ticketed separately (#891):
 #   obsidian_cmd() appends `--vault "$VAULT_NAME"`, and four of its five callers
-#   pass the same flag again, so those invocations carry `--vault` twice. Visible
-#   only in expected/obsidian-argv; stdout is identical either way.
+#   passed the same flag again, so those invocations carried `--vault` twice.
+#   Visible only in expected/obsidian-argv; stdout was identical either way.
+# #891 fixed the oracle and deliberately recaptured this corpus to match — see
+# that commit for the reason. Left in this header as a record of the class:
+# the same shape can recur, and the next instance should also get its own
+# ticket + deliberate recapture rather than a silent "cleanup" folded into
+# an unrelated change.
 
 setup() {
     HERE="$BATS_TEST_DIRNAME/golden/vault-health"
@@ -153,14 +158,20 @@ assert_golden() {
     [ "$seen" -eq 3 ]
 }
 
-@test "the argv log records the duplicated --vault flag the oracle emits" {
-    # Not a style note: it is the oracle's observable behaviour, and this test
-    # exists so a port that silently "cleans it up" goes red with an explanation
-    # instead of a bare diff. Fixing it is a deliberate recapture, ticketed.
-    grep -q 'orphans --vault knowledge --vault knowledge' \
+@test "the argv log no longer records a duplicated --vault flag (#891)" {
+    # Was: this test pinned the oracle's observable defect (obsidian_cmd()
+    # already appends --vault, and four of its five callers passed it again),
+    # so a port that silently "cleaned it up" would go red with an explanation
+    # instead of a bare diff. #891 fixed the oracle itself (dropped the
+    # redundant flag from the four callers) and this corpus was deliberately
+    # recaptured (tests/golden/vault-health/capture.sh) to match — so this test
+    # now pins the FIXED shape, and a regression back to double-passing the
+    # flag is what would turn it red.
+    ! grep -q -- '--vault knowledge --vault knowledge' \
         "$HERE/cases/all-pass/expected/obsidian-argv"
-    # The connectivity probe passes it only once - the inconsistency across call
-    # sites is itself evidence the duplication is accidental.
+    grep -qx -- '--no-sandbox orphans --vault knowledge' \
+        "$HERE/cases/all-pass/expected/obsidian-argv"
+    # The connectivity probe always passed it once; unaffected by the fix.
     grep -qx -- '--no-sandbox vault --vault knowledge' \
         "$HERE/cases/all-pass/expected/obsidian-argv"
 }


### PR DESCRIPTION
Closes #891.

## Problem

`obsidian_cmd()` in `scripts/vault-health.sh` already appends `--vault "$VAULT_NAME"`. Four of its five callers (orphans, dead-ends, unresolved, tags) passed the flag again, so those invocations carried `--vault` twice. The connectivity probe was the only caller that didn't — that inconsistency across call sites is what made the duplication read as accidental, per the issue.

Harmless in practice (the Obsidian CLI takes the last occurrence), but it was captured as a deliberate oracle defect in the CLI-021 golden characterization corpus (`tests/vault-health-golden.bats`) — the corpus exists precisely so the Go port under CLI-021 can be proved equivalent to the shell, defect included, rather than "improved while translating" in a way that couldn't be characterization-tested.

## Change

- Drop the redundant `--vault "$VAULT_NAME"` from the 4 affected call sites in `scripts/vault-health.sh`.
- Deliberately recapture the golden corpus against the fixed oracle: `tests/golden/vault-health/capture.sh` (all 16 cases), updating `ORACLE`'s content hash and every case's `expected/obsidian-argv`.
- Update the corpus test that pinned the old duplicated-flag shape (`the argv log records the duplicated --vault flag the oracle emits`) to instead pin the fixed single-flag shape, and update the file's header comment to record the fix and the general lesson (the next instance of this class should also get its own ticket + deliberate recapture, not a silent cleanup).

## Evidence

- `bats tests/vault-health-golden.bats` → 19/19
- `shellcheck scripts/vault-health.sh` clean; `bash -n` / `zsh -n` clean

Same class as #873/#874 per the issue.