### PR TITLE
fix(doctor): detect a vault linked worktree as a checkout (BUG-053, #806)

### DIFF
--- a/cli/internal/doctor/checks_vault_hooks.go
+++ b/cli/internal/doctor/checks_vault_hooks.go
@@ -32,8 +32,11 @@ func checkVaultHooks(sys *System, rep *Report, fix bool) {
 	vault := sys.env("VAULT_PATH", filepath.Join(sys.home(), "Projects", "knowledge"))
 
 	// Vault absent -> nothing to protect. SKIP, not FAIL: a machine that never
-	// syncs the vault is a valid state.
-	if !isDir(filepath.Join(vault, ".git")) {
+	// syncs the vault is a valid state. Asks git rather than assuming
+	// <vault>/.git is a directory — it is a gitdir: pointer FILE in a linked
+	// worktree, which used to make this SKIP a checkout that was genuinely
+	// present (#806).
+	if !isGitCheckout(sys, vault) {
 		rep.Skip("no vault checkout at " + vault + " — no secret gate to provision")
 		return
 	}

--- a/cli/internal/doctor/checks_vault_hooks_worktree_test.go
+++ b/cli/internal/doctor/checks_vault_hooks_worktree_test.go
@@ -1,0 +1,208 @@
+package doctor
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Real-git fixtures for #806. Every other test in this package models the
+// vault's layout with plain files (vaultTree, gitRepo) — sufficient for the
+// hooksPath/dispatcher logic, but not for THIS bug, which is specifically
+// that a linked worktree's ".git" is a gitdir: pointer FILE rather than a
+// directory. A synthetic fixture that writes ".git/hooks/..." can only ever
+// produce a directory, so it cannot reproduce the layout the bug depends on.
+// These tests run real `git` instead.
+
+// realGit runs a git command for real against dir, failing the test on error.
+// Fixture scaffolding only — the check under test still goes through the
+// System seam (see realVaultSystem).
+func realGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=doctor-test", "GIT_AUTHOR_EMAIL=doctor-test@example.com",
+		"GIT_COMMITTER_NAME=doctor-test", "GIT_COMMITTER_EMAIL=doctor-test@example.com",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s (in %s) failed: %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+	return string(out)
+}
+
+// isolateGitConfig points git's GLOBAL and SYSTEM config at /dev/null for the
+// remainder of the test, via t.Setenv (auto-restored, and incompatible with
+// t.Parallel — none of these tests use it).
+//
+// This machine (like every machine this repo's setup provisions) has
+// core.hooksPath set globally to the GUARD-001 dispatcher — without this,
+// `hooksDirFor` resolves every fixture repo's hooks to the REAL dispatcher on
+// $PATH, which happily reports the gate active for a repo that never had
+// anything installed. Isolating global/system config is what makes these
+// tests deterministic on a provisioned dev machine and in a bare CI runner
+// alike.
+func isolateGitConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+}
+
+// realLinkedWorktree builds an actual checkout plus an actual LINKED WORKTREE
+// via `git worktree add`, and asserts the fixture really has the shape the
+// bug depends on before trusting anything built on top of it.
+func realLinkedWorktree(t *testing.T) (main, worktree string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	isolateGitConfig(t)
+	root := t.TempDir()
+	main = filepath.Join(root, "main")
+	mkdirAll(t, main)
+	realGit(t, main, "init", "-q", "-b", "main")
+	writeFile(t, filepath.Join(main, ".pre-commit-config.yaml"), "repos: []\n")
+	realGit(t, main, "add", ".")
+	realGit(t, main, "commit", "-q", "-m", "seed")
+
+	worktree = filepath.Join(root, "linked")
+	realGit(t, main, "worktree", "add", "-q", worktree, "-b", "wt-branch")
+
+	info, err := os.Lstat(filepath.Join(worktree, ".git"))
+	if err != nil {
+		t.Fatalf("worktree .git missing: %v", err)
+	}
+	if info.IsDir() {
+		t.Fatalf("fixture bug: %s/.git is a directory, not the gitdir: pointer file "+
+			"this test needs — `git worktree add` did not do what was expected", worktree)
+	}
+	return main, worktree
+}
+
+// commonHooksDir resolves the shared hooks directory for a checkout via real
+// git, mirroring what hooksDirFor asks in production.
+func commonHooksDir(t *testing.T, repo string) string {
+	t.Helper()
+	common := strings.TrimSpace(realGit(t, repo, "rev-parse", "--git-common-dir"))
+	if !filepath.IsAbs(common) {
+		common = filepath.Join(repo, common)
+	}
+	return filepath.Join(common, "hooks")
+}
+
+// realVaultSystem wires the real git/exec seams (realSystem) but overrides
+// VAULT_PATH to point at the fixture, without touching the process's actual
+// environment or other seams.
+func realVaultSystem(vault string) *System {
+	sys := realSystem()
+	sys.Getenv = func(k string) string {
+		if k == "VAULT_PATH" {
+			return vault
+		}
+		return os.Getenv(k)
+	}
+	return sys
+}
+
+// #806 AC: a linked worktree with the gate missing must FAIL, not SKIP.
+// Before the fix, isDir(worktree/.git) was false (it's a pointer file), so
+// this reported "no vault checkout" — a false negative on a present,
+// unprotected vault, which is worse than a FAIL because it reads as healthy.
+func TestVaultHooks_LinkedWorktree_GateMissing_MustFail(t *testing.T) {
+	_, worktree := realLinkedWorktree(t)
+
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	checkVaultHooks(realVaultSystem(worktree), rep, false)
+
+	if rep.Failures() != 1 {
+		t.Fatalf("a linked worktree with no gate installed must FAIL, got %d failures:\n%s",
+			rep.Failures(), buf.String())
+	}
+	if strings.Contains(buf.String(), "no vault checkout") {
+		t.Errorf("must not misread the worktree as absent, got: %s", buf.String())
+	}
+}
+
+// #806 AC: a linked worktree with the gate installed must PASS. Hooks live in
+// the COMMON git dir, shared across every worktree — installed once, and a
+// linked worktree must see it exactly like the main checkout does.
+func TestVaultHooks_LinkedWorktree_GateInstalled_MustPass(t *testing.T) {
+	main, worktree := realLinkedWorktree(t)
+
+	hooks := commonHooksDir(t, main)
+	for _, stage := range []string{"pre-commit", "pre-push"} {
+		writeExecFile(t, filepath.Join(hooks, stage),
+			"#!/usr/bin/env bash\n# File generated by pre-commit: https://pre-commit.com\n")
+	}
+
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	checkVaultHooks(realVaultSystem(worktree), rep, false)
+
+	if rep.Failures() != 0 {
+		t.Fatalf("a linked worktree with the gate installed must PASS, got %d failures:\n%s",
+			rep.Failures(), buf.String())
+	}
+	if !strings.Contains(buf.String(), "gitleaks gate active") {
+		t.Errorf("want the installed PASS, got: %s", buf.String())
+	}
+}
+
+// #806 AC: ordinary (non-worktree) checkout behaviour is unchanged by the fix.
+func TestVaultHooks_RegularCheckout_StillWorks(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	isolateGitConfig(t)
+	root := t.TempDir()
+	main := filepath.Join(root, "main")
+	mkdirAll(t, main)
+	realGit(t, main, "init", "-q", "-b", "main")
+	writeFile(t, filepath.Join(main, ".pre-commit-config.yaml"), "repos: []\n")
+	realGit(t, main, "add", ".")
+	realGit(t, main, "commit", "-q", "-m", "seed")
+
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	checkVaultHooks(realVaultSystem(main), rep, false)
+
+	if rep.Failures() != 1 {
+		t.Fatalf("an ordinary checkout with no gate installed must still FAIL, got %d:\n%s",
+			rep.Failures(), buf.String())
+	}
+}
+
+// #806 AC: --fix from a linked worktree installs into the shared hooks dir
+// (so every worktree sees it, not just the one that ran --fix) and is
+// idempotent on a second run.
+func TestVaultHooks_LinkedWorktree_Fix_InstallsIntoCommonDirAndIsIdempotent(t *testing.T) {
+	if _, err := exec.LookPath("pre-commit"); err != nil {
+		t.Skip("pre-commit not on PATH")
+	}
+	main, worktree := realLinkedWorktree(t)
+
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	checkVaultHooks(realVaultSystem(worktree), rep, true)
+
+	if rep.Failures() != 0 {
+		t.Fatalf("--fix with pre-commit available must not FAIL, got %d:\n%s", rep.Failures(), buf.String())
+	}
+
+	hooks := commonHooksDir(t, main)
+	if _, err := os.Stat(filepath.Join(hooks, "pre-commit")); err != nil {
+		t.Fatalf("--fix must install into the COMMON git dir (%s), not the worktree: %v", hooks, err)
+	}
+
+	var buf2 bytes.Buffer
+	rep2 := capture(&buf2)
+	checkVaultHooks(realVaultSystem(worktree), rep2, true)
+	if rep2.Failures() != 0 {
+		t.Fatalf("a second --fix run must be idempotent, got %d failures:\n%s", rep2.Failures(), buf2.String())
+	}
+}

--- a/cli/internal/doctor/hookprobe.go
+++ b/cli/internal/doctor/hookprobe.go
@@ -27,6 +27,25 @@ import (
 // System.AgeRoundTrip, which proves a key decrypts rather than that a file
 // exists.
 
+// isGitCheckout reports whether path is a git checkout — a regular clone, a
+// LINKED WORKTREE, or a --separate-git-dir layout alike — by asking git
+// rather than assuming "<path>/.git is a directory" (#806).
+//
+// In a linked worktree (and under --separate-git-dir), <path>/.git is a
+// `gitdir:` pointer FILE, not a directory — the same trap #776/BUG-043 hit on
+// the hooks-dir side. isDir(path/.git) answers "is this a REGULAR checkout",
+// which for the vault's secret gate is the wrong question: it makes the check
+// SKIP — "no vault checkout, no secret gate to provision" — for a vault that
+// is present and whose gate is genuinely unverified. A SKIP that reads as
+// healthy is worse than a FAIL.
+func isGitCheckout(sys *System, path string) bool {
+	if sys == nil || sys.CommandOutput == nil {
+		return isDir(filepath.Join(path, ".git"))
+	}
+	out, err := sys.CommandOutput("git", "-C", path, "rev-parse", "--is-inside-work-tree")
+	return err == nil && strings.TrimSpace(out) == "true"
+}
+
 // effectiveHooksPath reports the core.hooksPath git will ACTUALLY use inside
 // repo. Reading `--global` answers a question about the machine; git resolves
 // local-over-global, so only this answers the question about a repo. "" means

--- a/cli/internal/doctor/hookprobe_test.go
+++ b/cli/internal/doctor/hookprobe_test.go
@@ -52,6 +52,12 @@ func (p *probeGit) system(vault string) *System {
 			}
 			repo := args[1]
 			switch {
+			case strings.Contains(joined, "--is-inside-work-tree"):
+				// Every repo this fake is asked about is one gitRepo() built, so
+				// it is a checkout in this fake's model — mirrors real git's
+				// answer for both a regular checkout and a linked worktree (#806
+				// covers the pointer-file layout with a real-git test instead).
+				return "true\n", nil
 			case strings.Contains(joined, "--git-common-dir"):
 				return filepath.Join(repo, ".git") + "\n", nil
 			case strings.Contains(joined, "core.hooksPath"):


### PR DESCRIPTION
Closes #806.

## Problem

`checkVaultHooks` decided whether the vault was present with `isDir(vault/.git)`. In a **linked git worktree** (and under `--separate-git-dir`), `.git` is a `gitdir:` pointer **file**, not a directory — so this SKIPped ("no vault checkout — no secret gate to provision") for a vault that was genuinely present and whose gate was genuinely unverified. That SKIP reads as healthy, which is worse than a FAIL: the vault runs no CI, and gitleaks at pre-push is its only defense against a pasted secret reaching a public push.

This repo's own documented convention for operating the vault is exactly the layout that triggers the bug: work from an isolated detached worktree when another session has staged work. Any `dotf doctor` run against such a checkout silently opted out of the only secret gate the vault has.

## Fix

`isGitCheckout` (new, `hookprobe.go`) asks git (`rev-parse --is-inside-work-tree`) instead of assuming the layout — the same "ask git, don't assume the layout" fix `hooksDirFor` already applied for the hooks-dir side of this exact class (#776/BUG-043). Same file, same lesson, different line; the second spot the original issue flagged (`vaultHookInstalled` naively joining `.git/hooks/<type>`) turned out to already be fixed by that earlier work — `stageReachesPreCommit`/`hooksDirFor` already resolve hooks via `git rev-parse --git-common-dir`.

## Tests

Four new tests build a **real** git checkout plus a **real** `git worktree add` linked worktree, not a simulated layout — this bug specifically lives in a layout no synthetic fixture reproduces (every other fixture in this file writes `.git/hooks/...`, which can only ever produce a directory). They isolate git's global/system config via `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null`: this dev machine's own `core.hooksPath` (the GUARD-001 dispatcher) would otherwise leak into the fixture and mask the bug entirely — first run without the isolation reported every fixture as a healthy gate, dispatcher included.

- `TestVaultHooks_LinkedWorktree_GateMissing_MustFail` — linked worktree, no gate → FAIL, not SKIP
- `TestVaultHooks_LinkedWorktree_GateInstalled_MustPass` — linked worktree, gate in the common dir → PASS
- `TestVaultHooks_RegularCheckout_StillWorks` — ordinary checkout behavior unchanged
- `TestVaultHooks_LinkedWorktree_Fix_InstallsIntoCommonDirAndIsIdempotent` — `--fix` from a linked worktree installs into the shared common dir and is idempotent on a second run

Mutation-verified: reverting `isGitCheckout` back to the old `isDir` check turns the two positive-path tests red with the exact original SKIP message, then restored.

Also updates the `probeGit` test fake (`hookprobe_test.go`) to answer `rev-parse --is-inside-work-tree`, which the existing dispatcher-fallback tests now also exercise through `isGitCheckout`.

## Evidence

- `go test ./internal/doctor/...` → all pass, including the 4 new + 8 pre-existing vault-hooks tests
- `go test ./...` (full CLI) → all packages pass
- `go build ./...`, `go vet ./...`, `gofmt -l` on touched files → clean
- `golangci-lint run ./...` (pinned v2.12.2) → 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vault hook checks now correctly recognize Git linked worktrees.
  * Missing hooks in linked worktrees are reported instead of being skipped.
  * Hook repair now installs hooks in the shared Git directory and remains safe to run repeatedly.
  * Existing behavior for regular Git checkouts remains unchanged.

* **Tests**
  * Added coverage for linked worktrees, regular checkouts, missing hooks, installed hooks, and automatic repair.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->