### PR TITLE
feat(spec): enforce adversarial-review independence with a reviewer pool gate

### DIFF
--- a/cli/internal/spec/review.go
+++ b/cli/internal/spec/review.go
@@ -213,5 +213,9 @@ func checkReviewGate(repoRoot, specID, specDir string, checker StalenessChecker)
 		return fmt.Errorf("%s is stale: %s\nre-run /adversarial-review against the current head, declare `review: waived` with a reason in proposal.md, or pass --force-without-review",
 			ReviewFile, reason)
 	}
-	return nil
+
+	// Last, because it is the only check that asks WHO reviewed rather than
+	// what they concluded — a valid, fresh, passing review signed by the wrong
+	// model is still a self-review, and the earlier checks cannot see that.
+	return checkReviewerPool(repoRoot, review.Reviewer)
 }

--- a/cli/internal/spec/reviewer_pool.go
+++ b/cli/internal/spec/reviewer_pool.go
@@ -1,0 +1,109 @@
+package spec
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ReviewerPoolFile is the repo-relative allow-list of models permitted to sign
+// a review.md (HARNESS-071, #955).
+const ReviewerPoolFile = "harness/reviewer-pool.json"
+
+// reviewerPool is the subset of that file this gate consumes. The file carries
+// more per-entry prose (runner, role, why) for humans; only the id is a
+// contract, so parsing just that keeps the gate indifferent to editorial
+// changes in the rest.
+type reviewerPool struct {
+	Pool []struct {
+		ID string `json:"id"`
+	} `json:"pool"`
+}
+
+// loadReviewerPool reads the allow-list.
+//
+// It returns (nil, nil) when the file does not exist, which means "this repo has
+// no opinion about who may review" rather than "nobody may". dotf runs in repos
+// that have no pool at all, and a gate that refused everywhere a pool is absent
+// would break them. Deleting the pool therefore disables the check — deliberately,
+// because that deletion is a visible diff, the same auditable-escape philosophy
+// as `review: waived` needing a stated reason.
+//
+// Every other failure is an error. A pool that exists but cannot be read is the
+// state where the gate cannot tell an allowed reviewer from a forbidden one, and
+// passing there would silently downgrade to no gate while looking like one.
+func loadReviewerPool(repoRoot string) ([]string, error) {
+	path := filepath.Join(repoRoot, ReviewerPoolFile)
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s exists but could not be read: %w", ReviewerPoolFile, err)
+	}
+
+	var p reviewerPool
+	if jErr := json.Unmarshal(raw, &p); jErr != nil {
+		return nil, fmt.Errorf("%s is not valid JSON: %w", ReviewerPoolFile, jErr)
+	}
+
+	ids := make([]string, 0, len(p.Pool))
+	for i, entry := range p.Pool {
+		id := strings.TrimSpace(entry.ID)
+		if id == "" {
+			return nil, fmt.Errorf("%s entry %d has a blank id", ReviewerPoolFile, i)
+		}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("%s declares an empty pool — remove the file to disable the check, or list the models allowed to review", ReviewerPoolFile)
+	}
+	return ids, nil
+}
+
+// checkReviewerPool refuses a review signed by a model outside the pool.
+//
+// This is the layer that makes reviewer independence true when nobody is
+// watching. The rest of the mechanism — a launcher that picks the right model, a
+// standing rule that the reviewer is never the implementer — is convention, and
+// convention is exactly what failed: BUG-074 was reviewed twice by
+// claude-opus-5, the same model family that wrote it, not by decision but by
+// path of least resistance. Both reviews happened to be rigorous, which is what
+// makes this worth fixing before a cheap PASS rather than after one.
+//
+// Matching is exact on the trimmed id — forgiving about spacing, strict about
+// identity. A prefix match would be actively wrong here: `agy` serves
+// claude-opus-4-6-thinking alongside the Gemini family, so ids, not tool names,
+// are what carry the guarantee.
+//
+// The guarantee's real bound, stated plainly because the spec must not imply a
+// stronger one: `reviewer:` is SELF-REPORTED. This defends against habit and
+// accident, not against an agent that lies about its identity — the same trust
+// level as the verdict field sitting three lines above it.
+func checkReviewerPool(repoRoot, reviewer string) error {
+	pool, err := loadReviewerPool(repoRoot)
+	if err != nil {
+		return fmt.Errorf("%w\nfix the file, or archive with --force-without-review", err)
+	}
+	if pool == nil {
+		return nil // no pool, no opinion
+	}
+
+	found := strings.TrimSpace(reviewer)
+	for _, id := range pool {
+		if found == id {
+			return nil
+		}
+	}
+
+	shown := found
+	if shown == "" {
+		shown = "(none recorded)"
+	}
+	return fmt.Errorf("%s records reviewer %q, which is not in %s\n"+
+		"the models allowed to review are: %s\n"+
+		"re-run /adversarial-review on one of them, declare `review: waived` with a reason in proposal.md, or pass --force-without-review",
+		ReviewFile, shown, ReviewerPoolFile, strings.Join(pool, ", "))
+}

--- a/cli/internal/spec/reviewer_pool_test.go
+++ b/cli/internal/spec/reviewer_pool_test.go
@@ -1,0 +1,165 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// reviewBy is passingReview with a chosen reviewer id — the field the pool gate
+// is about, and the one every other test leaves at "test".
+func reviewBy(id, reviewer string) string {
+	return "---\nspec: \"" + id + "\"\nverdict: \"PASS\"\n" +
+		"reviewed_sha: \"0000000000000000000000000000000000000000\"\n" +
+		"reviewer: \"" + reviewer + "\"\ndate: \"2026-08-13\"\n---\nno blocking findings\n"
+}
+
+// writePool lays down harness/reviewer-pool.json with the given raw content.
+func writePool(t *testing.T, root, content string) {
+	t.Helper()
+	dir := filepath.Join(root, "harness")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "reviewer-pool.json"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const testPool = `{"pool":[{"id":"nan/deepseek-v4-flash"},{"id":"agy/gemini-3.1-pro-high"}]}`
+
+// The reason this gate exists: BUG-074 was reviewed twice by claude-opus-5, the
+// same model family that implemented it, which is the single-agent self-review
+// the skill forbids. Nothing stopped it, because reviewer identity was recorded
+// and then ignored.
+func TestArchiveBlocksReviewerOutsideThePool(t *testing.T) {
+	root := t.TempDir()
+	writePool(t, root, testPool)
+	archivableSpec(t, root, "AI-001-x", reviewBy("AI-001-x", "claude-opus-5"))
+
+	_, err := Archive(root, "AI-001-x", ArchiveOptions{Staleness: fakeStaleness{}})
+	if err == nil {
+		t.Fatal("a reviewer outside the pool must block the archive")
+	}
+	// The refusal has to be diagnosable in one read: who signed it, and who was
+	// allowed to. Otherwise the operator has to open the source to find out.
+	for _, want := range []string{"claude-opus-5", "nan/deepseek-v4-flash", "agy/gemini-3.1-pro-high"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error must name %q, got: %v", want, err)
+		}
+	}
+	// Same contract as every other refusal in this gate: name the declared
+	// escapes rather than leaving the human to guess or to force blindly.
+	for _, want := range []string{"review: waived", "--force-without-review"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error must name the escape %q, got: %v", want, err)
+		}
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "specs", "archive", "AI-001-x")); !os.IsNotExist(statErr) {
+		t.Error("target must not be created when blocked")
+	}
+}
+
+func TestArchiveAllowsReviewerInThePool(t *testing.T) {
+	root := t.TempDir()
+	writePool(t, root, testPool)
+	archivableSpec(t, root, "AI-001-x", reviewBy("AI-001-x", "nan/deepseek-v4-flash"))
+
+	if _, err := Archive(root, "AI-001-x", ArchiveOptions{Staleness: fakeStaleness{}}); err != nil {
+		t.Fatalf("a pooled reviewer must archive cleanly: %v", err)
+	}
+}
+
+// A non-primary pool entry is just as valid: the array is an allow-list, and
+// only its FIRST element carries the extra meaning of being the launcher's
+// default. A fallback-signed review must not be second-class.
+func TestArchiveAllowsAnyPoolEntryNotOnlyTheFirst(t *testing.T) {
+	root := t.TempDir()
+	writePool(t, root, testPool)
+	archivableSpec(t, root, "AI-001-x", reviewBy("AI-001-x", "agy/gemini-3.1-pro-high"))
+
+	if _, err := Archive(root, "AI-001-x", ArchiveOptions{Staleness: fakeStaleness{}}); err != nil {
+		t.Fatalf("the fallback reviewer must archive cleanly: %v", err)
+	}
+}
+
+// dotf runs in repos that have no pool. Requiring one everywhere would break
+// them, so an absent pool skips the check — and deleting the pool stays a
+// visible diff, which is the same auditable-escape philosophy as `review:
+// waived`. This is also why the pre-existing tests (reviewer "test") still pass.
+func TestArchiveSkipsThePoolCheckWhenNoPoolExists(t *testing.T) {
+	root := t.TempDir()
+	archivableSpec(t, root, "AI-001-x", reviewBy("AI-001-x", "claude-opus-5"))
+
+	if _, err := Archive(root, "AI-001-x", ArchiveOptions{Staleness: fakeStaleness{}}); err != nil {
+		t.Fatalf("no pool means no opinion, so the archive must proceed: %v", err)
+	}
+}
+
+// A gate fails toward refusing. An unreadable pool is the state where the check
+// cannot tell an allowed reviewer from a forbidden one, so passing would be a
+// silent downgrade to no gate at all.
+func TestArchiveRefusesAMalformedPool(t *testing.T) {
+	cases := map[string]string{
+		"not json":     `{"pool": [`,
+		"empty pool":   `{"pool": []}`,
+		"missing pool": `{}`,
+		"blank id":     `{"pool":[{"id":"   "}]}`,
+	}
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			writePool(t, root, content)
+			archivableSpec(t, root, "AI-001-x", reviewBy("AI-001-x", "nan/deepseek-v4-flash"))
+
+			_, err := Archive(root, "AI-001-x", ArchiveOptions{Staleness: fakeStaleness{}})
+			if err == nil {
+				t.Fatal("an unusable pool must refuse, not silently allow")
+			}
+			if !strings.Contains(err.Error(), "reviewer-pool.json") {
+				t.Errorf("the error must name the file at fault, got: %v", err)
+			}
+		})
+	}
+}
+
+// Reviewer ids are self-reported free text, so surrounding whitespace is a
+// realistic way to fail a match that should have succeeded. Matching is exact
+// on the trimmed value: forgiving about spacing, strict about identity.
+func TestArchiveMatchesReviewerExactlyAfterTrimming(t *testing.T) {
+	root := t.TempDir()
+	writePool(t, root, testPool)
+	archivableSpec(t, root, "AI-001-x", reviewBy("AI-001-x", "  nan/deepseek-v4-flash  "))
+
+	if _, err := Archive(root, "AI-001-x", ArchiveOptions{Staleness: fakeStaleness{}}); err != nil {
+		t.Fatalf("padding around a pooled id must not refuse: %v", err)
+	}
+}
+
+// A prefix is not a member. `agy` also serves claude-opus-4-6-thinking, so a
+// substring match would let "nan/deepseek-v4-flash-lite" — or anything merely
+// starting with a pooled id — sign a review.
+func TestArchiveRejectsAReviewerThatMerelyResemblesAPoolEntry(t *testing.T) {
+	root := t.TempDir()
+	writePool(t, root, testPool)
+	archivableSpec(t, root, "AI-001-x", reviewBy("AI-001-x", "nan/deepseek-v4-flash-lite"))
+
+	if _, err := Archive(root, "AI-001-x", ArchiveOptions{Staleness: fakeStaleness{}}); err == nil {
+		t.Fatal("a near-miss id must refuse; membership is exact, not prefix")
+	}
+}
+
+// The escape must actually work, or the refusal is a wall rather than a gate.
+func TestArchiveForceOverridesThePoolCheck(t *testing.T) {
+	root := t.TempDir()
+	writePool(t, root, testPool)
+	archivableSpec(t, root, "AI-001-x", reviewBy("AI-001-x", "claude-opus-5"))
+
+	if _, err := Archive(root, "AI-001-x", ArchiveOptions{
+		Staleness:          fakeStaleness{},
+		ForceWithoutReview: true,
+	}); err != nil {
+		t.Fatalf("--force-without-review must bypass the pool check too: %v", err)
+	}
+}

--- a/harness/reviewer-pool.json
+++ b/harness/reviewer-pool.json
@@ -1,0 +1,41 @@
+{
+  "$comment": [
+    "Reviewer pool for /adversarial-review (HARNESS-071, #955).",
+    "",
+    "Ordered allow-list of models permitted to SIGN a review.md. The first entry",
+    "is the launcher's primary; the whole array is the gate's allow-list, which",
+    "dotf spec archive enforces via checkReviewGate.",
+    "",
+    "Standing rule: an adversarial review never runs on an Anthropic model. The",
+    "reviewer must not be the implementer, and Claude implements nearly every",
+    "change in this repo — BUG-074 was reviewed twice by claude-opus-5 before",
+    "anyone noticed, which is the incident this file exists to prevent.",
+    "",
+    "Entries are model IDS, not tool names, and that distinction is load-bearing:",
+    "`agy` also serves claude-opus-4-6-thinking and claude-sonnet-4-6, so pinning",
+    "the tool would guarantee nothing. Pinning the id does.",
+    "",
+    "Reasoning-class only. The latency-optimised daily models (nan/qwen3.6,",
+    "nan/gemma4, the gemini flash tier) are deliberately absent: a reviewer that",
+    "PASSes cheaply is worse than no gate, because it converts the gate into a",
+    "green checkmark. This file is read once per spec, so slow is fine.",
+    "",
+    "This is the load-bearing slice of H-044, not a replacement for it. H-044's",
+    "model-map.json maps a neutral tier (top|mid|low) to a provider per agent — a",
+    "different shape. Kept in a separate file so H-044 need not migrate this one."
+  ],
+  "pool": [
+    {
+      "id": "nan/deepseek-v4-flash",
+      "runner": "pi",
+      "role": "primary",
+      "why": "1M context and a mandatory reasoning chain — roughly 4x slower than qwen3.6 on trivial prompts, which is the correct trade for a gate that runs once per spec. Exercised: BUG-074 round 3 re-ran the mutation battery itself rather than trusting the spec's table."
+    },
+    {
+      "id": "agy/gemini-3.1-pro-high",
+      "runner": "agy",
+      "role": "fallback",
+      "why": "A second provider family, independent of both NaN and Anthropic — provider diversity rather than merely a different model. Pro tier at high effort; the flash tiers are excluded for the same reason qwen3.6 is."
+    }
+  ]
+}

--- a/specs/HARNESS-071-reviewer-pool/features.json
+++ b/specs/HARNESS-071-reviewer-pool/features.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "HARNESS-071-reviewer-pool-f1",
+    "behavior": "A review signed by a model outside the pool cannot be archived, and the refusal names both the reviewer found and the models allowed, so the mismatch is diagnosable without reading source",
+    "verification": "cd cli && go test ./internal/spec/ -run 'TestArchiveBlocksReviewerOutsideThePool$'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-071-reviewer-pool-f2",
+    "behavior": "Any pool entry may sign, not only the launcher's primary — the array is an allow-list whose first element merely carries the extra meaning of being the default",
+    "verification": "cd cli && go test ./internal/spec/ -run 'TestArchiveAllows(ReviewerInThePool|AnyPoolEntryNotOnlyTheFirst)$'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-071-reviewer-pool-f3",
+    "behavior": "An absent pool skips the check so dotf still works in repos that have none, while a pool that exists but cannot be read refuses rather than silently degrading to no gate",
+    "verification": "cd cli && go test ./internal/spec/ -run 'TestArchive(SkipsThePoolCheckWhenNoPoolExists|RefusesAMalformedPool)'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-071-reviewer-pool-f4",
+    "behavior": "Membership is exact on the trimmed id: padding is forgiven, but a near-miss id that merely resembles a pool entry is refused, since tool names cannot carry the guarantee when one tool serves several providers",
+    "verification": "cd cli && go test ./internal/spec/ -run 'TestArchive(MatchesReviewerExactlyAfterTrimming|RejectsAReviewerThatMerelyResemblesAPoolEntry)$'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-071-reviewer-pool-f5",
+    "behavior": "The declared escape still works, so the gate is a gate and not a wall",
+    "verification": "cd cli && go test ./internal/spec/ -run 'TestArchiveForceOverridesThePoolCheck$'",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/HARNESS-071-reviewer-pool/proposal.md
+++ b/specs/HARNESS-071-reviewer-pool/proposal.md
@@ -131,6 +131,20 @@ Decided explicitly, because these are the design rather than details:
 - **Windows.** tmux is Linux-only and `dotf` is cross-platform. The degrade must
   be explicit (no tmux → run in the foreground and say so), not implicit; the
   repo enforces Windows parity.
+- **Already-archived specs are signed by models the pool forbids, and that is
+  safe — verified, not assumed.** Two of the three archived `review.md` files
+  are signed `claude-sonnet-5`. They do not need a grandfather clause because
+  `checkReviewGate` has exactly one caller (`archive.go`, inside `Archive()`),
+  and nothing scans `specs/archive/` for reviews: the gate runs at archive time
+  only, so a spec that is already archived is never re-evaluated. If a future
+  change adds a sweep over archived reviews — a doctor drift check, a CI audit —
+  it must grandfather them or main goes red on history nobody can re-review.
+- **The gate is enforced by merged code, not by the binary on PATH.** Until this
+  PR merges and `dotf` redeploys, `~/.local/bin/dotf` predates the check and
+  archives a Claude-signed review cleanly (confirmed live, not inferred). This is
+  the same deployed-copy-lags-the-checkout class as ADR-030/#635, and it means
+  "a Claude-signed review cannot be archived" is true of the repo before it is
+  true of any given machine.
 - **Transcript size.** `--mode json` / `--output-format stream-json` emits an
   event stream. Committing it alongside `review.md` makes *how* a review reasoned
   auditable, which is the reusable half of observability — but it needs a size

--- a/specs/HARNESS-071-reviewer-pool/proposal.md
+++ b/specs/HARNESS-071-reviewer-pool/proposal.md
@@ -1,0 +1,164 @@
+---
+id: "HARNESS-071-reviewer-pool"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-13"
+issue: "mlorentedev/dotfiles#955"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# HARNESS-071-reviewer-pool
+
+## Why
+
+<!-- from issue #955 -->
+
+Adversarial review is the red-team gate between an implemented spec and
+`dotf spec archive`. Its entire value is **independence** — the skill says so and
+forbids single-agent self-review outright. Today that independence rests on
+convention: whoever launches the review picks the model, and nothing downstream
+checks what they picked.
+
+The convention failed twice in one session, on BUG-074:
+
+| Round | Reviewer | Verdict | Majors |
+|---|---|---|---|
+| 1 | `claude-opus-5` | FAIL | 3 REAL |
+| 2 | `claude-opus-5` | FAIL | 3 REAL |
+| 3 | `nan/deepseek-v4-flash` | PASS | 0 (+4 Minors → #956) |
+
+Rounds 1 and 2 were reviewed by the same model family that wrote the change.
+Not by decision — by path of least resistance. Both happened to be rigorous, so
+no harm resulted; that is exactly what makes it worth fixing now rather than
+after a cheap PASS. The gate that stops a rubber stamp cannot itself be a habit.
+
+`cli/internal/spec/review.go` already parses `reviewer:` and already has a
+refusal point (`checkReviewGate`, CLI-034). It inspects verdict, spec-id match
+and staleness. The reviewer identity is recorded and then ignored — a fact
+sitting one field away from the check that would use it.
+
+## What
+
+Three layers. Only one of them enforces, and saying which is the point.
+
+1. **Pool as data** — `harness/reviewer-pool.json`, an ordered array of
+   `provider/model` ids. First entry is the launcher's primary; the whole array
+   is the gate's allow-list. One field, both jobs.
+2. **Gate** — `checkReviewGate` additionally refuses a `review.md` whose
+   `reviewer:` is not in the pool. This is the layer that makes the rule true
+   when nobody is watching.
+3. **Launcher** — `dotf spec review <spec-id>` resolves the pinned reviewer from
+   the pool and runs it, instead of leaving the choice to whoever is at the
+   keyboard.
+
+The launcher does not execute a reviewer; it *selects a runner*. That separation
+is the whole architecture: `pi`, `agy`, `opencode`, tmux and Orca are local,
+personal and replaceable, while the pool, the gate, the entry point and the
+artifacts are what survive across machines, teammates and agents.
+
+### Why the runner cannot be the guarantee
+
+Two findings from building this, each of which would have made a runner-based
+design quietly wrong:
+
+- **`agy` serves Anthropic models too** — `agy models` lists
+  `claude-opus-4-6-thinking` and `claude-sonnet-4-6` beside the Gemini family.
+  "Run the review with agy" therefore guarantees nothing about provider
+  diversity.
+- **BUG-074's round 3 was pinned by coincidence, not by configuration.** It was
+  invoked as bare `pi -p`, which resolved to `nan/deepseek-v4-flash` only
+  because `~/.pi/agent/settings.json` on this machine happens to say so. That
+  file is per-machine, unversioned state; `pi`'s own default provider is
+  `google`. The verdict is still valid — `review.md`'s frontmatter records what
+  actually ran — but the *pinning mechanism* has never been exercised. The
+  launcher must pass `--provider`/`--model` explicitly.
+
+### Gate semantics
+
+Decided explicitly, because these are the design rather than details:
+
+- **Pool file absent → skip the check.** `dotf` runs in repos that have no pool,
+  and requiring one everywhere would break them. Deleting the pool is a visible
+  diff, which is the same auditable-escape philosophy as `review: waived`.
+- **Pool present but malformed → refuse.** A gate fails toward refusing
+  (`archive.go`'s own stated rule).
+- **Exact string match, trimmed.** The refusal prints both the found `reviewer:`
+  and the pool, so a mismatch is diagnosable in one read.
+- **The launcher tells the reviewer what to write.** Reviewer ids are
+  self-reported, so the prompt names the canonical id to record. A hand-run
+  review that guesses wrong gets a refusal naming the pool, not a silent pass.
+
+## Out of scope
+
+- **Running the review in CI** (`opencode github run` exists for it). Deferred
+  deliberately: encoding the policy inside a GitHub workflow re-attaches it to a
+  runner, which is the coupling this spec removes. Revisit once the contract is
+  stable — and note the repo is public, so a provider key in Actions secrets is
+  its own decision, not a detail.
+- **The full H-044 `model-map.json` / `capability-map.json` fan-out.** This is
+  the load-bearing slice of it, not a replacement. A dedicated file avoids
+  squatting on H-044's future schema, which maps a neutral tier
+  (`top|mid|low`) to a provider *per agent* — a different shape from this
+  allow-list.
+- **Orca integration.** Its CLI is unusable on this machine: all four resolution
+  paths from the `orca-cli` skill fail (`ORCA_CLI_COMMAND` unset,
+  `ORCA_DEV_REPO_ROOT` unset, `orca-ide` and the shim both exec an AppImage that
+  rejects `--no-sandbox`; scrubbing the inherited AppImage env does not help).
+  Tracked separately. Observability is met with tmux, which needs nothing from
+  Orca and which Orca can host anyway.
+- Fixing the reviewer's own findings on BUG-074 (#956).
+
+## Risks / open questions
+
+- **`reviewer:` is self-reported.** The gate defends against habit and accident,
+  not against an agent that lies about its identity. That is the same trust
+  level as the rest of `review.md` (verdict included), so it is not a regression
+  — but the spec must say it plainly rather than imply a stronger guarantee.
+- **A weak reviewer is worse than no gate.** It converts the gate into a green
+  checkmark. This is why the pool holds reasoning-class models and deliberately
+  excludes the latency-optimised defaults (`nan/qwen3.6`, `nan/gemma4`) that the
+  daily wrappers use. Evidence it matters: round 3 scored an all-A rubric where
+  round 2 scored B/C, and missed a documentation inconsistency the implementer
+  had deliberately left in place — a real reviewer, with less edge.
+- **The fallback must be exercised, not merely configured.** A fallback never
+  observed working is decoration — this repo's own #898 lesson. NaN's evidence
+  is BUG-074 round 3; Gemini has none yet, so producing one is an acceptance
+  criterion, not a follow-up.
+- **`agy --print-timeout` defaults to 5m.** Round 3 took roughly 25 minutes of
+  wall clock. The Gemini arm dies on default settings, so the launcher must
+  raise it — a concrete instance of "configured is not exercised".
+- **Windows.** tmux is Linux-only and `dotf` is cross-platform. The degrade must
+  be explicit (no tmux → run in the foreground and say so), not implicit; the
+  repo enforces Windows parity.
+- **Transcript size.** `--mode json` / `--output-format stream-json` emits an
+  event stream. Committing it alongside `review.md` makes *how* a review reasoned
+  auditable, which is the reusable half of observability — but it needs a size
+  sanity check before it becomes a habit.
+
+## Acceptance criteria
+
+- [ ] A `review.md` signed by a reviewer outside the pool is refused by
+      `dotf spec archive`, naming the declared escapes.
+- [ ] An absent pool skips the check; a malformed pool refuses.
+- [ ] The pool is data readable by any harness, not a Go constant.
+- [ ] `dotf spec review <spec-id>` passes the model explicitly, so the pin does
+      not depend on unversioned per-machine state.
+- [ ] The run is observable while it happens (named tmux session), with the
+      Windows/no-tmux degrade stated and implemented.
+- [ ] A machine-readable transcript lands beside `review.md`.
+- [ ] **Both configured paths produce a real review**: NaN (evidence: BUG-074
+      round 3) and Gemini via `agy` (evidence: one real run, to be produced).
+- [ ] The gate's predicate is mutation-tested — deleting the pool check turns a
+      named test red.
+
+## References
+
+- Bitácora board: mlorentedev/dotfiles#955
+- `cli/internal/spec/review.go` — `contractFiles`, `Review.Reviewer`, `checkReviewGate`
+- `harness/agent-frontmatter.schema.json` — the reserved neutral `model` key
+- `scripts/compile-harness.sh` — where `model` is dropped pending H-044
+- `specs/archive/HARNESS-043-curator-dogfood-slice/proposal.md` — where H-044 was deferred from
+- `specs/archive/BUG-074-doctor-bw-reach/review.md` — the three rounds this spec argues from
+- Related issues: #956 (the third review's own findings), #898 (a check never
+  observed failing is not evidence)

--- a/specs/HARNESS-071-reviewer-pool/tasks.md
+++ b/specs/HARNESS-071-reviewer-pool/tasks.md
@@ -40,6 +40,12 @@ created: "2026-08-13"
 
 ## Slice 2 — the launcher
 
+> **Slices 2 and 3 land in a follow-up PR.** Slice 1 is the layer that enforces
+> and is complete and independently verifiable on its own; the launcher is
+> convenience on top of it. Splitting keeps both within the PR-sizing policy, and
+> the unticked boxes below are the declared remainder — not an incomplete
+> checklist for the PR that carries slice 1.
+
 - [ ] [AC4] `dotf spec review <spec-id>`: resolve the primary from the pool and
       pass `--provider`/`--model` **explicitly**. Not optional polish — BUG-074
       round 3 was pinned only because `~/.pi/agent/settings.json` on this machine

--- a/specs/HARNESS-071-reviewer-pool/tasks.md
+++ b/specs/HARNESS-071-reviewer-pool/tasks.md
@@ -1,0 +1,80 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-13"
+---
+
+# Tasks - HARNESS-071-reviewer-pool
+
+> TDD order. One task = one focused commit. Tick as you go.
+
+## Setup
+
+- [x] Branch created from main: `feat/reviewer-pool` (worktree `dotfiles-wt-review`)
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] Work-gate linked: #955
+
+## Slice 1 — the gate (this is the layer that enforces)
+
+- [x] [AC3] `harness/reviewer-pool.json`: ordered allow-list of model **ids**,
+      not tool names. Separate file rather than a key in `manifest.json` (which
+      doctor's harness-drift section reads) and rather than `model-map.json`
+      (H-044's future schema, a different shape — squatting on the name would
+      force H-044 to migrate this file).
+- [x] [P] [AC1] Test: a reviewer outside the pool blocks the archive, and the
+      refusal names both the found reviewer and the whole pool.
+- [x] [P] [AC2] Test: absent pool skips the check; malformed pool refuses
+      (4 shapes: bad JSON, empty array, missing key, blank id).
+- [x] [P] Test: exact match after trimming; a near-miss id (`…-lite`) refuses;
+      any pool entry works, not only the first; `--force-without-review` still
+      overrides.
+- [x] Observe all of the above go red before implementing — confirmed: the three
+      refusal tests failed, the permission tests passed (no gate = allow).
+- [x] [AC1] Implement `loadReviewerPool` + `checkReviewerPool`, wired last in
+      `checkReviewGate` because it is the only check that asks *who* reviewed
+      rather than what they concluded.
+- [x] [AC8] Mutation-test the predicate — 5 mutants, **5 detected**, with a
+      harness that aborts when a mutation fails to apply.
+- [x] Live smoke against the REAL pool file, not a fixture: a `claude-opus-5`
+      signature is refused with the pool printed; `nan/deepseek-v4-flash`
+      archives cleanly.
+
+## Slice 2 — the launcher
+
+- [ ] [AC4] `dotf spec review <spec-id>`: resolve the primary from the pool and
+      pass `--provider`/`--model` **explicitly**. Not optional polish — BUG-074
+      round 3 was pinned only because `~/.pi/agent/settings.json` on this machine
+      happens to default to nan; pi's own default provider is `google`, and that
+      file is unversioned per-machine state.
+- [ ] [AC5] Named tmux session `review-<spec-id>` so the run is watchable while
+      it happens. Windows / no-tmux degrades to foreground and says so.
+- [ ] [AC6] Machine-readable transcript beside `review.md` (`pi --mode json`,
+      `agy --output-format stream-json`). Check the size before making it a habit.
+- [ ] Raise `agy --print-timeout` — it defaults to 5m and round 3 took ~25m, so
+      the fallback dies on defaults. A concrete instance of "configured is not
+      exercised".
+- [ ] [AC7] Prove the Gemini arm with one real review. NaN's evidence already
+      exists (BUG-074 round 3); a fallback never observed working is decoration.
+
+## Slice 3 — the standing rule where agents read it
+
+- [ ] Amend the skill's "Do NOT prescribe which agent, model, or IDE" line: the
+      pool records the human's standing choice and the gate enforces it, so the
+      skill should point at the pool rather than imply the reviewer is free to
+      choose. **Edit the vault source** (`00_meta/skills/adversarial-review/`),
+      direct to master, then `compile-harness.sh --refresh` — the repo copy is
+      generated. Check no other session has staged vault work first.
+
+## Closing
+
+- [ ] Every acceptance criterion covered by at least one test
+- [ ] `features.json` entries with non-vacuous verification commands
+- [ ] `go build ./...`, `go vet ./...`, `golangci-lint run` (pinned)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+- [ ] Fresh adversarial review — on a pooled model, which this spec is about
+
+## Machine-readable features
+
+See `features.json`. States stay at `pending`: an agent may not write `passing`,
+only the harness may, after running each `verification` command and capturing
+exit 0.

--- a/specs/HARNESS-071-reviewer-pool/verification.md
+++ b/specs/HARNESS-071-reviewer-pool/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-14"
+---
+
+# Verification - HARNESS-071-reviewer-pool
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/HARNESS-071-reviewer-pool/` -> `specs/archive/HARNESS-071-reviewer-pool/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
Refs #955. Spec: `specs/HARNESS-071-reviewer-pool/`.

Slice 1 of 3 — the layer that enforces. The launcher (`dotf spec review`) and the skill-text amendment land in a follow-up PR; `tasks.md` declares that split, so the unticked boxes there are a stated remainder rather than an unfinished checklist.

## Why

Adversarial review's whole value is independence — the skill forbids single-agent self-review outright. But `cli/internal/spec/review.go` already parsed `reviewer:` and already had a refusal point, and did nothing with the identity. The rule lived in prose and in memory.

It failed twice in one session. BUG-074 rounds 1 and 2 were both reviewed by `claude-opus-5`, the same model family that implemented the change — not by decision, by path of least resistance. Round 3 on `nan/deepseek-v4-flash` is what produced the finding neither Anthropic round did. Both earlier rounds happened to be rigorous, which is exactly why this is worth fixing before a cheap PASS rather than after one.

## What

`harness/reviewer-pool.json` — an ordered allow-list of model **ids**. `dotf spec archive` refuses a `review.md` signed outside it.

Ids, not tool names, and the distinction is load-bearing: `agy models` lists `claude-opus-4-6-thinking` and `claude-sonnet-4-6` beside the Gemini family, so pinning the tool would guarantee nothing about provider diversity. Only reasoning-class models are pooled; the latency-optimised daily models are deliberately excluded, because a reviewer that PASSes cheaply is worse than no gate — it converts the gate into a green checkmark.

Semantics, decided rather than inherited:

| State | Behaviour | Why |
|---|---|---|
| pool absent | skip | `dotf` runs in repos with no pool; deleting the file is a visible diff, the same auditable escape as `review: waived` needing a reason |
| pool malformed | **refuse** | a gate fails toward refusing; an unreadable pool cannot tell an allowed reviewer from a forbidden one, so passing would silently downgrade to no gate while looking like one |
| match | exact after trimming | a prefix match would admit `…-flash-lite` |
| refusal | prints the reviewer found, the whole pool, and both declared escapes | diagnosable in one read |

## Verification

- Proved red before implementing: the three refusal tests failed, the permission tests passed (no gate = allow).
- **Mutation battery: 5 mutants, 5 detected** — gate removed, prefix match, malformed-passes, empty-as-absent, absent-refuses. Run through a harness that aborts when a mutation fails to apply, after an earlier battery in this repo reported false SURVIVEDs from a `sed` that silently matched nothing.
- Live smoke against the real pool file rather than a fixture:

```
$ dotf spec archive ZZZ-001-smoke        # signed claude-opus-5
Error: review.md records reviewer "claude-opus-5", which is not in harness/reviewer-pool.json
the models allowed to review are: nan/deepseek-v4-flash, agy/gemini-3.1-pro-high
re-run /adversarial-review on one of them, declare `review: waived` ... or --force-without-review

$ dotf spec archive ZZZ-001-smoke        # signed nan/deepseek-v4-flash
[OK] Archived
```

- `go build ./...`, `go vet ./...`, full `go test ./...`, `golangci-lint run` → 0 issues on the pinned 2.12.2.

## Two things verified rather than assumed

**Archived specs signed by forbidden models are safe.** Two of three archived `review.md` files are signed `claude-sonnet-5`. No grandfather clause is needed because `checkReviewGate` has exactly one caller, inside `Archive()`, and nothing sweeps `specs/archive/` — the gate runs at archive time only. A future sweep would have to grandfather them or turn main red on history nobody can re-review; recorded in the spec's risks.

**The gate is enforced by merged code, not by the binary on PATH.** Until this merges and `dotf` redeploys, `~/.local/bin/dotf` predates the check and archives a Claude-signed review cleanly — confirmed live, not inferred. Same deployed-copy-lags-checkout class as ADR-030/#635.

## Honest bound

`reviewer:` is self-reported. This defends against habit and accident, not against an agent that lies about its identity — the same trust level as the `verdict:` field three lines above it. Stated in the code rather than implied.
