### PR TITLE
docs(spec): align three spec records with what was actually done

### DIFF
--- a/specs/BUG-082-status-poisons-item-reads/proposal.md
+++ b/specs/BUG-082-status-poisons-item-reads/proposal.md
@@ -1,7 +1,7 @@
 ---
 id: "BUG-082-status-poisons-item-reads"
 type: spec
-status: draft # draft | implementing | verifying | archived
+status: verifying # draft | implementing | verifying | archived
 created: "2026-08-16"
 issue: "mlorentedev/dotfiles#988"   # repo#NNN — GitHub issue / Project item that tracks this spec
 tags: [spec, proposal]

--- a/specs/BUG-084-secrets-write-bw-serve/proposal.md
+++ b/specs/BUG-084-secrets-write-bw-serve/proposal.md
@@ -1,7 +1,7 @@
 ---
 id: "BUG-084-secrets-write-bw-serve"
 type: spec
-status: draft # draft | implementing | verifying | archived
+status: verifying # draft | implementing | verifying | archived
 created: "2026-08-15"
 issue: "mlorentedev/dotfiles#993"   # repo#NNN — GitHub issue / Project item that tracks this spec
 tags: [spec, proposal]

--- a/specs/BUG-084-secrets-write-bw-serve/tasks.md
+++ b/specs/BUG-084-secrets-write-bw-serve/tasks.md
@@ -42,5 +42,8 @@ created: "2026-08-15"
 - [x] `golangci-lint run` at the pinned 2.12.2 — 0 issues
 - [x] AC5 guard mutation-checked: reintroducing the split-brain makes it fail red
 - [x] AC4 observed live, before and after, against a real unlocked daemon
-- [ ] AC1/AC2 live write against a canary item — **pending operator authorization**
-      (a real vault mutation; not done unilaterally)
+- [x] AC1/AC2 live write against a canary item — authorised by the operator and run.
+      It FAILED on its first pass, which is why it was worth insisting on: the write
+      landed on the server while the daemon kept serving its cached value, so the
+      read-back returned the previous fingerprint. Fixed by syncing after every write
+      (`syncAfterWrite`); the canary now passes with no explicit sync of its own.

--- a/specs/BUG-086-verify-partial-registry/proposal.md
+++ b/specs/BUG-086-verify-partial-registry/proposal.md
@@ -1,7 +1,7 @@
 ---
 id: "BUG-086-verify-partial-registry"
 type: spec
-status: draft # draft | implementing | verifying | archived
+status: verifying # draft | implementing | verifying | archived
 created: "2026-08-16"
 issue: "mlorentedev/dotfiles#1004"   # repo#NNN — GitHub issue / Project item that tracks this spec
 tags: [spec, proposal]
@@ -77,6 +77,11 @@ non-zero.
       secret, so every write path keeps failing loudly.
 - [ ] AC7 — a structural failure (unparseable YAML, unsupported version) still aborts
       rather than degrading into a report.
+- [ ] AC8 — a duplicate id reports BOTH halves: the definition that validated resolves
+      normally, and every defect sharing that id is reported. Added after review (#1020):
+      because a rejected secret does not reserve its id (AC4), one id can name a valid
+      entry AND one or more defects, and reporting only the defect hides the half that
+      actually resolves.
 
 ## References
 

--- a/specs/BUG-086-verify-partial-registry/verification.md
+++ b/specs/BUG-086-verify-partial-registry/verification.md
@@ -16,6 +16,7 @@ created: "2026-08-16"
 | AC5 | `TestParseRegistryPartial_DefectiveSecretsNeverReachEntries` |
 | AC6 | `TestParseRegistry_StrictStillFailsOnFirstDefect` + the whole pre-existing suite |
 | AC7 | `TestSecretsVerify_StructuralFailureStillAborts` |
+| AC8 | `TestSecretsVerify_ScopedToDuplicateIdReportsBothHalves`, `TestSecretsVerify_SeveralDefectsOnOneId` — both observed failing with the short-circuit reintroduced |
 
 ### Mutation check — the guards were observed failing
 


### PR DESCRIPTION
Docs only. Refs #993, #988, #1004.

**Must merge BEFORE the adversarial reviews run**, not after — editing a spec's contract files after a review invalidates its own `reviewed_sha`. That is the trap HARNESS-072 hit (#998), and it costs a whole 25-minute review round.

## What was stale

**1. `status: draft` on all three.** They are implemented, verified and awaiting only the adversarial review. `verifying` is the accurate state (the same one `CLI-024-secrets-bw-serve` carried while active).

**2. BUG-084 still listed the canary as pending.**

```
- [ ] AC1/AC2 live write against a canary item — **pending operator authorization**
```

Stale — it was authorised and run. A reviewer reading the task list would have flagged an unmet task, which is a false finding produced by my own record rather than by the code.

Recorded with the reason it mattered rather than just ticked: **the canary failed on its first pass**, catching a defect that three fakes and a fully green unit suite had missed. A daemon `PUT` lands on the server while the daemon keeps answering reads from its own cache, so the read-back returned the *previous* fingerprint — meaning `dotf secrets set` followed by `dotf secrets run` in another process would have served the pre-write value.

**3. BUG-086 gained behaviour after review with no AC covering it.**

#1020's CodeRabbit review surfaced that a rejected secret not reserving its id — deliberate, so a defect cannot make the *next* valid entry look like the duplicate — means one id can name a valid entry **and** its defects. Two tests now cover it, but without a contract line they were coverage nothing traced to, which is exactly what an adversarial reviewer flags as untraceable. Added as **AC8**, mapped to its two tests in `verification.md`.

## What was deliberately NOT changed

The unchecked `- [ ] AC…` boxes in each `proposal.md`. I checked the convention against an archived spec (`specs/archive/CLI-024-secrets-verify/`) rather than assuming: it is `status: archived` with all AC boxes still unticked. The proposal's ACs are the **contract**, not a checklist; the evidence lives in `verification.md`. Ticking them would have looked tidier and been wrong.
