### PR TITLE
refactor(secrets): apply the adversarial review's two actionable findings

### DIFF
--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -250,10 +250,17 @@ func scopeVerify(reg *secrets.Registry, defects []secrets.SecretDefect, args []s
 		ds, isDefect := byID[tok]
 		inScope = append(inScope, ds...)
 
-		// One token can name BOTH a defect and a valid entry — a duplicate id whose
-		// first definition validated and whose second did not. Reporting only the
-		// defect would hide the entry that actually resolves, which is the half the
-		// caller most needs. So a defect match does not short-circuit the lookup.
+		// One token can name BOTH a defect and a valid entry, in two distinct ways,
+		// and neither may short-circuit the other:
+		//
+		//   1. a duplicate id whose first definition validated and whose second did
+		//      not — reporting only the defect hides the half that resolves;
+		//   2. a NAME COLLISION: a malformed secret whose id is "FOO" alongside a
+		//      well-formed secret exposing a var called "FOO". Two genuinely
+		//      different secrets, both named by one token, both owed an answer.
+		//
+		// Case 2 was surfaced by the adversarial review as undocumented; it is pinned
+		// by TestSecretsVerify_TokenThatIsBothADefectIdAndAValidVar.
 		_, known := reg.Selector(tok)
 		if known || !isDefect {
 			// Unknown-and-not-a-defect falls through deliberately, so resolveOnly

--- a/cli/internal/cmd/secrets_registry_test.go
+++ b/cli/internal/cmd/secrets_registry_test.go
@@ -533,3 +533,32 @@ func TestSecretsVerify_SeveralDefectsOnOneId(t *testing.T) {
 		t.Errorf("the one valid definition must still resolve:\n%s", out)
 	}
 }
+
+// TestSecretsVerify_TokenThatIsBothADefectIdAndAValidVar is the adversarial review's
+// second Minor (THEORETICAL) on BUG-086, pinned as behaviour rather than left implicit.
+//
+// One token can name two different secrets: a malformed entry whose ID is `SHARED`, and
+// a well-formed entry that EXPOSES a var called `SHARED`. `scopeVerify` matches the
+// first against the defect table and the second through reg.Selector, so both report.
+//
+// That is correct — they are genuinely two secrets and the caller named both — but it
+// was undocumented and untested, which is the reviewer's point. Reporting only one of
+// them would hide a real answer behind a name collision.
+func TestSecretsVerify_TokenThatIsBothADefectIdAndAValidVar(t *testing.T) {
+	useTempRegistry(t, "version: 1\nsecrets:\n"+
+		"  - {id: SHARED, plane: app, backend: nonsense, age: a, expose: {env: OTHER}}\n"+
+		"  - {id: exposer, plane: app, backend: age, age: b, expose: {env: SHARED}}\n")
+	alwaysResolves(t)
+
+	out, err := runVerify(t, "SHARED")
+
+	if !strings.Contains(out, "registry:") {
+		t.Errorf("the defect whose id is SHARED must be reported:\n%s", out)
+	}
+	if !strings.Contains(out, "OK") || !strings.Contains(out, "SHARED") {
+		t.Errorf("the well-formed secret exposing a var named SHARED must resolve:\n%s", out)
+	}
+	if err == nil {
+		t.Errorf("a defect in scope must still exit non-zero:\n%s", out)
+	}
+}

--- a/cli/internal/secrets/registry.go
+++ b/cli/internal/secrets/registry.go
@@ -137,8 +137,6 @@ func (e *EnvExpose) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-// ParseRegistry parses and validates registry.yaml. Validation is fail-fast: a
-// malformed registry is a configuration error, never silently tolerated.
 // SecretDefect is one secret that failed validation, kept apart from the registry so a
 // caller can report it instead of being stopped by it.
 type SecretDefect struct {
@@ -229,73 +227,89 @@ func secretLabel(s *Secret, i int) string {
 // uniqueness state; this function only READS them — registration is the caller's, so
 // that a rejected secret never reserves anything.
 func validateSecret(s *Secret, i int, seen map[string]bool, seenVar map[string]string) error {
-	{
-		if s.ID == "" {
-			return fmt.Errorf("secret #%d: empty id", i)
+	if s.ID == "" {
+		return fmt.Errorf("secret #%d: empty id", i)
+	}
+	if seen[s.ID] {
+		return fmt.Errorf("duplicate secret id %q", s.ID)
+	}
+	// ValidBackends is the SSOT for this list; a resolver-coverage test binds
+	// it to the Loader, so a backend accepted here always has somewhere to go.
+	if !slices.Contains(ValidBackends(), s.Backend) {
+		return fmt.Errorf("secret %q: unknown backend %q", s.ID, s.Backend)
+	}
+	if err := checkExpose(s); err != nil {
+		return err
+	}
+	// Each backend must resolve a source for everything it exposes.
+	switch s.Backend {
+	case BackendAge, BackendAgeOffline:
+		if err := s.checkAgeSources(); err != nil {
+			return err
 		}
-		if seen[s.ID] {
-			return fmt.Errorf("duplicate secret id %q", s.ID)
+	case BackendBW:
+		if err := s.checkBwSources(); err != nil {
+			return err
 		}
+	}
+	if err := checkBWFolder(s); err != nil {
+		return err
+	}
+	return checkVarNames(s, seenVar)
+}
 
-		// ValidBackends is the SSOT for this list; a resolver-coverage test binds
-		// it to the Loader, so a backend accepted here always has somewhere to go.
-		if !slices.Contains(ValidBackends(), s.Backend) {
-			return fmt.Errorf("secret %q: unknown backend %q", s.ID, s.Backend)
+// checkExpose enforces that a secret exposes exactly one of env|file, and that a file
+// expose's mode is octal. The mode is applied at materialization (#612 B2), so it is
+// rejected here rather than degrading to a silent 0600 much later.
+func checkExpose(s *Secret) error {
+	hasEnv, hasFile := len(s.Expose.Env.Vars) > 0, s.Expose.File != nil
+	if hasEnv == hasFile { // both, or neither
+		return fmt.Errorf("secret %q: expose must have exactly one of env|file", s.ID)
+	}
+	if hasFile && s.Expose.File.Mode != "" {
+		if _, err := strconv.ParseUint(s.Expose.File.Mode, 8, 32); err != nil {
+			return fmt.Errorf("secret %q: invalid file mode %q (want octal, e.g. 0600)", s.ID, s.Expose.File.Mode)
 		}
+	}
+	return nil
+}
 
-		hasEnv, hasFile := len(s.Expose.Env.Vars) > 0, s.Expose.File != nil
-		if hasEnv == hasFile { // both, or neither
-			return fmt.Errorf("secret %q: expose must have exactly one of env|file", s.ID)
+// checkBWFolder validates bw.folder against the ratified taxonomy and the secret's plane.
+//
+// bw.folder is pre-declared dormant metadata (ADR-028 §2 addendum): a secret's bw: block,
+// folder included, is written up front while backend is still age and only activated on
+// migrate. Gating this on backend == "bw" (as checkBwSources does for item/field) would
+// leave every dormant folder value unvalidated until the moment migrate reads it and
+// hands it straight to ResolveFolder — which CREATES an arbitrary Bitwarden folder for a
+// typo, exactly the drift this taxonomy exists to prevent (OPS-028 adversarial review,
+// Major finding). So this runs for every secret carrying a bw: block, whatever its
+// current backend.
+func checkBWFolder(s *Secret) error {
+	if s.BW == nil || s.BW.Folder == "" {
+		return nil
+	}
+	if !validBWFolders[s.BW.Folder] {
+		return fmt.Errorf("secret %q: bw.folder %q is not in the ratified taxonomy (apps, infra)", s.ID, s.BW.Folder)
+	}
+	if want := planeFolder[s.Plane]; want != "" && s.BW.Folder != want {
+		return fmt.Errorf("secret %q: bw.folder %q does not match plane %q (want %q)", s.ID, s.BW.Folder, s.Plane, want)
+	}
+	return nil
+}
+
+// checkVarNames enforces that every exposed var is a valid env identifier (B5) and unique
+// across the whole registry (B1): a var mapped by two secrets has no single source, and
+// render's dedup was age-only, so run/show would silently resolve last-write.
+//
+// It only READS seenVar — registration is the caller's, so a rejected secret never
+// reserves a name and cannot make the next valid secret look like the duplicate.
+func checkVarNames(s *Secret, seenVar map[string]string) error {
+	for _, v := range s.Vars() {
+		if !validVarName.MatchString(v) {
+			return fmt.Errorf("secret %q: invalid var name %q (want an env identifier [A-Za-z_][A-Za-z0-9_]*)", s.ID, v)
 		}
-
-		// A file expose's mode is applied at materialization (#612 B2); reject a
-		// non-octal here so the failure surfaces at parse, not as a silent 0600.
-		if hasFile && s.Expose.File.Mode != "" {
-			if _, err := strconv.ParseUint(s.Expose.File.Mode, 8, 32); err != nil {
-				return fmt.Errorf("secret %q: invalid file mode %q (want octal, e.g. 0600)", s.ID, s.Expose.File.Mode)
-			}
-		}
-
-		// Each backend must resolve a source for everything it exposes.
-		switch s.Backend {
-		case BackendAge, BackendAgeOffline:
-			if err := s.checkAgeSources(); err != nil {
-				return err
-			}
-		case BackendBW:
-			if err := s.checkBwSources(); err != nil {
-				return err
-			}
-		}
-
-		// bw.folder is pre-declared dormant metadata (ADR-028 §2 addendum): a secret's
-		// bw: block, folder included, is written up front while backend is still age
-		// and only activated on migrate. Gating this check on backend == "bw" (as
-		// checkBwSources does for item/field) would leave every dormant folder value
-		// unvalidated until the moment migrate reads it and hands it straight to
-		// ResolveFolder — which CREATES an arbitrary Bitwarden folder for a typo,
-		// exactly the drift this taxonomy exists to prevent (OPS-028 adversarial
-		// review, Major finding). So this runs for every secret carrying a bw: block,
-		// regardless of current backend.
-		if s.BW != nil && s.BW.Folder != "" {
-			if !validBWFolders[s.BW.Folder] {
-				return fmt.Errorf("secret %q: bw.folder %q is not in the ratified taxonomy (apps, infra)", s.ID, s.BW.Folder)
-			}
-			if want := planeFolder[s.Plane]; want != "" && s.BW.Folder != want {
-				return fmt.Errorf("secret %q: bw.folder %q does not match plane %q (want %q)", s.ID, s.BW.Folder, s.Plane, want)
-			}
-		}
-
-		// Every exposed var must be a valid env identifier (B5) and unique across the
-		// whole registry (B1): a var mapped by two secrets has no single source, and
-		// render's dedup was age-only, so run/show would silently resolve last-write.
-		for _, v := range s.Vars() {
-			if !validVarName.MatchString(v) {
-				return fmt.Errorf("secret %q: invalid var name %q (want an env identifier [A-Za-z_][A-Za-z0-9_]*)", s.ID, v)
-			}
-			if first, dup := seenVar[v]; dup {
-				return fmt.Errorf("var %q is exposed by both %q and %q — each var must map to exactly one secret", v, first, s.ID)
-			}
+		if first, dup := seenVar[v]; dup {
+			return fmt.Errorf("var %q is exposed by both %q and %q — each var must map to exactly one secret", v, first, s.ID)
 		}
 	}
 	return nil

--- a/specs/BUG-086-verify-partial-registry/review.md
+++ b/specs/BUG-086-verify-partial-registry/review.md
@@ -1,0 +1,66 @@
+---
+spec: "BUG-086-verify-partial-registry"
+verdict: "PASS"
+reviewed_sha: "e033302489a9e446efa8e38253cb7aa5a7b8a590"
+reviewer: "nan/deepseek-v4-flash"
+date: "2026-08-16"
+---
+
+## Adversarial review
+
+**Scope**: BUG-086-verify-partial-registry
+**Sources**:
+- `specs/BUG-086-verify-partial-registry/proposal.md` — 8 acceptance criteria, explicit non-goals, risks documented
+- `specs/BUG-086-verify-partial-registry/tasks.md` — all 8 implementation tasks ticked; verification box ticked
+- `specs/BUG-086-verify-partial-registry/verification.md` — named tests per AC, mutation check observed failing, build/vet/test results
+- `cli/internal/secrets/registry.go` — `ParseRegistryPartial`, `SecretDefect`, `validateSecret` at HEAD
+- `cli/internal/cmd/secrets.go` — `loadRegistryPartial`, `scopeVerify`, verify's RunE at HEAD
+- `cli/internal/secrets/registry_test.go` — new and pre-existing validation tests
+- `cli/internal/cmd/secrets_registry_test.go` — new verify tests
+- `718c895` — the implementing commit (merge-ancestor of HEAD)
+- `git diff 718c895~1..718c895` — full implementation diff
+
+### Spec and task alignment
+
+All 8 implementation tasks are ticked `[x]`. The diff covers exactly what the tasks describe:
+- [AC6] `validate` → `validateSecret` split ✓ (registry.go)
+- [AC1] `ParseRegistryPartial` with per-secret validation, defects returned ✓
+- [AC6] `ParseRegistry` reimplemented on top of it ✓
+- [AC5] Defective secrets excluded from returned registry ✓
+- [AC4] id/vars registered only after validation ✓
+- [AC1] verify reports each defect as FAILED row ✓
+- [AC2, AC3] `scopeVerify` matches args against defects and registry ✓
+- Tests, including mutation check ✓
+
+No `[AGENT-DRAFT]` or `[AGENT-SUGGESTION]` tags remain in any spec artifact. The proposal's frontmatter does not declare `review: waived`, so this review is in-scope.
+
+### Findings
+
+| Severity | Reality | Area | Finding | Evidence | Test (named, or UNTESTED) | Fix location |
+|----------|---------|------|---------|----------|---------------------------|-------------|
+| Minor | REAL | maintainability | `validateSecret` is 72 lines, nearly 2× the AGENTS.md guideline of ≤40 lines per function. The function is a sequential validation list (each check is independent and short), but the length exceeds the stated threshold without inline justification. | Code read at `cli/internal/secrets/registry.go:231-302`. `scopeVerify` also edges over at 41 lines. | `TestParseRegistry_DefectiveSecretsNeverReachEntries` exercises all internal paths transitively; no test *directly* asserts anything about function length. | code — either inline a comment explaining why length is justified (sequential checks), or extract one or two of the longer blocks (e.g. bw.folder validation, file mode validation) into named helpers. |
+| Minor | THEORETICAL | clarity | `scopeVerify` double-counts a token that is BOTH a defect id and a valid var name (e.g. a malformed secret with `id: FOO` and a well-formed secret with `expose: {env: FOO}`). The token produces both a defect row and a healthy var resolution, which is arguably correct (AC8), but the behavior is not documented in the function's comment. | Code read at `scopeVerify` (secrets.go:225-258), specifically the `known || !isDefect` branch. No existing test exercises this specific cross-over. | UNTESTED — no named test exercises the case where a defect id collides with a well-formed var name. | spec — document the expected behaviour in `proposal.md`'s AC8 or in a new subsection; tests — optionally add a regression test if the collision is considered within scope. |
+| Minor | SPECULATIVE | performance | `ParseRegistryPartial` builds a `kept` slice and copies each validated secret with `kept = append(kept, *s)`, which copies the entire struct (including all string fields, slices, maps). For very large registries (hundreds of secrets), this allocates O(n) memory beyond the original YAML decode. The original strict door did no copying because it returned instantly on the first defect. | Code read at registry.go `ParseRegistryPartial` loop. No reproduction or observed failure. | UNTESTED — no benchmark exists for this path. | — (surface only; no action needed unless a registry exceeds ~500 secrets) |
+
+### Evaluator rubric
+
+| Dimension | Grade (A-D) | Rationale (one line) |
+|-----------|-------------|----------------------|
+| Correctness | A | All 8 ACs verified; negative paths covered by named tests; mutation tests confirm the exact bug is caught on reintroduction; `go test ./...` green on all packages. |
+| Verification | A | Each AC maps to a named `Test*` function; verification.md proves the mutation guard was observed failing; build/vet/entire-test-suite run and green; real-registry smoke test (`dotf secrets verify` → 33 ok) run. |
+| Scope | A | Diff touches only the files the spec describes: `registry.go` (split + partial), `secrets.go` (verify wiring + scopeVerify), test files, spec files. The unrelated `probe` command was added in a later commit. No creep. |
+| Reliability | A | All error paths handled: structural failures (YAML, version) stay fatal; per-secret defects recorded and excluded; nil-map reads safe; empty registries yield no entries; exit codes correct for all conditions. |
+| Maintainability | B | `validateSecret` at 72 lines exceeds the 40-line guideline; `scopeVerify` at 41 lines barely does. Both are clear, well-documented, and follow a sequential-check pattern, but the length gap is measurable. |
+| Handoff-readiness | A | Spec artifacts (proposal, tasks, verification) complete and consistent with the diff. Lessons evaluated as "no new rule" with a reasoned citation to existing lessons. No stale sections. |
+
+### Verdict
+
+**PASS**
+
+No blockers or majors. The rubric grades are all B or above (aggregation rule: PASS). The two Minor findings — function length (`validateSecret`) and an undocumented edge case in `scopeVerify` — are surfaced but do not move the verdict. See recommended next steps before archive.
+
+### Recommended next steps (before archive)
+
+1. **Minor (maintainability):** Either add an inline comment in `validateSecret` explaining why the sequential-check pattern justifies exceeding 40 lines, or extract the bw.folder block and/or the file-mode block into named helpers. Either approach resolves the finding without a behaviour change.
+2. **Minor (clarity):** If the collision case (a token matching both a defect id and a valid var name) is considered a supported scenario, document it in `proposal.md` under AC8 or a new subsection. If it is not intentional and should be a guard, add a test and a short-circuit. This does not block archive.
+3. **Archive readiness:** No `[AGENT-DRAFT]` tags, spec files are stable, and `review.md` is present with the correct frontmatter. `dotf spec archive` is **advisable** in the current state. The two minors above are optional follow-ups, not preconditions.

--- a/specs/BUG-086-verify-partial-registry/verification.md
+++ b/specs/BUG-086-verify-partial-registry/verification.md
@@ -44,6 +44,33 @@ $ dotf secrets verify        # real registry, built from this branch
 That is the point: this changes what happens when the registry is broken, and nothing
 about what happens when it is not.
 
+## Adversarial review — PASS, and what was done with its findings
+
+`nan/deepseek-v4-flash` against `e033302`, **4m 48s**, verdict **PASS**, 0 blockers,
+0 majors, 3 minors. Verdict in `review.md`.
+
+| # | Class | Finding | Disposition |
+|---|---|---|---|
+| 1 | Minor / REAL | `validateSecret` was 72 lines against AGENTS.md's `< 40` guideline; `scopeVerify` at 41 | **APPLIED** — extracted `checkExpose`, `checkBWFolder` and `checkVarNames`. 72 → **31 lines**, no behaviour change |
+| 2 | Minor / THEORETICAL | a token that is both a defect id and a valid var name produces two rows; correct but undocumented and untested | **APPLIED** — pinned by `TestSecretsVerify_TokenThatIsBothADefectIdAndAValidVar` and documented at the branch |
+| 3 | Minor / SPECULATIVE | `kept` copies each validated secret; O(n) beyond the YAML decode for very large registries | **DECLINED** — the registry holds 33 secrets and the reviewer scoped it to "~500+". Optimising an unmeasured path would trade a clear implementation for a guess |
+
+Finding 1 was a real violation of this repo's own Code Quality Rules, found by reading
+the code against the stated threshold rather than by running anything — the kind a test
+suite structurally cannot produce.
+
+Finding 2 is the sharper one. Two *different* secrets can be named by one token — a
+malformed entry with `id: FOO` and a well-formed entry exposing a var called `FOO` — and
+answering for only one of them would hide a real result behind a name collision. The
+behaviour was already correct; what was missing was anything asserting it stays correct.
+
+**Both applied without touching `proposal.md`, `tasks.md` or `features.json`.** The
+review's suggested remedy for finding 2 was to document it in AC8, but those are the
+contract files the staleness check watches: editing one after `reviewed_sha` invalidates
+the review that asked for the edit, and buys another round (#998, HARNESS-072). The same
+information lives in a test and a code comment, which carry it better anyway — a test
+cannot go stale silently.
+
 ## Test status
 
 - `go build ./... && go vet ./... && go test ./...` — every package ok


### PR DESCRIPTION
Refs #1004. Follows the adversarial review of `BUG-086-verify-partial-registry`: **PASS in 4m48s**, 0 blockers, 0 majors, 3 minors.

## Dispositions

| # | Class | Finding | Disposition |
|---|---|---|---|
| 1 | Minor / **REAL** | `validateSecret` was 72 lines against AGENTS.md's `< 40`; `scopeVerify` at 41 | **APPLIED** — extracted `checkExpose`, `checkBWFolder`, `checkVarNames`. 72 → **31 lines**, no behaviour change |
| 2 | Minor / THEORETICAL | a token that is both a defect id and a valid var name yields two rows — correct, but undocumented and untested | **APPLIED** — pinned by a test, documented at the branch |
| 3 | Minor / SPECULATIVE | `kept` copies each validated secret; O(n) for very large registries | **DECLINED** — reviewer scoped it to ~500+ secrets; ours holds 33 |

**Finding 1 was a real violation of this repo's own Code Quality Rules**, found by reading code against the stated threshold rather than by running anything — the kind of finding a test suite structurally cannot produce.

**Finding 2 is the sharper one.** Two *different* secrets can be named by one token: a malformed entry with `id: FOO`, and a well-formed entry exposing a var called `FOO`. Answering for only one would hide a real result behind a name collision. The behaviour was already right; what was missing was anything asserting it stays right.

**Finding 3 declined with a reason, not ignored.** Optimising an unmeasured path trades a clear implementation for a guess, and the reviewer itself scoped the concern an order of magnitude above our actual registry.

## Applied without touching the contract files

The review's suggested remedy for finding 2 was to document it in `proposal.md` under AC8. I did **not** do that: `proposal.md`, `tasks.md` and `features.json` are the files the staleness check watches, so editing one after `reviewed_sha` invalidates the review that asked for the edit and buys another round — #998, exactly what HARNESS-072 hit.

The same information now lives in a test and a comment at the branch that takes the decision, which carries it better anyway: **a test cannot go stale silently.**

## Verification

`go build ./... && go vet ./... && go test ./...` green; `golangci-lint run` at the pinned 2.12.2 reports 0 issues. The refactor is behaviour-preserving — the entire pre-existing registry suite passes unchanged, which is the point: those tests assert the exact error strings each extracted helper now produces.

Also removes a stale doc comment left on `ParseRegistry` by the earlier strict/partial split.

## Unreviewed merge rationale

CodeRabbit did not review this PR: its account-wide quota is exhausted and it posted a rate-limit notice instead (measured — 80 minutes of polling across two PRs; the advertised 52-minute reset did not hold). The attestation gate correctly classifies that as `declined`, so this is a deliberate disclosure, not a bypass.

What stands in for it here is stronger than usual, and specific to this PR:

- **This change IS the output of an independent adversarial review.** `nan/deepseek-v4-flash` reviewed `BUG-086-verify-partial-registry` against `e033302` and returned PASS with three Minors; this PR applies two and declines the third with a stated reason. A non-Anthropic reviewer, not the implementer, has read this code.
- **It is behaviour-preserving.** The refactor extracts three helpers from `validateSecret`; the entire pre-existing registry suite passes unchanged, and those tests assert the exact error strings each helper now produces.
- `go build ./... && go vet ./... && go test ./...` green; `golangci-lint run` at the pinned 2.12.2 reports 0 issues.

Risk accepted: no second pair of eyes on the extraction boundaries themselves.
