### PR TITLE
fix(spec): land the agy reviewer fixes that missed #959's merge

### DIFF
--- a/cli/internal/cmd/spec.go
+++ b/cli/internal/cmd/spec.go
@@ -152,7 +152,7 @@ is the only record of how.`,
 
 			skill := spec.ReviewerSkillPath(chosen.Runner)
 			prompt := spec.ReviewPrompt(id, repoRoot, chosen.ID, skill)
-			argv, err := spec.ReviewerCommand(chosen, prompt, timeout)
+			argv, err := spec.ReviewerCommand(chosen, prompt, timeout, repoRoot)
 			if err != nil {
 				return err
 			}

--- a/cli/internal/spec/review_launch.go
+++ b/cli/internal/spec/review_launch.go
@@ -69,7 +69,7 @@ type ReviewerEntry struct {
 //
 // Every flag here is verified against the installed binaries. An earlier draft
 // also invented a --prompt-file that neither runner has.
-func ReviewerCommand(e ReviewerEntry, prompt string, timeout time.Duration) ([]string, error) {
+func ReviewerCommand(e ReviewerEntry, prompt string, timeout time.Duration, repoRoot string) ([]string, error) {
 	if timeout <= 0 {
 		timeout = DefaultReviewerTimeout
 	}
@@ -104,13 +104,46 @@ func ReviewerCommand(e ReviewerEntry, prompt string, timeout time.Duration) ([]s
 		// --print goes LAST and carries the prompt as its value. Order matters:
 		// any flag placed between --print and the prompt is consumed as the
 		// prompt instead.
-		return append(base,
+		//
+		// --dangerously-skip-permissions is required, not optional. agy prompts
+		// for approval on every tool call, and a detached reviewer has no human
+		// to answer: each call is auto-DENIED. Observed exactly that — the run
+		// read a few files, was refused `git rev-parse HEAD`, and gave up after
+		// 14 seconds while reporting `status: SUCCESS` with an empty response.
+		// A reviewer that cannot run the test suite cannot review, so the choice
+		// is this flag or no fallback arm at all.
+		//
+		// The name is a fair warning and the posture is real: the reviewer gets
+		// unattended shell in this repo. That is inherent to adversarial review
+		// — running the suite and mutating the code IS the job, and the pi arm
+		// has the same reach without asking. What bounds it is the deadline
+		// above, the pool restricting WHICH models get here, and the fact that
+		// the reviewer's only sanctioned output is review.md.
+		//
+		// --add-dir is what makes the review possible at all. Without it agy runs
+		// its shell commands in its OWN install directory, not the repo: `pwd`
+		// answers ~/.gemini/antigravity-cli and `git rev-parse HEAD` fails with
+		// "not a git repository". A reviewer that cannot reach the tree cannot
+		// run the suite or mutate anything, so it reviews by reading and grades
+		// generously — which is exactly what the first Gemini review did.
+		//
+		// --sandbox bounds what the auto-approval above can touch. Verified not
+		// to cost anything the review needs: under it, git, `go test` and file
+		// writes all still work.
+		agyArgs := []string{
 			"agy",
 			"--model", e.Model,
 			"--output-format", "stream-json",
 			"--print-timeout", timeout.String(),
-			"--print", prompt,
-		), nil
+			"--dangerously-skip-permissions",
+			"--sandbox",
+		}
+		if strings.TrimSpace(repoRoot) != "" {
+			agyArgs = append(agyArgs, "--add-dir", repoRoot)
+		}
+		// --print goes LAST and carries the prompt as its value.
+		agyArgs = append(agyArgs, "--print", prompt)
+		return append(base, agyArgs...), nil
 
 	default:
 		return nil, fmt.Errorf("pool entry %q names runner %q, which the launcher does not know how to invoke\n"+

--- a/cli/internal/spec/review_launch_test.go
+++ b/cli/internal/spec/review_launch_test.go
@@ -34,7 +34,7 @@ func TestReviewerCommandPinsProviderAndModelExplicitly(t *testing.T) {
 	argv, err := ReviewerCommand(ReviewerEntry{
 		ID: "nan/deepseek-v4-flash", Runner: "pi",
 		Provider: "nan", Model: "deepseek-v4-flash",
-	}, "review this spec", 0)
+	}, "review this spec", 0, "/repo")
 	if err != nil {
 		t.Fatalf("building the pi command: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestReviewerCommandRunsThroughTheSecretsFacade(t *testing.T) {
 		{ID: "nan/x", Runner: "pi", Provider: "nan", Model: "x"},
 		{ID: "agy/y", Runner: "agy", Model: "y"},
 	} {
-		argv, err := ReviewerCommand(e, "p", 0)
+		argv, err := ReviewerCommand(e, "p", 0, "/repo")
 		if err != nil {
 			t.Fatalf("%s: %v", e.ID, err)
 		}
@@ -79,7 +79,7 @@ func TestReviewerCommandRunsThroughTheSecretsFacade(t *testing.T) {
 func TestReviewerCommandRaisesTheAgyPrintTimeout(t *testing.T) {
 	argv, err := ReviewerCommand(ReviewerEntry{
 		ID: "agy/gemini-3.1-pro-high", Runner: "agy", Model: "gemini-3.1-pro-high",
-	}, "p", 0)
+	}, "p", 0, "/repo")
 	if err != nil {
 		t.Fatalf("building the agy command: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestReviewerCommandRaisesTheAgyPrintTimeout(t *testing.T) {
 // A machine-readable stream is the only record of HOW a reviewer reasoned. The
 // verdict alone is not auditable by anyone who was not watching.
 func TestReviewerCommandRequestsAMachineReadableStream(t *testing.T) {
-	pi, err := ReviewerCommand(ReviewerEntry{ID: "nan/x", Runner: "pi", Provider: "nan", Model: "x"}, "p", 0)
+	pi, err := ReviewerCommand(ReviewerEntry{ID: "nan/x", Runner: "pi", Provider: "nan", Model: "x"}, "p", 0, "/repo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func TestReviewerCommandRequestsAMachineReadableStream(t *testing.T) {
 		t.Errorf("pi must emit json, got %q", argvValue(pi, "--mode"))
 	}
 
-	agy, err := ReviewerCommand(ReviewerEntry{ID: "agy/y", Runner: "agy", Model: "y"}, "p", 0)
+	agy, err := ReviewerCommand(ReviewerEntry{ID: "agy/y", Runner: "agy", Model: "y"}, "p", 0, "/repo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestReviewerCommandRefusesRatherThanFallBackToADefault(t *testing.T) {
 	}
 	for name, e := range cases {
 		t.Run(name, func(t *testing.T) {
-			if _, err := ReviewerCommand(e, "p", 0); err == nil {
+			if _, err := ReviewerCommand(e, "p", 0, "/repo"); err == nil {
 				t.Fatal("an unusable pool entry must error, not silently use a default")
 			}
 		})
@@ -296,7 +296,7 @@ func TestReviewPromptNamesTheExactReviewerIDAndProtectsContractFiles(t *testing.
 func TestReviewerCommandGivesAgyThePromptAsThePrintValue(t *testing.T) {
 	argv, err := ReviewerCommand(ReviewerEntry{
 		ID: "agy/gemini-3.1-pro-high", Runner: "agy", Model: "gemini-3.1-pro-high",
-	}, "REVIEW-PROMPT", 0)
+	}, "REVIEW-PROMPT", 0, "/repo")
 	if err != nil {
 		t.Fatalf("building the agy command: %v", err)
 	}
@@ -320,7 +320,7 @@ func TestReviewerCommandGivesAgyThePromptAsThePrintValue(t *testing.T) {
 func TestReviewerCommandGivesPiThePromptAsATrailingPositional(t *testing.T) {
 	argv, err := ReviewerCommand(ReviewerEntry{
 		ID: "nan/x", Runner: "pi", Provider: "nan", Model: "x",
-	}, "REVIEW-PROMPT", 0)
+	}, "REVIEW-PROMPT", 0, "/repo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -355,7 +355,7 @@ func TestDefaultReviewerTimeoutIsBoundedFromBothSides(t *testing.T) {
 func TestReviewerCommandHonoursAnExplicitTimeoutAndTreatsZeroAsUnset(t *testing.T) {
 	e := ReviewerEntry{ID: "agy/y", Runner: "agy", Model: "y"}
 
-	custom, err := ReviewerCommand(e, "p", 90*time.Minute)
+	custom, err := ReviewerCommand(e, "p", 90*time.Minute, "/repo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,11 +363,79 @@ func TestReviewerCommandHonoursAnExplicitTimeoutAndTreatsZeroAsUnset(t *testing.
 		t.Errorf("an explicit timeout must reach the runner, got %q", got)
 	}
 
-	zero, err := ReviewerCommand(e, "p", 0)
+	zero, err := ReviewerCommand(e, "p", 0, "/repo")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got := argvValue(zero, "--print-timeout"); got != DefaultReviewerTimeout.String() {
 		t.Errorf("zero must mean the default, not an absent deadline, got %q", got)
+	}
+}
+
+// agy prompts for approval on every tool call. A detached reviewer has no human
+// to answer, so each call is auto-DENIED — and the failure does not look like
+// one: the observed run read a few files, was refused `git rev-parse HEAD`, and
+// stopped after 14 seconds while reporting `status: SUCCESS` with an empty
+// response and no review.md.
+//
+// Running the suite and mutating the code IS the review, so a reviewer that
+// cannot execute cannot review. pi needs no equivalent, which is precisely why a
+// configured fallback is not a proven one.
+func TestReviewerCommandLetsAgyActWithoutAHumanToApprove(t *testing.T) {
+	argv, err := ReviewerCommand(ReviewerEntry{
+		ID: "agy/gemini-3.1-pro-high", Runner: "agy", Model: "gemini-3.1-pro-high",
+	}, "p", 0, "/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if argvIndex(argv, "--dangerously-skip-permissions") < 0 {
+		t.Fatal("a detached agy reviewer cannot answer permission prompts, so every tool call is denied")
+	}
+}
+
+// Without --add-dir, agy runs its shell commands in its OWN install directory:
+// `pwd` answers ~/.gemini/antigravity-cli and `git rev-parse HEAD` fails with
+// "not a git repository". A reviewer that cannot reach the tree cannot run the
+// suite or mutate anything — it reviews by reading and grades generously, which
+// is precisely what the first Gemini review did (all A's, one SPECULATIVE Minor,
+// no independent verification).
+//
+// This is the difference between a fallback that produces an artifact and one
+// that produces a review.
+func TestReviewerCommandGivesAgyReachIntoTheRepo(t *testing.T) {
+	argv, err := ReviewerCommand(ReviewerEntry{
+		ID: "agy/gemini-3.1-pro-high", Runner: "agy", Model: "gemini-3.1-pro-high",
+	}, "p", 0, "/repo/root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := argvValue(argv, "--add-dir"); got != "/repo/root" {
+		t.Fatalf("agy must be given the repo as a workspace or it cannot execute in it, got %q", got)
+	}
+	// The auto-approval above is bounded rather than bare. Verified not to cost
+	// the review anything: git, `go test` and file writes all work under it.
+	if argvIndex(argv, "--sandbox") < 0 {
+		t.Error("unattended auto-approval should run inside the sandbox")
+	}
+	// --print must still be last, or it consumes a flag as the prompt.
+	if i := argvIndex(argv, "--print"); i != len(argv)-2 {
+		t.Fatalf("--print must remain the final flag, at %d of %d", i, len(argv))
+	}
+}
+
+// pi needs neither flag: it runs in the caller's directory and asks for no
+// approval. The arms differ, and pretending otherwise is what produced two
+// silent failures in this one already.
+func TestReviewerCommandDoesNotGivePiAgySpecificFlags(t *testing.T) {
+	argv, err := ReviewerCommand(ReviewerEntry{
+		ID: "nan/x", Runner: "pi", Provider: "nan", Model: "x",
+	}, "p", 0, "/repo/root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, flag := range []string{"--add-dir", "--sandbox", "--dangerously-skip-permissions"} {
+		if argvIndex(argv, flag) >= 0 {
+			t.Errorf("pi must not receive agy's %s", flag)
+		}
 	}
 }

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -25,7 +25,7 @@ date order). Regenerate after adding entries with:
 awk '/^## Entries$/,0' docs/lessons.md | grep '^### \[' | sed -E 's/^### \[([0-9-]+)\] (.*)$/- [\1] \2/'
 ```
 
-<!-- Generated 2026-08-14; 200 entries at last regen. -->
+<!-- Generated 2026-08-14; 201 entries at last regen. -->
 
 - [2026-08-10] Go's exec.LookPath is blind to extensionless scripts on Windows
 - [2025-12-15] echo -e breaks in zsh
@@ -227,6 +227,7 @@ awk '/^## Entries$/,0' docs/lessons.md | grep '^### \[' | sed -E 's/^### \[([0-9
 - [2026-08-13] A PR's `head.sha` not matching your latest push can mean the PR is already merged, not that the API is lagging
 - [2026-08-13] A default is not a pin: the model that reviewed your code may not be the one you think
 - [2026-08-14] A dormant declared field must be validated on the same schedule it's written, not the schedule it activates on
+- [2026-08-14] An agent that cannot reach the repo still writes a confident review
 
 ---
 
@@ -2350,3 +2351,15 @@ The blast radius was also wider than the one function: because `compile-harness.
 **Rule**: when a schema pre-declares a field that activates later (a dormant `bw:` block, a feature flag's config, a "coming soon" API shape already being written to storage), validate it at write time — the moment a human or a pipeline can put a bad value in — not at activation time. Gating a check on "is this live yet" optimizes for the code path that runs least; the value sits wrong and silent through every state before it, and the state that finally reads it is usually the one where failing loud is most expensive (a live side effect, not a parse error). If existing code already gates a sibling check the same way, that's precedent, not proof it's correct — check what the gated-out state can actually reach before reusing the pattern.
 
 **Tags**: `secrets`, `bitwarden`, `validation`, `spec-driven-development`, `adversarial-review`
+
+### [2026-08-14] An agent that cannot reach the repo still writes a confident review
+
+**Context**: HARNESS-071 (#955) added a reviewer pool and `dotf spec review`, with `agy/gemini-3.1-pro-high` as the non-Anthropic fallback beside `nan/deepseek-v4-flash`. The spec's acceptance criterion demanded each configured arm produce a *real review*, on the grounds that a fallback never observed working is decoration (#898).
+
+**Problem**: the Gemini arm failed three times, and **every failure presented as success**. (1) `agy --print` consumes a value, so `agy --print --model X … "<prompt>"` made `--print` swallow `--model`: the model went unset, the prompt was orphaned, and agy replied with a session greeting at exit 0. (2) agy prompts for approval on every tool call, and a detached run has no human to answer — every call was auto-*denied*, and the run stopped after 14 seconds reporting `{"status":"SUCCESS","response":""}`. (3) Worst: agy runs its shell commands in its **own install directory**, not the caller's — `pwd` answered `~/.gemini/antigravity-cli` and `git rev-parse HEAD` failed with "not a git repository". That run wrote a *well-formed* `review.md`: correct frontmatter, correct spec id, correct self-reported reviewer, verdict PASS. It would have passed the archive gate. And it had not executed a single test.
+
+**Solution**: `--dangerously-skip-permissions` (a detached reviewer cannot answer prompts), `--sandbox` (bounds what that approval reaches — verified to cost nothing: git, `go test` and file writes all work under it), and `--add-dir <repoRoot>`, isolated as the fix for the reach problem: with it alone `pwd` resolves to the repo, git resolves the right sha, and the suite runs from inside the reviewer. `pi` needs none of the three, so the two arms are pinned apart by tests in both directions rather than "unified".
+
+**Rule**: when delegating work to another agent, verify it can *reach and act on* the target before trusting anything it returns — a well-formed artifact is evidence about the agent's formatting, not about its access. The tell was in the output all along: an all-A rubric, one speculative finding restating someone else's, nothing independently verified. Treat a suspiciously agreeable review as a **capability** symptom first and a judgement symptom second. And prove reach with the cheapest possible probe (`pwd`, `git rev-parse`, one real command) before spending twenty minutes on a review whose conclusions you cannot use.
+
+**Tags**: `ai-tooling`, `verification`, `adversarial-review`, `delegation`


### PR DESCRIPTION
Refs #955. Fix-forward for three commits that missed #959's squash-merge.

## Why this exists

The fixes were pushed after #959 had already been merged, so they never reached main. Verified **by content**, not by `--is-ancestor` — a squash-merge always answers that wrongly:

```
add-dir                       MISSING from main
dangerously-skip-permissions  MISSING from main
sandbox                       MISSING from main
DefaultReviewerTimeout        IN MAIN
```

Same shape as the HARNESS-070 lesson already in `docs/lessons.md`.

## What was broken

All three were found by actually running the Gemini fallback arm, and **all three presented as success** — which is why no smoke test would have caught them.

| # | Defect | How it looked |
|---|---|---|
| 1 | agy prompts for approval on every tool call; detached there is no human, so every call is auto-**denied** | stopped after 14s reporting `{"status":"SUCCESS","response":""}`, no review written |
| 2 | **agy runs its shell commands in its own install directory, not the repo** | wrote a well-formed `review.md` that would have passed the gate — while unable to run a single test |
| 3 | auto-approval was unbounded | — |

The second is the one worth reading twice. `pwd` answered `~/.gemini/antigravity-cli` and `git rev-parse HEAD` failed with *"not a git repository"*, with or without `--sandbox`. The reviewer could not reach the tree it was reviewing, so it reviewed by reading: all A's on the rubric, one SPECULATIVE Minor restating a finding CodeRabbit had already made, nothing independently verified. **The weak verdict was the symptom; the unreachable repo was the cause.**

## The fix, isolated

`--add-dir <repoRoot>` alone resolves it — verified in isolation:

```
pwd                          → /home/manu/Projects/dotfiles-wt-review
git rev-parse --short HEAD   → ae08296        (the right sha)
go -C cli test ./internal/spec/  → ok          (from inside the reviewer)
```

`--sandbox` bounds what the auto-approval can touch, and was verified to cost the review nothing: git, `go test` and file writes all work under it.

`pi` receives none of the three — it already runs in the caller's directory and asks for no approval. Tests pin the difference **in both directions**, so an edit that "unifies" the arms breaks a test rather than a reviewer.

## Verification

- `go build`, `go vet`, `go test ./...` — all packages ok
- `golangci-lint run` → 0 issues on the pinned 2.12.2
- `GOOS=windows go build ./...` clean

## What this still does not prove

AC7 remains open on #955. Gemini has now produced a review artifact, but it produced it **blind** — before this fix it could not execute anything. A review that could not run the suite is not the "real review" the criterion asks for. The honest next step is one more run with these flags in place, and reading what it finds when it can actually reach the tree.
