### PR TITLE
fix(crystallize): add log_error to the standalone fallback (BUG-065)

### DIFF
--- a/scripts/knowledge-crystallize.sh
+++ b/scripts/knowledge-crystallize.sh
@@ -23,6 +23,13 @@ else
     log_info()    { printf '[INFO]    %s\n' "$1"; }
     log_success() { printf '[SUCCESS] %s\n' "$1"; }
     log_warning() { printf '[WARNING] %s\n' "$1"; }
+    # log_error was missing from this set (BUG-065): process_project() calls
+    # it 4x on the BUG-062 refusal path, and under set -euo pipefail a
+    # missing command is exit 127 -- the script dies mid-message instead of
+    # refusing cleanly, exactly the failure mode BUG-062's guard exists to
+    # avoid. Latent today (utils.sh is a sibling and always found), live the
+    # moment this script is copied out of the repo standalone.
+    log_error()   { printf '[ERROR]   %s\n' "$1"; }
 fi
 
 usage() {

--- a/tests/golden/crystallize/ORACLE
+++ b/tests/golden/crystallize/ORACLE
@@ -5,9 +5,9 @@
 # shallow, where `git log -1 -- <path>` names the merge commit for every file,
 # and a rebase changes a SHA without changing a byte.
 #
-# Captured: 2026-08-09
-# git (informational): 9caedc1 scripts/knowledge-crystallize.sh
+# Captured: 2026-08-12
+# git (informational): 87f6ecb scripts/knowledge-crystallize.sh
 # git (informational): 9caedc1 scripts/knowledge-crystallize.ps1
 
-0be7559f651881393c1ebc285b939851e707a1b9d7e7e8abb756010f0b069865  scripts/knowledge-crystallize.sh
+8360e7ffa4be53b79e8dd1a69d7af6ec1083c2c4c7488cc4aedc667cedaaab07  scripts/knowledge-crystallize.sh
 b68b516edc22068357af18d3f3484fb420cbddcf3a769b66cc162267ec983297  scripts/knowledge-crystallize.ps1

--- a/tests/knowledge-crystallize.bats
+++ b/tests/knowledge-crystallize.bats
@@ -125,3 +125,42 @@ EOF
     [ "$date_line" -lt "$handoff_line" ]
     rm -rf "$FAKE_HOME"
 }
+
+@test "knowledge-crystallize.sh standalone (no utils.sh sibling) refuses cleanly on a BUG-062 block-scalar file, not with a bash command-not-found (BUG-065)" {
+    # Runs a COPY of the real script alone in a scratch dir, with no utils.sh
+    # beside it, so the "Minimal fallbacks when run standalone" branch is the
+    # one that actually executes -- the scenario the fallback exists for.
+    #
+    # Empirically verified before fixing (not assumed from the issue text):
+    # a missing log_error() does NOT crash the whole script under
+    # set -euo pipefail here, because process_project() is called as an `if`
+    # condition (`if ! process_project ...; then`), and bash suspends -e's
+    # abort-on-error for every command inside a function invoked as an if
+    # condition. The real, verified defect is milder but still real: the
+    # refusal still exits 1, but its message degrades from the intended
+    # `[ERROR] Refusing to stamp ...` lines to bash's own
+    # "log_error: command not found", which is not actionable and defeats
+    # the guard's whole point.
+    local scratch standalone_script fake_home fake_project encoded mem_dir
+    scratch="$(mktemp -d)"
+    mkdir -p "$scratch/scripts"
+    cp "$BATS_TEST_DIRNAME/../scripts/knowledge-crystallize.sh" "$scratch/scripts/"
+    standalone_script="$scratch/scripts/knowledge-crystallize.sh"
+
+    fake_home="$scratch/home"
+    fake_project="$scratch/project"
+    mkdir -p "$fake_project"
+    encoded="$(printf '%s' "$fake_project" | tr '/' '-')"
+    mem_dir="$fake_home/.claude/projects/$encoded/memory"
+    mkdir -p "$mem_dir"
+    # BUG-062 shape: a YAML block scalar, which is_yaml_block_scalar detects
+    # and process_project() refuses to touch.
+    printf -- '---\nbody: |\n  some content\n' > "$mem_dir/MEMORY.md"
+
+    HOME="$fake_home" run "$standalone_script" "$fake_project"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[ERROR]"*"Refusing to stamp"* ]]
+    [[ "$output" != *"command not found"* ]]
+    rm -rf "$scratch"
+}


### PR DESCRIPTION
Closes #874.

## Problem

`knowledge-crystallize.sh`'s fallback for when `utils.sh` is absent (the "run standalone" path) defined `log_info`/`log_success`/`log_warning` but not `log_error`, which `process_project()` calls 4x on the BUG-062 refusal path.

## What I actually verified (not just the issue's claim)

The issue states this "kills the script" under `set -euo pipefail`. Empirically reproduced **before** fixing: it does not. `process_project` is invoked as `if ! process_project ...; then exit 1; fi`, and bash suspends `-e`'s abort-on-error for every command inside a function invoked as an `if` condition — a well-known but easy-to-misjudge quirk. So the real, verified defect is milder than "crashes": the refusal still exits 1, but its message degrades from the intended `[ERROR] Refusing to stamp ...` lines to bash's own `log_error: command not found` — not actionable, and it defeats BUG-062's whole point ("refusing is strictly better than corrupting" only holds if the refusal message is legible).

## Fix

Added `log_error()` to the fallback set, matching the existing three functions' shape exactly (same `[TAG]` column alignment, no color codes since `$RED`/`$NC` aren't defined in the standalone context).

## Evidence

- New test runs a **copy** of the real script alone in a scratch dir with no `utils.sh` beside it — the actual standalone scenario, not a simulation — against a BUG-062 block-scalar fixture, and asserts the clean `[ERROR]` output with no `command not found`.
- Mutation-verified: reverting the fix turns the test red with exactly the `command not found` text it exists to catch.
- `bats tests/knowledge-crystallize.bats` → 16/16
- `shellcheck`, `bash -n`, `zsh -n` clean