### PR TITLE
fix(shell): scope the agent secret wrappers with --only, and stop wrapping agy

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -75,15 +75,25 @@ export NAN_BASE_URL="https://api.nan.builders/v1"
 
 # Secrets are NOT auto-loaded into the ambient shell (ADR-028 "not always
 # exposed"). On demand: `dotf secrets run -- <cmd>` injects the decrypted secrets
-# into that child process only. The AI CLIs that read their keys from the
-# environment are wrapped to launch through it, so the secret lives only in their
-# process, never this shell. No `--only` -> full mapped set (parity with the old
-# ambient export). Recursion-safe: dotf resolves the real binary on PATH, not
-# this function.
+# into that child process only, so a key lives in the agent's process and never
+# in this shell. Recursion-safe: dotf resolves the real binary on PATH, not this
+# function.
+#
+# Each wrapper is scoped with `--only`, and the scope is load-bearing. The
+# unscoped form resolved the WHOLE registry on every launch — deliberate parity
+# with the old ambient export, and free while every secret was age-backed, which
+# is a local decrypt in milliseconds. After the Bitwarden migration (#961) each
+# resolution is a `bw` shell-out at ~1.5s, so an unscoped launch paid ~45s of
+# latency before the agent started, and died on the first locked entry even when
+# the agent had no use for it (#976). Scoping is least privilege and startup
+# time at once.
 if command -v dotf >/dev/null 2>&1; then
-    opencode() { dotf secrets run -- opencode "$@"; }
-    pi() { dotf secrets run -- pi "$@"; }
-    agy() { dotf secrets run -- agy "$@"; }
+    opencode() { dotf secrets run --only NAN_API_KEY,OPENROUTER_API_KEY,OPENAI_API_KEY -- opencode "$@"; }
+    pi() { dotf secrets run --only NAN_API_KEY,OPENROUTER_API_KEY -- pi "$@"; }
+    # agy is deliberately NOT wrapped. It authenticates with its own stored
+    # credentials and reads no variable this registry exposes — verified against
+    # both its settings files and the strings of the binary itself. Wrapping it
+    # injected nothing and cost a full registry resolution per launch.
 fi
 export APPS_HOME="$HOME/Applications"
 export NINJA_HOME="$HOME/.console-ninja"

--- a/.zshrc
+++ b/.zshrc
@@ -53,15 +53,25 @@ export NAN_BASE_URL="https://api.nan.builders/v1"
 
 # Secrets are NOT auto-loaded into the ambient shell (ADR-028 "not always
 # exposed"). On demand: `dotf secrets run -- <cmd>` injects the decrypted secrets
-# into that child process only. The AI CLIs that read their keys from the
-# environment are wrapped to launch through it, so the secret lives only in their
-# process, never this shell. No `--only` -> full mapped set (parity with the old
-# ambient export). Recursion-safe: dotf resolves the real binary on PATH, not
-# this function.
+# into that child process only, so a key lives in the agent's process and never
+# in this shell. Recursion-safe: dotf resolves the real binary on PATH, not this
+# function.
+#
+# Each wrapper is scoped with `--only`, and the scope is load-bearing. The
+# unscoped form resolved the WHOLE registry on every launch — deliberate parity
+# with the old ambient export, and free while every secret was age-backed, which
+# is a local decrypt in milliseconds. After the Bitwarden migration (#961) each
+# resolution is a `bw` shell-out at ~1.5s, so an unscoped launch paid ~45s of
+# latency before the agent started, and died on the first locked entry even when
+# the agent had no use for it (#976). Scoping is least privilege and startup
+# time at once.
 if command -v dotf >/dev/null 2>&1; then
-    opencode() { dotf secrets run -- opencode "$@"; }
-    pi() { dotf secrets run -- pi "$@"; }
-    agy() { dotf secrets run -- agy "$@"; }
+    opencode() { dotf secrets run --only NAN_API_KEY,OPENROUTER_API_KEY,OPENAI_API_KEY -- opencode "$@"; }
+    pi() { dotf secrets run --only NAN_API_KEY,OPENROUTER_API_KEY -- pi "$@"; }
+    # agy is deliberately NOT wrapped. It authenticates with its own stored
+    # credentials and reads no variable this registry exposes — verified against
+    # both its settings files and the strings of the binary itself. Wrapping it
+    # injected nothing and cost a full registry resolution per launch.
 fi
 export APPS_HOME="$HOME/Applications"
 export NINJA_HOME="$HOME/.console-ninja"

--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -237,14 +237,25 @@ $env:NAN_BASE_URL = 'https://api.nan.builders/v1'
 
 # Secrets are NOT auto-loaded into the ambient session (ADR-028 "not always
 # exposed"). On demand: `dotf secrets run -- <cmd>` injects the decrypted secrets
-# into that child process only. The AI CLIs that read their keys from the
-# environment are wrapped to launch through it, so the secret lives only in their
-# process, never this session. Recursion-safe: dotf resolves the real binary on
-# PATH, not this function.
+# into that child process only, so a key lives in the agent's process and never
+# in this session. Recursion-safe: dotf resolves the real binary on PATH, not
+# this function.
+#
+# Each wrapper is scoped with `--only`, and the scope is load-bearing. The
+# unscoped form resolved the WHOLE registry on every launch: deliberate parity
+# with the old ambient export, and free while every secret was age-backed, which
+# is a local decrypt in milliseconds. After the Bitwarden migration (#961) each
+# resolution is a `bw` shell-out at ~1.5s, so an unscoped launch paid ~45s of
+# latency before the agent started, and died on the first locked entry even when
+# the agent had no use for it (#976). Scoping is least privilege and startup
+# time at once.
 if (Get-Command dotf -ErrorAction SilentlyContinue) {
-    function opencode { dotf secrets run -- opencode @args }
-    function pi { dotf secrets run -- pi @args }
-    function agy { dotf secrets run -- agy @args }
+    function opencode { dotf secrets run --only NAN_API_KEY,OPENROUTER_API_KEY,OPENAI_API_KEY -- opencode @args }
+    function pi { dotf secrets run --only NAN_API_KEY,OPENROUTER_API_KEY -- pi @args }
+    # agy is deliberately NOT wrapped. It authenticates with its own stored
+    # credentials and reads no variable this registry exposes, verified against
+    # both its settings files and the strings of the binary itself. Wrapping it
+    # injected nothing and cost a full registry resolution per launch.
 }
 
 # ============================================================================


### PR DESCRIPTION
`pi` started taking ~45s to launch, or hanging until interrupted. The keys were correct;
the launch path was not.

## Cause

The wrappers ran `dotf secrets run -- <agent>` with **no `--only`**, so each launch
resolved the whole registry. That was deliberate — the comment read *"No `--only` -> full
mapped set (parity with the old ambient export)"* — and it was free while every secret was
age-backed: a local decrypt, milliseconds. #961 moved 28 secrets to Bitwarden, where a
resolution is a `bw` shell-out at ~1.5-1.7s (measured on #585). The same unchanged line
went from ~0ms to ~45s per launch. On a locked vault it fails on the *first* locked entry,
which is why the reported error names `github-bitacora-pat` — a secret `pi` never uses.

Root cause is #976: the migration changed an availability contract while being reviewed as
a storage change.

## Scope, derived from what each agent reads

Not from the registry's `consumers:` field, which is already demonstrably stale — it lists
`OPENROUTER_API_KEY` for opencode only, while `~/.pi/agent/settings.json` enables
`openrouter/*` models.

| wrapper | scope | resolutions |
|---|---|---|
| `pi` | `NAN_API_KEY,OPENROUTER_API_KEY` | 28 -> 2 |
| `opencode` | `NAN_API_KEY,OPENROUTER_API_KEY,OPENAI_API_KEY` | 28 -> 3 |
| `agy` | **unwrapped** | 28 -> 0 |

`agy` authenticates with its own stored credentials and reads no variable this registry
exposes — verified against its settings files **and** the strings of the binary, rather
than inferred from metadata. It was paying a full registry resolution to be handed nothing.

`opencode.jsonc` references `{env:OLLAMA_API_KEY}`, which is not a registry id. Left out of
the scope deliberately: naming an unknown id to `--only` is an error, and adding it to the
registry is a separate decision.

## Verification

- `bash -n` and `zsh -n` over **both** rc files (each file checked in both shells).
- Added PowerShell lines are ASCII-only (the file's two pre-existing non-ASCII lines at
  117/121 are untouched).
- All three surfaces changed together — a Linux-only fix leaves Windows paying the same 45s.

**Wall-clock before/after is not included, and that is deliberate rather than an
oversight.** Measuring it requires an unlocked vault; the attempt made during this change
returned ~0.47s for both arms because the vault had re-locked and both were failing fast on
the first entry. Reporting those as a before/after would have been a measurement of the
error path. What is verified is the **resolution count**, which is counted, not estimated;
the wall-clock follows from #585's per-call figure. The live benchmark belongs with #975's
operator smoke test, which needs the same unlocked vault.

## Not fixed here

`dotf spec review` hard-wraps every runner in `dotf secrets run --` in Go
(`cli/internal/spec/review_launch.go`), so an adversarial review still pays the full
resolution. Deliberately untouched: it is HARNESS-071 territory and that spec's review of
record was running while this was written. Follow-up is an optional `secrets: []` per
reviewer-pool entry — absent means bare invocation, which is exactly `agy`'s case.

## SDD skip rationale

Configuration fix with a fully diagnosed root cause, pinned to the commit that caused it
(#961) and to the measured per-call cost that made it expensive. No production Go LOC, no
public contract, no new dependency. The behaviour change is three wrapper lines; everything
else in the diff is the comment explaining why the unscoped form was correct before and is
not now.

Refs #976
