### PR TITLE
docs(spec): record the HARNESS-072 review verdict and the lesson the session produced

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -231,6 +231,7 @@ awk '/^## Entries$/,0' docs/lessons.md | grep '^### \[' | sed -E 's/^### \[([0-9
 - [2026-08-14] Widening a shared return type is a change to every consumer, and Go's zero values hide the ones you missed
 - [2026-08-15] A check whose precondition the architecture forbids reports SKIP forever, and SKIP reads as nothing-to-check
 - [2026-08-15] A check that cannot fail the way you cite it
+- [2026-08-15] `bw status` answers for the CLI's session, not for the daemon your code actually uses
 
 ---
 
@@ -2401,3 +2402,15 @@ The blast radius was also wider than the one function: because `compile-harness.
 **Rule**: when a spec names a command as the mitigation for a risk, open the command and find the line that would fail. A check earns its citation by the question it actually asks, and the question is usually narrower than its name suggests — `--check` also cannot see a committed record trailing its vault source, because it is offline by design (ADR-013), which is how six stale records sat clean until someone ran `--refresh`. This is the `pattern-verification-fails-toward-unproven` family in its cheapest form: not a check that ran and lied, but a check that was never capable of the answer and was trusted for it anyway. The tell is a mitigation you can state but not demonstrate red.
 
 **Tags**: `harness`, `verification`, `spec-driven-development`, `ci`
+
+### [2026-08-15] `bw status` answers for the CLI's session, not for the daemon your code actually uses
+
+**Context**: every `bw`-backed secret was failing at once — `dotf secrets run -- true` died on `dockerhub`, and `dotf secrets verify` showed a wall of FAILED with `bw serve returned no parseable envelope: invalid character 'I'`. Looking for a single cause behind a mass failure, I ran `bw status`, got `{"status":"locked"}`, and reported the blocker as a locked vault needing the user's master password.
+
+**Problem**: the vault was not locked. ADR-028's runtime path does not go through the `bw` CLI's own session at all — `dotf secrets` resolves through the long-lived `bw serve` daemon, which holds a *separate* unlocked session. Both readings were true about different subjects, and the one I measured was not the one the failing code uses. A parallel session refuted it with the measurement I should have run: `dotf secrets run --only NAN_API_KEY -- true` exits 0 while unscoped resolution dies. The real cause was one broken item mapping killing an unscoped batch read (#985/#988), and "ask the user to unlock" would have fixed nothing while looking like progress — a plausible cause that explains the symptom is not the same as the cause.
+
+**Solution**: measure the path the failing code takes. `dotf secrets run --only <ID> -- true` exercises exactly the daemon, the mapping and the item that production uses; `bw status` exercises a CLI session nothing in ADR-028's hot path reads. When a mass failure has an obvious single explanation, prefer the probe that is *specific to one working element* over the one that reports global state — a scoped success falsifies "everything is down" in one command.
+
+**Rule**: before believing a diagnostic, name the subject it reports on and check it is the subject that is failing. Tools that front a daemon, a cache, a proxy or a pool almost always have two states — the client's and the server's — and the human-facing status command usually reports the client's, because that is the one it can see without asking. `git status` vs the remote, `docker ps` vs the daemon, `kubectl config` vs the cluster, `bw status` vs `bw serve`: same shape. The tell is a global explanation ("it's locked", "it's down") arriving before any single-element probe was tried.
+
+**Tags**: `secrets`, `bitwarden`, `diagnosis`, `verification`

--- a/specs/HARNESS-072-pr-stewardship/review.md
+++ b/specs/HARNESS-072-pr-stewardship/review.md
@@ -1,0 +1,75 @@
+---
+spec: "HARNESS-072-pr-stewardship"
+verdict: "PASS"
+reviewed_sha: "1320efa1b384c2d90023cf9b3e08bcada76bef73"
+reviewer: "nan/deepseek-v4-flash"
+date: "2026-08-15"
+---
+
+## Adversarial review
+
+**Scope**: HARNESS-072-pr-stewardship (PR #986, merged at 62d2e84)
+**Sources**: `specs/HARNESS-072-pr-stewardship/{proposal,tasks,verification}.md`, `features.json`, `harness/enforced/pr-stewardship.md`, `harness/manifest.json`, `scripts/compile-harness.sh`, `tests/compile-harness.bats`, `harness/skills/pr-review-triage/SKILL.md`, `AGENTS.md`, `ai/claude/CLAUDE.md`, `~/.claude/CLAUDE.md`, `~/.gemini/GEMINI.md`, `~/.codex/AGENTS.md`, vault `00_meta/patterns/pattern-change-lifecycle.md` (HEAD at 2e351f1a)
+
+### Spec and task alignment
+
+All 8 acceptance criteria are addressed by the implementation. The proposal, tasks, and verification form a coherent chain. Two tasks claim a scope discipline that does not fully hold (see Findings).
+
+### Verified evidence
+
+Run against the current tree at `1320efa` (a descendant of the merged PR commit `62d2e84`; spec contract files unchanged since `62d2e84`):
+
+| Check | Result | Command |
+|---|---|---|
+| 47/47 bats tests | ✅ | `bats tests/compile-harness.bats` |
+| shellcheck | ✅ | `shellcheck scripts/compile-harness.sh` |
+| `bash -n` | ✅ | `bash -n scripts/compile-harness.sh` |
+| `--check` no drift | ✅ exit 0 | `./scripts/compile-harness.sh --check` |
+| All 8 features pass | ✅ | `for i in 1..8; jq .verification features.json; bash -c "$cmd"` |
+| Vault section matches record | ✅ byte-identical | `diff /tmp/vault-section.md harness/enforced/pr-stewardship.md` |
+| AC2: 5 surfaces, 1 hit each | ✅ | `grep -c 'the disposition, not the waiting'` on AGENTS.md, ai/claude/CLAUDE.md, ~/.claude/CLAUDE.md, ~/.gemini/GEMINI.md, ~/.codex/AGENTS.md |
+| AC2: caps hold | ✅ | GEMINI 6503/12000, codex 6503/32768 (`wc -c`) |
+| Mutation: remove from inject → GAP | ✅ | `jq` removed pr-stewardship from ai/claude/CLAUDE.md inject, `--check` → `[GAP]` + exit 1; reverted clean |
+| No [AGENT-DRAFT] tags | ✅ | g[r]ep -rn AGENT-DRAFT specs/HARNESS-072/ → none |
+| Vault pattern present | ✅ | `grep -c "## PR Stewardship"` at vault HEAD (contains 2e351f1a) |
+| pr-review-triage body gh-only | ✅ | uses `gh pr checks`, `gh pr view`, `gh api`, `gh run view` — no Claude-specific primitives |
+| Reviewer-pool claim verified | ✅ | `harness/reviewer-pool.json` exists; `archive.go` calls `checkReviewGate`; spec-gate.yml enforces archive-on-merge |
+| Working tree clean | ✅ | `git status --short` → empty |
+
+### Findings
+
+| Severity | Reality | Area | Finding | Evidence | Test (named, or UNTESTED) | Fix location |
+|----------|---------|------|---------|----------|---------------------------|-------------|
+| Minor | REAL | .gitignore completeness | PR adds `specs/*/review-transcript.jsonl` but `review_launch.go`'s `StderrPath` also writes `.jsonl.stderr` | `git show 62d2e84:.gitignore` shows only the `.jsonl` line; `.stderr` file appeared untracked at session start. Fixed by a concurrent session in 1320efa (not yet on origin/main) | UNTESTED | code (already fixed as 1320efa; note that the fix is not yet on origin/main) |
+| Minor | REAL | Scope claim | tasks.md closing checklist: "[x] No unrelated changes in the diff — the record sync is its own commit". The diff (6252eba..62d2e84) includes `harness/skills/dispatching-parallel-agents/SKILL.md` (16 lines, reconciliation block — substantive unrelated content), `harness/agents/curator/AGENT.md` (owner field), `harness/skills/systematic-debugging/defense-in-depth.md` + `root-cause-tracing.md` (frontmatter). These are unavoidable vault-drift syncs (the PR author kept six others out at b678103), but the claim is inaccurate. | `git diff 6252eba..62d2e84 --stat` shows these files changed; the dispatching-parallel-agents change is a real feature addition (mandatory reconciliation block) unrelated to PR stewardship | UNTESTED | spec artifacts (correct the tasks.md claim to acknowledge the drift sync) |
+| Minor | THEORETICAL | Verification | features.json f2 checks only the 2 committed surfaces + doctrine.inject, not the 3 $HOME deployed surfaces that AC2 requires. The verification.md supplies session evidence for those, but the machine-readable check is weaker than the AC. | `jq '.[1].verification'` shows f2 checks AGENTS.md, ai/claude/CLAUDE.md, and doctrine.inject — not the agy/codex payloads. The grep on $HOME payloads confirms the sentence is present, but the f2 command would not fail if a deploy regressed | UNTESTED | tests (extend f2 to also check deployed surfaces, or document the proxy) |
+| Minor | THEORETICAL | Tests | `check_coverage`'s doctrine branch is untested by fixtures. The 3 bats tests use a manifest without a `doctrine` section. The real tree passes (pr-sizing is in doctrine.inject, coverage OK), but a regression wouldn't be caught. | `sed -n '851,880p' scripts/compile-harness.sh` shows the doctrine surface handling; the 3 bats tests use `write_two_surface_manifest` which has no doctrine section | UNTESTED | tests (add a 4th bats test with a doctrine surface) |
+
+### Evaluator rubric
+
+| Dimension | Grade (A-D) | Rationale (one line) |
+|-----------|-------------|----------------------|
+| Correctness | B | All acceptance criteria verified; negative paths covered (AC8's partial-injection case proven by 3 bats tests + real-tree mutation). Minor gap: middle-ground opt_out interpretations (e.g., a truthful but misleading opt_out reason) are not tested — but that's a human judgement, not a mechanical gap. |
+| Verification | B | Evidence is thorough and mostly reproducible (commands + outputs). AC2's $HOME payload evidence is session-dependent but verifiable. Features.json f2 is a proxy for the full AC2. One lesson captured in docs/lessons.md. |
+| Scope | B | Diff is focused on the spec. The vault-drift sync (dispatching-parallel-agents reconciliation block, curator owner field, sysdebug frontmatter) is unavoidable generated-file drift, but the tasks.md claim contradicts the diff. |
+| Reliability | B | Error paths handled (GAP messages, DRIFT detection, exit codes). The coverage guard is idempotent. The "ten minutes" default is acknowledged as a guess — the mitigation (demotion to default mechanism) is sound. |
+| Maintainability | A | `check_coverage` is a clean 30-line function with a WHY comment explaining the blind spot it exists for. 3 bats tests are clear with comments. Region text is terse. The lesson in `docs/lessons.md` is comprehensive. |
+| Handoff-readiness | B | Spec updates included (tasks.md, verification.md, archive checklist). Lesson captured in docs/lessons.md. The "six stale records" finding is documented. Minor: the scope claim in tasks.md is inaccurate. |
+
+### Verdict
+
+**PASS**
+
+- No **Blocker** or **Major** findings. All findings are **Minor**.
+- **No C or D** in any rubric dimension. All grades are B or above.
+- The coverage guard (`check_coverage`) is the spec's most important contribution and works correctly on the real tree (verified by mutation test).
+- The region text is injected into all 5 surfaces, satisfies all acceptance criteria, and matches the vault source byte-for-byte.
+- The pr-review-triage skill is correctly updated to cover the reviewer bot.
+- The `dotf spec archive` gate is `advisable` in the current state — the spec meets the mechanical requirements for archiving.
+
+### Recommended next steps (before archive)
+
+1. **Correct the tasks.md scope claim** — the diff does contain unrelated generated-record syncs (dispatching-parallel-agents reconciliation block, curator owner field, sysdebug frontmatter). Acknowledge them as unavoidable vault-drift syncs rather than claiming "no unrelated changes".
+2. **(Optional) Add a 4th bats test** — exercise `check_coverage`'s doctrine surface branch with a fixture manifest that includes a `doctrine` section.
+3. **(Optional) Extend f2** — have the features.json verification command also confirm the $HOME doctrine payloads are grep-positive, or document that f2 is a proxy for the committed-world subset.
+4. **Note the .gitignore .stderr gap** — the `.stderr` companion is not yet ignored on `origin/main` (the fix at 1320efa is on a fix branch, not merged). If the spec is archived before that fix lands, the next `dotf spec review` run will leave an untracked `.stderr` file.


### PR DESCRIPTION
Refs #963 — deliberately not a closing keyword. #963 closes when the spec archives, which is the follow-up this PR makes possible.

Docs only. Two records from one session, both of which would otherwise be lost.

## 1. The adversarial review verdict

**PASS** from `nan/deepseek-v4-flash` against `1320efa`, and a *real* review rather than a well-formed artifact — the distinction #978 was fought over. It ran the eight `features.json` commands, the 47 bats tests, shellcheck, `--check`, diffed the vault section against the committed record byte-for-byte, and grepped all five deployed surfaces. Its transcript contains the `git rev-parse HEAD` reach probe that #978 made the bar.

It is committed because a 25-minute run was living untracked in a worktree, and it took three blocked attempts across the session to obtain: the launcher announced a dead run as a live one (#989, fixed in #994) while the real cause was unscoped secret resolution (#985/#988).

**Four Minor findings, none blocking, to be dispositioned before the archive:**

| # | Finding | Status |
|---|---|---|
| 1 | `.gitignore` missed the `.stderr` sibling | **fixed** in #994 |
| 2 | `tasks.md` claims "no unrelated changes" while six vault-drift record syncs rode along | to fix in the archive PR |
| 3 | `features.json` f2 is weaker than AC2 — checks the two committed surfaces and `doctrine.inject`, not the three deployed `$HOME` payloads | to fix in the archive PR |
| 4 | `check_coverage`'s doctrine branch has no fixture, so a regression there is uncaught | to fix in the archive PR |

Findings 2-4 are fair and land in the archive PR rather than here, so this stays a record and not a mixed change.

## 2. The lesson

`bw status` reported `locked` and I called the vault locked. It was not: ADR-028's runtime path resolves through the `bw serve` daemon, which held a *separate* unlocked session. Both readings were true about different subjects, and the one I measured was not the one the failing code uses — the remediation I was about to ask the user for would have fixed nothing while looking like progress.

Generalised past bitwarden, because the shape recurs: `git status` vs the remote, `docker ps` vs the daemon, `kubectl config` vs the cluster. Anything fronting a daemon, cache, proxy or pool has two states, and the human-facing status command reports the client's — the one it can see without asking. The tell is a global explanation ("it's locked") arriving before any single-element probe was tried.