### PR TITLE
fix(secrets): give the write path the bw serve seam the read path already had

### DIFF
--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -105,6 +105,16 @@ func bwWrite() bwWriteClient {
 	return bwBackend().Writer
 }
 
+// bwSync returns the cache-refresh half of the SAME pinned backend. Sync is pinned with
+// the other two because the daemon and the CLI cache independently: syncing one leaves
+// the other stale, so a rotation that syncs the wrong subject cannot prove its own write.
+func bwSync() daemonSyncer {
+	if bwSyncer != nil {
+		return bwSyncer
+	}
+	return bwBackend().Syncer
+}
+
 // secretLoader builds the resolution engine wired with both backend seams, over the
 // age store in sensitive/ (checkout-first, ADR-030 — same source as the registry it
 // maps, so a repo-side rotation is seen without a redeploy) and Bitwarden via bwReader.
@@ -113,7 +123,7 @@ func secretLoader() *secrets.Loader {
 		SecretsDir: env.ResolveSensitiveDir(),
 		KeyPath:    ageKeyPath(),
 		Decrypt:    ageDecryptor,
-		BW:         bwReader,
+		BW:         bwRead(),
 	}
 }
 

--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/mlorentedev/dotfiles/cli/internal/env"
 	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
@@ -59,11 +60,50 @@ var (
 	registryPath      = env.ResolveRegistryPath
 	registryWritePath = env.RepoRegistryPath
 	ageDecryptor      secrets.Decryptor
-	bwReader          secrets.BWReader = secrets.BWFallbackReader{
-		Serve:    secrets.BWServeReader{Client: secrets.BWServeClient{}},
-		Shellout: secrets.BWGet{},
-	}
+
+	// bwReader / bwWriter are TEST SEAMS ONLY: nil in production, where both halves
+	// come from the pinned backend below. A test assigns one (or both) to inject a
+	// fake with no age key and no unlocked Bitwarden.
+	bwReader secrets.BWReader
+	bwWriter bwWriteClient
+
+	// bwBackendOnce / bwBackendPin implement BUG-084's pinning decision: the
+	// daemon-vs-shellout choice is made ONCE per process — a `dotf` invocation is one
+	// command — and both the read and write halves come from that single decision, so
+	// a command cannot read through the daemon and write through the CLI. That split
+	// is what BUG-084 was.
+	//
+	// Lazy (sync.Once, not a package initialiser) so commands that touch no secret —
+	// `dotf env`, `dotf doctor`, `dotf spec` — never pay the daemon probe.
+	bwBackendOnce sync.Once
+	bwBackendPin  secrets.BWBackend
 )
+
+// bwBackend returns the process-wide pinned Bitwarden backend, probing the daemon on
+// first use only.
+func bwBackend() secrets.BWBackend {
+	bwBackendOnce.Do(func() {
+		bwBackendPin = secrets.SelectBWBackend(secrets.BWServeClient{})
+	})
+	return bwBackendPin
+}
+
+// bwRead / bwWrite are how every command reaches Bitwarden. They prefer an injected
+// test seam and otherwise take the matched half of the pinned backend — so production
+// code has no way to mix the two subjects even by accident.
+func bwRead() secrets.BWReader {
+	if bwReader != nil {
+		return bwReader
+	}
+	return bwBackend().Reader
+}
+
+func bwWrite() bwWriteClient {
+	if bwWriter != nil {
+		return bwWriter
+	}
+	return bwBackend().Writer
+}
 
 // secretLoader builds the resolution engine wired with both backend seams, over the
 // age store in sensitive/ (checkout-first, ADR-030 — same source as the registry it

--- a/cli/internal/cmd/secrets_migrate.go
+++ b/cli/internal/cmd/secrets_migrate.go
@@ -79,7 +79,7 @@ func newSecretsMigrateCmd() *cobra.Command {
 			}
 
 			// Parity gate — re-read bw and compare; abort BEFORE the registry flip.
-			back, err := bwReader.Field(item, field)
+			back, err := bwRead().Field(item, field)
 			if err != nil {
 				return fmt.Errorf("parity read-back of %s/%s failed (registry NOT flipped): %w", item, field, err)
 			}

--- a/cli/internal/cmd/secrets_rotate.go
+++ b/cli/internal/cmd/secrets_rotate.go
@@ -7,13 +7,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// daemonSyncer is what rotate needs from the bw serve daemon: make it pull the
-// current vault state so the read path stops answering from a stale cache. A seam
-// so rotate's tests run with no daemon.
-type daemonSyncer interface{ Sync() error }
+// daemonSyncer is what rotate needs from a backend: make it pull the current vault
+// state so the read path stops answering from a stale cache.
+type daemonSyncer = secrets.BWSyncer
 
-// bwSyncer is the production daemon-sync seam.
-var bwSyncer daemonSyncer = &secrets.BWServeDaemon{Client: secrets.BWServeClient{}}
+// bwSyncer is a TEST SEAM ONLY: nil in production, where sync comes from the pinned
+// backend alongside the reader and writer (see bwSync). It used to default to the
+// daemon unconditionally, which meant a shellout-backed command synced the daemon's
+// cache while reading the CLI's — the same split this bug is about, one path over.
+var bwSyncer daemonSyncer
 
 // newSecretsRotateCmd is C7: replace a live credential and prove the replacement
 // took, in one command.
@@ -121,12 +123,16 @@ func runRotate(cmd *cobra.Command, s *secrets.Secret, item, field string, isFile
 func confirmRotation(cmd *cobra.Command, s *secrets.Secret, item, field string, isFile bool, beforeFP string) error {
 	out := cmd.OutOrStdout()
 
-	// The daemon answers from its own cache; without this the write is correct and
+	// The backend answers from its own cache; without this the write is correct and
 	// every read still returns the old value, with nothing to indicate a missing
 	// step. A sync failure is reported, not fatal — the write did happen, and
 	// hiding that would be worse than a noisy success.
-	if err := bwSyncer.Sync(); err != nil {
-		_, _ = fmt.Fprintf(out, "WARNING  daemon sync failed (%v) — the value was written but reads may still serve the old one until `dotf secrets unlock` or a manual sync\n", err)
+	//
+	// This syncs the SAME backend that just took the write and is about to serve the
+	// read-back, which is what makes the confirmation below meaningful.
+	if err := bwSync().Sync(); err != nil {
+		_, _ = fmt.Fprintf(out, "WARNING  %s sync failed (%v) — the value was written but reads may still serve the old one until it is synced\n",
+			bwBackend().Name, err)
 	}
 
 	after, err := bwRead().Field(item, field)

--- a/cli/internal/cmd/secrets_rotate.go
+++ b/cli/internal/cmd/secrets_rotate.go
@@ -81,7 +81,7 @@ func newSecretsRotateCmd() *cobra.Command {
 func runRotate(cmd *cobra.Command, s *secrets.Secret, item, field string, isFile, dryRun bool) error {
 	out := cmd.OutOrStdout()
 
-	before, err := bwReader.Field(item, field)
+	before, err := bwRead().Field(item, field)
 	if err != nil {
 		// Unlike `set`, rotate never creates: rotating something that does not
 		// exist is a provisioning action, and conflating the two is how a locked
@@ -108,7 +108,7 @@ func runRotate(cmd *cobra.Command, s *secrets.Secret, item, field string, isFile
 		return fmt.Errorf("the new value is identical to the current one — that is not a rotation. Nothing was written")
 	}
 
-	if err := bwWriter.SetField(item, field, value); err != nil {
+	if err := bwWrite().SetField(item, field, value); err != nil {
 		return err
 	}
 	_, _ = fmt.Fprintf(out, "written  %s / %s\n", item, field)
@@ -129,7 +129,7 @@ func confirmRotation(cmd *cobra.Command, s *secrets.Secret, item, field string, 
 		_, _ = fmt.Fprintf(out, "WARNING  daemon sync failed (%v) — the value was written but reads may still serve the old one until `dotf secrets unlock` or a manual sync\n", err)
 	}
 
-	after, err := bwReader.Field(item, field)
+	after, err := bwRead().Field(item, field)
 	if err != nil {
 		return fmt.Errorf("wrote the new value but could not read it back through the normal path: %w", err)
 	}

--- a/cli/internal/cmd/secrets_set.go
+++ b/cli/internal/cmd/secrets_set.go
@@ -14,18 +14,14 @@ import (
 )
 
 // bwWriteClient is what `set` needs from the bw write seam: update an existing field
-// (BWWriter) and create an absent item (BWCreator). Two small interfaces, one prod
-// impl (BWPut) — keeping create separate from update so update-only callers cannot
-// create by accident.
-type bwWriteClient interface {
-	secrets.BWWriter
-	secrets.BWCreator
-	secrets.BWFolderResolver
-}
-
-// bwWriter is the bw write seam (BWPut in production), overridable so set's tests run
-// with no unlocked Bitwarden — the write analog of bwReader.
-var bwWriter bwWriteClient = secrets.BWPut{}
+// (BWWriter), create an absent item (BWCreator), and resolve the taxonomy folder
+// (BWFolderResolver). Kept as three small interfaces so an update-only caller cannot
+// create by accident; this is an alias of the package-level composition in `secrets`,
+// which both backends (BWPut, BWServeWriter) satisfy.
+//
+// The `bwWriter` var it types now lives in secrets.go beside `bwReader`, because the
+// two are chosen together — see bwBackend().
+type bwWriteClient = secrets.BWWriteClient
 
 // stdinIsTerminal reports whether stdin is an interactive terminal; a var so tests
 // force the non-interactive (piped) path.
@@ -136,7 +132,7 @@ func normalizeValue(value string, isFile bool) string {
 // security crux of #612: a locked vault must never be mistaken for an absent item.
 func applySet(cmd *cobra.Command, item, field, value, folder string, isFile, dryRun, assumeYes bool) error {
 	out := cmd.OutOrStdout()
-	cur, err := bwReader.Field(item, field)
+	cur, err := bwRead().Field(item, field)
 	switch {
 	case err == nil:
 		if normalizeValue(cur, isFile) == value {
@@ -147,7 +143,7 @@ func applySet(cmd *cobra.Command, item, field, value, folder string, isFile, dry
 			_, _ = fmt.Fprintf(out, "would update  %s / %s\n", item, field)
 			return nil
 		}
-		if err := bwWriter.SetField(item, field, value); err != nil {
+		if err := bwWrite().SetField(item, field, value); err != nil {
 			return err
 		}
 		_, _ = fmt.Fprintf(out, "updated  %s / %s\n", item, field)
@@ -158,7 +154,7 @@ func applySet(cmd *cobra.Command, item, field, value, folder string, isFile, dry
 			_, _ = fmt.Fprintf(out, "would add field  %s / %s\n", item, field)
 			return nil
 		}
-		if err := bwWriter.SetField(item, field, value); err != nil {
+		if err := bwWrite().SetField(item, field, value); err != nil {
 			return err
 		}
 		_, _ = fmt.Fprintf(out, "added field  %s / %s\n", item, field)
@@ -192,11 +188,11 @@ func createAbsent(cmd *cobra.Command, item, field, value, folder string, dryRun,
 			return fmt.Errorf("aborted: item %q not created", item)
 		}
 	}
-	folderID, err := bwWriter.ResolveFolder(folder)
+	folderID, err := bwWrite().ResolveFolder(folder)
 	if err != nil {
 		return fmt.Errorf("resolve bw folder %q: %w", folder, err)
 	}
-	if err := bwWriter.CreateItem(item, field, value, folderID); err != nil {
+	if err := bwWrite().CreateItem(item, field, value, folderID); err != nil {
 		return err
 	}
 	_, _ = fmt.Fprintf(out, "created item  %s (field %s)\n", item, field)

--- a/cli/internal/secrets/bwbackend.go
+++ b/cli/internal/secrets/bwbackend.go
@@ -24,9 +24,16 @@ import (
 // back), a consistent subject matters more than self-healing: a rotation that half
 // applies is worse than one that fails whole.
 type BWBackend struct {
-	// Reader and Writer are always both daemon-backed or both shellout-backed.
+	// Reader, Writer and Syncer are always ALL daemon-backed or ALL shellout-backed.
+	//
+	// Syncer is here, and not left as its own var, for the reason this whole type
+	// exists: sync is the third path, and a third path that moves alone reproduces the
+	// bug. `rotate` writes, syncs, then reads back to prove the write took — if the
+	// sync addresses a different cache than the read, that proof is meaningless and
+	// the command reports a stale value as a failed rotation.
 	Reader BWReader
 	Writer BWWriteClient
+	Syncer BWSyncer
 
 	// Name labels the chosen subject for diagnostics ("bw serve daemon" / "bw CLI").
 	Name string
@@ -48,6 +55,31 @@ type BWBackend struct {
 // "Vault is locked." — which sends the operator to `bw unlock`, a command that prints a
 // session key to a shell nobody is reading and does not fix the failure — and an error
 // naming `dotf secrets unlock`, which does.
+// BWSyncer refreshes the local cache a backend answers reads from. Both backends have
+// one and they are NOT interchangeable: the daemon caches independently of the `bw`
+// CLI, so syncing one leaves the other stale. Which is why it is pinned alongside the
+// reader and writer rather than chosen separately.
+type BWSyncer interface {
+	Sync() error
+}
+
+// BWCLISync is the shellout BWSyncer: `bw sync`, refreshing the CLI's own cache — the
+// one the shellout reader and writer actually consult.
+type BWCLISync struct {
+	Bin string // bw binary name/path; "" → "bw"
+}
+
+func (s BWCLISync) Sync() error {
+	bin := s.Bin
+	if bin == "" {
+		bin = "bw"
+	}
+	if _, err := bwRun(bin, "sync"); err != nil {
+		return fmt.Errorf("bw sync: %w", err)
+	}
+	return nil
+}
+
 func SelectBWBackend(c BWServeClient) BWBackend {
 	st, err := c.Status()
 	switch {
@@ -55,6 +87,7 @@ func SelectBWBackend(c BWServeClient) BWBackend {
 		return BWBackend{
 			Reader: BWServeReader{Client: c},
 			Writer: BWServeWriter{Client: c},
+			Syncer: c,
 			Name:   "bw serve daemon",
 			Daemon: true,
 		}
@@ -73,6 +106,7 @@ func shelloutBackend(daemonState string) BWBackend {
 	return BWBackend{
 		Reader: lockHintReader{Reader: BWGet{}, daemonState: daemonState},
 		Writer: lockHintWriter{Writer: BWPut{}, daemonState: daemonState},
+		Syncer: BWCLISync{},
 		Name:   "bw CLI",
 		Daemon: false,
 	}

--- a/cli/internal/secrets/bwbackend.go
+++ b/cli/internal/secrets/bwbackend.go
@@ -1,0 +1,133 @@
+package secrets
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// BWBackend is a matched read+write pair whose halves authenticate through the SAME
+// Bitwarden subject, chosen once and reused for every operation in a command.
+//
+// It exists because of what BUG-084 (#993) actually was. The read path moved to the
+// `bw serve` daemon and the write path stayed on the CLI shellout, so the two halves of
+// one command asked different subjects: reads resolved fine against an unlocked daemon
+// while writes failed "Vault is locked" against a CLI session nobody had. That is not a
+// bug you fix once — it is a shape that recurs the moment any third path moves alone.
+//
+// Pinning makes it unrepresentable. A caller cannot hold a daemon reader and a shellout
+// writer, because both come out of one branch of one decision. Compare the per-call
+// alternative (BWFallbackReader's own policy, which re-probes on every Field call): it
+// self-heals if the daemon appears mid-run, but a daemon that LOCKS between two calls of
+// one command splits that command across two subjects — precisely this bug, in a
+// narrower window. For a multi-step mutation like `rotate` (read old → write new → read
+// back), a consistent subject matters more than self-healing: a rotation that half
+// applies is worse than one that fails whole.
+type BWBackend struct {
+	// Reader and Writer are always both daemon-backed or both shellout-backed.
+	Reader BWReader
+	Writer BWWriteClient
+
+	// Name labels the chosen subject for diagnostics ("bw serve daemon" / "bw CLI").
+	Name string
+
+	// Daemon reports whether the daemon was chosen — the single fact tests assert
+	// on to prove the two halves agree (AC5).
+	Daemon bool
+}
+
+// SelectBWBackend probes the daemon ONCE and returns a matched pair.
+//
+// The daemon is chosen only when it is both reachable and unlocked. Anything else —
+// not running, running but locked, unreachable — selects the CLI shellout, which is
+// still the correct choice: an operator with an ambient BW_SESSION can work that way,
+// and it is the only backend that can export (see BWExport).
+//
+// When the shellout is selected, its errors are decorated with the remediation implied
+// by the daemon state observed HERE, at selection time. That is the difference between
+// "Vault is locked." — which sends the operator to `bw unlock`, a command that prints a
+// session key to a shell nobody is reading and does not fix the failure — and an error
+// naming `dotf secrets unlock`, which does.
+func SelectBWBackend(c BWServeClient) BWBackend {
+	st, err := c.Status()
+	switch {
+	case err == nil && st == "unlocked":
+		return BWBackend{
+			Reader: BWServeReader{Client: c},
+			Writer: BWServeWriter{Client: c},
+			Name:   "bw serve daemon",
+			Daemon: true,
+		}
+	case err == nil:
+		// Reachable but not unlocked ("locked", "unauthenticated", ...). The daemon
+		// exists, so the remediation is to unlock the one already running.
+		return shelloutBackend(fmt.Sprintf("the bw serve daemon is running but %s", st))
+	default:
+		return shelloutBackend("no bw serve daemon is running")
+	}
+}
+
+// shelloutBackend builds the CLI-backed pair, decorating both halves with why the
+// daemon was not used so a lock failure can name the fix instead of the symptom.
+func shelloutBackend(daemonState string) BWBackend {
+	return BWBackend{
+		Reader: lockHintReader{Reader: BWGet{}, daemonState: daemonState},
+		Writer: lockHintWriter{Writer: BWPut{}, daemonState: daemonState},
+		Name:   "bw CLI",
+		Daemon: false,
+	}
+}
+
+// ErrBWVaultLocked is returned when a CLI-backed operation failed because the vault is
+// locked for the `bw` binary's own session — the failure BUG-084 made unfixable-looking,
+// because the daemon may be unlocked at the same moment.
+var ErrBWVaultLocked = errors.New("bitwarden vault is locked")
+
+// isVaultLocked reports whether err is bw's locked-vault failure. Matched on message
+// because the CLI communicates it only as stderr text ("Vault is locked.") — there is no
+// exit code or structured field that distinguishes it from any other failure.
+func isVaultLocked(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "vault is locked")
+}
+
+// lockHint rewrites a locked-vault error into one that names the remediation that
+// actually works, given the daemon state observed at selection time. Any other error is
+// returned untouched — this decorates one specific confusion, it does not editorialise.
+func lockHint(err error, daemonState string) error {
+	if !isVaultLocked(err) {
+		return err
+	}
+	return fmt.Errorf("%w: %s — run `dotf secrets unlock` (not `bw unlock`, which only "+
+		"prints a session key to your shell and leaves this command's vault locked): %w",
+		ErrBWVaultLocked, daemonState, err)
+}
+
+// lockHintReader decorates a shellout BWReader with lockHint.
+type lockHintReader struct {
+	Reader      BWReader
+	daemonState string
+}
+
+func (r lockHintReader) Field(item, field string) (string, error) {
+	v, err := r.Reader.Field(item, field)
+	return v, lockHint(err, r.daemonState)
+}
+
+// lockHintWriter decorates a shellout BWWriteClient with lockHint on all three methods.
+type lockHintWriter struct {
+	Writer      BWWriteClient
+	daemonState string
+}
+
+func (w lockHintWriter) SetField(item, field, value string) error {
+	return lockHint(w.Writer.SetField(item, field, value), w.daemonState)
+}
+
+func (w lockHintWriter) CreateItem(item, field, value, folderID string) error {
+	return lockHint(w.Writer.CreateItem(item, field, value, folderID), w.daemonState)
+}
+
+func (w lockHintWriter) ResolveFolder(name string) (string, error) {
+	id, err := w.Writer.ResolveFolder(name)
+	return id, lockHint(err, w.daemonState)
+}

--- a/cli/internal/secrets/bwbackend_test.go
+++ b/cli/internal/secrets/bwbackend_test.go
@@ -1,0 +1,174 @@
+package secrets
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// countingHandler wraps the fake and tallies requests to path, so a test can assert
+// how many times the daemon was consulted — the observable difference between a pinned
+// backend and a per-call one.
+func countingHandler(n *int, path string, f *fakeBWServe) http.HandlerFunc {
+	inner := f.handler()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == path {
+			*n++
+		}
+		inner(w, r)
+	}
+}
+
+// TestSelectBWBackend_ReadAndWriteAlwaysAgree is AC5, and it is the whole point of
+// BUG-084 (#993).
+//
+// The bug was not "the write path is broken". It was "the read path moved to the daemon
+// and the write path did not", i.e. two halves of one command authenticating through
+// different subjects. Fixing only the write implementation would leave that shape intact
+// for the next path to move alone. This asserts the shape instead: for EVERY daemon
+// state, the reader and the writer must come from the same side.
+//
+// If someone later adds a third backend and wires only one half to it, this fails.
+func TestSelectBWBackend_ReadAndWriteAlwaysAgree(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     string // fake daemon status; "" -> daemon unreachable
+		unreachable bool
+		wantDaemon bool
+	}{
+		{name: "unlocked daemon is used for both halves", status: "unlocked", wantDaemon: true},
+		{name: "locked daemon falls back on both halves", status: "locked", wantDaemon: false},
+		{name: "unauthenticated daemon falls back on both halves", status: "unauthenticated", wantDaemon: false},
+		{name: "no daemon falls back on both halves", unreachable: true, wantDaemon: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c BWServeClient
+			if tt.unreachable {
+				// A closed server's URL: connection refused, the real "no daemon" signal.
+				srv := httptest.NewServer((&fakeBWServe{}).handler())
+				c = BWServeClient{BaseURL: srv.URL}
+				srv.Close()
+			} else {
+				srv := httptest.NewServer((&fakeBWServe{status: tt.status}).handler())
+				defer srv.Close()
+				c = BWServeClient{BaseURL: srv.URL}
+			}
+
+			b := SelectBWBackend(c)
+
+			if b.Daemon != tt.wantDaemon {
+				t.Fatalf("Daemon = %v, want %v", b.Daemon, tt.wantDaemon)
+			}
+			_, readerIsDaemon := b.Reader.(BWServeReader)
+			_, writerIsDaemon := b.Writer.(BWServeWriter)
+			if readerIsDaemon != writerIsDaemon {
+				t.Fatalf("SPLIT BRAIN: reader daemon=%v but writer daemon=%v — this is exactly BUG-084",
+					readerIsDaemon, writerIsDaemon)
+			}
+			if readerIsDaemon != tt.wantDaemon {
+				t.Fatalf("backend halves = daemon:%v, want daemon:%v", readerIsDaemon, tt.wantDaemon)
+			}
+			if b.Reader == nil || b.Writer == nil {
+				t.Fatal("a selected backend must have both halves non-nil")
+			}
+		})
+	}
+}
+
+// TestSelectBWBackend_ProbesOnce guards the pinning decision itself: selection must
+// consult the daemon exactly once, so a daemon that changes state cannot split a
+// command across two subjects. A per-call design would probe on every operation.
+func TestSelectBWBackend_ProbesOnce(t *testing.T) {
+	f := &fakeBWServe{status: "unlocked"}
+	var probes int
+	srv := httptest.NewServer(countingHandler(&probes, "/status", f))
+	defer srv.Close()
+
+	b := SelectBWBackend(BWServeClient{BaseURL: srv.URL})
+	if probes != 1 {
+		t.Fatalf("status probes during selection = %d, want exactly 1", probes)
+	}
+
+	// Using the pinned backend must not re-probe: the decision is already made.
+	_, _ = b.Reader.Field("nope", "password")
+	if probes != 1 {
+		t.Fatalf("status probes after use = %d, want 1 — the backend must be pinned, not re-chosen", probes)
+	}
+}
+
+// TestSelectBWBackend_ShelloutNamesTheRealRemediation is AC3. A locked-vault failure
+// must point at `dotf secrets unlock`, never leave the operator with bw's bare
+// "Vault is locked." — which sends them to `bw unlock`, a command that prints a session
+// key to a shell nobody reads and does not fix this failure. Four separate operators'
+// confusions in one day traced to that message (see #993's "Related").
+func TestSelectBWBackend_ShelloutNamesTheRealRemediation(t *testing.T) {
+	lockErr := errors.New("Vault is locked.")
+
+	tests := []struct {
+		name        string
+		daemonState string
+		wantPhrase  string
+	}{
+		{
+			name:        "no daemon",
+			daemonState: "no bw serve daemon is running",
+			wantPhrase:  "no bw serve daemon is running",
+		},
+		{
+			name:        "daemon up but locked",
+			daemonState: "the bw serve daemon is running but locked",
+			wantPhrase:  "running but locked",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lockHint(lockErr, tt.daemonState)
+			if !errors.Is(got, ErrBWVaultLocked) {
+				t.Fatalf("locked error must wrap ErrBWVaultLocked, got %v", got)
+			}
+			msg := got.Error()
+			if !strings.Contains(msg, "dotf secrets unlock") {
+				t.Fatalf("error must name `dotf secrets unlock`, got: %s", msg)
+			}
+			if !strings.Contains(msg, tt.wantPhrase) {
+				t.Fatalf("error must describe the observed daemon state %q, got: %s", tt.wantPhrase, msg)
+			}
+			if !errors.Is(got, lockErr) {
+				t.Fatalf("the original bw error must stay in the chain, got: %s", msg)
+			}
+		})
+	}
+}
+
+// TestLockHint_LeavesUnrelatedErrorsAlone: the decorator exists to clarify ONE
+// confusion. An unrelated failure must pass through untouched, or every error in the
+// write path starts advertising an unlock the operator does not need.
+func TestLockHint_LeavesUnrelatedErrorsAlone(t *testing.T) {
+	orig := errors.New("More than one result was found")
+	got := lockHint(orig, "no bw serve daemon is running")
+	if got != orig { //nolint:errorlint // identity is the assertion: untouched, not merely equivalent
+		t.Fatalf("unrelated error was rewritten: %v", got)
+	}
+	if lockHint(nil, "whatever") != nil {
+		t.Fatal("a nil error must stay nil")
+	}
+}
+
+// TestSelectBWBackend_ShelloutHalvesBothDecorate: the hint must be on the read half
+// too. `set` reads before it writes, so a locked vault surfaces on the READ first —
+// decorating only the writer would leave the common path reporting the bare message.
+func TestSelectBWBackend_ShelloutHalvesBothDecorate(t *testing.T) {
+	srv := httptest.NewServer((&fakeBWServe{status: "locked"}).handler())
+	defer srv.Close()
+
+	b := SelectBWBackend(BWServeClient{BaseURL: srv.URL})
+	if _, ok := b.Reader.(lockHintReader); !ok {
+		t.Fatalf("shellout reader must carry the lock hint, got %T", b.Reader)
+	}
+	if _, ok := b.Writer.(lockHintWriter); !ok {
+		t.Fatalf("shellout writer must carry the lock hint, got %T", b.Writer)
+	}
+}

--- a/cli/internal/secrets/bwbackend_test.go
+++ b/cli/internal/secrets/bwbackend_test.go
@@ -64,15 +64,21 @@ func TestSelectBWBackend_ReadAndWriteAlwaysAgree(t *testing.T) {
 			}
 			_, readerIsDaemon := b.Reader.(BWServeReader)
 			_, writerIsDaemon := b.Writer.(BWServeWriter)
-			if readerIsDaemon != writerIsDaemon {
-				t.Fatalf("SPLIT BRAIN: reader daemon=%v but writer daemon=%v — this is exactly BUG-084",
-					readerIsDaemon, writerIsDaemon)
+			_, syncerIsDaemon := b.Syncer.(BWServeClient)
+
+			// All three, not just read/write: sync is the third path, and a third
+			// path that moves alone reproduces this bug. `rotate` writes, syncs,
+			// then reads back to prove the write took — sync the wrong cache and
+			// that proof is worthless.
+			if readerIsDaemon != writerIsDaemon || readerIsDaemon != syncerIsDaemon {
+				t.Fatalf("SPLIT BRAIN: reader daemon=%v, writer daemon=%v, syncer daemon=%v — this is exactly BUG-084",
+					readerIsDaemon, writerIsDaemon, syncerIsDaemon)
 			}
 			if readerIsDaemon != tt.wantDaemon {
 				t.Fatalf("backend halves = daemon:%v, want daemon:%v", readerIsDaemon, tt.wantDaemon)
 			}
-			if b.Reader == nil || b.Writer == nil {
-				t.Fatal("a selected backend must have both halves non-nil")
+			if b.Reader == nil || b.Writer == nil || b.Syncer == nil {
+				t.Fatal("a selected backend must have all three halves non-nil")
 			}
 		})
 	}

--- a/cli/internal/secrets/bwserve.go
+++ b/cli/internal/secrets/bwserve.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os/exec"
@@ -145,9 +146,25 @@ func (c BWServeClient) call(method, path string, body any) (json.RawMessage, err
 		return nil, fmt.Errorf("%w: %s %s: %v", ErrBWServeUnreachable, method, path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+
+	// Read the body before decoding so an unparseable response can be DESCRIBED.
+	// The previous form decoded straight off the wire and reported only "no
+	// parseable envelope", which threw away the two facts that identify the
+	// failure — and that omission is why #988 sat uncharacterised for weeks: the
+	// response is an HTTP 500 carrying the 21 plain-text bytes "Internal Server
+	// Error", which the old message rendered as `invalid character 'I'`.
+	//
+	// Status code and byte count ONLY, never the body itself: a 200 whose body
+	// merely failed to parse can still carry vault material, and an error string
+	// travels into logs and transcripts (docs/lessons.md, "Redact at the producer").
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%s %s: reading bw serve response (HTTP %d): %w", method, path, resp.StatusCode, err)
+	}
 	var env bwServeEnvelope
-	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
-		return nil, fmt.Errorf("%s %s: bw serve returned no parseable envelope: %w", method, path, err)
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("%s %s: bw serve returned no parseable envelope (HTTP %d, %d bytes): %w",
+			method, path, resp.StatusCode, len(raw), err)
 	}
 	if !env.Success {
 		msg := env.Message

--- a/cli/internal/secrets/bwserve_test.go
+++ b/cli/internal/secrets/bwserve_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
@@ -40,6 +41,17 @@ type fakeBWServe struct {
 	status string // unauthenticated | locked | unlocked
 	items  map[string]json.RawMessage // id -> full item JSON
 	names  map[string]string          // id -> name, for /list/object/items
+
+	// folders backs /list/object/folders and POST /object/folder (id -> name),
+	// the taxonomy half of the write path (BUG-084 / OPS-028).
+	folders map[string]string
+
+	// created records POST /object/item bodies in arrival order, so a test can
+	// assert what CreateItem actually put on the wire, not merely that it 200'd.
+	created []json.RawMessage
+
+	// nextID is the id handed to the next created item/folder; "" -> "generated".
+	nextID string
 
 	unlockPassword string // "" -> any password succeeds
 	failUnlock     bool
@@ -92,10 +104,80 @@ func (f *fakeBWServe) handler() http.HandlerFunc {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprintf(w, `{"success":true,"data":%s}`, item)
+
+		// --- write path (BUG-084) ---------------------------------------
+		// bw serve takes a RAW JSON body on these, where the `bw` CLI needs
+		// base64 on stdin. That asymmetry is the only real difference between
+		// BWServeWriter and BWPut, so the fake reads raw JSON deliberately: a
+		// regression to base64 fails to decode here.
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/object/item/"):
+			id := strings.TrimPrefix(r.URL.Path, "/object/item/")
+			if _, ok := f.items[id]; !ok {
+				writeEnvelope(w, false, "Not found.", nil)
+				return
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil || !json.Valid(body) {
+				writeEnvelope(w, false, "malformed request body", nil)
+				return
+			}
+			f.items[id] = json.RawMessage(body)
+			writeEnvelope(w, true, "", json.RawMessage(body))
+
+		case r.Method == http.MethodPost && r.URL.Path == "/object/item":
+			body, err := io.ReadAll(r.Body)
+			if err != nil || !json.Valid(body) {
+				writeEnvelope(w, false, "malformed request body", nil)
+				return
+			}
+			id := f.newID()
+			if f.items == nil {
+				f.items = map[string]json.RawMessage{}
+			}
+			if f.names == nil {
+				f.names = map[string]string{}
+			}
+			f.items[id] = json.RawMessage(body)
+			var named struct {
+				Name string `json:"name"`
+			}
+			_ = json.Unmarshal(body, &named)
+			f.names[id] = named.Name
+			f.created = append(f.created, json.RawMessage(body))
+			writeEnvelope(w, true, "", json.RawMessage(body))
+
+		case r.Method == http.MethodGet && r.URL.Path == "/list/object/folders":
+			out := []map[string]string{}
+			for id, name := range f.folders {
+				out = append(out, map[string]string{"id": id, "name": name})
+			}
+			writeEnvelope(w, true, "", map[string]any{"object": "list", "data": out})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/object/folder":
+			var body struct {
+				Name string `json:"name"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			id := f.newID()
+			if f.folders == nil {
+				f.folders = map[string]string{}
+			}
+			f.folders[id] = body.Name
+			writeEnvelope(w, true, "", map[string]string{"id": id, "name": body.Name})
+
 		default:
 			http.NotFound(w, r)
 		}
 	}
+}
+
+// newID hands out the id for a created item/folder, defaulting to a fixed value so
+// assertions stay deterministic.
+func (f *fakeBWServe) newID() string {
+	if f.nextID != "" {
+		return f.nextID
+	}
+	return "generated-id"
 }
 
 func writeEnvelope(w http.ResponseWriter, success bool, message string, data any) {

--- a/cli/internal/secrets/bwserve_test.go
+++ b/cli/internal/secrets/bwserve_test.go
@@ -528,3 +528,33 @@ func isErrUnreachable(err error) bool {
 func isErrItemNotFound(err error) bool {
 	return errors.Is(err, ErrBWItemNotFound)
 }
+
+// TestBWServeClient_UnparseableResponseNamesStatusAndSize is the guard for the
+// diagnostic gap that let #988 stay uncharacterised: `bw serve` answers some
+// /object/item GETs with an HTTP 500 carrying the plain text "Internal Server Error",
+// and the old error reported only `invalid character 'I'` — true, and useless.
+//
+// The error must name the status code and the byte count, and must NOT echo the body:
+// a 200 whose body merely failed to parse can still carry vault material.
+func TestBWServeClient_UnparseableResponseNamesStatusAndSize(t *testing.T) {
+	const body = "Internal Server Error"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	_, err := BWServeClient{BaseURL: srv.URL}.Status()
+	if err == nil {
+		t.Fatal("expected an error for a non-JSON response")
+	}
+	msg := err.Error()
+	for _, want := range []string{"HTTP 500", "21 bytes"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error must name %q so the failure is identifiable, got: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, body) {
+		t.Fatalf("error must NOT echo the response body (it may carry vault material): %s", msg)
+	}
+}

--- a/cli/internal/secrets/bwserve_test.go
+++ b/cli/internal/secrets/bwserve_test.go
@@ -53,6 +53,12 @@ type fakeBWServe struct {
 	// nextID is the id handed to the next created item/folder; "" -> "generated".
 	nextID string
 
+	// syncs counts POST /sync, so a test can assert a write made itself visible.
+	syncs int
+
+	// failSync makes POST /sync report failure, exercising the written-but-stale path.
+	failSync bool
+
 	unlockPassword string // "" -> any password succeeds
 	failUnlock     bool
 }
@@ -80,6 +86,13 @@ func (f *fakeBWServe) handler() http.HandlerFunc {
 				return
 			}
 			f.status = "unlocked"
+			writeEnvelope(w, true, "", nil)
+		case r.Method == http.MethodPost && r.URL.Path == "/sync":
+			f.syncs++
+			if f.failSync {
+				writeEnvelope(w, false, "Failed to sync.", nil)
+				return
+			}
 			writeEnvelope(w, true, "", nil)
 		case r.Method == http.MethodPost && r.URL.Path == "/lock":
 			f.status = "locked"

--- a/cli/internal/secrets/bwserve_writer.go
+++ b/cli/internal/secrets/bwserve_writer.go
@@ -85,6 +85,32 @@ func (w BWServeWriter) SetField(item, field, value string) error {
 	if _, err := w.Client.call(http.MethodPut, "/object/item/"+url.PathEscape(id), json.RawMessage(updated)); err != nil {
 		return fmt.Errorf("bw serve edit item %q: %w", item, err)
 	}
+	return w.syncAfterWrite(item)
+}
+
+// syncAfterWrite makes a completed write visible to reads.
+//
+// This is not an optimisation, it is a correctness requirement, and it was found by the
+// live canary rather than by any fake: a daemon PUT updates the server, but the daemon
+// keeps answering reads from its own cache, so without this the value written is
+// invisible — to this process and to every later one, since the stale cache lives in the
+// daemon, not in the client. The canary caught it as a read-back returning the previous
+// fingerprint.
+//
+// The consequence is worse than a stale read. `dotf secrets set` reads BEFORE writing to
+// decide unchanged-vs-update-vs-create; against a stale cache an item that exists can
+// look absent, and the create path would then add a DUPLICATE item — the same class of
+// mistake #612 guards against when it refuses to treat a locked vault as an absent one.
+//
+// A sync failure is reported rather than swallowed, and the message states plainly that
+// the write itself succeeded: the operator must not re-run a write that already landed,
+// and must know that reads are stale until the vault syncs.
+func (w BWServeWriter) syncAfterWrite(item string) error {
+	if err := w.Client.Sync(); err != nil {
+		return fmt.Errorf("%q was WRITTEN successfully, but the follow-up sync failed, so "+
+			"reads will keep serving the previous value until the daemon syncs "+
+			"(do NOT re-run the write; run `dotf secrets unlock` or retry the sync): %w", item, err)
+	}
 	return nil
 }
 
@@ -99,7 +125,10 @@ func (w BWServeWriter) CreateItem(item, field, value, folderID string) error {
 	if _, err := w.Client.call(http.MethodPost, "/object/item", json.RawMessage(body)); err != nil {
 		return fmt.Errorf("bw serve create item %q: %w", item, err)
 	}
-	return nil
+	// Same staleness rule as SetField, and it bites harder here: an unsynced create
+	// leaves the new item invisible to the very next lookup, so a retry would create
+	// it a SECOND time.
+	return w.syncAfterWrite(item)
 }
 
 // ResolveFolder returns the id of the folder named name, creating it when absent.

--- a/cli/internal/secrets/bwserve_writer.go
+++ b/cli/internal/secrets/bwserve_writer.go
@@ -1,0 +1,143 @@
+package secrets
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// BWWriteClient is the whole write surface a Bitwarden-backed mutation needs: update
+// an existing field (BWWriter), create an absent item (BWCreator), and resolve — or
+// create — the folder the registry's taxonomy declares (BWFolderResolver). The three
+// stay separate interfaces so an update-only caller cannot create by accident; this
+// alias exists because `set`/`rotate`/`migrate` need all three at once and threading
+// three parameters through them buys nothing.
+//
+// Two implementations: BWPut (the `bw` CLI shellout) and BWServeWriter (the daemon).
+type BWWriteClient interface {
+	BWWriter
+	BWCreator
+	BWFolderResolver
+}
+
+// BWServeWriter is the serve-backed BWWriteClient: the write analog of BWServeReader,
+// and the fix for BUG-084 (#993). CLI-024-secrets-bw-serve moved the read path to the
+// daemon and deferred the write path as "a natural fast-follow"; nothing enforced that,
+// so `dotf secrets set` kept shelling out to a `bw` binary that authenticates from
+// BW_SESSION — the ambient variable ADR-028 exists to abolish. The result was a write
+// path that could not write on a correctly-unlocked machine.
+//
+// Every method reuses the same pure core as BWPut (setItemField, newItemBody, itemID),
+// so an item created or edited through the daemon is byte-identical to one created or
+// edited through the CLI. Only the transport differs — which is the entire point of
+// the seam, and what makes the two backends safe to choose between at runtime.
+//
+// Not available here: export. `bw serve` exposes no export route (verified against the
+// @bitwarden/cli 2026.5.0 bundle — the sole "/export" string in it is an *organization*
+// export against the cloud API), so BWExport stays a CLI shellout permanently. See
+// Backup's error path and BUG-084's proposal Out of scope.
+type BWServeWriter struct {
+	Client BWServeClient
+}
+
+// SetField sets field on item to value, preserving every other key of the item.
+//
+// Read-modify-write, exactly like BWPut.SetField: resolve the item, mutate one field,
+// PUT the whole thing back. It reuses BWServeReader.getItemJSON for the resolution so
+// the daemon's name/id disambiguation cannot drift from the read path's, and
+// setItemField for the mutation so field placement cannot drift from the CLI's.
+//
+// The item JSON goes back as a raw JSON body (json.RawMessage), NOT base64: the
+// daemon's REST API takes JSON directly, where the `bw` CLI needs `bw encode`d stdin.
+// That asymmetry is the only real difference between the two implementations.
+//
+// It does NOT sync first — deliberately, for parity with BWPut, so the two backends
+// behave identically under the same vault state (AC5). The daemon answers reads from
+// its own cache, so a sibling field edited in the web vault since the last sync can be
+// clobbered by this read-modify-write. That risk is inherited, not introduced (the CLI
+// has the same cache), but an unlocked daemon is easier to leave running for days,
+// which widens the window. Callers that care sync explicitly first — see
+// BWServeClient.Sync, and CLI-037's rotate.
+func (w BWServeWriter) SetField(item, field, value string) error {
+	// Same shape, same client: the read half of this read-modify-write is literally the
+	// read backend, so a conversion keeps them provably identical (and stops compiling
+	// if the two ever diverge) rather than re-deriving one from the other.
+	cur, err := BWServeReader(w).getItemJSON(item)
+	if err != nil {
+		// getItemJSON already classifies absence as ErrBWItemNotFound; re-wrap it
+		// with the same remediation BWPut.SetField gives, so `set`'s create-absent
+		// gate keys off one sentinel regardless of which backend answered.
+		if errors.Is(err, ErrBWItemNotFound) {
+			return fmt.Errorf("%w: %q (use `dotf secrets set` to create it)", ErrBWItemNotFound, item)
+		}
+		return fmt.Errorf("bw serve get item %q (it must already exist to edit): %w", item, err)
+	}
+	id, err := itemID(cur)
+	if err != nil {
+		return err
+	}
+	updated, err := setItemField(cur, field, value)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Client.call(http.MethodPut, "/object/item/"+url.PathEscape(id), json.RawMessage(updated)); err != nil {
+		return fmt.Errorf("bw serve edit item %q: %w", item, err)
+	}
+	return nil
+}
+
+// CreateItem creates a new login item named item carrying field=value, filed under
+// folderID when non-empty. Same minimal-login-template core as BWPut.CreateItem
+// (newItemBody), so a created item is identical whichever backend created it.
+func (w BWServeWriter) CreateItem(item, field, value, folderID string) error {
+	body, err := newItemBody(item, field, value, folderID)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Client.call(http.MethodPost, "/object/item", json.RawMessage(body)); err != nil {
+		return fmt.Errorf("bw serve create item %q: %w", item, err)
+	}
+	return nil
+}
+
+// ResolveFolder returns the id of the folder named name, creating it when absent.
+// Empty name → empty id (no folder declared is a no-op, not an error), matching
+// BWPut.ResolveFolder's contract exactly.
+//
+// It carries the same accepted limitation as the CLI implementation: idempotent for
+// sequential calls, NOT safe against concurrent ones, since Bitwarden permits duplicate
+// folder names and two racing processes can both observe the folder absent (OPS-028
+// adversarial review). `dotf secrets` has no concurrent-writer story anywhere in its
+// design, so this is a limitation, not a regression.
+func (w BWServeWriter) ResolveFolder(name string) (string, error) {
+	if name == "" {
+		return "", nil
+	}
+	data, err := w.Client.call(http.MethodGet, "/list/object/folders", nil)
+	if err != nil {
+		return "", fmt.Errorf("bw serve list folders: %w", err)
+	}
+	var list bwServeListData
+	if err := json.Unmarshal(data, &list); err != nil {
+		return "", fmt.Errorf("bw serve list folders: unparseable data: %w", err)
+	}
+	for _, f := range list.Data {
+		if f.Name == name {
+			return f.ID, nil
+		}
+	}
+	created, err := w.Client.call(http.MethodPost, "/object/folder", map[string]string{"name": name})
+	if err != nil {
+		return "", fmt.Errorf("bw serve create folder %q: %w", name, err)
+	}
+	var f bwServeListItem
+	if err := json.Unmarshal(created, &f); err != nil {
+		return "", fmt.Errorf("bw serve create folder %q: unparseable data: %w", name, err)
+	}
+	if f.ID == "" {
+		return "", fmt.Errorf("bw serve create folder %q: response carried no id", name)
+	}
+	return f.ID, nil
+}

--- a/cli/internal/secrets/bwserve_writer_live_test.go
+++ b/cli/internal/secrets/bwserve_writer_live_test.go
@@ -1,0 +1,130 @@
+package secrets
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestLiveBWServeWriter_CanaryRoundTrip is AC1/AC2 of BUG-084 against a REAL unlocked
+// `bw serve` daemon — the half a fake cannot prove.
+//
+// It is opt-in and skipped everywhere by default, including CI, because it needs an
+// unlocked vault. Run it deliberately:
+//
+//	DOTF_LIVE_BW=1 go test ./internal/secrets/ -run TestLiveBWServeWriter -v
+//
+// Safety properties, each deliberate:
+//
+//   - It NEVER touches a registry secret. It creates its own throwaway item, named with
+//     a timestamp so a leftover from an interrupted run can never be mistaken for a real
+//     entry, and deletes it at the end.
+//   - It NEVER prints a value. Every comparison is over `Fingerprint` (a truncated
+//     SHA-256), which is enough to prove two values differ and is not reversible. The
+//     values it writes are synthetic anyway, but the habit is the point:
+//     docs/lessons.md, "Redact at the producer" — and a second credential was leaked in
+//     this repo on the same day by curling this very endpoint to look at the reply.
+//   - Cleanup runs via t.Cleanup, so a mid-test failure still removes the item.
+func TestLiveBWServeWriter_CanaryRoundTrip(t *testing.T) {
+	if os.Getenv("DOTF_LIVE_BW") != "1" {
+		t.Skip("live Bitwarden smoke: set DOTF_LIVE_BW=1 with an unlocked `bw serve` daemon")
+	}
+
+	client := BWServeClient{}
+	st, err := client.Status()
+	if err != nil {
+		t.Fatalf("no reachable bw serve daemon (`dotf secrets unlock` first): %v", err)
+	}
+	if st != "unlocked" {
+		t.Fatalf("daemon is %q, need \"unlocked\" (`dotf secrets unlock`)", st)
+	}
+
+	// Prove the premise of the whole bug: no ambient session anywhere. If this is set,
+	// a passing test would prove nothing about the daemon path.
+	if os.Getenv("BW_SESSION") != "" {
+		t.Fatal("BW_SESSION is set — unset it, or this test cannot show the daemon path works without one")
+	}
+
+	w := BWServeWriter{Client: client}
+	item := fmt.Sprintf("dotf-canary-bug084-%d", time.Now().Unix())
+
+	// --- AC2: create, including folder resolution (OPS-028 taxonomy) -------------
+	folderID, err := w.ResolveFolder("apps")
+	if err != nil {
+		t.Fatalf("ResolveFolder(apps): %v", err)
+	}
+	t.Logf("resolved folder apps -> id present: %v", folderID != "")
+
+	first := fmt.Sprintf("canary-%d-first", time.Now().UnixNano())
+	if err := w.CreateItem(item, "password", first, folderID); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	t.Cleanup(func() { deleteCanaryItem(t, client, item) })
+
+	r := BWServeReader{Client: client}
+	got, err := r.Field(item, "password")
+	if err != nil {
+		t.Fatalf("read back created item: %v", err)
+	}
+	if Fingerprint(got) != Fingerprint(first) {
+		t.Fatalf("created value fingerprint mismatch: got %s, want %s", Fingerprint(got), Fingerprint(first))
+	}
+	t.Logf("AC2 create: fingerprint %s", Fingerprint(first))
+
+	// --- AC1: update an existing item -------------------------------------------
+	second := fmt.Sprintf("canary-%d-second", time.Now().UnixNano())
+	if err := w.SetField(item, "password", second); err != nil {
+		t.Fatalf("SetField: %v", err)
+	}
+	// NO explicit sync here, deliberately: BWServeWriter.syncAfterWrite must make the
+	// write visible on its own. This test failed exactly here before that existed.
+	got2, err := r.Field(item, "password")
+	if err != nil {
+		t.Fatalf("read back updated item: %v", err)
+	}
+	if Fingerprint(got2) != Fingerprint(second) {
+		t.Fatalf("updated value fingerprint mismatch: got %s, want %s", Fingerprint(got2), Fingerprint(second))
+	}
+	if Fingerprint(got2) == Fingerprint(first) {
+		t.Fatal("value did not change — the write did not take effect on the read path")
+	}
+	t.Logf("AC1 update: %s -> %s", Fingerprint(first), Fingerprint(second))
+
+	// --- the sibling-preservation property, live --------------------------------
+	if err := w.SetField(item, "CANARY_FIELD", "sibling-value"); err != nil {
+		t.Fatalf("SetField(custom field): %v", err)
+	}
+	still, err := r.Field(item, "password")
+	if err != nil {
+		t.Fatalf("read password after custom-field write: %v", err)
+	}
+	if Fingerprint(still) != Fingerprint(second) {
+		t.Fatal("writing a custom field clobbered the login password — read-modify-write is broken")
+	}
+	t.Logf("sibling preserved: password still %s after writing CANARY_FIELD", Fingerprint(second))
+}
+
+// deleteCanaryItem removes the throwaway item. It calls the daemon directly rather than
+// through a production seam on purpose: `dotf secrets` has no delete capability and this
+// test must not be the reason one gets added (#938 designs the retire path deliberately).
+func deleteCanaryItem(t *testing.T, c BWServeClient, item string) {
+	t.Helper()
+	raw, err := BWServeReader{Client: c}.getItemJSON(item)
+	if err != nil {
+		t.Errorf("CLEANUP FAILED - delete %q by hand: %v", item, err)
+		return
+	}
+	id, err := itemID(raw)
+	if err != nil {
+		t.Errorf("CLEANUP FAILED - delete %q by hand: %v", item, err)
+		return
+	}
+	if _, err := c.call(http.MethodDelete, "/object/item/"+url.PathEscape(id), nil); err != nil {
+		t.Errorf("CLEANUP FAILED - delete %q by hand: %v", item, err)
+		return
+	}
+	t.Logf("cleaned up canary item %s", item)
+}

--- a/cli/internal/secrets/bwserve_writer_test.go
+++ b/cli/internal/secrets/bwserve_writer_test.go
@@ -203,3 +203,63 @@ func TestBWServeWriter_SatisfiesWriteClient(t *testing.T) {
 	var _ BWWriteClient = BWServeWriter{}
 	var _ BWWriteClient = BWPut{}
 }
+
+// TestBWServeWriter_SyncsAfterWrite is the guard for the defect the live canary found,
+// which no fake had caught: a daemon PUT/POST updates the server, but the daemon keeps
+// answering reads from its own cache. Without a follow-up sync the value just written is
+// invisible — to this process and to every later one, because the stale cache lives in
+// the daemon, not the client.
+//
+// The sharpest consequence is not a stale read: `set` reads BEFORE writing to choose
+// unchanged-vs-update-vs-create, so against a stale cache an existing item can look
+// absent and the create path adds a DUPLICATE.
+func TestBWServeWriter_SyncsAfterWrite(t *testing.T) {
+	t.Run("SetField syncs", func(t *testing.T) {
+		f, w, closeSrv := newWriterFake(t)
+		defer closeSrv()
+		if err := w.SetField("dockerhub", "password", "v"); err != nil {
+			t.Fatalf("SetField: %v", err)
+		}
+		if f.syncs != 1 {
+			t.Fatalf("syncs = %d, want 1 — an unsynced write is invisible to reads", f.syncs)
+		}
+	})
+
+	t.Run("CreateItem syncs", func(t *testing.T) {
+		f, w, closeSrv := newWriterFake(t)
+		defer closeSrv()
+		if err := w.CreateItem("brand-new", "password", "v", ""); err != nil {
+			t.Fatalf("CreateItem: %v", err)
+		}
+		if f.syncs != 1 {
+			t.Fatalf("syncs = %d, want 1 — an unsynced create is invisible, so a retry duplicates it", f.syncs)
+		}
+	})
+
+	// A failed sync must not read as a failed write. The operator's next move differs
+	// completely: re-running a write that already landed is how duplicates happen.
+	t.Run("a failed sync reports that the write DID land", func(t *testing.T) {
+		f, w, closeSrv := newWriterFake(t)
+		defer closeSrv()
+		f.failSync = true
+
+		err := w.SetField("dockerhub", "password", "v")
+		if err == nil {
+			t.Fatal("a failed sync must be reported, not swallowed")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "WRITTEN successfully") {
+			t.Fatalf("error must state the write landed, got: %s", msg)
+		}
+		if !strings.Contains(msg, "do NOT re-run") {
+			t.Fatalf("error must warn against re-running the write, got: %s", msg)
+		}
+		// The write really did land, despite the error.
+		var got map[string]any
+		_ = json.Unmarshal(f.items["item-id-1"], &got)
+		login, _ := got["login"].(map[string]any)
+		if login["password"] != "v" {
+			t.Fatalf("the write should have landed before the sync failed, got %v", login["password"])
+		}
+	})
+}

--- a/cli/internal/secrets/bwserve_writer_test.go
+++ b/cli/internal/secrets/bwserve_writer_test.go
@@ -1,0 +1,205 @@
+package secrets
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newWriterFake returns a fake daemon holding one login item, plus the writer under
+// test wired to it.
+func newWriterFake(t *testing.T) (*fakeBWServe, BWServeWriter, func()) {
+	t.Helper()
+	f := &fakeBWServe{
+		status: "unlocked",
+		names:  map[string]string{"item-id-1": "dockerhub"},
+		items: map[string]json.RawMessage{
+			"item-id-1": json.RawMessage(`{"id":"item-id-1","type":1,"name":"dockerhub",` +
+				`"notes":"keep me","login":{"username":"manu","password":"old-secret"},` +
+				`"fields":[{"name":"PAT","value":"old-pat","type":1}]}`),
+		},
+	}
+	srv := httptest.NewServer(f.handler())
+	return f, BWServeWriter{Client: BWServeClient{BaseURL: srv.URL}}, srv.Close
+}
+
+// TestBWServeWriter_SetField_UpdatesAndPreserves: a write must change exactly one field
+// and leave every other key intact. It is read-modify-write, so a sloppy implementation
+// that PUTs a minimal body silently destroys the item's other fields — the most
+// damaging failure available on this path, and one that only shows up later.
+func TestBWServeWriter_SetField_UpdatesAndPreserves(t *testing.T) {
+	f, w, closeSrv := newWriterFake(t)
+	defer closeSrv()
+
+	if err := w.SetField("dockerhub", "password", "new-secret"); err != nil {
+		t.Fatalf("SetField: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(f.items["item-id-1"], &got); err != nil {
+		t.Fatalf("stored item is not valid JSON: %v", err)
+	}
+	login, _ := got["login"].(map[string]any)
+	if login["password"] != "new-secret" {
+		t.Fatalf("password = %v, want new-secret", login["password"])
+	}
+	if login["username"] != "manu" {
+		t.Fatalf("sibling username was clobbered: %v", login["username"])
+	}
+	if got["notes"] != "keep me" {
+		t.Fatalf("notes were clobbered: %v", got["notes"])
+	}
+	if got["id"] != "item-id-1" || got["name"] != "dockerhub" {
+		t.Fatalf("identity keys were clobbered: id=%v name=%v", got["id"], got["name"])
+	}
+	fields, _ := got["fields"].([]any)
+	if len(fields) != 1 {
+		t.Fatalf("custom fields were clobbered: %v", fields)
+	}
+}
+
+// TestBWServeWriter_SetField_MatchesBWPutShape is the parity assertion that keeps the
+// two backends interchangeable: for the same item and the same edit, the daemon writer
+// must store byte-identical JSON to what the CLI writer would have produced. Both go
+// through setItemField, and this test is what stops a future change from "optimising"
+// one of them into divergence.
+func TestBWServeWriter_SetField_MatchesBWPutShape(t *testing.T) {
+	f, w, closeSrv := newWriterFake(t)
+	defer closeSrv()
+	original := append(json.RawMessage(nil), f.items["item-id-1"]...)
+
+	if err := w.SetField("dockerhub", "PAT", "new-pat"); err != nil {
+		t.Fatalf("SetField: %v", err)
+	}
+
+	want, err := setItemField(original, "PAT", "new-pat")
+	if err != nil {
+		t.Fatalf("reference setItemField: %v", err)
+	}
+	if string(f.items["item-id-1"]) != string(want) {
+		t.Fatalf("daemon write diverged from the CLI shape:\n got: %s\nwant: %s", f.items["item-id-1"], want)
+	}
+}
+
+// TestBWServeWriter_SetField_AbsentItemIsClassified: `set` decides whether to offer
+// creation by testing for ErrBWItemNotFound. If the daemon writer reported absence as a
+// generic error, `set` would refuse to create against a daemon while creating happily
+// against the CLI — the same asymmetry BUG-084 is about, one level up. The security
+// crux of #612 also depends on this: a LOCKED vault must never look like an absent item.
+func TestBWServeWriter_SetField_AbsentItemIsClassified(t *testing.T) {
+	_, w, closeSrv := newWriterFake(t)
+	defer closeSrv()
+
+	err := w.SetField("no-such-item", "password", "v")
+	if !errors.Is(err, ErrBWItemNotFound) {
+		t.Fatalf("absent item must be ErrBWItemNotFound, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "dotf secrets set") {
+		t.Fatalf("absence should name the remediation, got: %v", err)
+	}
+}
+
+// TestBWServeWriter_CreateItem_SendsRawJSON: the daemon takes a raw JSON body where the
+// CLI needs base64-on-stdin. A regression to base64 would send a JSON string where an
+// object is expected; the fake rejects anything that is not valid JSON, so this pins the
+// one genuine behavioural difference between the two writers.
+func TestBWServeWriter_CreateItem_SendsRawJSON(t *testing.T) {
+	f, w, closeSrv := newWriterFake(t)
+	defer closeSrv()
+
+	if err := w.CreateItem("brand-new", "password", "v1", "folder-id-9"); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	if len(f.created) != 1 {
+		t.Fatalf("expected exactly one POST /object/item, got %d", len(f.created))
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(f.created[0], &got); err != nil {
+		t.Fatalf("created body is not raw JSON (base64 regression?): %v", err)
+	}
+	if got["name"] != "brand-new" {
+		t.Fatalf("name = %v", got["name"])
+	}
+	if got["folderId"] != "folder-id-9" {
+		t.Fatalf("folderId = %v, want folder-id-9 (OPS-028 taxonomy)", got["folderId"])
+	}
+	login, _ := got["login"].(map[string]any)
+	if login["password"] != "v1" {
+		t.Fatalf("password = %v", login["password"])
+	}
+
+	want, err := newItemBody("brand-new", "password", "v1", "folder-id-9")
+	if err != nil {
+		t.Fatalf("reference newItemBody: %v", err)
+	}
+	if string(f.created[0]) != string(want) {
+		t.Fatalf("created item diverged from the CLI shape:\n got: %s\nwant: %s", f.created[0], want)
+	}
+}
+
+// TestBWServeWriter_ResolveFolder covers the taxonomy half: an existing folder resolves
+// to its id without creating anything, an absent one is created, and an empty name is a
+// no-op rather than an error (so callers never special-case the unfoldered secret).
+func TestBWServeWriter_ResolveFolder(t *testing.T) {
+	t.Run("existing folder resolves without creating", func(t *testing.T) {
+		f, w, closeSrv := newWriterFake(t)
+		defer closeSrv()
+		f.folders = map[string]string{"fid-apps": "apps", "fid-infra": "infra"}
+
+		id, err := w.ResolveFolder("apps")
+		if err != nil {
+			t.Fatalf("ResolveFolder: %v", err)
+		}
+		if id != "fid-apps" {
+			t.Fatalf("id = %q, want fid-apps", id)
+		}
+		if len(f.folders) != 2 {
+			t.Fatalf("resolving an existing folder must not create one: %v", f.folders)
+		}
+	})
+
+	t.Run("absent folder is created", func(t *testing.T) {
+		f, w, closeSrv := newWriterFake(t)
+		defer closeSrv()
+		f.folders = map[string]string{"fid-apps": "apps"}
+		f.nextID = "fid-new"
+
+		id, err := w.ResolveFolder("infra")
+		if err != nil {
+			t.Fatalf("ResolveFolder: %v", err)
+		}
+		if id != "fid-new" {
+			t.Fatalf("id = %q, want fid-new", id)
+		}
+		if f.folders["fid-new"] != "infra" {
+			t.Fatalf("folder was not created: %v", f.folders)
+		}
+	})
+
+	t.Run("empty name is a no-op", func(t *testing.T) {
+		f, w, closeSrv := newWriterFake(t)
+		defer closeSrv()
+
+		id, err := w.ResolveFolder("")
+		if err != nil {
+			t.Fatalf("empty name must not error: %v", err)
+		}
+		if id != "" {
+			t.Fatalf("id = %q, want empty", id)
+		}
+		if len(f.folders) != 0 {
+			t.Fatalf("empty name must not create a folder: %v", f.folders)
+		}
+	})
+}
+
+// TestBWServeWriter_SatisfiesWriteClient is a compile-time guarantee that the daemon
+// writer covers the same surface as BWPut. Without it, a half-implemented backend fails
+// only at the call site that happens to use the missing method.
+func TestBWServeWriter_SatisfiesWriteClient(t *testing.T) {
+	var _ BWWriteClient = BWServeWriter{}
+	var _ BWWriteClient = BWPut{}
+}

--- a/cli/internal/secrets/escrow.go
+++ b/cli/internal/secrets/escrow.go
@@ -41,13 +41,38 @@ func (e BWExport) Export() ([]byte, error) {
 		bin = "bw"
 	}
 	if _, err := bwRun(bin, "sync"); err != nil {
-		return nil, fmt.Errorf("bw sync: %w", err)
+		return nil, fmt.Errorf("bw sync: %w", exportLockHint(err))
 	}
 	out, err := bwRun(bin, "export", "--format", "json", "--raw")
 	if err != nil {
-		return nil, fmt.Errorf("bw export: %w", err)
+		return nil, fmt.Errorf("bw export: %w", exportLockHint(err))
 	}
 	return out, nil
+}
+
+// exportLockHint explains the one asymmetry BUG-084 could not remove.
+//
+// `set`, `rotate` and `migrate` moved to the bw serve daemon, so their locked-vault
+// errors now say "run `dotf secrets unlock`". Export cannot follow them: `bw serve`
+// exposes NO export route — verified by enumerating the shipped @bitwarden/cli 2026.5.0
+// router table, where the sole "/export" string is an *organization* export against the
+// cloud API, not personal-vault export. So the escrow is permanently CLI-backed and
+// permanently needs that binary's own session.
+//
+// Telling an operator to run `dotf secrets unlock` here would be actively wrong: it
+// unlocks the daemon, the escrow still fails, and the message has taught them a fix that
+// cannot work. This is why the DR escrow silently never existed until 2026-08-15 (#997):
+// the failure was real, but nothing it printed pointed anywhere useful.
+func exportLockHint(err error) error {
+	if !isVaultLocked(err) {
+		return err
+	}
+	return fmt.Errorf("%w: the escrow cannot go through the bw serve daemon — `bw serve` "+
+		"exposes no export endpoint, so this is the one `dotf secrets` operation that needs "+
+		"the bw CLI's own session. `dotf secrets unlock` will NOT fix it. Run:\n"+
+		"    BW_SESSION=\"$(bw unlock --raw)\" dotf secrets backup\n"+
+		"which confines the session to that one process rather than exporting it: %w",
+		ErrBWVaultLocked, err)
 }
 
 // bwRun executes `bw <args...> --nointeraction`, returning stdout or an error carrying

--- a/cli/internal/secrets/escrow_test.go
+++ b/cli/internal/secrets/escrow_test.go
@@ -3,10 +3,12 @@ package secrets
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -184,5 +186,39 @@ func TestBackup_EmptyExport_Refused(t *testing.T) {
 func TestBackup_NilExporter_Errors(t *testing.T) {
 	if _, err := Backup(BackupConfig{}); err == nil {
 		t.Fatal("expected an error when no exporter is configured")
+	}
+}
+
+// TestExportLockHint_NamesTheOnlyInvocationThatWorks is AC4 of BUG-084.
+//
+// Export is the one write-side operation with no daemon equivalent, so its locked-vault
+// error must NOT send the operator to `dotf secrets unlock` (which unlocks the daemon and
+// leaves the escrow failing). It must name the BW_SESSION form, and say why.
+func TestExportLockHint_NamesTheOnlyInvocationThatWorks(t *testing.T) {
+	got := exportLockHint(errors.New("Vault is locked."))
+	if !errors.Is(got, ErrBWVaultLocked) {
+		t.Fatalf("must wrap ErrBWVaultLocked, got %v", got)
+	}
+	msg := got.Error()
+	for _, want := range []string{
+		`BW_SESSION="$(bw unlock --raw)" dotf secrets backup`,
+		"no export endpoint",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("export lock error must contain %q, got: %s", want, msg)
+		}
+	}
+	// The critical negative: it must not teach the fix that cannot work here.
+	if strings.Contains(msg, "run `dotf secrets unlock`") {
+		t.Fatalf("export error must not prescribe `dotf secrets unlock` — it does not fix export: %s", msg)
+	}
+}
+
+// TestExportLockHint_PassesThroughUnrelatedErrors: an offline sync failure must not be
+// reported as a lock problem.
+func TestExportLockHint_PassesThroughUnrelatedErrors(t *testing.T) {
+	orig := errors.New("Failed to fetch: getaddrinfo ENOTFOUND")
+	if got := exportLockHint(orig); got != orig { //nolint:errorlint // identity is the assertion
+		t.Fatalf("unrelated error was rewritten: %v", got)
 	}
 }

--- a/specs/BUG-084-secrets-write-bw-serve/proposal.md
+++ b/specs/BUG-084-secrets-write-bw-serve/proposal.md
@@ -1,0 +1,124 @@
+---
+id: "BUG-084-secrets-write-bw-serve"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-15"
+issue: "mlorentedev/dotfiles#993"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# BUG-084-secrets-write-bw-serve
+
+> **Naming**: file lives at `<repo>/specs/BUG-084-secrets-write-bw-serve/proposal.md`. `BUG-084-secrets-write-bw-serve` is `AREA-NNN-slug`.
+
+## Why
+
+<!-- from issue #993: BUG-084: dotf secrets set is unusable under the sanctioned unlock model — the write path never moved to bw serve -->
+
+`dotf secrets set` cannot write anything on a machine unlocked the way ADR-028 and
+CLI-024 prescribe. CLI-024-secrets-bw-serve moved the **read** path to the `bw serve`
+daemon and deliberately deferred the write path as "a natural fast-follow"; that
+fast-follow never happened, so `BWPut` still shells out to a `bw` binary that
+authenticates from `BW_SESSION` — the ambient variable ADR-028 exists to abolish. Every
+write therefore fails with `Vault is locked.` no matter how recently the operator
+unlocked, because the daemon holds the unlocked session and the shellout asks a
+different subject. This is not a corner case: it is the entire provisioning and rotation
+story, and it blocks the Phase 3 migration outright.
+
+## What
+
+The write path gains the same daemon seam the read path already has.
+
+- A `BWServeWriter` implementing `SetField`, `CreateItem` and `ResolveFolder` against
+  the daemon's REST API — `PUT /object/item/:id`, `POST /object/item`,
+  `GET /list/object/folders` + `POST /object/folder`.
+- A `BWFallbackWriter` selecting daemon-vs-shellout, mirroring `BWFallbackReader`.
+- `dotf secrets set <ID>` (both the edit-existing and create-new paths), and by
+  extension `rotate` and `migrate`, succeed against an unlocked daemon with no
+  `BW_SESSION` anywhere in the environment.
+- Where a write genuinely cannot proceed, the error names the remediation that works
+  (`dotf secrets unlock`), never a bare `Vault is locked.` that sends the operator to
+  `bw unlock` — which prints a session key to a shell nobody is reading and does not
+  fix the failure.
+- `dotf secrets backup` keeps its shellout, and gains an error that says *why* the
+  daemon cannot serve it and names the invocation that does work. See Out of scope.
+
+## Out of scope
+
+- **Serve-backed `Export` / `dotf secrets backup`.** Not deferred by preference —
+  impossible. Enumerated from the shipped `@bitwarden/cli` 2026.5.0 bundle, `bw serve`
+  exposes **no export route**; the sole `"/export"` string in it is
+  `apiService.send("GET", "/organizations/" + organizationId + "/export")`, an
+  *organization* export against the cloud API. `BWExport` therefore stays a `bw`
+  shellout permanently, and `BW_SESSION="$(bw unlock --raw)" dotf secrets backup` is its
+  standing invocation, not a workaround with an expiry date. Only its error message
+  changes here.
+- **Assembling the escrow from `GET /list/object/items` + `/list/object/folders`.** It
+  would *probably* yield an importable `{encrypted:false,folders,items}` document, and
+  *probably* is not a property a disaster-recovery escrow may have. Proving it requires
+  a real `bw import` round-trip into a scratch vault. Shipping it unverified produces an
+  escrow that looks like it works and fails only during an actual recovery — the exact
+  class of #997, #992 and #906. Filed separately with that round-trip as its acceptance
+  criterion.
+- **`DELETE /object/item/:id`.** The daemon exposes it; nothing in `dotf secrets` needs
+  it, and a delete capability on the write seam is a footgun with no current caller
+  (#938's retire path is a separate, deliberate design).
+- **#1004 (verify aborts on registry validation)** — same package, adjacent symptom,
+  different surface (registry loader, not the bw backend). Parked behind this spec by
+  the same session, not bundled.
+- **Windows daemon-lifecycle validation.** Cross-platform by construction, live-verified
+  on Linux only, per the precedent set by CLI-024-secrets-bw-serve.
+
+## Risks / open questions
+
+- **Read/write backend split-brain.** The failure this bug *is*: two halves of one
+  command authenticating through different subjects. `rotate` (#996/#1003) reads and
+  writes in a single invocation, making it the sharpest detector — if reads resolve
+  through the daemon and writes through a shellout, rotation half-succeeds. AC5 exists
+  to make that unrepresentable rather than merely tested.
+- **Read-modify-write over a stale daemon cache.** `SetField` is RMW: read item, mutate
+  one field, write it back. If the daemon's cache is stale relative to the server, a
+  sibling field edited elsewhere is silently clobbered. `BWPut` inherits the same risk
+  today via the CLI's own cache, so this is not a regression — but the daemon makes it
+  easier to hold an unlocked session open for days, which widens the window. Mitigation:
+  `POST /sync` before the read half of an RMW (`BWServeClient.Sync()` already exists).
+- **`bw serve`'s REST API is unauthenticated by design.** Already accepted and mitigated
+  by the loopback bind invariant (`bwServeHostname`, AC5 of CLI-024-secrets-bw-serve).
+  This spec adds *write* capability to that surface, which raises the consequence of a
+  bind regression from vault disclosure to vault mutation. No new mitigation proposed;
+  the existing bind test is now load-bearing for integrity, not just confidentiality,
+  and this spec records that.
+- **Live verification requires a real unlocked vault**, which CI does not have. Thin I/O
+  is live-smoke-verified only, per the standing convention for `BWGet`/`BWPut`. Any real
+  write must target the designated canary item and print fingerprints, never values
+  (`docs/lessons.md`, "Redact at the producer").
+
+## Acceptance criteria
+
+- [ ] AC1 — `dotf secrets set <ID>` succeeds against an unlocked `bw serve` daemon with
+      no `BW_SESSION` anywhere in the environment, for an **existing** item.
+- [ ] AC2 — the same holds for a **new** item, exercising `CreateItem` and
+      `ResolveFolder` (an entry declaring a `bw.folder` lands in that folder).
+- [ ] AC3 — with no daemon and no session, the error names `dotf secrets unlock`, not a
+      bare `Vault is locked.`
+- [ ] AC4 — `dotf secrets backup` with no session fails with an error that names
+      `BW_SESSION="$(bw unlock --raw)" dotf secrets backup` and states that the daemon
+      has no export endpoint.
+- [ ] AC5 — a test asserts the read and write fallbacks agree on backend selection for
+      the same daemon state, so the next path cannot move alone (the guard this bug's
+      own existence proves is needed).
+- [ ] AC6 — the failure is observed red against real state before the fix, and green
+      after, with both captured in `verification.md`.
+
+## References
+
+- Bitácora board: `mlorentedev/dotfiles#993` (see `issue:` frontmatter)
+- `specs/CLI-024-secrets-bw-serve/proposal.md` — the read-path move; names this work as
+  its fast-follow in Out of scope
+- `specs/archive/CLI-024-secrets-bw-writer/` — the original write seam being extended
+- `docs/adr/adr-028-secrets-two-tier-bitwarden-age.md` — why the ambient environment is
+  empty by design
+- #997 (escrow severity), #992 (parse guard), #1004 (verify scoping) — adjacent, other
+  sessions or parked
+- `docs/lessons.md`, "Redact at the producer" — binding on any live write verification

--- a/specs/BUG-084-secrets-write-bw-serve/tasks.md
+++ b/specs/BUG-084-secrets-write-bw-serve/tasks.md
@@ -1,0 +1,46 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-15"
+---
+
+# Tasks - BUG-084-secrets-write-bw-serve
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers** (optional, additive — borrowed from `github/spec-kit`, adapt-not-adopt per #141):
+> - `[P]` — this task has **no dependency on another unchecked task**, so it is safe to run in parallel (fan out to a `Workflow`, or just batch). TDD chains (test → implement → refactor of the *same* behavior) are sequential and must NOT carry `[P]`; independent behaviors can.
+> - `[AC<n>]` — this task helps satisfy **acceptance criterion #`<n>`** from `proposal.md`. Lets `/spec check` map coverage deterministically; omit it and the check falls back to semantic judgment.
+
+## Setup
+
+- [x] Branch created from main: `fix/bug-084-secrets-write-bw-serve`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] Open questions resolved before implementing: the daemon's write surface was
+      enumerated from the shipped `@bitwarden/cli` 2026.5.0 bundle rather than assumed
+      (the issue asserted `PUT /object/item/<id>` and also assumed `backup` could move
+      with it — the first is right, the second is not), and the pin-vs-per-call backend
+      question was put to the operator and answered "pin once per command".
+
+## Implementation
+
+- [x] [AC5] Enumerate the real `bw serve` router table; establish that export has no
+      endpoint and revise scope accordingly (recorded on #993, comment 5304815767)
+- [x] [AC1] `BWServeWriter.SetField` — read-modify-write via `GET` + `PUT /object/item/:id`,
+      reusing `setItemField` so field placement cannot diverge from `BWPut`
+- [x] [AC2] `BWServeWriter.CreateItem` — `POST /object/item`, reusing `newItemBody`
+- [x] [AC2] `BWServeWriter.ResolveFolder` — `GET /list/object/folders` + `POST /object/folder`
+- [x] [AC5] `BWBackend` + `SelectBWBackend` — one probe, matched read/write pair
+- [x] [AC3] `lockHint` decorator on the shellout pair, keyed to the observed daemon state
+- [x] [AC4] `exportLockHint` on `BWExport.Export` — names the BW_SESSION form, and
+      explicitly says `dotf secrets unlock` will NOT fix export
+- [x] Wire `bwRead()` / `bwWrite()` accessors in `internal/cmd`, pinning per process
+- [x] Extend the shared `fakeBWServe` with the write endpoints (one fake, both paths)
+
+## Verification
+
+- [x] `go build ./... && go vet ./... && go test ./...` — all green
+- [x] `golangci-lint run` at the pinned 2.12.2 — 0 issues
+- [x] AC5 guard mutation-checked: reintroducing the split-brain makes it fail red
+- [x] AC4 observed live, before and after, against a real unlocked daemon
+- [ ] AC1/AC2 live write against a canary item — **pending operator authorization**
+      (a real vault mutation; not done unilaterally)

--- a/specs/BUG-084-secrets-write-bw-serve/verification.md
+++ b/specs/BUG-084-secrets-write-bw-serve/verification.md
@@ -1,0 +1,97 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-15"
+---
+
+# Verification - BUG-084-secrets-write-bw-serve
+
+## Evidence
+
+| AC | Claim | Proof |
+|---|---|---|
+| AC1 | `set` succeeds against an unlocked daemon with no `BW_SESSION`, existing item | `TestBWServeWriter_SetField_UpdatesAndPreserves`, `TestBWServeWriter_SetField_MatchesBWPutShape` — **live canary write still pending** (see Gaps) |
+| AC2 | same for a new item, incl. folder resolution | `TestBWServeWriter_CreateItem_SendsRawJSON`, `TestBWServeWriter_ResolveFolder` — **live canary write still pending** |
+| AC3 | no daemon + no session names `dotf secrets unlock` | `TestSelectBWBackend_ShelloutNamesTheRealRemediation`, `TestSelectBWBackend_ShelloutHalvesBothDecorate` |
+| AC4 | `backup` names the `BW_SESSION` form and says why | `TestExportLockHint_NamesTheOnlyInvocationThatWorks` + live capture below |
+| AC5 | read and write agree on backend | `TestSelectBWBackend_ReadAndWriteAlwaysAgree`, `TestSelectBWBackend_ProbesOnce`, mutation-checked |
+| AC6 | observed red before, green after | live capture below |
+
+### AC4 observed live (the headline evidence)
+
+Preconditions: `BW_SESSION` unset; `bw serve` daemon **running and unlocked**. That
+combination is the whole point — the daemon being unlocked is exactly why the old
+message misled.
+
+```
+######## BEFORE - installed 0.41.0 ########
+Error: backup: bw export: Vault is locked.
+
+######## AFTER - this branch ########
+Error: backup: bw export: bitwarden vault is locked: the escrow cannot go through the
+bw serve daemon - `bw serve` exposes no export endpoint, so this is the one
+`dotf secrets` operation that needs the bw CLI's own session. `dotf secrets unlock`
+will NOT fix it. Run:
+    BW_SESSION="$(bw unlock --raw)" dotf secrets backup
+which confines the session to that one process rather than exporting it: Vault is locked.
+```
+
+The "before" line is the message under which the DR escrow silently never existed
+(#997): true, useless, and pointing nowhere.
+
+### AC5 mutation-checked
+
+A guard never observed failing is not evidence (#898). The split-brain was reintroduced
+(daemon reader + shellout writer) and the guard caught it:
+
+```
+--- FAIL: TestSelectBWBackend_ReadAndWriteAlwaysAgree/unlocked_daemon_is_used_for_both_halves
+    bwbackend_test.go:68: SPLIT BRAIN: reader daemon=true but writer daemon=false
+        - this is exactly BUG-084
+```
+
+Restored, suite green again.
+
+## Test status
+
+- `go build ./... && go vet ./... && go test ./...` — every package ok
+- `golangci-lint run` (pinned 2.12.2, matching `versions.conf`) — **0 issues**
+- No regressions: the existing `internal/cmd` suite passes unchanged, including the
+  tests that inject `bwReader` / `bwWriter` directly — both remain test seams.
+
+## Gaps (stated, not hidden)
+
+- **AC1/AC2 have no live write yet.** They are proven against an httptest double of the
+  daemon, not against Bitwarden. Closing them means writing to a real vault item, which
+  is an operator decision, not an agent's — deliberately left for explicit authorization
+  rather than performed unilaterally. The repo convention for this is the canary item
+  (#612 C8).
+
+## Decisions made during implementation
+
+- **Backend pinned per command, not chosen per call** (operator decision). The read
+  path's `BWFallbackReader` re-probes on every call, which self-heals if the daemon
+  appears mid-run but lets a daemon that *locks* mid-command split that command across
+  two subjects — a narrower instance of this very bug. For `rotate` (read → write →
+  read back) a consistent subject beats self-healing: failing whole is better than
+  half-applying. `BWFallbackReader` is left in place, unused by the pinned path, since
+  it is still the documented read-only seam.
+- **`backup` scoped out on evidence, not preference.** `bw serve` has no export route.
+  Recorded on #993 with the enumerated router table so the next person does not re-derive
+  it.
+- **The escrow is NOT assembled from `/list/object/items`.** It would probably produce an
+  importable document; *probably* is not a property a DR escrow may have. Filed
+  separately with a `bw import` round-trip as its acceptance criterion.
+- **Lock hints decorate both halves**, not just the writer: `set` reads before it writes,
+  so a locked vault surfaces on the read first.
+
+## Promotion candidates
+
+- [x] Lesson for the repo's `docs/lessons.md`? **Yes** — "a seam moved halfway is worse
+      than a seam not moved": the read path moving alone produced a system where the
+      daemon was unlocked, reads worked, and writes reported a locked vault, so every
+      diagnostic pointed at the wrong subject. The generalizable rule is that when a
+      backend is swapped behind an interface, the *selection* must be one decision, not
+      one per caller.
+- [ ] ADR-worthy? No — this implements ADR-028 as already ratified; it decides nothing new.
+- [ ] New pattern for `00_meta/patterns/`? Not yet. If a third instance of
+      "which session is locked?" appears outside this repo, revisit.

--- a/specs/BUG-084-secrets-write-bw-serve/verification.md
+++ b/specs/BUG-084-secrets-write-bw-serve/verification.md
@@ -9,8 +9,8 @@ created: "2026-08-15"
 
 | AC | Claim | Proof |
 |---|---|---|
-| AC1 | `set` succeeds against an unlocked daemon with no `BW_SESSION`, existing item | `TestBWServeWriter_SetField_UpdatesAndPreserves`, `TestBWServeWriter_SetField_MatchesBWPutShape` — **live canary write still pending** (see Gaps) |
-| AC2 | same for a new item, incl. folder resolution | `TestBWServeWriter_CreateItem_SendsRawJSON`, `TestBWServeWriter_ResolveFolder` — **live canary write still pending** |
+| AC1 | `set` succeeds against an unlocked daemon with no `BW_SESSION`, existing item | `TestBWServeWriter_SetField_UpdatesAndPreserves`, `..._MatchesBWPutShape`, **+ live: `TestLiveBWServeWriter_CanaryRoundTrip`** |
+| AC2 | same for a new item, incl. folder resolution | `TestBWServeWriter_CreateItem_SendsRawJSON`, `..._ResolveFolder`, **+ live (same test)** |
 | AC3 | no daemon + no session names `dotf secrets unlock` | `TestSelectBWBackend_ShelloutNamesTheRealRemediation`, `TestSelectBWBackend_ShelloutHalvesBothDecorate` |
 | AC4 | `backup` names the `BW_SESSION` form and says why | `TestExportLockHint_NamesTheOnlyInvocationThatWorks` + live capture below |
 | AC5 | read, write **and sync** agree on backend | `TestSelectBWBackend_ReadAndWriteAlwaysAgree`, `TestSelectBWBackend_ProbesOnce`, mutation-checked |
@@ -78,13 +78,52 @@ Restored, suite green again.
 - No regressions: the existing `internal/cmd` suite passes unchanged, including the
   tests that inject `bwReader` / `bwWriter` directly — both remain test seams.
 
+### AC1/AC2 closed by a live canary — which found a defect no fake had
+
+Operator-authorized, run against the real unlocked daemon with `BW_SESSION` unset. The
+test creates its own throwaway item, compares only fingerprints, and deletes it:
+
+```
+$ env -u BW_SESSION DOTF_LIVE_BW=1 go test ./internal/secrets/ -run TestLiveBWServeWriter -v
+    resolved folder apps -> id present: true
+    AC2 create: fingerprint 189dea85d0fc
+    AC1 update: 189dea85d0fc -> 41021d0caee6
+    sibling preserved: password still 41021d0caee6 after writing CANARY_FIELD
+    cleaned up canary item dotf-canary-bug084-1786839835
+--- PASS
+```
+
+**Its first run FAILED**, and that is the point of having run it:
+
+```
+    AC2 create: fingerprint 7060b0a2a2c3
+    updated value fingerprint mismatch: got 7060b0a2a2c3, want 67c2cd6b084e
+```
+
+The read-back returned the value from *before* the write. A daemon `PUT` updates the
+server but the daemon keeps answering reads from its own cache, so the written value was
+invisible — and the stale cache lives in the daemon, not the client, so every later
+process saw the old value too.
+
+The sharpest consequence is not a stale read. `dotf secrets set` reads *before* writing
+to choose unchanged-vs-update-vs-create; against a stale cache an item that exists can
+look absent, and the create path would then add a **duplicate** — the same class of
+mistake #612 guards against when it refuses to treat a locked vault as an absent item.
+
+Fixed by `syncAfterWrite` on both `SetField` and `CreateItem`, and the live test now
+passes with **no explicit sync of its own**. A failed sync is reported as "written
+successfully, but…" rather than as a failed write, because re-running a write that
+already landed is exactly how the duplicate gets created.
+
+This is the entry that justifies AC6's insistence on live verification: three fakes and
+a full unit suite were green while the write was invisible in production.
+
 ## Gaps (stated, not hidden)
 
-- **AC1/AC2 have no live write yet.** They are proven against an httptest double of the
-  daemon, not against Bitwarden. Closing them means writing to a real vault item, which
-  is an operator decision, not an agent's — deliberately left for explicit authorization
-  rather than performed unilaterally. The repo convention for this is the canary item
-  (#612 C8).
+- **Windows daemon lifecycle is unverified**, per the precedent set by
+  CLI-024-secrets-bw-serve. Cross-platform by construction, exercised on Linux only.
+- **The live canary is opt-in and not in CI** (`DOTF_LIVE_BW=1`), because CI has no
+  unlocked vault. It is a smoke test an operator runs, not a gate.
 
 ## Decisions made during implementation
 

--- a/specs/BUG-084-secrets-write-bw-serve/verification.md
+++ b/specs/BUG-084-secrets-write-bw-serve/verification.md
@@ -13,7 +13,7 @@ created: "2026-08-15"
 | AC2 | same for a new item, incl. folder resolution | `TestBWServeWriter_CreateItem_SendsRawJSON`, `TestBWServeWriter_ResolveFolder` — **live canary write still pending** |
 | AC3 | no daemon + no session names `dotf secrets unlock` | `TestSelectBWBackend_ShelloutNamesTheRealRemediation`, `TestSelectBWBackend_ShelloutHalvesBothDecorate` |
 | AC4 | `backup` names the `BW_SESSION` form and says why | `TestExportLockHint_NamesTheOnlyInvocationThatWorks` + live capture below |
-| AC5 | read and write agree on backend | `TestSelectBWBackend_ReadAndWriteAlwaysAgree`, `TestSelectBWBackend_ProbesOnce`, mutation-checked |
+| AC5 | read, write **and sync** agree on backend | `TestSelectBWBackend_ReadAndWriteAlwaysAgree`, `TestSelectBWBackend_ProbesOnce`, mutation-checked |
 | AC6 | observed red before, green after | live capture below |
 
 ### AC4 observed live (the headline evidence)
@@ -37,6 +37,26 @@ which confines the session to that one process rather than exporting it: Vault i
 
 The "before" line is the message under which the DR escrow silently never existed
 (#997): true, useless, and pointing nowhere.
+
+### Read path re-verified live (regression caught in review)
+
+The first implementation changed `bwReader`'s production default to nil but left one
+bare-var use in `secretLoader()` (`BW: bwReader`), which the call-site rewrite did not
+match. Every unit test still passed, because they all inject `bwReader`; the live smoke
+had only exercised `backup`, which does not go through the Loader. The one production
+path not run was the one that broke — a read path that worked *before* this change.
+
+Fixed to `BW: bwRead()`, and the gap that hid it closed by actually running it:
+
+```
+$ env -u BW_SESSION dotf secrets verify     # no ambient session; daemon unlocked
+...
+33 ok, 0 missing, 0 failed
+exit=0
+```
+
+That is also the AC1 read-half evidence: 33 secrets resolved through the pinned daemon
+backend with no `BW_SESSION` anywhere.
 
 ### AC5 mutation-checked
 
@@ -81,6 +101,11 @@ Restored, suite green again.
 - **The escrow is NOT assembled from `/list/object/items`.** It would probably produce an
   importable document; *probably* is not a property a DR escrow may have. Filed
   separately with a `bw import` round-trip as its acceptance criterion.
+- **Sync was folded into the pinned backend too.** `bwSyncer` defaulted to the daemon
+  unconditionally, so a shellout-backed command synced the daemon's cache while reading
+  the CLI's — the same split, one path over, inside the very PR fixing it. `rotate`
+  writes, syncs, then reads back to prove the write took; syncing the wrong cache makes
+  that proof worthless. The AC5 guard now asserts all three halves, not two.
 - **Lock hints decorate both halves**, not just the writer: `set` reads before it writes,
   so a locked vault surfaces on the read first.
 


### PR DESCRIPTION
Refs #993 (BUG-084) — **closing keyword deliberately withheld until the spec is archived in this same PR.**

The SDD lifecycle ends by archiving `specs/BUG-084-secrets-write-bw-serve/` here, and `dotf spec archive` requires a passing independent adversarial review (non-Anthropic reviewer pool — the reviewer must not be the implementer, and Claude implemented this). That review runs against the final SHA. Once it returns PASS the spec is archived and this line becomes `Closes #993`.

## The bug

`dotf secrets set` could not write anything on a machine unlocked the way ADR-028 and CLI-024 prescribe. CLI-024 moved the **read** path to the `bw serve` daemon and deferred the write path as "a natural fast-follow". Nothing enforced that, so `BWPut` kept shelling out to a `bw` binary that authenticates from `BW_SESSION` — the ambient variable ADR-028 exists to abolish.

The result was worse than a plain failure: reads resolved fine against an unlocked daemon while writes reported `Vault is locked.`, and `bw unlock` appeared not to work, because it prints a session key to a shell that is not the one being asked. Four separate "which session is locked?" confusions in one day trace to this.

## Scope, corrected on evidence

The issue named one seam (`SetField`). There were **four**, all shellout-only — `SetField`, `CreateItem`, `ResolveFolder`, `Export`. Fixing only the first would have left `set`'s create-a-new-item path still broken.

The issue also assumed `backup` could be fixed alongside. **It cannot.** Enumerated from the shipped `@bitwarden/cli` 2026.5.0 bundle, `bw serve` exposes no export route; the sole `"/export"` string in it is `apiService.send("GET", "/organizations/" + organizationId + "/export")` — an *organization* export against the cloud API. Full router table on #993 (comment 5304815767), independently re-verified by the session on #997.

## What changed

- **`BWServeWriter`** — `SetField` / `CreateItem` / `ResolveFolder` against `PUT /object/item/:id`, `POST /object/item`, `GET /list/object/folders` + `POST /object/folder`. Reuses the same pure cores as `BWPut` (`setItemField`, `newItemBody`), so an item written through either backend is byte-identical — asserted, not assumed.
- **`BWBackend` + `SelectBWBackend`** — the daemon is probed **once per command** and both halves come from that one decision. `bwRead()` / `bwWrite()` replace the two independently-initialised vars.
- **Lock hints** — a locked-vault failure now names `dotf secrets unlock` and reports the daemon state actually observed at selection time.
- **`exportLockHint`** — `backup` says *why* the daemon cannot serve it and names `BW_SESSION="$(bw unlock --raw)" dotf secrets backup`, explicitly stating that `dotf secrets unlock` will **not** fix it.

## The design decision, and why

Pinning the backend per command rather than per call was the operator's call. The read path's `BWFallbackReader` re-probes on every `Field()`: it self-heals if the daemon appears mid-run, but a daemon that *locks* between two calls of one command splits that command across two subjects — a narrower instance of this very bug. For `rotate` (read old → write new → read back), a consistent subject beats self-healing: failing whole is better than half-applying.

## Evidence

**AC4, live, before and after** — with `BW_SESSION` unset and the daemon **running and unlocked**, which is precisely why the old message misled:

```
######## BEFORE - installed 0.41.0 ########
Error: backup: bw export: Vault is locked.

######## AFTER - this branch ########
Error: backup: bw export: bitwarden vault is locked: the escrow cannot go through the
bw serve daemon - `bw serve` exposes no export endpoint, so this is the one
`dotf secrets` operation that needs the bw CLI's own session. `dotf secrets unlock`
will NOT fix it. Run:
    BW_SESSION="$(bw unlock --raw)" dotf secrets backup
```

The "before" line is the message under which the DR escrow silently never existed (#997).

**AC5, mutation-checked** — a guard never observed failing is not evidence (#898). The split-brain was reintroduced deliberately:

```
--- FAIL: TestSelectBWBackend_ReadAndWriteAlwaysAgree/unlocked_daemon_is_used_for_both_halves
    bwbackend_test.go:68: SPLIT BRAIN: reader daemon=true but writer daemon=false
        - this is exactly BUG-084
```

**Suite** — `go build ./... && go vet ./... && go test ./...` all green; `golangci-lint run` at the pinned 2.12.2 reports 0 issues.

## Gap, stated rather than hidden

**AC1/AC2 have no live write yet.** They are proven against an httptest double of the daemon, not against Bitwarden. Closing them means writing to a real vault item — an operator decision, not an agent's, so it was deliberately not done unilaterally. The repo convention for this is the canary item (#612 C8). Reviewers should treat the daemon write path as unit-verified and not yet smoke-verified.

## Follow-up filed separately

Assembling the escrow from `/list/object/items` + `/list/object/folders` would *probably* yield an importable document. *Probably* is not a property a disaster-recovery escrow may have, so it is not in this PR; it needs a real `bw import` round-trip as its acceptance criterion.
