### PR TITLE
fix(spec): store the review transcript's events, not its streaming frames (BUG-083, #995)

### DIFF
--- a/cli/internal/cmd/spec.go
+++ b/cli/internal/cmd/spec.go
@@ -30,6 +30,7 @@ func newSpecCmd() *cobra.Command {
 	cmd.AddCommand(newSpecInitCmd())
 	cmd.AddCommand(newSpecReviewCmd())
 	cmd.AddCommand(newSpecArchiveCmd())
+	cmd.AddCommand(newSpecTranscriptSinkCmd())
 	return cmd
 }
 
@@ -186,7 +187,7 @@ is the only record of how.`,
 
 			launch := argv
 			if useTmux {
-				launch = spec.TmuxWrap(session, repoRoot, argv, transcript)
+				launch = spec.TmuxWrap(session, repoRoot, argv, transcript, transcriptSink(transcript))
 			}
 
 			if dryRun {
@@ -221,6 +222,46 @@ is the only record of how.`,
 	cmd.Flags().DurationVar(&timeout, "timeout", spec.DefaultReviewerTimeout,
 		"how long the reviewer may run before it is killed; a stuck run should be noticed, not waited on")
 	return cmd
+}
+
+// newSpecTranscriptSinkCmd is plumbing, not a user command: `spec review` pipes
+// the reviewer into it. Hidden because nobody should need to type it, exposed as
+// a subcommand because the pipeline needs something executable to name.
+func newSpecTranscriptSinkCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "transcript-sink <path>",
+		Short:  "Internal: pass a reviewer stream through, storing only its auditable events",
+		Long: `Read a reviewer's jsonl stream on stdin, write every line to stdout, and
+store only the settled events at <path>.
+
+The live tmux pane wants every frame — the incremental deltas are the visible
+progress. The transcript on disk wants the events, because its purpose is that a
+finished review can be audited. One raw file cannot serve both: a real 25-minute
+review streamed 527 MB, of which 525 MB was the same message re-emitted at every
+growing length (#995).`,
+		Hidden: true,
+		Args:   cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return spec.SinkTranscript(cmd.InOrStdin(), cmd.OutOrStdout(), args[0])
+		},
+	}
+}
+
+// transcriptSink names the command the reviewer's stdout is piped into.
+//
+// It resolves THIS binary by absolute path rather than trusting `dotf` on PATH:
+// the pipeline runs detached under tmux, and a launcher built from one version
+// handing work to whatever `dotf` a $PATH happens to resolve is how a subcommand
+// that exists here goes missing there. Same binary in, same binary out.
+//
+// If the executable cannot be resolved, an empty sink tells TmuxWrap to fall
+// back to plain `tee` — a huge transcript beats a broken pipeline.
+var transcriptSink = func(transcript string) []string {
+	self, err := os.Executable()
+	if err != nil {
+		return nil
+	}
+	return []string{self, "spec", "transcript-sink", transcript}
 }
 
 // confirmLaunched turns "the session was created" into "the reviewer survived

--- a/cli/internal/spec/review_launch.go
+++ b/cli/internal/spec/review_launch.go
@@ -284,13 +284,20 @@ func ShellJoin(argv []string) string {
 // that can be audited while it happens and one that reports only at the end.
 // `-c dir` pins the working directory so the reviewer resolves the repo the same
 // way the launcher did.
-func TmuxWrap(session, dir string, argv []string, transcript string) []string {
+// sink is the command the reviewer's stdout is piped into; it must pass the
+// stream through and write the transcript itself. An empty sink falls back to
+// plain `tee`, which stores the raw stream — correct, just enormous (#995).
+func TmuxWrap(session, dir string, argv []string, transcript string, sink []string) []string {
+	store := "tee " + shellQuote(transcript)
+	if len(sink) > 0 {
+		store = ShellJoin(sink)
+	}
 	return []string{
 		"tmux", "new-session", "-d",
 		"-s", session,
 		"-c", dir,
 		ShellJoin(argv) +
 			" 2> " + shellQuote(StderrPath(transcript)) +
-			" | tee " + shellQuote(transcript),
+			" | " + store,
 	}
 }

--- a/cli/internal/spec/review_launch_test.go
+++ b/cli/internal/spec/review_launch_test.go
@@ -242,7 +242,7 @@ func TestWrappersQuoteAnArgumentThatWouldOtherwiseExecute(t *testing.T) {
 	// Single quotes cannot nest, so a literal ' becomes '\'' — close, escape, reopen.
 	want := `'text with '\''quotes'\'' and ` + "`backticks`" + ` and $(id)'`
 
-	argv := TmuxWrap("s", "/repo", []string{"echo", nasty}, "/tmp/t.jsonl")
+	argv := TmuxWrap("s", "/repo", []string{"echo", nasty}, "/tmp/t.jsonl", nil)
 	joined := argv[len(argv)-1]
 
 	if !strings.Contains(joined, want) {

--- a/cli/internal/spec/transcript.go
+++ b/cli/internal/spec/transcript.go
@@ -1,0 +1,98 @@
+package spec
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// The reviewer streams its work as jsonl. Two consumers want different things
+// from that stream and cannot share one file:
+//
+//   - the tmux pane, watched live, wants every frame — the incremental deltas
+//     ARE the visible progress;
+//   - the transcript on disk wants the settled events, because its purpose is
+//     that a finished review can be audited afterwards.
+//
+// Writing the raw stream to disk served the first and defeated the second.
+// Measured on a real 25-minute review: 527 MB, of which 525 MB was
+// `message_update` — the same message re-emitted at every growing length.
+// Keeping only settled events left 1.95 MB (0.37%) and 664 lines, which is a
+// file a human opens and a script greps (#995).
+//
+// So the sink passes everything through and filters only what it stores.
+
+// isIncrementalFrame reports whether a line is a partial frame on the way to an
+// event rather than an event. Anything unrecognised is KEPT: a line we cannot
+// parse is more likely a diagnostic worth having than noise worth dropping, and
+// this filter must never be the reason a failure left no trace.
+func isIncrementalFrame(line []byte) bool {
+	var ev struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(line, &ev); err != nil {
+		return false
+	}
+	return ev.Type == "message_update" || strings.HasSuffix(ev.Type, "_delta")
+}
+
+// SinkTranscript copies in to out verbatim while writing only the auditable
+// events to path. It is the `tee` of the reviewer pipeline, with the storage
+// side filtered.
+//
+// Errors writing the transcript do not stop the passthrough: the review itself
+// is the valuable thing in flight, and losing its live output because a file
+// could not be written would trade a large problem for a larger one.
+func SinkTranscript(in io.Reader, out io.Writer, path string) (err error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("opening the transcript for writing: %w", err)
+	}
+	// Close is checked, not deferred blindly: on a buffered file it is where a
+	// short write finally surfaces, and swallowing it would mean reporting a
+	// complete transcript we did not finish writing — the failure mode this
+	// whole file exists to stop.
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing the transcript: %w", cerr)
+		}
+	}()
+
+	// bufio.Reader, not Scanner: a single settled message can exceed any token
+	// cap we would pick, and Scanner turns that into an error that truncates
+	// the stream. ReadString has no such ceiling.
+	r := bufio.NewReader(in)
+	w := bufio.NewWriter(f)
+
+	var storeErr error
+	for {
+		line, readErr := r.ReadString('\n')
+		if line != "" {
+			if _, err := io.WriteString(out, line); err != nil {
+				return fmt.Errorf("passing the reviewer stream through: %w", err)
+			}
+			if storeErr == nil && !isIncrementalFrame([]byte(strings.TrimRight(line, "\n"))) {
+				if _, err := w.WriteString(line); err != nil {
+					storeErr = err
+				}
+			}
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			return fmt.Errorf("reading the reviewer stream: %w", readErr)
+		}
+	}
+	if ferr := w.Flush(); ferr != nil && storeErr == nil {
+		storeErr = ferr
+	}
+	if storeErr != nil {
+		return fmt.Errorf("writing the transcript: %w", storeErr)
+	}
+	return nil
+}

--- a/cli/internal/spec/transcript_test.go
+++ b/cli/internal/spec/transcript_test.go
@@ -1,0 +1,102 @@
+package spec
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The sink has two jobs that pull in opposite directions: the pane must see
+// everything, the file must stay auditable. Both are asserted on one run.
+func TestSinkTranscriptPassesEverythingThroughButStoresOnlyEvents(t *testing.T) {
+	in := strings.NewReader(strings.Join([]string{
+		`{"type":"message_start"}`,
+		`{"type":"message_update","text":"partial"}`,
+		`{"type":"thinking_delta","text":"more"}`,
+		`{"type":"message_end","text":"settled"}`,
+	}, "\n") + "\n")
+
+	var pane bytes.Buffer
+	path := filepath.Join(t.TempDir(), "t.jsonl")
+	if err := SinkTranscript(in, &pane, path); err != nil {
+		t.Fatalf("SinkTranscript: %v", err)
+	}
+
+	for _, want := range []string{"message_start", "message_update", "thinking_delta", "message_end"} {
+		if !strings.Contains(pane.String(), want) {
+			t.Errorf("the live pane must see every frame, %q is missing:\n%s", want, pane.String())
+		}
+	}
+
+	stored, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, dropped := range []string{"message_update", "thinking_delta"} {
+		if strings.Contains(string(stored), dropped) {
+			t.Errorf("%q is an incremental frame and must not be stored:\n%s", dropped, stored)
+		}
+	}
+	for _, keep := range []string{"message_start", "message_end"} {
+		if !strings.Contains(string(stored), keep) {
+			t.Errorf("%q is a settled event and must be stored:\n%s", keep, stored)
+		}
+	}
+}
+
+// A line the filter cannot parse is kept. The filter must never be the reason a
+// failure left no trace — dropping the unrecognised is how a diagnostic
+// disappears exactly when it matters.
+func TestSinkTranscriptKeepsUnparseableLines(t *testing.T) {
+	in := strings.NewReader("Error: bw resolve dockerhub/password: not found\n{\"type\":\"message_update\"}\n")
+
+	var pane bytes.Buffer
+	path := filepath.Join(t.TempDir(), "t.jsonl")
+	if err := SinkTranscript(in, &pane, path); err != nil {
+		t.Fatalf("SinkTranscript: %v", err)
+	}
+
+	stored, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(stored), "bw resolve dockerhub/password") {
+		t.Errorf("a non-JSON line must survive into the transcript:\n%s", stored)
+	}
+}
+
+// A settled message can be larger than any token cap a scanner would pick; the
+// sink must not truncate the stream on one.
+func TestSinkTranscriptHandlesAVeryLongLine(t *testing.T) {
+	huge := `{"type":"message_end","text":"` + strings.Repeat("x", 4<<20) + `"}`
+	in := strings.NewReader(huge + "\n")
+
+	var pane bytes.Buffer
+	path := filepath.Join(t.TempDir(), "t.jsonl")
+	if err := SinkTranscript(in, &pane, path); err != nil {
+		t.Fatalf("SinkTranscript on a 4 MB line: %v", err)
+	}
+
+	stored, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stored) < 4<<20 {
+		t.Errorf("the long settled event was truncated: stored %d bytes", len(stored))
+	}
+}
+
+// TmuxWrap falls back to plain tee when no sink is available: an oversized
+// transcript is a defect, a broken pipeline is an outage.
+func TestTmuxWrapFallsBackToTeeWithoutASink(t *testing.T) {
+	withSink := TmuxWrap("s", "/repo", []string{"pi"}, "/tmp/t.jsonl", []string{"/usr/bin/dotf", "spec", "transcript-sink", "/tmp/t.jsonl"})
+	if !strings.Contains(withSink[len(withSink)-1], "transcript-sink") {
+		t.Errorf("a supplied sink must be used:\n%s", withSink[len(withSink)-1])
+	}
+	fallback := TmuxWrap("s", "/repo", []string{"pi"}, "/tmp/t.jsonl", nil)
+	if !strings.Contains(fallback[len(fallback)-1], "tee ") {
+		t.Errorf("without a sink the pipeline must still store the transcript:\n%s", fallback[len(fallback)-1])
+	}
+}


### PR DESCRIPTION
Closes #995.

The transcript exists so that *how* a review reasoned is auditable, not only its conclusion (HARNESS-071). At 527 MB it delivered the opposite: nothing a human opens, nothing a script greps cheaply. The artifact existed and the property did not.

## Measured, on the HARNESS-072 review — a real 25-minute run

```
527.2 MB total
525.2 MB of it "message_update"
43391 lines
```

`message_update` is the same message re-emitted at every growing length, so the file was one text written hundreds of times. `pi` has no non-streaming mode (`--mode` offers text/json/rpc only), so the fix is downstream.

## The shape of the fix

The two consumers of that stream want opposite things and cannot share a file:

- the **tmux pane**, watched live, wants every frame — the deltas *are* the visible progress;
- the **transcript on disk** wants settled events, because it is read after the fact.

So `spec transcript-sink` replaces `tee` in the pipeline: everything passes through to the pane, only events are stored.

```
527.2 MB -> 1.95 MB  (0.37%), 664 lines, 4.8s
```

**The audit property survives intact**, which is the whole point. All 70 of the reviewer's tool executions remain recoverable from the filtered file:

```json
{"command": "git rev-parse HEAD"}
```

— including the reach probe that #978 made the bar for distinguishing a real review from a blind one.

## Two deliberate conservatisms

**An unparseable line is kept.** Dropping the unrecognised is how a diagnostic disappears exactly when it matters; this filter must never be the reason a failure left no trace. Tested.

**The sink resolves via `os.Executable()`, not `dotf` on PATH.** The pipeline runs detached under tmux, and a launcher built from one version handing work to whatever `dotf` a `$PATH` resolves is how a subcommand that exists here goes missing there. If resolution fails, `TmuxWrap` falls back to plain `tee` — an oversized transcript beats a broken pipeline. Tested both ways.

## Evidence

- Round-trip against the **real 527 MB transcript**, twice, byte-identical output at 1.95 MB.
- 4 new tests: passthrough-vs-storage asserted on one run, unparseable line survives, a 4 MB single line is not truncated, tee fallback.
- `go build` · `go vet` · `go test ./...` ok · `golangci-lint` **pinned 2.12.2** — 0 issues.
- `errcheck` caught `f.Close`/`w.Flush` going unchecked; fixed rather than silenced. On a buffered file that is where a short write surfaces, and swallowing it would report a complete transcript we did not finish writing — the same class of lie this PR is about.

## SDD skip rationale

Bug fix with a measured cause, reproduced on real data before and after. No behaviour change to any user-facing command: `transcript-sink` is hidden plumbing that `spec review` pipes into, and the only observable difference is that the transcript it writes is 0.37% of its former size with the same auditable content. Opening a spec folder would also pull this into the archive-on-merge chain, which is the very pipeline being repaired.