### PR TITLE
fix(doctor): key DR escrow severity to real exposure, not a flat policy

### DIFF
--- a/cli/internal/doctor/checks_dr.go
+++ b/cli/internal/doctor/checks_dr.go
@@ -66,7 +66,7 @@ func reportAbsentEscrow(rep *Report, escrow string, live int, regErr error) {
 		return
 	}
 	if live > 0 {
-		// The count carries the argument. "No backup" is abstract; "26 secrets
+		// The count carries the argument. "No backup" is abstract; "28 secrets
 		// exist only on a remote server you do not control" is what makes an
 		// operator act.
 		//
@@ -122,8 +122,19 @@ func checkDisasterRecovery(sys *System, cfg *Config, rep *Report) {
 
 	escrow := filepath.Join(cfg.DotfilesDir, "sensitive", "dr", "bitwarden-export.age")
 	switch info, err := os.Stat(escrow); {
-	case err != nil:
+	case os.IsNotExist(err):
 		reportAbsentEscrow(rep, escrow, live, regErr)
+	case err != nil:
+		// A stat error is NOT proof of absence, and the distinction only started
+		// to matter with this change: as a SKIP, treating "cannot read" as
+		// "not there" was harmless, but as a FAIL it asserts something the check
+		// never established — "these 28 secrets have no local copy" — when the
+		// escrow may be sitting right there behind a permission or I/O error.
+		// Claiming an unverified fact is the exact failure this whole check
+		// exists to stop, so it must not be committed in the fix for it.
+		rep.Warn(fmt.Sprintf(
+			"cannot inspect DR escrow at %s (%v) — neither its presence nor its freshness was established",
+			escrow, err))
 	case sys.Now().Sub(info.ModTime()) > escrowMaxAge:
 		rep.Warn(fmt.Sprintf("DR escrow is %d days old — re-run `dotf secrets backup`; secrets added since are not in it",
 			int(sys.Now().Sub(info.ModTime()).Hours()/24)))

--- a/cli/internal/doctor/checks_dr.go
+++ b/cli/internal/doctor/checks_dr.go
@@ -35,16 +35,95 @@ func drillMarkerPath(cfg *Config) string {
 	return filepath.Join(cfg.DotfilesDir, ".dr-drill")
 }
 
+// reportAbsentEscrow renders the missing-escrow state at the severity its real
+// exposure earns: `live` is how many registry entries resolve through Bitwarden,
+// and regErr is non-nil when the registry could not be read to find out.
+//
+// Split out from checkDisasterRecovery so the severity rule — the whole point of
+// #997 — is testable on its own, the same way checkBWSyncAge is split out of the
+// reach check.
+//
+// No rep.Fix here, deliberately: this check performs no repair, and the
+// neighbouring reach check documents what happens when a remediation string is
+// emitted as a Fix — a read-only run reports "Applied 1 fix action(s)" for a
+// repair that never happened. The command belongs in the message.
+func reportAbsentEscrow(rep *Report, escrow string, live int, regErr error) {
+	if regErr != nil {
+		// Exposure is UNKNOWN, and the two wrong answers are both tempting.
+		//
+		// Silence (the reach check's "degrade to advisory, treat as unexposed")
+		// would emit a SKIP reading "nothing depends on it" — precisely the
+		// sentence #997 exists to delete, now printed on a machine where it was
+		// never checked. FAIL would go red from any healthy machine: env.RepoDir
+		// falls back to a cwd walk-up for .git, so `dotf doctor` from inside any
+		// other git repo lands here, and a doctor that is red where nothing is
+		// wrong is one nobody reads.
+		//
+		// So: audible, but honest about what it does not know.
+		rep.Warn(fmt.Sprintf(
+			"no DR escrow at %s, and the registry could not be read (%v) — cannot tell whether any secret depends on it",
+			escrow, regErr))
+		return
+	}
+	if live > 0 {
+		// The count carries the argument. "No backup" is abstract; "26 secrets
+		// exist only on a remote server you do not control" is what makes an
+		// operator act.
+		//
+		// The BW_SESSION form is named plainly, because for `backup` it is not a
+		// workaround — it is the invocation, permanently.
+		//
+		// Everything else in the write path is moving to the bw serve daemon
+		// (#993), and it was tempting to phrase this as "broken until that
+		// lands". It is not: `bw serve`'s router exposes /status, /sync, /unlock,
+		// /lock, /generate, /list/object/:object, /object/:object[/:id],
+		// /attachment, /move, /send/*, /device-approval/* — and no export route
+		// at all. The only "/export" in the shipped bundle is an ORGANIZATION
+		// export against the cloud API, not a personal-vault serve route. So
+		// `bw export` has no daemon path to migrate to, and this command will
+		// need a CLI session for as long as that remains true. Citing #993 here
+		// would have made the message wrong the day #993 merged.
+		rep.Fail(fmt.Sprintf(
+			"no DR escrow at %s — %d secret(s) resolve through Bitwarden and have no local copy, "+
+				"so the remote account is their only copy; create one with "+
+				"`BW_SESSION=\"$(bw unlock --raw)\" dotf secrets backup` "+
+				"(the export path has no bw serve endpoint, so it needs a CLI session)",
+			escrow, live))
+		return
+	}
+	// Nothing resolves through Bitwarden yet: every secret still has its age
+	// copy on disk, so the escrow is a convenience and its absence costs
+	// nothing. Staying quiet here is what keeps the FAIL above credible.
+	rep.Skip("no DR escrow at " + escrow + " — no secret resolves through Bitwarden yet, so nothing depends on it")
+}
+
 func checkDisasterRecovery(sys *System, cfg *Config, rep *Report) {
 	rep.Section("Disaster recovery")
 
-	// The escrow. Absent is a SKIP, not a FAIL: #586 item 5 has not shipped, so
-	// its absence is a known state rather than a regression. It becomes a live
-	// freshness check the moment `dotf secrets backup` produces one.
+	// The escrow. SEVERITY IS KEYED TO REAL EXPOSURE, not to a flat policy —
+	// the same rule checkBitwardenReach already applies in this package, and for
+	// the same reason.
+	//
+	// The old behaviour was a flat SKIP, justified by "#586 item 5 has not
+	// shipped, so its absence is a known state". That justification expired
+	// without anyone noticing (#997). While every registry entry carried an
+	// `age:` pointer, an absent escrow really did cost nothing: each secret had
+	// a local encrypted copy. Then `migrate` began dropping that pointer as it
+	// flipped entries to Bitwarden (#971), and for those secrets the remote
+	// account became the ONLY copy in existence. An absent escrow stopped being
+	// an inconvenience and became a single point of total loss — still reported
+	// as "nothing to check here".
+	//
+	// So: SKIP while nothing depends on it, FAIL from the first bw-backed entry
+	// onward. This is the class named by #972 and #898 — a check whose only
+	// reachable branch is the no-op one proves nothing, and a SKIP is
+	// indistinguishable from "no problem here".
+	live, regErr := sys.BWBackedSecrets()
+
 	escrow := filepath.Join(cfg.DotfilesDir, "sensitive", "dr", "bitwarden-export.age")
 	switch info, err := os.Stat(escrow); {
 	case err != nil:
-		rep.Skip("no DR escrow at " + escrow + " — `dotf secrets backup` has not run (#586 item 5)")
+		reportAbsentEscrow(rep, escrow, live, regErr)
 	case sys.Now().Sub(info.ModTime()) > escrowMaxAge:
 		rep.Warn(fmt.Sprintf("DR escrow is %d days old — re-run `dotf secrets backup`; secrets added since are not in it",
 			int(sys.Now().Sub(info.ModTime()).Hours()/24)))

--- a/cli/internal/doctor/checks_dr_test.go
+++ b/cli/internal/doctor/checks_dr_test.go
@@ -9,11 +9,20 @@ import (
 	"time"
 )
 
-func drSys(now time.Time) *System {
+// drSys builds a System for the DR check with NO bw-backed secrets, i.e. the
+// pre-migration machine where an absent escrow costs nothing. Severity is keyed
+// to that count (#997), so most tests need to state it; this is the neutral one.
+func drSys(now time.Time) *System { return drSysExposed(now, 0, nil) }
+
+// drSysExposed states the exposure explicitly: how many registry entries resolve
+// through Bitwarden, and whether the registry could be read at all. Those two
+// are the only inputs that move this check's severity.
+func drSysExposed(now time.Time, bwBacked int, regErr error) *System {
 	return &System{
-		Getenv:   func(string) string { return "" },
-		LookPath: func(n string) (string, error) { return "/usr/bin/" + n, nil },
-		Now:      func() time.Time { return now },
+		Getenv:          func(string) string { return "" },
+		LookPath:        func(n string) (string, error) { return "/usr/bin/" + n, nil },
+		Now:             func() time.Time { return now },
+		BWBackedSecrets: func() (int, error) { return bwBacked, regErr },
 	}
 }
 
@@ -84,20 +93,74 @@ func TestDR_StaleDrillWarns(t *testing.T) {
 	}
 }
 
-// An absent escrow is a known state (#586 item 5 has not shipped), not a
-// regression -- SKIP, so it does not train anyone to ignore this section.
-func TestDR_AbsentEscrowSkipsNotFails(t *testing.T) {
+// With nothing resolving through Bitwarden, an absent escrow costs nothing --
+// every secret still has its age copy on disk. SKIP, because a red doctor for a
+// harmless condition is how operators are trained to ignore red doctors.
+func TestDR_AbsentEscrowNoExposure_Skips(t *testing.T) {
 	cfg := &Config{DotfilesDir: t.TempDir()}
 	var buf bytes.Buffer
 	rep := capture(&buf)
 
-	checkDisasterRecovery(drSys(time.Now()), cfg, rep)
+	checkDisasterRecovery(drSysExposed(time.Now(), 0, nil), cfg, rep)
 
 	if rep.Failures() != 0 {
-		t.Fatalf("absent escrow must not FAIL, got %d", rep.Failures())
+		t.Fatalf("absent escrow with no bw-backed secrets must not FAIL, got %d:\n%s", rep.Failures(), buf.String())
 	}
 	if !strings.Contains(buf.String(), "no DR escrow") {
 		t.Errorf("want the escrow SKIP, got: %s", buf.String())
+	}
+}
+
+// The defect this issue exists for (#997). Once a secret resolves through
+// Bitwarden, `migrate` has dropped its age: pointer (#971) -- so the remote
+// account is the ONLY copy, and an absent escrow is a single point of total
+// loss. Reported for months as "nothing to check here".
+func TestDR_AbsentEscrowWithExposure_Fails(t *testing.T) {
+	cfg := &Config{DotfilesDir: t.TempDir()}
+	var buf bytes.Buffer
+	rep := capture(&buf)
+
+	checkDisasterRecovery(drSysExposed(time.Now(), 26, nil), cfg, rep)
+
+	if rep.Failures() != 1 {
+		t.Fatalf("absent escrow with bw-backed secrets must FAIL, got %d failure(s):\n%s", rep.Failures(), buf.String())
+	}
+	out := buf.String()
+	// The count is the whole argument: "no backup" is abstract, "26 secrets
+	// exist only on a remote server" is what makes an operator act.
+	if !strings.Contains(out, "26") {
+		t.Errorf("the FAIL must name how many secrets have no local copy, got: %s", out)
+	}
+	// The remedy must be the invocation that actually works. A bare
+	// `dotf secrets backup` fails with "Vault is locked": its export path has no
+	// bw serve endpoint (verified against the shipped @bitwarden/cli bundle --
+	// the serve router has no export route), so it needs a CLI session. This is
+	// permanent, not pending #993, which is why the message names it plainly.
+	if !strings.Contains(out, "BW_SESSION") {
+		t.Errorf("the FAIL must name the invocation that actually creates an escrow, got: %s", out)
+	}
+	if strings.Contains(out, "#993") {
+		t.Errorf("the remedy is permanent, not blocked on #993; citing it dates the message: %s", out)
+	}
+}
+
+// A stale escrow stays a WARN even under exposure: a 120-day-old copy is a
+// degraded backup, not an absent one, and the two must not read alike.
+func TestDR_StaleEscrowWithExposure_StillWarns(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &Config{DotfilesDir: dir}
+	now := time.Now()
+	touchAt(t, filepath.Join(dir, "sensitive", "dr", "bitwarden-export.age"), now.Add(-120*24*time.Hour))
+	var buf bytes.Buffer
+	rep := capture(&buf)
+
+	checkDisasterRecovery(drSysExposed(now, 26, nil), cfg, rep)
+
+	if rep.Failures() != 0 {
+		t.Fatalf("a stale escrow is degraded, not absent; want WARN not FAIL:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "DR escrow is 120 days old") {
+		t.Errorf("want the escrow staleness warning, got: %s", buf.String())
 	}
 }
 

--- a/cli/internal/doctor/checks_dr_test.go
+++ b/cli/internal/doctor/checks_dr_test.go
@@ -2,12 +2,28 @@ package doctor
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 )
+
+// lineContaining returns the first report line mentioning substr, so a case can
+// assert the status tag of the line it cares about. The DR section emits two
+// independent lines (escrow, drill) and a bare Contains over the whole buffer
+// would happily match the drill's WARN while the escrow line said something
+// else entirely.
+func lineContaining(out, substr string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, substr) {
+			return line
+		}
+	}
+	return ""
+}
 
 // drSys builds a System for the DR check with NO bw-backed secrets, i.e. the
 // pre-migration machine where an absent escrow costs nothing. Severity is keyed
@@ -93,54 +109,73 @@ func TestDR_StaleDrillWarns(t *testing.T) {
 	}
 }
 
-// With nothing resolving through Bitwarden, an absent escrow costs nothing --
-// every secret still has its age copy on disk. SKIP, because a red doctor for a
-// harmless condition is how operators are trained to ignore red doctors.
-func TestDR_AbsentEscrowNoExposure_Skips(t *testing.T) {
-	cfg := &Config{DotfilesDir: t.TempDir()}
-	var buf bytes.Buffer
-	rep := capture(&buf)
+// The escrow severity rule (#997), one case per branch.
+//
+// Asserted on the STATUS TAG rather than on prose: the tag is the contract
+// (it decides doctor's exit code), the wording is not. Remediation text is
+// pinned only for the FAIL case, where the message is the deliverable -- an
+// operator who cannot act on it has been told nothing.
+func TestDR_EscrowSeverityFollowsExposure(t *testing.T) {
+	now := time.Now()
+	for _, tt := range []struct {
+		name     string
+		bwBacked int
+		regErr   error
+		wantTag  string
+		wantFail int
+	}{
+		{
+			// Every secret still has its age copy on disk, so an absent escrow
+			// costs nothing. Staying quiet here is what keeps the FAIL credible.
+			name: "no exposure: absence costs nothing", bwBacked: 0, wantTag: "[SKIP]",
+		},
+		{
+			// The defect #997 exists for: `migrate` drops the age: pointer (#971),
+			// so for these the remote account is the only copy in existence.
+			name: "exposed: the only copy is remote", bwBacked: 28, wantTag: "[FAIL]", wantFail: 1,
+		},
+		{
+			// Exposure unknown. Must not claim "nothing depends on it" (it was
+			// never checked) and must not go red on a healthy machine -- doctor
+			// run from any other git repo lands here via env.RepoDir's walk-up.
+			name: "registry unreadable: exposure unknown", regErr: errors.New("open registry.yaml: no such file"), wantTag: "[WARN]",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{DotfilesDir: t.TempDir()}
+			var buf bytes.Buffer
+			rep := capture(&buf)
 
-	checkDisasterRecovery(drSysExposed(time.Now(), 0, nil), cfg, rep)
+			checkDisasterRecovery(drSysExposed(now, tt.bwBacked, tt.regErr), cfg, rep)
 
-	if rep.Failures() != 0 {
-		t.Fatalf("absent escrow with no bw-backed secrets must not FAIL, got %d:\n%s", rep.Failures(), buf.String())
-	}
-	if !strings.Contains(buf.String(), "no DR escrow") {
-		t.Errorf("want the escrow SKIP, got: %s", buf.String())
-	}
-}
-
-// The defect this issue exists for (#997). Once a secret resolves through
-// Bitwarden, `migrate` has dropped its age: pointer (#971) -- so the remote
-// account is the ONLY copy, and an absent escrow is a single point of total
-// loss. Reported for months as "nothing to check here".
-func TestDR_AbsentEscrowWithExposure_Fails(t *testing.T) {
-	cfg := &Config{DotfilesDir: t.TempDir()}
-	var buf bytes.Buffer
-	rep := capture(&buf)
-
-	checkDisasterRecovery(drSysExposed(time.Now(), 26, nil), cfg, rep)
-
-	if rep.Failures() != 1 {
-		t.Fatalf("absent escrow with bw-backed secrets must FAIL, got %d failure(s):\n%s", rep.Failures(), buf.String())
-	}
-	out := buf.String()
-	// The count is the whole argument: "no backup" is abstract, "26 secrets
-	// exist only on a remote server" is what makes an operator act.
-	if !strings.Contains(out, "26") {
-		t.Errorf("the FAIL must name how many secrets have no local copy, got: %s", out)
-	}
-	// The remedy must be the invocation that actually works. A bare
-	// `dotf secrets backup` fails with "Vault is locked": its export path has no
-	// bw serve endpoint (verified against the shipped @bitwarden/cli bundle --
-	// the serve router has no export route), so it needs a CLI session. This is
-	// permanent, not pending #993, which is why the message names it plainly.
-	if !strings.Contains(out, "BW_SESSION") {
-		t.Errorf("the FAIL must name the invocation that actually creates an escrow, got: %s", out)
-	}
-	if strings.Contains(out, "#993") {
-		t.Errorf("the remedy is permanent, not blocked on #993; citing it dates the message: %s", out)
+			out := buf.String()
+			escrowLine := lineContaining(out, "DR escrow")
+			if !strings.Contains(escrowLine, tt.wantTag) {
+				t.Errorf("want %s on the escrow line, got: %s", tt.wantTag, escrowLine)
+			}
+			if rep.Failures() != tt.wantFail {
+				t.Errorf("want %d failure(s), got %d:\n%s", tt.wantFail, rep.Failures(), out)
+			}
+			if tt.wantTag != "[FAIL]" {
+				return
+			}
+			// The count is the whole argument: "no backup" is abstract, "28
+			// secrets exist only on a remote server" is what makes someone act.
+			if !strings.Contains(escrowLine, "28") {
+				t.Errorf("the FAIL must name how many secrets have no local copy, got: %s", escrowLine)
+			}
+			// A bare `dotf secrets backup` fails with "Vault is locked": its
+			// export path has no bw serve endpoint (verified against the shipped
+			// @bitwarden/cli bundle -- the serve router has no export route), so
+			// it needs a CLI session. Permanent, not pending #993, which is why
+			// the message names it plainly and must not cite that issue.
+			if !strings.Contains(escrowLine, "BW_SESSION") {
+				t.Errorf("the FAIL must name the invocation that actually creates an escrow, got: %s", escrowLine)
+			}
+			if strings.Contains(escrowLine, "#993") {
+				t.Errorf("the remedy is permanent, not blocked on #993; citing it dates the message: %s", escrowLine)
+			}
+		})
 	}
 }
 
@@ -154,13 +189,51 @@ func TestDR_StaleEscrowWithExposure_StillWarns(t *testing.T) {
 	var buf bytes.Buffer
 	rep := capture(&buf)
 
-	checkDisasterRecovery(drSysExposed(now, 26, nil), cfg, rep)
+	checkDisasterRecovery(drSysExposed(now, 28, nil), cfg, rep)
 
 	if rep.Failures() != 0 {
 		t.Fatalf("a stale escrow is degraded, not absent; want WARN not FAIL:\n%s", buf.String())
 	}
 	if !strings.Contains(buf.String(), "DR escrow is 120 days old") {
 		t.Errorf("want the escrow staleness warning, got: %s", buf.String())
+	}
+}
+
+// A stat error is not proof of absence. Under exposure the absent branch FAILs
+// with "these N secrets have no local copy" -- a claim the check has not earned
+// when the escrow may be sitting there behind a permission error. Asserting the
+// unverified is the exact failure #997 is about, so it must not appear in its fix.
+func TestDR_UnreadableEscrowWarnsRatherThanClaimingAbsence(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// chmod(0) does not deny the owner on Windows, so the parent stays
+		// readable and this exercises nothing. Gated rather than reshaped: the
+		// alternatives (a file as the parent dir) map to path-not-found there
+		// and would silently test the ABSENT branch instead of this one.
+		t.Skip("directory permissions do not gate stat on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions, so the escrow stays readable")
+	}
+	dir := t.TempDir()
+	cfg := &Config{DotfilesDir: dir}
+	drDir := filepath.Join(dir, "sensitive", "dr")
+	touchAt(t, filepath.Join(drDir, "bitwarden-export.age"), time.Now())
+	if err := os.Chmod(drDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(drDir, 0o755) }) // else TempDir cleanup fails
+
+	var buf bytes.Buffer
+	rep := capture(&buf)
+
+	checkDisasterRecovery(drSysExposed(time.Now(), 28, nil), cfg, rep)
+
+	if rep.Failures() != 0 {
+		t.Fatalf("an unreadable escrow is not a proven-absent one; want WARN not FAIL:\n%s", buf.String())
+	}
+	line := lineContaining(buf.String(), "DR escrow")
+	if !strings.Contains(line, "[WARN]") || !strings.Contains(line, "cannot inspect") {
+		t.Errorf("want the inspection WARN, got: %s", line)
 	}
 }
 


### PR DESCRIPTION
## What

An absent disaster-recovery escrow was reported as `SKIP` unconditionally. Severity is now keyed to real exposure — `SKIP` while nothing resolves through Bitwarden, `FAIL` from the first `backend: bw` entry onward — which is the rule `checkBitwardenReach` already applies in this same package.

## Why the old severity was defensible and stopped being so

The `SKIP` carried its own justification in a comment: *"#586 item 5 has not shipped, so its absence is a known state rather than a regression."* That was true while every registry entry still carried an `age:` pointer — each secret had a local encrypted copy, so a missing escrow cost nothing.

Then `migrate` began dropping that pointer as it flipped entries to Bitwarden (#971). For those secrets the remote account became **the only copy in existence**. A missing escrow stopped being an inconvenience and became a single point of total loss — and was still reported as "nothing to check here". The justification expired silently; nothing re-read it.

On this machine that state persisted with **28 secrets exposed**, and `dotf doctor` never once complained. That is the same class as #972 and #898: a check whose only reachable branch is the no-op one proves nothing.

## The unknown-exposure branch

When the registry cannot be read, exposure is unknown, and both obvious answers are wrong:

- Treating it as unexposed (the reach check's "degrade to advisory") prints `no secret resolves through Bitwarden yet, so nothing depends on it` — the exact sentence this issue exists to delete — on a machine where it was never checked.
- Failing goes red from any healthy machine: `env.RepoDir` falls back to a cwd walk-up for `.git`, so `dotf doctor` run from inside any other git repo lands here.

It `WARN`s instead, naming what it could not determine.

## The remedy string names `BW_SESSION` plainly, not as a workaround

The issue asked for a message that does not name a command which cannot run, and anticipated depending on #993. That dependency dissolved on inspection: **`bw serve` exposes no export route.** Enumerated from the shipped `@bitwarden/cli` bundle, the serve router has `/status`, `/sync`, `/unlock`, `/lock`, `/generate`, `/list/object/:object`, `/object/:object[/:id]`, `/attachment`, `/move`, `/send/*`, `/device-approval/*` — and no export. The only `"/export"` string in the bundle is an *organization* export against the cloud API, not a personal-vault serve route.

So `bw export` has no daemon path to migrate to, `dotf secrets backup` needs a CLI session for as long as that holds, and citing #993 would have dated the message the day it merged.

## Evidence

Against the **real** registry (28 `backend: bw` entries), escrow absent, real code path — not a fixture:

```
# new binary
[Disaster recovery]
  [FAIL] no DR escrow at .../sensitive/dr/bitwarden-export.age — 28 secret(s) resolve
         through Bitwarden and have no local copy, so the remote account is their only
         copy; create one with `BW_SESSION="$(bw unlock --raw)" dotf secrets backup`
         (the export path has no bw serve endpoint, so it needs a CLI session)

# released 0.41.0, same state
  [SKIP] no DR escrow at ... — `dotf secrets backup` has not run (#586 item 5)
```

The tests were also observed failing against the pre-fix check, so they are not passing vacuously:

```
--- FAIL: TestDR_AbsentEscrowWithExposure_Fails
    absent escrow with bw-backed secrets must FAIL, got 0 failure(s)
```

`go build`, `go vet`, `go test ./internal/doctor/` and `golangci-lint run` (v2.12.2, the `versions.conf` pin) all clean.

**Honest limit on the exit-code claim:** doctor already exits 1 on this machine from a pre-existing unrelated `[PAT expiry]` FAIL (#983, the dead `BITACORA_PAT`), so the exit-code effect of this change is masked here. What was observed directly is the section severity. `setup-linux.sh:1505` invokes doctor as `dotf doctor || log_warning`, so the new FAIL cannot break a bootstrap.

## Scope

The escrow-present, stale-escrow and recovery-drill branches are unchanged, as the issue's acceptance criteria require.

## SDD skip rationale

Bug fix with a fully diagnosed root cause, on an issue that already carries the design: #997 specifies the severity table and the acceptance criteria this PR implements verbatim, which is the substance a `proposal.md` would have restated. The gate counts 87 production LOC, but **66 of those are comments and blank lines** recording why the old severity expired — the actual behavioural change is **21 lines**: one `BWBackedSecrets` call and the extraction of `reportAbsentEscrow`. No public contract, no dependency, no multi-PR sequence. The verification a spec would have demanded is already here: before/after evidence against the real registry, the tests observed red against the pre-fix code, and the unchanged branches pinned by tests. Same shape and same escape as #973, a `fix(doctor):` bug fix of this class.

Closes #997


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disaster recovery diagnostics for missing Bitwarden escrow.
  * Reports a warning when registry exposure cannot be determined.
  * Reports a failure when Bitwarden-backed secrets are exposed, including the affected count and `BW_SESSION` remediation guidance.
  * Skips the check when no Bitwarden-backed secrets are present.
  * Continues to report stale escrow as a warning, preserving existing recovery checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->