### PR TITLE
fix(ci): make the failing attestation step say why, not just exit 1

### DIFF
--- a/.github/workflows/review-attestation.yml
+++ b/.github/workflows/review-attestation.yml
@@ -133,4 +133,29 @@ jobs:
       - name: Fail the run when the PR is not attested
         env:
           CODE: ${{ steps.attest.outputs.code }}
-        run: exit "$CODE"
+          SUMMARY: ${{ steps.attest.outputs.summary }}
+        # The verdict is repeated here, not just in the step that computed it.
+        # A bare `exit "$CODE"` made the RED step say nothing: the diagnostic sat
+        # in an earlier, green step, so anyone opening the failure saw an exit
+        # code and no reason. Reported by a parallel session whose PRs this gate
+        # began failing.
+        #
+        # That is this gate's own fourth constraint — a check that fails closed
+        # must still say why — violated one layer up, inside the check built to
+        # enforce it. Collapsing "why" into an exit code is the same defect as
+        # #988's error path discarding HTTP 500 and surfacing `invalid character
+        # 'I'`: the diagnostic threw away the diagnosis.
+        run: |
+          if [ "$CODE" != "0" ]; then
+            echo "::error title=Review attestation::$SUMMARY"
+            echo "$SUMMARY"
+            echo
+            echo "Options:"
+            echo "  (a) Get the PR reviewed. This gate re-runs on new comments — no push needed."
+            echo "  (b) Declare the unreviewed merge: add the 'merged-unreviewed' label AND a"
+            echo "      non-empty '## Unreviewed merge rationale' section to the PR body."
+            echo
+            echo "This check is NOT required in branch protection: it reports, it does not veto."
+            echo "Proceeding on an unreviewed PR is allowed. Proceeding silently is not."
+          fi
+          exit "$CODE"

--- a/tests/check-review-attestation.bats
+++ b/tests/check-review-attestation.bats
@@ -357,3 +357,14 @@ sys.exit(0 if 'pull_request' in on and 'issue_comment' in on else 1)
     grep -q 'not active on' "$wf"
     grep -qE 'if \[ ! -x scripts/check-review-attestation.sh \]' "$wf"
 }
+
+@test "AC7: the failing step states the verdict, not just an exit code" {
+    # A bare `exit "$CODE"` made the RED step say nothing — the diagnostic was
+    # in an earlier, green step, so anyone opening the failure saw a code and no
+    # reason. This gate's own fourth constraint (fail closed, but say why),
+    # violated at the job level inside the check that enforces it.
+    local wf="$REPO/.github/workflows/review-attestation.yml"
+    grep -q '::error title=Review attestation::' "$wf"
+    grep -q 'merged-unreviewed' "$wf"
+    grep -q 'does not veto' "$wf"
+}


### PR DESCRIPTION
Addresses a defect in #1019, reported within minutes of it merging by a parallel session whose PRs the gate began failing.

## The defect

The red step said nothing.

The diagnostic is printed by the step that *computes* the verdict — which passes. The step that actually **fails** was a bare `exit "$CODE"`. So anyone opening the failure saw an exit code and no reason:

```
Fail the run when the PR is not attested
  CODE: 1
  Error: Process completed with exit code 1.
```

The peer's words, and they are right: *"a gate that fails without saying why is a step back from the prose refusals #960 complains about."*

## Why it matters more than a UX nit

This is **GUARD-002's own fourth design constraint** — *a check that fails closed must still say why* — violated one layer up, inside the check built to enforce it.

It is the same shape as #988's second defect, where the error path discarded the HTTP status and surfaced `invalid character 'I'` instead of `HTTP 500`: **the diagnostic threw away the diagnosis**. That is the half of #988 that made it survive weeks of being looked at, and I wrote it into GUARD-002's spec as a constraint hours before committing it myself.

## The fix

The failing step now repeats the verdict, emits a `::error` annotation so it surfaces in the PR view rather than only in the log, and states both exits:

- **(a)** get it reviewed — the gate re-runs on new comments, no push needed
- **(b)** declare the unreviewed merge: `merged-unreviewed` label **and** a non-empty `## Unreviewed merge rationale` section

It also says outright that **the check is not required in branch protection**. That line earns its place: the first question anyone asks a red gate is whether they are stuck, and here they are not — this gate reports, it never vetoes. The peer asked exactly that question, which is how I know the answer was not discoverable from the output.

## Evidence

```
$ bats tests/check-review-attestation.bats
37 tests, 0 failures       (36 -> 37)
```

The new case asserts the verdict, the escape and the not-a-veto line are all present in the workflow.

## Note

Spec-gate: 27 production LOC, below the 50 threshold — no spec folder required. The behaviour it changes is covered by `specs/GUARD-002-review-attestation`, already archived-pending on `main`.

Credit for the finding to the session running #1026/#1027, which hit it and asked rather than routing around the gate.

## Unreviewed merge rationale

CodeRabbit's account-wide quota is exhausted and it posted a rate-limit notice instead of a review; the gate correctly reads that as `declined`. Disclosed rather than bypassed.

Specific to this PR: it changes only what the gate **says** when it refuses, not whether it refuses. The failure path is exercised by the bats suite (`AC6: every failure path says it could not determine, rather than implying fine`), and its own gate ran on this branch and refused it — which is the behaviour under change working on itself.

Risk accepted: the wording of a diagnostic has not been read by a second party. Low blast radius; a wrong word here costs clarity, not correctness.
