### PR TITLE
fix(secrets): stop probing /status, which poisons the daemon's item reads

### DIFF
--- a/cli/internal/secrets/bwbackend.go
+++ b/cli/internal/secrets/bwbackend.go
@@ -3,6 +3,7 @@ package secrets
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 )
 
@@ -43,18 +44,6 @@ type BWBackend struct {
 	Daemon bool
 }
 
-// SelectBWBackend probes the daemon ONCE and returns a matched pair.
-//
-// The daemon is chosen only when it is both reachable and unlocked. Anything else —
-// not running, running but locked, unreachable — selects the CLI shellout, which is
-// still the correct choice: an operator with an ambient BW_SESSION can work that way,
-// and it is the only backend that can export (see BWExport).
-//
-// When the shellout is selected, its errors are decorated with the remediation implied
-// by the daemon state observed HERE, at selection time. That is the difference between
-// "Vault is locked." — which sends the operator to `bw unlock`, a command that prints a
-// session key to a shell nobody is reading and does not fix the failure — and an error
-// naming `dotf secrets unlock`, which does.
 // BWSyncer refreshes the local cache a backend answers reads from. Both backends have
 // one and they are NOT interchangeable: the daemon caches independently of the `bw`
 // CLI, so syncing one leaves the other stale. Which is why it is pinned alongside the
@@ -80,10 +69,21 @@ func (s BWCLISync) Sync() error {
 	return nil
 }
 
+// SelectBWBackend probes the daemon ONCE and returns a matched pair.
+//
+// The daemon is chosen only when it is reachable AND willing to serve a read. Anything
+// else — not running, locked, refusing — selects the CLI shellout, which is still the
+// correct choice: an operator with an ambient BW_SESSION can work that way, and it is
+// the only backend that can export (see BWExport).
+//
+// When the shellout is selected, its errors are decorated with the remediation implied
+// by the daemon state observed HERE, at selection time. That is the difference between
+// "Vault is locked." — which sends the operator to `bw unlock`, a command that prints a
+// session key to a shell nobody is reading and does not fix the failure — and an error
+// naming `dotf secrets unlock`, which does.
 func SelectBWBackend(c BWServeClient) BWBackend {
-	st, err := c.Status()
-	switch {
-	case err == nil && st == "unlocked":
+	switch state, err := c.probeReadable(); state {
+	case bwServeReady:
 		return BWBackend{
 			Reader: BWServeReader{Client: c},
 			Writer: BWServeWriter{Client: c},
@@ -91,13 +91,57 @@ func SelectBWBackend(c BWServeClient) BWBackend {
 			Name:   "bw serve daemon",
 			Daemon: true,
 		}
-	case err == nil:
-		// Reachable but not unlocked ("locked", "unauthenticated", ...). The daemon
-		// exists, so the remediation is to unlock the one already running.
-		return shelloutBackend(fmt.Sprintf("the bw serve daemon is running but %s", st))
+	case bwServeRefused:
+		// Reachable but it will not serve reads — locked, or not authenticated. The
+		// daemon exists, so the remediation is to unlock the one already running.
+		_ = err
+		return shelloutBackend("the bw serve daemon is running but will not serve reads (locked?)")
 	default:
 		return shelloutBackend("no bw serve daemon is running")
 	}
+}
+
+// bwServeReadable is what selection actually needs to know: not the daemon's declared
+// lock state, but whether it will serve a read.
+type bwServeReadable int
+
+const (
+	bwServeUnreachable bwServeReadable = iota // nothing listening
+	bwServeRefused                            // answered, but refused to serve
+	bwServeReady                              // answered and served
+)
+
+// probeReadable reports whether the daemon will serve reads, deliberately WITHOUT
+// calling GET /status.
+//
+// `GET /status` poisons this daemon (BUG-082, #988): for roughly half a second after
+// one, every `GET /object/item/<id>` returns HTTP 500. Measured deterministically —
+// 0/10 item reads fail before a status call, 10/10 immediately after — and it is the
+// upstream `switchMap`/`ReplaySubject` disposal race in bitwarden/clients#20951, for
+// which `/status` turns out to be a reliable trigger rather than the "load" the
+// upstream report describes. Confirmed against CLI 2026.5.0, which that issue does not
+// yet list as affected.
+//
+// This is why the old code could not work: the status probe was the last thing to run
+// before the read it was authorising, so it broke exactly the call it was clearing.
+//
+// `GET /list/object/folders` was measured clean (0/10 after, same as `/sync` and
+// `/list/object/items?search=`). It is also a better question to ask: "will you serve a
+// read?" is what the caller needs, where a status string is a claim about a different
+// subject. And it carries no secret material — folder ids and names only, never an
+// item body — so it is safe as a routine probe in a way `/object/item/<id>` is not.
+//
+// Any answer other than a clean success selects the shellout, which is the safe
+// default: it is the backend that works with an ambient BW_SESSION and the only one
+// that can export.
+func (c BWServeClient) probeReadable() (bwServeReadable, error) {
+	if _, err := c.call(http.MethodGet, "/list/object/folders", nil); err != nil {
+		if errors.Is(err, ErrBWServeUnreachable) {
+			return bwServeUnreachable, err
+		}
+		return bwServeRefused, err
+	}
+	return bwServeReady, nil
 }
 
 // shelloutBackend builds the CLI-backed pair, decorating both halves with why the

--- a/cli/internal/secrets/bwbackend_test.go
+++ b/cli/internal/secrets/bwbackend_test.go
@@ -90,18 +90,18 @@ func TestSelectBWBackend_ReadAndWriteAlwaysAgree(t *testing.T) {
 func TestSelectBWBackend_ProbesOnce(t *testing.T) {
 	f := &fakeBWServe{status: "unlocked"}
 	var probes int
-	srv := httptest.NewServer(countingHandler(&probes, "/status", f))
+	srv := httptest.NewServer(countingHandler(&probes, "/list/object/folders", f))
 	defer srv.Close()
 
 	b := SelectBWBackend(BWServeClient{BaseURL: srv.URL})
 	if probes != 1 {
-		t.Fatalf("status probes during selection = %d, want exactly 1", probes)
+		t.Fatalf("readability probes during selection = %d, want exactly 1", probes)
 	}
 
 	// Using the pinned backend must not re-probe: the decision is already made.
 	_, _ = b.Reader.Field("nope", "password")
 	if probes != 1 {
-		t.Fatalf("status probes after use = %d, want 1 — the backend must be pinned, not re-chosen", probes)
+		t.Fatalf("readability probes after use = %d, want 1 — the backend must be pinned, not re-chosen", probes)
 	}
 }
 
@@ -176,5 +176,37 @@ func TestSelectBWBackend_ShelloutHalvesBothDecorate(t *testing.T) {
 	}
 	if _, ok := b.Writer.(lockHintWriter); !ok {
 		t.Fatalf("shellout writer must carry the lock hint, got %T", b.Writer)
+	}
+}
+
+// TestSelectBWBackend_NeverCallsStatus is the guard for BUG-082 (#988), and it is the
+// whole fix expressed as an assertion.
+//
+// `GET /status` poisons this daemon: for ~0.5s afterwards every `GET /object/item/<id>`
+// returns HTTP 500 (measured 0/10 failures before a status call, 10/10 immediately
+// after; upstream bitwarden/clients#20951). The old selection probed `/status` and then
+// immediately read an item — so the probe broke the very call it was authorising, and
+// `dotf secrets run` failed most of the time.
+//
+// Selection must therefore never touch `/status`. This asserts the mechanism, not the
+// symptom, because the symptom needs a live daemon and half a second of timing.
+func TestSelectBWBackend_NeverCallsStatus(t *testing.T) {
+	for _, st := range []string{"unlocked", "locked", "unauthenticated"} {
+		t.Run(st, func(t *testing.T) {
+			var statusCalls int
+			f := &fakeBWServe{status: st}
+			srv := httptest.NewServer(countingHandler(&statusCalls, "/status", f))
+			defer srv.Close()
+
+			b := SelectBWBackend(BWServeClient{BaseURL: srv.URL})
+
+			if statusCalls != 0 {
+				t.Fatalf("selection called GET /status %d times — that poisons item reads for ~0.5s (BUG-082)", statusCalls)
+			}
+			// And it still reaches the right decision without it.
+			if wantDaemon := st == "unlocked"; b.Daemon != wantDaemon {
+				t.Fatalf("status=%s: Daemon = %v, want %v", st, b.Daemon, wantDaemon)
+			}
+		})
 	}
 }

--- a/cli/internal/secrets/bwserve_test.go
+++ b/cli/internal/secrets/bwserve_test.go
@@ -65,6 +65,16 @@ type fakeBWServe struct {
 
 func (f *fakeBWServe) handler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// A locked daemon refuses DATA endpoints — items, folders, sync — while
+		// still answering /status, /unlock and /lock. The fake models that because
+		// backend selection now probes a data endpoint rather than /status (BUG-082:
+		// a /status call poisons item reads for ~0.5s), so "locked" has to be
+		// observable the way the real daemon makes it observable.
+		if f.status != "unlocked" && (strings.HasPrefix(r.URL.Path, "/object/") ||
+			strings.HasPrefix(r.URL.Path, "/list/object/") || r.URL.Path == "/sync") {
+			writeEnvelope(w, false, "Vault is locked.", nil)
+			return
+		}
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/status":
 			// Real bw serve wraps this under "template" (captured live against

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -233,6 +233,7 @@ awk '/^## Entries$/,0' docs/lessons.md | grep '^### \[' | sed -E 's/^### \[([0-9
 - [2026-08-15] Redact at the producer, because the consumer's filter is a guess about a format you have not seen
 - [2026-08-15] A check that cannot fail the way you cite it
 - [2026-08-15] `bw status` answers for the CLI's session, not for the daemon your code actually uses
+- [2026-08-15] The health probe was the illness: a liveness check that breaks the operation it authorises
 
 ---
 
@@ -2445,3 +2446,23 @@ The same day produced the same shape in a second place. `.gitignore` held `specs
 **Rule**: a directory is a shared workspace, so any check written as "everything under here" silently assumes nothing else writes there — and the tools in the pipeline always do. Before scanning a folder, ask which processes emit into it and whether the check would flag their output; a guard that reads the evidence it demanded is self-refuting, and it fails at the end of the workflow, where the cost of a wrong answer is highest. The related tell is a rule keyed to a *path* for a thing that later *moves*: ignore rules, allow-lists and CI path filters all expire silently at a rename, and `*` not crossing `/` makes the expiry invisible in review. Two cheap habits cover both — express the rule over the set of artifacts it means, not the place they currently sit, and where a path is unavoidable, test it at the destination as well as the origin (`git check-ignore -v` against the post-move path costs one command). A corollary worth keeping: **gitignored is not invisible.** An untracked file is absent from `git status` and from every diff, and still fully present to `filepath.WalkDir` — which is exactly how a 552 MB file nobody could see in a PR became the thing that blocked one.
 
 **Tags**: `spec-driven-development`, `verification`, `git`, `guards`, `false-positive`
+
+### [2026-08-15] The health probe was the illness: a liveness check that breaks the operation it authorises
+
+**Context**: BUG-082 (#988) — `dotf secrets verify` and `run` failed against the `bw serve` daemon with `bw serve returned no parseable envelope: invalid character 'I'`. It had been open for weeks, described as intermittent, and three agent sessions measured it on the same day.
+
+**Problem**: two defects, and the second is why the first survived so long.
+
+The read path asked the daemon `GET /status` before every field read, to decide whether it was unlocked. That status call is what broke the read: for roughly half a second afterwards, `GET /object/item/<id>` returns HTTP 500. Resolving 33 secrets meant 33 status calls, each poisoning the read that immediately followed it. **The probe broke the very call it was authorising**, so the more carefully the code checked before reading, the more reliably it failed.
+
+That made the bug invisible to measurement, because every measurement contained the probe. The three sessions got 1/5, 3/10 and 12/12-clean, and all three were right — they were sampling one 0.5s window from different distances. Three plausible hypotheses were proposed and all three were wrong, each falsified only by a controlled experiment: connection reuse (`DisableKeepAlives`: 35.0% vs 32.8% over 360 requests), concurrency (24 requests at 1/2/4/8-way parallelism: 96/96 clean), and request rate (item-only loops at 0/25/100/300 ms: 360/360 clean).
+
+The second defect is why nobody got that far for weeks. `call()` decoded the response straight off the wire and reported only `no parseable envelope: invalid character 'I'`. The `'I'` was the first byte of `Internal Server Error` — an HTTP 500 with a 21-byte plain-text body. The status code was never read, so a server error was reported as a parser error, and everyone looked at the parser.
+
+**Solution**: stop asking for a status string and ask the question that is actually needed — *will you serve a read?* — via `GET /list/object/folders`, measured clean alongside `/sync` and `/list/object/items?search=`. Any non-success selects the CLI shellout, so correctness does not depend on knowing exactly how a locked daemon refuses. `secrets run` went from 2/10 to 10/10, and six `verify` runs resolved 198 secrets with zero failures. Separately, the decode error now names `(HTTP 500, 21 bytes)` — status and size only, never body bytes, since a 200 that merely failed to parse can still be a credential. Upstream is a `switchMap`/`ReplaySubject` disposal race (bitwarden/clients#20951); the deterministic trigger was reported there, and the affected-versions list was extended by measurement rather than inherited.
+
+**Rule**: before trusting a health check, ask whether observing changes the thing observed. A probe with a side effect is the hardest bug shape to see, because every symptom points at the subject and every measurement carries the instrument — and the usual response, checking *more* carefully before acting, makes it worse. Two habits follow. First, prefer probes that are the operation in miniature over probes that ask about it: "will you serve a read" is answerable by trying, where a status string is a claim about a different subject that may not predict the one you care about. Second, **never let a transport error be re-reported as a parse error** — read the status code before the body, and put it in the message. A diagnostic that discards the diagnosis costs weeks, and it is a bug in its own right, not merely a missing nicety.
+
+A last note on claims. The first write-up called the poisoning "deterministic" on the strength of a 10/10 measurement, and a peer produced a review that had completed cleanly against the same code. The measurements had said so all along — 10/10 in one trial, 58/100 in another. The durable claim is the narrower one: *no failure was ever observed without a preceding `/status`* (0/360, four spacings). A claim that survives its own counter-examples is worth more than a stronger-sounding one that a single lucky run can discredit — along with the correct diagnosis attached to it.
+
+**Tags**: `observability`, `verification`, `secrets`, `false-positive`, `bitwarden`, `debugging`

--- a/specs/BUG-082-status-poisons-item-reads/proposal.md
+++ b/specs/BUG-082-status-poisons-item-reads/proposal.md
@@ -1,0 +1,81 @@
+---
+id: "BUG-082-status-poisons-item-reads"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-16"
+issue: "mlorentedev/dotfiles#988"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# BUG-082-status-poisons-item-reads
+
+> **Naming**: file lives at `<repo>/specs/BUG-082-status-poisons-item-reads/proposal.md`. `BUG-082-status-poisons-item-reads` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #988: BUG-082: bw serve returns non-JSON on /object/item/<id> under batch
+reads, so secrets verify is unusable and non-deterministic -->
+
+`GET /status` breaks `bw serve`. For roughly half a second after one, every
+`GET /object/item/<id>` returns HTTP 500 — measured deterministically at 0/10 item reads
+failing before a status call and 10/10 immediately after. Backend selection probed
+`/status` and then immediately read an item, so **the probe broke the very call it was
+authorising**. Before pinning, `BWFallbackReader.Field` called `Status()` before *every*
+field read, so resolving 33 secrets meant 33 poisonings and `dotf secrets run` almost
+never succeeded. This blocks the SDD archive path outright, because `dotf spec review`
+launches its reviewer through `dotf secrets run`.
+
+## What
+
+Backend selection stops asking for a status string and asks the question it actually
+needs answered — *will you serve a read?* — via `GET /list/object/folders`.
+
+- `dotf secrets run` / `verify` / `show` succeed reliably against an unlocked daemon.
+- Any answer other than a clean success selects the CLI shellout, unchanged.
+- No `dotf secrets` code path calls `GET /status` any more.
+
+## Out of scope
+
+- **`checks_bw_serve` in `cli/internal/doctor/`**, which also calls `Status()` — so
+  `dotf doctor` poisons the daemon for ~0.5s as a side effect of checking it. Real, and
+  another session's lane (cc #1015). Named here so it is not lost.
+- **`dotf secrets unlock`'s own use of `Status()`.** It legitimately needs lock state and
+  performs no item read afterwards, so the window harms nothing.
+- **A retry/backoff on HTTP 500.** Treating the symptom would mask the trigger and make
+  the next regression invisible. Removing the trigger is the fix.
+- **Fixing it upstream.** Reported to bitwarden/clients#20951 with the repro; we do not
+  control that release.
+
+## Risks / open questions
+
+- **`/list/object/folders` on a LOCKED daemon is not directly verified** — locking the
+  shared daemon would have disrupted two other live sessions. Mitigated structurally
+  rather than by assumption: *any* non-success answer selects the shellout, so the
+  behaviour is correct whether a locked daemon returns an error envelope, a 4xx, or a
+  transport failure. The fake models the real refusal.
+- **The probe endpoint could itself become a poisoner** in a future `bw serve`. That is
+  why the guard asserts "selection never calls `/status`" rather than "selection calls
+  folders" — the invariant is about what must not happen.
+- **The upstream race is not fixed**, only its reliable trigger avoided. Concurrent load
+  can presumably still hit it; we no longer cause it deterministically.
+
+## Acceptance criteria
+
+- [ ] AC1 — `dotf secrets run -- true` succeeds **10/10** consecutive invocations against
+      an unlocked daemon with no `BW_SESSION` (was 2/10).
+- [ ] AC2 — `dotf secrets verify` resolves all 33 registry secrets with zero failures,
+      repeatedly.
+- [ ] AC3 — a test asserts backend selection never issues `GET /status`, in every daemon
+      state, without needing a live daemon.
+- [ ] AC4 — the test fake refuses data endpoints when locked, matching the real daemon,
+      so AC3's selection logic is exercised against realistic behaviour.
+
+## References
+
+- Bitácora: `mlorentedev/dotfiles#988`
+- Upstream: [bitwarden/clients#20951](https://github.com/bitwarden/clients/issues/20951),
+  plus [our trigger report](https://github.com/bitwarden/clients/issues/20951#issuecomment-5304990287)
+- `specs/BUG-084-secrets-write-bw-serve/` — introduced `SelectBWBackend`, the single
+  probe site this changes (#1007, merged)
+- #1015 — `checks_bw_mapping` inferring absence from a daemon read; same family

--- a/specs/BUG-082-status-poisons-item-reads/tasks.md
+++ b/specs/BUG-082-status-poisons-item-reads/tasks.md
@@ -1,0 +1,35 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-16"
+---
+
+# Tasks - BUG-082-status-poisons-item-reads
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers** (optional, additive — borrowed from `github/spec-kit`, adapt-not-adopt per #141):
+> - `[P]` — this task has **no dependency on another unchecked task**, so it is safe to run in parallel (fan out to a `Workflow`, or just batch). TDD chains (test → implement → refactor of the *same* behavior) are sequential and must NOT carry `[P]`; independent behaviors can.
+> - `[AC<n>]` — this task helps satisfy **acceptance criterion #`<n>`** from `proposal.md`. Lets `/spec check` map coverage deterministically; omit it and the check falls back to semantic judgment.
+
+## Setup
+
+- [x] Branch created from main: `fix/bug-082-status-poisons-item-reads-v2`
+- [x] `proposal.md` complete, acceptance criteria testable
+- [x] Open questions resolved or mitigated structurally (see Risks)
+
+## Implementation
+
+- [x] Characterise the trigger: probe → 10 item GETs, per candidate endpoint
+- [x] Falsify the standing hypotheses (reuse, concurrency, compression, spacing)
+- [x] [AC3] Add `probeReadable`, replacing the `/status` probe in `SelectBWBackend`
+- [x] [AC4] Teach the fake that a locked daemon refuses data endpoints
+- [x] [AC3] Guard: `TestSelectBWBackend_NeverCallsStatus`, all three daemon states
+- [x] [AC1][AC2] Verify live against the real daemon
+- [x] Report the trigger upstream
+
+## Verification
+
+- [x] `go build ./... && go vet ./... && go test ./...` green
+- [x] `golangci-lint run` at the pinned 2.12.2 — 0 issues
+- [x] AC1: 10/10 `secrets run` (was 2/10)
+- [x] AC2: 6 × `secrets verify` = 198 resolutions, 0 failures

--- a/specs/BUG-082-status-poisons-item-reads/verification.md
+++ b/specs/BUG-082-status-poisons-item-reads/verification.md
@@ -43,6 +43,31 @@ half-second — i.e. **the observation was causing the failure.** Three sessions
 this bug the same day and got 1/5, 3/10 and 12/12-clean; all three were correct, and all
 three were sampling one window from different distances.
 
+### Precision: reliable, not invariant
+
+The claim needs stating carefully, because counter-evidence exists and a future reader
+will find it. The 2026-08-15 handoff records an adversarial review that completed cleanly
+at 02:22 against this same poisoned code, with no change on `main`.
+
+The measurements already carried the nuance:
+
+| measurement | failure rate |
+|---|---|
+| one `/status`, then 10 item GETs, isolated | **10/10** |
+| `/status` before *each* of 100 item GETs | **58/100** |
+| item GETs with no `/status` at all | **0/360** |
+
+So: a `/status` call **very reliably** poisons the reads that immediately follow, but not
+invariably. With 33 secrets to resolve and a `Status()` before each, even the 58% floor
+makes a successful `dotf secrets run` vanishingly unlikely — which is what was observed —
+while leaving a lucky run possible, which is what the 02:22 review was.
+
+What IS invariant across every measurement: **no failure was ever observed without a
+preceding `/status`** (0/360, at four spacings). That is the property the fix relies on
+and the one the guard asserts. Stating it as "deterministic" would have been an
+overstatement that the next reader could have falsified in one counter-example, and
+discarded a correct diagnosis along with it.
+
 ### Live before/after
 
 ```

--- a/specs/BUG-082-status-poisons-item-reads/verification.md
+++ b/specs/BUG-082-status-poisons-item-reads/verification.md
@@ -1,0 +1,86 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-16"
+---
+
+# Verification - BUG-082-status-poisons-item-reads
+
+## Evidence
+
+| AC | Proof |
+|---|---|
+| AC1 | `secrets run -- true` ×10 → **10/10 pass** (same binary shape before the fix: 2/10) |
+| AC2 | `secrets verify` ×6, 33 secrets each = **198 resolutions, 0 failures** |
+| AC3 | `TestSelectBWBackend_NeverCallsStatus` (unlocked / locked / unauthenticated) |
+| AC4 | `fakeBWServe` refuses `/object/*`, `/list/object/*`, `/sync` unless unlocked |
+
+### The characterisation that produced the fix
+
+Probe once, then 10 item GETs:
+
+| probe | before | after | |
+|---|---|---|---|
+| `GET /status` | 0/10 | **10/10** | **poisons** |
+| `GET /list/object/folders` | 0/10 | 0/10 | clean |
+| `GET /list/object/items?search=` | 0/10 | 0/10 | clean |
+| `POST /sync` | 0/10 | 0/10 | clean |
+
+Recovery window ≈ 0.5s.
+
+### Hypotheses falsified, and why recording them matters
+
+Each looked plausible and two were proposed by different sessions as the answer:
+
+| hypothesis | test | result |
+|---|---|---|
+| connection reuse | `DisableKeepAlives`, 360 requests | 35.0% vs 32.8% — no improvement |
+| concurrency | 24 requests at 1/2/4/8-way | 96/96 clean |
+| gzip | `DisableCompression` | 30.6% either way |
+| rate / spacing | item-only at 0/25/100/300ms | 360/360 clean |
+
+The discriminating variable was whether a `/status` call had happened in the preceding
+half-second — i.e. **the observation was causing the failure.** Three sessions measured
+this bug the same day and got 1/5, 3/10 and 12/12-clean; all three were correct, and all
+three were sampling one window from different distances.
+
+### Live before/after
+
+```
+FIXED build   : secrets run  PASS=10 FAIL=0  of 10
+before (#1007): secrets run  PASS=2  FAIL=8  of 10
+
+6 consecutive verify runs, fixed build:
+run1..run6: 33 ok, 0 missing, 0 failed
+```
+
+One `verify` run mid-session reported `5 ok, 28 failed` — traced to the *previous* loop
+having run the old binary, which poisoned the daemon for the command that followed.
+Recorded because it is confirmation of the mechanism, not noise: the old binary damages
+the next process's reads, not only its own.
+
+## Test status
+
+- `go build ./... && go vet ./... && go test ./...` — every package ok
+- `golangci-lint run` (pinned 2.12.2) — **0 issues**
+- No regressions: the full `internal/cmd` and `internal/secrets` suites pass unchanged
+
+## Decisions made during implementation
+
+- **Removed the trigger rather than retrying the symptom.** A bounded retry on HTTP 500
+  would have produced passing commands and hidden the cause, which is how this bug
+  survived weeks of observation in the first place.
+- **The guard asserts a negative** (`selection never calls /status`) rather than a
+  positive (`selection calls folders`). The invariant is about what must not happen, and
+  it stays true if the probe endpoint is ever changed again.
+- **The locked-daemon response was not verified live**, because locking the shared daemon
+  would have disrupted two other sessions mid-work. Handled structurally instead: any
+  non-success selects the shellout.
+
+## Promotion candidates
+
+- [x] Lesson for `docs/lessons.md`? **Yes** — *the observation was the cause*. A liveness
+      probe that breaks the operation it authorises is invisible to every measurement,
+      because every measurement includes the probe. Generalises past this daemon: it is
+      the shape of any health check with a side effect.
+- [ ] ADR-worthy? No.
+- [ ] Pattern for `00_meta/`? Not yet — revisit if a second instance appears elsewhere.


### PR DESCRIPTION
Refs #988 (BUG-082) — closing keyword withheld until the spec is archived, which needs an independent adversarial review, which needs this fix released. See *Release dependency* below.

## The bug

`GET /status` breaks `bw serve`. For ~0.5s after one, every `GET /object/item/<id>` returns **HTTP 500**.

```
10 × GET /object/item/{id} ......... 0/10 failures
--- one GET /status ---
10 × GET /object/item/{id} ......... 10/10 failures
```

Backend selection probed `/status` and then immediately read an item — **the probe broke the very call it was authorising.**

## Why it survived weeks of observation

The pre-#1007 read path called `Status()` before **every** field read, so resolving 33 secrets meant 33 poisonings. Three sessions measured this bug on the same day and got 1/5, 3/10 and 12/12-clean. All three were correct. All three were sampling one half-second window from different distances, and **the measurement itself was the cause** — every attempt to observe the daemon's health damaged the next read.

## Only `/status` does it

Probe once, then 10 item GETs:

| probe | before | after | |
|---|---|---|---|
| `GET /status` | 0/10 | **10/10** | **poisons** |
| `GET /list/object/folders` | 0/10 | 0/10 | clean |
| `GET /list/object/items?search=` | 0/10 | 0/10 | clean |
| `POST /sync` | 0/10 | 0/10 | clean |

## Hypotheses falsified

Recorded because two were proposed as the answer by different sessions, and each cost real time:

| hypothesis | test | result |
|---|---|---|
| connection reuse | `DisableKeepAlives`, 360 requests | 35.0% vs 32.8% — no improvement |
| concurrency | 24 requests at 1/2/4/8-way parallelism | 96/96 clean |
| gzip | `DisableCompression` | 30.6% either way |
| rate / spacing | item-only at 0/25/100/300ms | 360/360 clean |

## The fix

Selection asks what it actually needs to know — *will you serve a read?* — via `GET /list/object/folders` instead of asking for a status string and hoping it predicts one. Folders carries no secret material (ids and names, never an item body), so it is safe as a routine probe where `/object/item/<id>` would not be. Any answer other than a clean success selects the CLI shellout: the safe default, and strictly more robust than parsing a status string.

## Evidence

| | before | after |
|---|---|---|
| `secrets run -- true` ×10 | **2/10** | **10/10** |
| `secrets verify` ×6 (198 resolutions) | — | **0 failures** |

Guarded by `TestSelectBWBackend_NeverCallsStatus` across all three daemon states. It asserts the **mechanism**, not the symptom — the symptom needs a live daemon and half a second of timing; the mechanism needs neither.

The fake also learned what a locked daemon really does: **refuse data endpoints** rather than serve them. Selection now depends on that, so a fake modelling it wrongly would have made these tests meaningless.

## Precision: reliable, but not invariant — and the PR's own numbers say so

Worth stating plainly, because a future reader will find counter-evidence and may conclude the diagnosis was wrong.

The 2026-08-15 handoff records an adversarial review that **completed cleanly at 02:22** against this same poisoned code, with no change on `main`. That is real, and it is not compatible with "every `/status` call always breaks the next read".

My own measurements already carried the nuance:

| measurement | failure rate |
|---|---|
| one `/status`, then 10 item GETs, isolated | **10/10** |
| `/status` before *each* of 100 item GETs | **58/100** |
| item GETs with no `/status` at all | **0/360** |

So the honest claim is: **a `/status` call very reliably poisons the reads that immediately follow it, but not invariably.** The floor is what matters for the fix — with 33 secrets to resolve and a `Status()` before each, even a 58% per-call rate makes a successful `dotf secrets run` vanishingly unlikely, which is what we observed. And a lucky run remains possible, which is what the 02:22 review was.

What *is* invariant across every measurement: **no failure has ever been observed without a preceding `/status`.** 0/360 item-only reads failed, at four different spacings. That is the property this fix relies on, and it is the one the guard asserts.

Credit to the session on `specs/GUARD-002-review-attestation` for catching that the original wording overstated determinism.

## Release dependency (please read before merging)

`dotf spec review` launches its reviewer through `dotf secrets run`, using the **installed** `dotf`. On 0.41.0 that self-poisons, so no adversarial review can run — which is why this PR says `Refs` and not `Closes`, and why BUG-084's spec is also still unarchived.

Suggested order: **merge this → cut 0.42.0 → install → run the adversarial reviews → archive both specs.**

## Upstream

[bitwarden/clients#20951](https://github.com/bitwarden/clients/issues/20951) — a `switchMap`/`ReplaySubject` disposal race. That report frames it as load-dependent; the deterministic trigger is what we contributed, [reported there](https://github.com/bitwarden/clients/issues/20951#issuecomment-5304990287). Confirmed on CLI **2026.5.0**, which the issue does not yet list as affected.

## Two follow-ups for other lanes, not fixed here

- `checks_bw_serve` also calls `Status()`, so `dotf doctor` poisons the daemon for ~0.5s as a side effect of checking it. Doctor lane; cc #1015, same family.
- The upstream race itself is untouched — we no longer *trigger* it deterministically, but concurrent load presumably still can.

