### PR TITLE
fix(secrets): let verify report a broken registry instead of dying on it

### DIFF
--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -234,9 +234,11 @@ func scopeVerify(reg *secrets.Registry, defects []secrets.SecretDefect, args []s
 	if len(args) == 0 {
 		return defects, nil, nil
 	}
-	byID := make(map[string]secrets.SecretDefect, len(defects))
+	// Keyed to a SLICE, not a single defect: one id can carry several. A duplicate id
+	// is itself a defect, so "one defect per id" is the assumption the data disproves.
+	byID := make(map[string][]secrets.SecretDefect, len(defects))
 	for _, d := range defects {
-		byID[d.ID] = d
+		byID[d.ID] = append(byID[d.ID], d)
 	}
 	var inScope []secrets.SecretDefect
 	var healthy []string
@@ -244,11 +246,19 @@ func scopeVerify(reg *secrets.Registry, defects []secrets.SecretDefect, args []s
 		if tok = strings.TrimSpace(tok); tok == "" {
 			continue
 		}
-		if d, ok := byID[tok]; ok {
-			inScope = append(inScope, d)
-			continue
+		ds, isDefect := byID[tok]
+		inScope = append(inScope, ds...)
+
+		// One token can name BOTH a defect and a valid entry — a duplicate id whose
+		// first definition validated and whose second did not. Reporting only the
+		// defect would hide the entry that actually resolves, which is the half the
+		// caller most needs. So a defect match does not short-circuit the lookup.
+		_, known := reg.Selector(tok)
+		if known || !isDefect {
+			// Unknown-and-not-a-defect falls through deliberately, so resolveOnly
+			// produces the "unknown id" error rather than this silently accepting it.
+			healthy = append(healthy, tok)
 		}
-		healthy = append(healthy, tok)
 	}
 	if len(healthy) == 0 {
 		// Every named id is defective: select no healthy entries, but still report.

--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -153,17 +153,26 @@ func newSecretsVerifyCmd() *cobra.Command {
 			"(--require-all also fails on MISSING).",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			reg, err := loadRegistry()
+			// The partial door, deliberately: a health check must not be stopped by
+			// the very kind of breakage it exists to report (BUG-086, #1004).
+			reg, defects, err := loadRegistryPartial()
 			if err != nil {
 				return err
 			}
-			only, err := resolveOnly(reg, strings.Join(args, ","))
+			defects, only, err := scopeVerify(reg, defects, args)
 			if err != nil {
 				return err
 			}
 			loader := secretLoader()
 			w := cmd.OutOrStdout()
 			var ok, missing, failed int
+			// A malformed entry is a FAILED row for that secret, not an abort. Its
+			// vars are not expanded — the entry is exactly what could not be read, so
+			// naming them would be guesswork.
+			for _, d := range defects {
+				failed++
+				_, _ = fmt.Fprintf(w, "FAILED   %-30s registry: %v\n", d.ID, d.Err)
+			}
 			for _, e := range reg.Entries(env.Home()) {
 				if only != nil && !only[e.Var] {
 					continue
@@ -197,6 +206,60 @@ func loadRegistry() (*secrets.Registry, error) {
 		return nil, fmt.Errorf("read registry: %w", err)
 	}
 	return secrets.ParseRegistry(data)
+}
+
+// loadRegistryPartial is the health-check door: it returns the well-formed secrets plus
+// a defect per malformed one, instead of failing on the first. ONLY `verify` uses it —
+// every write path stays on loadRegistry's fail-loud behaviour, because a half-valid
+// registry is precisely the state in which `set`/`migrate`/`render` must not run.
+func loadRegistryPartial() (*secrets.Registry, []secrets.SecretDefect, error) {
+	data, err := os.ReadFile(registryPath())
+	if err != nil {
+		return nil, nil, fmt.Errorf("read registry: %w", err)
+	}
+	return secrets.ParseRegistryPartial(data)
+}
+
+// scopeVerify splits verify's arguments across the two populations a partial load
+// produces: defective secrets (which exist only as defects) and well-formed ones (which
+// exist only in the registry).
+//
+// Without this, a scoped `verify <malformed-id>` would report "unknown id" — the entry
+// was excluded from the registry precisely because it is the one being asked about.
+//
+// With no args, everything is in scope. With args, an entry the caller did not name is
+// neither validated nor resolved (BUG-086 AC2): a defect elsewhere in the file must not
+// make a scoped check fail.
+func scopeVerify(reg *secrets.Registry, defects []secrets.SecretDefect, args []string) ([]secrets.SecretDefect, map[string]bool, error) {
+	if len(args) == 0 {
+		return defects, nil, nil
+	}
+	byID := make(map[string]secrets.SecretDefect, len(defects))
+	for _, d := range defects {
+		byID[d.ID] = d
+	}
+	var inScope []secrets.SecretDefect
+	var healthy []string
+	for _, tok := range args {
+		if tok = strings.TrimSpace(tok); tok == "" {
+			continue
+		}
+		if d, ok := byID[tok]; ok {
+			inScope = append(inScope, d)
+			continue
+		}
+		healthy = append(healthy, tok)
+	}
+	if len(healthy) == 0 {
+		// Every named id is defective: select no healthy entries, but still report.
+		// A non-nil empty map means "filter to nothing", where nil would mean "all".
+		return inScope, map[string]bool{}, nil
+	}
+	only, err := resolveOnly(reg, strings.Join(healthy, ","))
+	if err != nil {
+		return nil, nil, err
+	}
+	return inScope, only, nil
 }
 
 // newSecretsLsCmd lists registry ids with plane + exposed vars — never values. The CI

--- a/cli/internal/cmd/secrets_registry_test.go
+++ b/cli/internal/cmd/secrets_registry_test.go
@@ -487,3 +487,49 @@ func TestSecretsVerify_StructuralFailureStillAborts(t *testing.T) {
 		t.Error("an unsupported registry version must still abort, not degrade to a report")
 	}
 }
+
+// TestSecretsVerify_ScopedToDuplicateIdReportsBothHalves is CodeRabbit's Major finding
+// on #1020, and it was right.
+//
+// A rejected secret does not reserve its id, so a duplicate id leaves TWO things sharing
+// one name: the first definition, which validated and is in the registry, and the second,
+// which is a defect. Scoping to that id must report both — the original code matched the
+// defect and short-circuited, so `verify dup` reported the defect and silently skipped
+// the entry that actually resolves, which is the half the caller most needs.
+func TestSecretsVerify_ScopedToDuplicateIdReportsBothHalves(t *testing.T) {
+	useTempRegistry(t, "version: 1\nsecrets:\n"+
+		"  - {id: dup, plane: app, backend: age, age: a, expose: {env: VALID_HALF}}\n"+
+		"  - {id: dup, plane: app, backend: age, age: b, expose: {env: DEFECT_HALF}}\n")
+	alwaysResolves(t)
+
+	out, err := runVerify(t, "dup")
+
+	if !strings.Contains(out, "VALID_HALF") {
+		t.Errorf("the valid definition sharing the id must still be resolved:\n%s", out)
+	}
+	if !strings.Contains(out, "duplicate secret id") {
+		t.Errorf("the defect sharing the id must still be reported:\n%s", out)
+	}
+	if err == nil {
+		t.Errorf("a defect in scope must still exit non-zero:\n%s", out)
+	}
+}
+
+// TestSecretsVerify_SeveralDefectsOnOneId: defects are keyed to a slice, so two bad
+// definitions of one id are both reported rather than one overwriting the other.
+func TestSecretsVerify_SeveralDefectsOnOneId(t *testing.T) {
+	useTempRegistry(t, "version: 1\nsecrets:\n"+
+		"  - {id: trip, plane: app, backend: age, age: a, expose: {env: FIRST_OK}}\n"+
+		"  - {id: trip, plane: app, backend: age, age: b, expose: {env: SECOND}}\n"+
+		"  - {id: trip, plane: app, backend: age, age: c, expose: {env: THIRD}}\n")
+	alwaysResolves(t)
+
+	out, _ := runVerify(t, "trip")
+
+	if n := strings.Count(out, "duplicate secret id"); n != 2 {
+		t.Errorf("want both duplicate definitions reported, got %d:\n%s", n, out)
+	}
+	if !strings.Contains(out, "FIRST_OK") {
+		t.Errorf("the one valid definition must still resolve:\n%s", out)
+	}
+}

--- a/cli/internal/cmd/secrets_registry_test.go
+++ b/cli/internal/cmd/secrets_registry_test.go
@@ -358,3 +358,132 @@ func TestSecretsVerify_UnknownId_Errors(t *testing.T) {
 		t.Error("verify with an unknown id must error")
 	}
 }
+
+// --- BUG-086 (#1004): a malformed entry must not take down the whole report ---------
+
+// malformedRegistry has one bad secret ("broken": an unknown backend) between two good
+// ones, so a test can prove the good ones still report.
+const malformedRegistry = "version: 1\nsecrets:\n" +
+	"  - {id: good-one, plane: app, backend: age, age: a, expose: {env: GOOD_ONE}}\n" +
+	"  - {id: broken, plane: app, backend: nonsense, age: b, expose: {env: BROKEN}}\n" +
+	"  - {id: good-two, plane: app, backend: age, age: c, expose: {env: GOOD_TWO}}\n"
+
+// alwaysResolves points the age seam at a value so the well-formed entries report OK,
+// isolating the registry-defect behaviour from resolution behaviour.
+func alwaysResolves(t *testing.T) {
+	t.Helper()
+	old := ageDecryptor
+	ageDecryptor = func(string, string) ([]byte, error) { return []byte("v\n"), nil }
+	t.Cleanup(func() { ageDecryptor = old })
+}
+
+func runVerify(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	cmd := newSecretsVerifyCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs(args)
+	// Explicit, because Go evaluates return operands left to right: `return
+	// out.String(), cmd.Execute()` would read the buffer before the command wrote it.
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// TestSecretsVerify_MalformedEntryDoesNotHideTheRest is BUG-086's AC1.
+//
+// Before this, ParseRegistry failed on the first bad secret, so ONE typo made
+// `dotf secrets verify` unable to report anything at all — a health check taken down by
+// the class of breakage it exists to find, and by an entry the caller never asked about.
+func TestSecretsVerify_MalformedEntryDoesNotHideTheRest(t *testing.T) {
+	useTempRegistry(t, malformedRegistry)
+	alwaysResolves(t)
+
+	out, err := runVerify(t)
+
+	for _, want := range []string{"OK", "GOOD_ONE", "GOOD_TWO", "FAILED", "broken"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("verify output missing %q:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "registry:") {
+		t.Errorf("a malformed entry should be reported as a registry defect:\n%s", out)
+	}
+	if err == nil {
+		t.Error("verify must exit non-zero when an entry is malformed")
+	}
+}
+
+// TestSecretsVerify_ScopedAwayFromDefect is AC2: an entry the caller did not name is
+// neither validated nor resolved, so a defect elsewhere cannot fail a scoped check.
+func TestSecretsVerify_ScopedAwayFromDefect(t *testing.T) {
+	useTempRegistry(t, malformedRegistry)
+	alwaysResolves(t)
+
+	out, err := runVerify(t, "good-one")
+
+	if err != nil {
+		t.Errorf("a scoped verify must not fail on an out-of-scope defect: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "broken") {
+		t.Errorf("an out-of-scope defect must not be reported:\n%s", out)
+	}
+	if !strings.Contains(out, "GOOD_ONE") {
+		t.Errorf("the named secret should still be reported:\n%s", out)
+	}
+	if strings.Contains(out, "GOOD_TWO") {
+		t.Errorf("scoping must exclude unnamed secrets:\n%s", out)
+	}
+}
+
+// TestSecretsVerify_ScopedToTheDefect: naming the malformed entry must report it, not
+// claim it is unknown. It was excluded from the registry precisely because it is the
+// thing being asked about, so the lookup has to consult the defects too.
+func TestSecretsVerify_ScopedToTheDefect(t *testing.T) {
+	useTempRegistry(t, malformedRegistry)
+	alwaysResolves(t)
+
+	out, err := runVerify(t, "broken")
+
+	if err == nil {
+		t.Errorf("verify must exit non-zero when the named entry is malformed:\n%s", out)
+	}
+	if strings.Contains(out, "unknown id") {
+		t.Errorf("a malformed entry must be reported as FAILED, not as unknown:\n%s", out)
+	}
+	if !strings.Contains(out, "FAILED") || !strings.Contains(out, "broken") {
+		t.Errorf("the named defect should be a FAILED row:\n%s", out)
+	}
+}
+
+// TestSecretsVerify_DuplicateIdBlamesTheSecondOne: the FIRST definition is valid and
+// must still verify; only the later one is the defect. A rejected secret must not
+// reserve its id, or it would make the valid one look like the duplicate.
+func TestSecretsVerify_DuplicateIdBlamesTheSecondOne(t *testing.T) {
+	useTempRegistry(t, "version: 1\nsecrets:\n"+
+		"  - {id: dup, plane: app, backend: age, age: a, expose: {env: FIRST}}\n"+
+		"  - {id: dup, plane: app, backend: age, age: b, expose: {env: SECOND}}\n")
+	alwaysResolves(t)
+
+	out, err := runVerify(t)
+
+	if err == nil {
+		t.Errorf("a duplicate id must fail verify:\n%s", out)
+	}
+	if !strings.Contains(out, "FIRST") {
+		t.Errorf("the first definition is valid and must still be verified:\n%s", out)
+	}
+	if !strings.Contains(out, "duplicate secret id") {
+		t.Errorf("the defect should name the duplication:\n%s", out)
+	}
+}
+
+// TestSecretsVerify_StructuralFailureStillAborts: the partial door is for "this ENTRY is
+// wrong", not for "the document is unreadable". With no parseable version there is
+// nothing to report per-secret, so failing loudly is correct.
+func TestSecretsVerify_StructuralFailureStillAborts(t *testing.T) {
+	useTempRegistry(t, "version: 99\nsecrets: []\n")
+	if _, err := runVerify(t); err == nil {
+		t.Error("an unsupported registry version must still abort, not degrade to a report")
+	}
+}

--- a/cli/internal/secrets/registry.go
+++ b/cli/internal/secrets/registry.go
@@ -139,32 +139,103 @@ func (e *EnvExpose) UnmarshalYAML(node *yaml.Node) error {
 
 // ParseRegistry parses and validates registry.yaml. Validation is fail-fast: a
 // malformed registry is a configuration error, never silently tolerated.
-func ParseRegistry(data []byte) (*Registry, error) {
-	var reg Registry
-	if err := yaml.Unmarshal(data, &reg); err != nil {
-		return nil, fmt.Errorf("parse registry: %w", err)
-	}
-	if err := reg.validate(); err != nil {
-		return nil, err
-	}
-	return &reg, nil
+// SecretDefect is one secret that failed validation, kept apart from the registry so a
+// caller can report it instead of being stopped by it.
+type SecretDefect struct {
+	ID  string // the secret's id, or "#<index>" when the id itself is missing
+	Err error
 }
 
-func (r *Registry) validate() error {
-	if r.Version != 1 {
-		return fmt.Errorf("registry version %d unsupported (want 1)", r.Version)
+// ParseRegistry parses and validates the registry, failing on the FIRST bad secret.
+//
+// This is the strict door, and it stays the default for every caller: a half-valid
+// registry is exactly the state in which `set`, `migrate` and `render` must not run,
+// because they write. Only `dotf secrets verify` uses the partial door below.
+//
+// It is implemented ON TOP of ParseRegistryPartial rather than beside it — one set of
+// per-secret checks, two policies over the result. Two independent validation paths is
+// the shape that produced BUG-084 (#993): the moment one moves, they disagree, and the
+// disagreement is silent.
+func ParseRegistry(data []byte) (*Registry, error) {
+	reg, defects, err := ParseRegistryPartial(data)
+	if err != nil {
+		return nil, err
 	}
-	seen := make(map[string]bool, len(r.Secrets))
+	if len(defects) > 0 {
+		return nil, defects[0].Err
+	}
+	return reg, nil
+}
+
+// ParseRegistryPartial parses the registry and validates each secret INDEPENDENTLY,
+// returning the well-formed ones plus a defect per secret that failed.
+//
+// It exists for BUG-086 (#1004): `verify` is a health check, and a health check whose
+// job is to tell you what is broken must not be the first thing to break. Before this,
+// one malformed entry made the whole registry unloadable, so a typo in a secret the
+// caller never asked about hid the health of all the others.
+//
+// Structural failures are still fatal, and returned as an error rather than a defect:
+// unparseable YAML or an unsupported version leave nothing to report per-secret. The
+// distinction is "cannot read the document" versus "read it, and this entry is wrong".
+//
+// Defective secrets are EXCLUDED from the returned registry. They are not merely
+// flagged, because the rest of this package treats validation as having happened —
+// parseFileMode, for one, documents that a bad mode "is impossible in practice" because
+// validate() rejected it. Letting an invalid secret reach Entries() would trade a clear
+// failure for an undefined one.
+func ParseRegistryPartial(data []byte) (*Registry, []SecretDefect, error) {
+	var reg Registry
+	if err := yaml.Unmarshal(data, &reg); err != nil {
+		return nil, nil, fmt.Errorf("parse registry: %w", err)
+	}
+	if reg.Version != 1 {
+		return nil, nil, fmt.Errorf("registry version %d unsupported (want 1)", reg.Version)
+	}
+
+	seen := make(map[string]bool, len(reg.Secrets))
 	seenVar := make(map[string]string) // var name -> first secret id that exposed it
-	for i := range r.Secrets {
-		s := &r.Secrets[i]
+	kept := make([]Secret, 0, len(reg.Secrets))
+	var defects []SecretDefect
+
+	for i := range reg.Secrets {
+		s := &reg.Secrets[i]
+		if err := validateSecret(s, i, seen, seenVar); err != nil {
+			defects = append(defects, SecretDefect{ID: secretLabel(s, i), Err: err})
+			continue
+		}
+		// Registered only on success, so a defective secret cannot claim an id or a
+		// var name and make the NEXT valid secret look like the duplicate.
+		seen[s.ID] = true
+		for _, v := range s.Vars() {
+			seenVar[v] = s.ID
+		}
+		kept = append(kept, *s)
+	}
+	reg.Secrets = kept
+	return &reg, defects, nil
+}
+
+// secretLabel names a secret for a defect message, falling back to its position when
+// the id is the very thing that is missing.
+func secretLabel(s *Secret, i int) string {
+	if s.ID == "" {
+		return fmt.Sprintf("#%d", i)
+	}
+	return s.ID
+}
+
+// validateSecret runs every per-secret rule. seen/seenVar carry the cross-secret
+// uniqueness state; this function only READS them — registration is the caller's, so
+// that a rejected secret never reserves anything.
+func validateSecret(s *Secret, i int, seen map[string]bool, seenVar map[string]string) error {
+	{
 		if s.ID == "" {
 			return fmt.Errorf("secret #%d: empty id", i)
 		}
 		if seen[s.ID] {
 			return fmt.Errorf("duplicate secret id %q", s.ID)
 		}
-		seen[s.ID] = true
 
 		// ValidBackends is the SSOT for this list; a resolver-coverage test binds
 		// it to the Loader, so a backend accepted here always has somewhere to go.
@@ -225,7 +296,6 @@ func (r *Registry) validate() error {
 			if first, dup := seenVar[v]; dup {
 				return fmt.Errorf("var %q is exposed by both %q and %q — each var must map to exactly one secret", v, first, s.ID)
 			}
-			seenVar[v] = s.ID
 		}
 	}
 	return nil

--- a/cli/internal/secrets/registry_test.go
+++ b/cli/internal/secrets/registry_test.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -302,5 +303,68 @@ func TestParseRegistry_Validation(t *testing.T) {
 				t.Errorf("expected error for %q, got nil", name)
 			}
 		})
+	}
+}
+
+// TestParseRegistryPartial_DefectiveSecretsNeverReachEntries is the structural guard
+// behind BUG-086's design.
+//
+// The partial door EXCLUDES defective secrets rather than flagging them in place,
+// because the rest of this package treats validation as already done: parseFileMode's
+// own comment says a bad mode "is impossible in practice" since validate() rejected it.
+// Letting an invalid secret through would trade a clear failure for an undefined one.
+func TestParseRegistryPartial_DefectiveSecretsNeverReachEntries(t *testing.T) {
+	reg, defects, err := ParseRegistryPartial([]byte("version: 1\nsecrets:\n" +
+		"  - {id: fine, plane: app, backend: age, age: a, expose: {env: FINE}}\n" +
+		"  - {id: bad-backend, plane: app, backend: nonsense, age: b, expose: {env: BAD1}}\n" +
+		"  - {id: bad-expose, plane: app, backend: age, age: c, expose: {}}\n" +
+		"  - {id: bad-mode, plane: app, backend: age, age: d, expose: {file: {path: p, mode: \"99z\"}}}\n"))
+	if err != nil {
+		t.Fatalf("a document with bad ENTRIES must still parse: %v", err)
+	}
+	if len(defects) != 3 {
+		t.Fatalf("defects = %d, want 3: %v", len(defects), defects)
+	}
+	if len(reg.Secrets) != 1 || reg.Secrets[0].ID != "fine" {
+		t.Fatalf("only the well-formed secret may survive, got %+v", reg.Secrets)
+	}
+	for _, e := range reg.Entries("/home/nobody") {
+		if e.Var != "FINE" {
+			t.Fatalf("a defective secret reached Entries(): %q", e.Var)
+		}
+	}
+	// Each defect must name its own secret, or a report cannot say what to fix.
+	for _, d := range defects {
+		if d.ID == "" || d.Err == nil {
+			t.Fatalf("defect is unusable: %+v", d)
+		}
+	}
+}
+
+// TestParseRegistry_StrictStillFailsOnFirstDefect: the strict door is unchanged for
+// every write path. `set`/`migrate`/`render` against a half-valid registry is the
+// dangerous case, and it must keep failing loudly.
+func TestParseRegistry_StrictStillFailsOnFirstDefect(t *testing.T) {
+	_, err := ParseRegistry([]byte("version: 1\nsecrets:\n" +
+		"  - {id: fine, plane: app, backend: age, age: a, expose: {env: FINE}}\n" +
+		"  - {id: bad, plane: app, backend: nonsense, age: b, expose: {env: BAD}}\n"))
+	if err == nil {
+		t.Fatal("the strict parser must still reject a registry containing a bad secret")
+	}
+	if !strings.Contains(err.Error(), "bad") {
+		t.Fatalf("the error should name the offending secret, got: %v", err)
+	}
+}
+
+// TestParseRegistryPartial_EmptyIdIsLabelledByPosition: a defect must be nameable even
+// when the missing field is the name.
+func TestParseRegistryPartial_EmptyIdIsLabelledByPosition(t *testing.T) {
+	_, defects, err := ParseRegistryPartial([]byte("version: 1\nsecrets:\n" +
+		"  - {id: \"\", plane: app, backend: age, age: a, expose: {env: X}}\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(defects) != 1 || defects[0].ID != "#0" {
+		t.Fatalf("want a positional label for an id-less secret, got %+v", defects)
 	}
 }

--- a/specs/BUG-086-verify-partial-registry/proposal.md
+++ b/specs/BUG-086-verify-partial-registry/proposal.md
@@ -1,0 +1,86 @@
+---
+id: "BUG-086-verify-partial-registry"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-16"
+issue: "mlorentedev/dotfiles#1004"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# BUG-086-verify-partial-registry
+
+> **Naming**: file lives at `<repo>/specs/BUG-086-verify-partial-registry/proposal.md`. `BUG-086-verify-partial-registry` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #1004: BUG-086: dotf secrets verify aborts on registry validation, so it
+can never report per-var health -->
+
+`Registry.validate()` returns on the **first** bad secret and `ParseRegistry` propagates
+that, so one malformed entry makes the whole registry unloadable. For `dotf secrets
+verify` that is self-defeating: a health check whose job is to tell you what is broken
+becomes the first thing to break, and it is taken down by an entry the caller never asked
+about. Scoping does not help either, because validation runs at load time, before
+resolution.
+
+## What
+
+`verify` reports a per-var status for every well-formed entry even when another entry is
+malformed, showing the malformed one as a `FAILED` row naming the defect, and exiting
+non-zero.
+
+- `dotf secrets verify` — every healthy entry reports; each defect is one `FAILED` row.
+- `dotf secrets verify <id>` — only the named ids are validated and resolved. A defect
+  elsewhere in the file is neither reported nor fatal.
+- `dotf secrets verify <malformed-id>` — reported as `FAILED`, not as "unknown id".
+- Every other command is unchanged: a half-valid registry still fails loudly.
+
+## Out of scope
+
+- **Relaxing validation anywhere else.** `set`, `migrate` and `render` write, and a
+  half-valid registry is exactly the state in which they must not run. Only `verify`
+  takes the partial door.
+- **Repairing malformed entries.** `verify` reports; it does not edit.
+- **The original trigger.** The issue cites `GITHUB_PERSONAL_ACCESS_TOKEN` carrying
+  `bw.folder: apps` instead of `Dotfiles/apps`. #982 inverted the taxonomy, so that value
+  is now correct and the entry is well-formed. The issue says it itself — *"Fix 2 is the
+  actual ticket; 1 is the trigger"* — and the trigger vanishing is an argument for
+  fixing this, not against: the check is one typo away from being unusable again, with
+  nothing to warn until it happens.
+
+## Risks / open questions
+
+- **Defective secrets must not reach `Entries()`.** The package treats validation as
+  having happened — `parseFileMode` documents that a bad mode "is impossible in practice"
+  because `validate()` rejected it. So the partial parser *excludes* defective secrets
+  rather than flagging them in place; anything else trades a clear failure for an
+  undefined one. Guarded by a test.
+- **Two validation paths would be the real hazard.** A separate lenient validator would
+  drift from the strict one exactly as the read and write paths drifted in BUG-084 (#993)
+  — silently, and only under the case nobody exercises. Avoided structurally: the strict
+  parser is implemented ON TOP of the partial one, so there is one set of per-secret
+  checks and two policies over the result.
+- **A rejected secret must not reserve its id or vars**, or the *next*, valid secret
+  would be blamed as the duplicate. Registration happens only after a secret validates.
+
+## Acceptance criteria
+
+- [ ] AC1 — `verify` reports a per-var status for every well-formed entry when another
+      entry is malformed; the malformed one is `FAILED`, exit is non-zero.
+- [ ] AC2 — `verify <id>` validates and resolves only the named ids; an out-of-scope
+      defect is neither reported nor fatal.
+- [ ] AC3 — `verify <malformed-id>` reports it as `FAILED`, never "unknown id".
+- [ ] AC4 — a duplicate id blames the *later* definition; the first still verifies.
+- [ ] AC5 — no defective secret reaches `Entries()`.
+- [ ] AC6 — the strict door is unchanged: `ParseRegistry` still fails on the first bad
+      secret, so every write path keeps failing loudly.
+- [ ] AC7 — a structural failure (unparseable YAML, unsupported version) still aborts
+      rather than degrading into a report.
+
+## References
+
+- Bitácora: `mlorentedev/dotfiles#1004`
+- #992 — same family: an AC met by circumstance while its guard stays unbuilt
+- #997, #906 — a real gap invisible because nothing checked
+- #985 (BUG-080) — registry entries pointing at nonexistent Bitwarden items

--- a/specs/BUG-086-verify-partial-registry/tasks.md
+++ b/specs/BUG-086-verify-partial-registry/tasks.md
@@ -1,0 +1,35 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-16"
+---
+
+# Tasks - BUG-086-verify-partial-registry
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers** (optional, additive — borrowed from `github/spec-kit`, adapt-not-adopt per #141):
+> - `[P]` — this task has **no dependency on another unchecked task**, so it is safe to run in parallel (fan out to a `Workflow`, or just batch). TDD chains (test → implement → refactor of the *same* behavior) are sequential and must NOT carry `[P]`; independent behaviors can.
+> - `[AC<n>]` — this task helps satisfy **acceptance criterion #`<n>`** from `proposal.md`. Lets `/spec check` map coverage deterministically; omit it and the check falls back to semantic judgment.
+
+## Setup
+
+- [x] Branch created from main: `fix/bug-086-verify-partial-registry`
+- [x] `proposal.md` complete, acceptance criteria testable
+
+## Implementation
+
+- [x] [AC6] Split `validate()` into per-secret `validateSecret` + document-level checks
+- [x] [AC1] `ParseRegistryPartial` — per-secret validation, defects returned not raised
+- [x] [AC6] Reimplement `ParseRegistry` ON TOP of it (one check set, two policies)
+- [x] [AC5] Exclude defective secrets from the returned registry
+- [x] [AC4] Register id/vars only after a secret validates
+- [x] [AC1] `verify` reports each defect as a `FAILED` row
+- [x] [AC2][AC3] `scopeVerify` — match args against defects as well as the registry
+- [x] Tests, including the mutation check
+
+## Verification
+
+- [x] `go build ./... && go vet ./... && go test ./...` green
+- [x] `golangci-lint run` at the pinned 2.12.2 — 0 issues
+- [x] Four AC guards observed FAILING with the bug reintroduced
+- [x] Real registry unchanged: `33 ok, 0 missing, 0 failed`

--- a/specs/BUG-086-verify-partial-registry/verification.md
+++ b/specs/BUG-086-verify-partial-registry/verification.md
@@ -1,0 +1,73 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-16"
+---
+
+# Verification - BUG-086-verify-partial-registry
+
+## Evidence
+
+| AC | Proof |
+|---|---|
+| AC1 | `TestSecretsVerify_MalformedEntryDoesNotHideTheRest` |
+| AC2 | `TestSecretsVerify_ScopedAwayFromDefect` |
+| AC3 | `TestSecretsVerify_ScopedToTheDefect` |
+| AC4 | `TestSecretsVerify_DuplicateIdBlamesTheSecondOne` |
+| AC5 | `TestParseRegistryPartial_DefectiveSecretsNeverReachEntries` |
+| AC6 | `TestParseRegistry_StrictStillFailsOnFirstDefect` + the whole pre-existing suite |
+| AC7 | `TestSecretsVerify_StructuralFailureStillAborts` |
+
+### Mutation check — the guards were observed failing
+
+A guard never seen failing is not evidence (#898). `verify` was pointed back at the
+strict door (the exact defect) and the four behavioural guards failed:
+
+```
+--- FAIL: TestSecretsVerify_MalformedEntryDoesNotHideTheRest
+    verify output missing "FAILED"
+--- FAIL: TestSecretsVerify_ScopedAwayFromDefect
+--- FAIL: TestSecretsVerify_ScopedToTheDefect
+    the named defect should be a FAILED row
+--- FAIL: TestSecretsVerify_DuplicateIdBlamesTheSecondOne
+```
+
+Restored, suite green.
+
+### No behaviour change on a healthy registry
+
+```
+$ dotf secrets verify        # real registry, built from this branch
+33 ok, 0 missing, 0 failed
+```
+
+That is the point: this changes what happens when the registry is broken, and nothing
+about what happens when it is not.
+
+## Test status
+
+- `go build ./... && go vet ./... && go test ./...` — every package ok
+- `golangci-lint run` (pinned 2.12.2) — **0 issues**
+- No regressions: the pre-existing registry suite passes unchanged, which is also AC6's
+  evidence — those tests assert the strict door's messages, and the strict door is now a
+  thin policy over the partial one.
+
+## Decisions made during implementation
+
+- **Strict implemented on top of partial, not beside it.** One set of per-secret checks,
+  two policies. Two independent validators is the shape that produced BUG-084: the moment
+  one moves, they disagree silently. `ParseRegistry` is now literally
+  `ParseRegistryPartial` + "any defect → first error".
+- **Defective secrets are excluded, not flagged in place.** The package's other code
+  documents that it relies on validation having run.
+- **Defect vars are not expanded.** The entry is exactly what could not be read, so
+  naming the vars it "would have" exposed is guesswork; the row is keyed by secret id.
+- **Structural failures stay fatal.** "Cannot read the document" and "read it, and this
+  entry is wrong" are different conditions, and only the second has anything to report.
+
+## Promotion candidates
+
+- [ ] Lesson for `docs/lessons.md`? No — the lesson this belongs to is already written
+      (*"a check whose precondition the architecture forbids reports SKIP forever"* and
+      the #997 family). This is another instance, not a new rule.
+- [ ] ADR-worthy? No.
+- [ ] Pattern for `00_meta/`? No.


### PR DESCRIPTION
Refs #1004 (BUG-086) — closing keyword withheld until the spec is archived, which needs an adversarial review, which needs 0.42.0. Same pattern as #1018.

## The bug

`Registry.validate()` returned on the **first** bad secret and `ParseRegistry` propagated it, so one malformed entry made the whole registry unloadable.

For a health check that is self-defeating: **the command whose job is to tell you what is broken became the first thing to break** — and it was taken down by an entry the caller never asked about. Scoping did not help either, because validation ran at load time, before resolution.

## What changes

- `dotf secrets verify` — every well-formed entry reports its status; each malformed one is a `FAILED` row naming the defect. Exit non-zero.
- `dotf secrets verify <id>` — only the named ids are validated and resolved. A defect elsewhere in the file is neither reported nor fatal.
- `dotf secrets verify <malformed-id>` — reported as `FAILED`, **not** "unknown id". It was excluded from the registry precisely because it is the thing being asked about, so the lookup consults the defects too.
- **Every other command is unchanged.**

## Three constraints that shaped it

1. **The strict parser is implemented ON TOP of the partial one** — one set of per-secret checks, two policies over the result. `ParseRegistry` is now literally `ParseRegistryPartial` + *"any defect → first error"*. Two independent validators is the shape that produced BUG-084 (#993): the moment one moves, they disagree, silently, under the case nobody exercises.
2. **Defective secrets are excluded, not flagged in place.** The package relies on validation having run — `parseFileMode`'s own comment says a bad mode *"is impossible in practice"* because `validate()` rejected it. Letting an invalid secret reach `Entries()` would trade a clear failure for an undefined one.
3. **A rejected secret registers neither its id nor its vars**, or the *next*, valid secret would be blamed as the duplicate.

Only `verify` takes the partial door. `set`, `migrate` and `render` write, and a half-valid registry is exactly the state in which they must not run.

## Evidence

**Mutation-checked** — a guard never observed failing is not evidence (#898). `verify` was pointed back at the strict door, i.e. the exact defect reintroduced:

```
--- FAIL: TestSecretsVerify_MalformedEntryDoesNotHideTheRest
    verify output missing "FAILED"
--- FAIL: TestSecretsVerify_ScopedAwayFromDefect
--- FAIL: TestSecretsVerify_ScopedToTheDefect
    the named defect should be a FAILED row
--- FAIL: TestSecretsVerify_DuplicateIdBlamesTheSecondOne
```

Restored, suite green.

**No behaviour change on a healthy registry** — `dotf secrets verify` against the real one, built from this branch: `33 ok, 0 missing, 0 failed`. This changes what happens when the registry is broken and nothing about when it is not.

`go build ./... && go vet ./... && go test ./...` green; `golangci-lint run` at the pinned 2.12.2 reports 0 issues. The pre-existing registry suite passes unchanged, which is also the evidence for AC6 — those tests assert the strict door's messages, and the strict door is now a thin policy over the partial one.

## A note on this issue's trigger, which has since disappeared

The issue cites `GITHUB_PERSONAL_ACCESS_TOKEN` carrying `bw.folder: apps` instead of `Dotfiles/apps`. #982 inverted the taxonomy, so that value is now the **correct** one and the entry is well-formed — `verify` currently reports 33 ok.

The issue anticipated this: *"Fix 2 is the actual ticket; 1 is the trigger that surfaced it."* The trigger vanishing is an argument for fixing it, not against — the check was one typo away from being unusable again, with nothing to warn until it happened. Same family as #992 (AC1 met by circumstance, its guard unbuilt) and #997.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `secrets verify` now reports valid and malformed registry entries independently.
  * Malformed entries appear as `FAILED` results, while healthy entries continue to be checked.
  * Scoped verification correctly includes requested malformed IDs and excludes unrelated entries.
  * Structurally unreadable registries still stop verification with an error.

* **Documentation**
  * Added proposal, implementation tasks, and verification documentation for partial registry validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->