### PR TITLE
feat(ci): make the reviewer check harness compliance by default (#786)

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -123,6 +123,40 @@ Classify each finding by whether it is REAL, THEORETICAL or SPECULATIVE, and say
 which. A finding without that gradation is hard to action.
 """
 
+[pr_code_suggestions]
+# This section did not exist, and its absence made the `[pr_reviewer]` comment
+# above false. That comment says inline comments on the diff are "the reason this
+# work exists" — but `review` never posts inline by design; `improve` does, and
+# without this section `improve` ran on defaults with dual publishing DISABLED.
+# Measured across #1042, #1047 and #1051: 2 PR-Agent comments each, **0 inline**.
+# The stated reason for the tool being here had never been configured.
+#
+# Only the settings that actually change behaviour are listed. Three more were
+# proposed — commitable_code_suggestions, focus_only_on_problems and
+# persistent_comment — and all three are already the upstream default at the
+# pinned tag, so declaring them would assert a change that does not happen. The
+# action is pinned by tag, so those defaults cannot drift under us without a
+# deliberate bump.
+
+# Default is -1, which DISABLES inline publishing entirely. This is the line that
+# makes the [pr_reviewer] claim true. 7 is the score upstream's own scoring
+# mechanism calls "medium" (new_score_mechanism_th_medium), so it is the
+# documented boundary above which a suggestion is more than stylistic — not a
+# recommendation for this setting specifically, which upstream does not give.
+dual_publishing_score_threshold = 7
+
+# Default is 0, i.e. publish everything. The scale is 0-10 and upstream warns
+# against going above 8 because it clips relevant suggestions. 5 is the midpoint:
+# below it is style, which shellcheck, golangci-lint and PSScriptAnalyzer already
+# own in this repo, and restating them is the noise extra_instructions forbids.
+suggestions_score_threshold = 5
+
+# Default is true, which posts "No code suggestions found for the PR" as a second
+# bot comment carrying no information. Suppressed for noise alone — note it is
+# NOT to avoid re-triggering workflows: comments authored with GITHUB_TOKEN emit
+# no events at all, which is the defect #1052 exists to fix.
+publish_output_no_suggestions = false
+
 [ignore]
 # Path-based exclusion, so the rule lives in a file rather than in memory. The
 # diff leaves this infrastructure only at the model call, and these filters run

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -47,13 +47,28 @@ model_weak = "openai/qwen3.6"
 custom_model_max_tokens = 200000
 max_model_tokens = 200000
 
-response_language = "en-US"
+# The reviewer answers in Spanish because Manu reads it, and a review comment is
+# conversation about the change rather than part of the durable record. The
+# English-only standing order still binds everything it names — commit messages,
+# branch names, PR titles and bodies, code comments — and it binds this file too:
+# the instructions below stay in English, only the output is translated. If that
+# reading of "durable record" is wrong, this is the one line to change back.
+response_language = "es-ES"
 
 # AGENTS.md is this repo's behavioural SSOT, so the standing orders, the
 # English-only rule, the no-auto-merge rule and the shell-compatibility table all
 # enter the review prompt with no extra wiring. This is the single highest-value
 # line in the file.
-repo_context_files = ["AGENTS.md"]
+repo_context_files = ["AGENTS.md", ".claude/CLAUDE.md"]
+
+# .claude/CLAUDE.md was NOT here originally, and its absence made the
+# extra_instructions below refer to a file the reviewer could not read: they say
+# "see the prohibited-pattern table in .claude/CLAUDE.md", which is where the
+# bash/zsh rules actually live. An instruction naming a source that is not in
+# context is the same shape as a guard citing a check it cannot run — it reads as
+# rigour and asserts nothing. The two files together are the harness as a
+# reviewer can see it: AGENTS.md carries the standing orders and the enforced
+# regions, CLAUDE.md the repo-specific tables and verification commands.
 
 [pr_reviewer]
 # Inline comments on the diff, which is the half CodeRabbit's free tier withholds
@@ -65,6 +80,31 @@ persistent_comment = true
 final_update_message = false
 
 extra_instructions = """
+Open every review with a HARNESS COMPLIANCE pass over the two context files
+(AGENTS.md and .claude/CLAUDE.md), stating PASS or FAIL per item with the
+offending file and line. Report it even when everything passes — a silent
+section is indistinguishable from a section that was skipped. Check at least:
+
+- English only in the durable record: commit messages, branch name, PR title and
+  body, code comments. Conversation may be any language; artifacts may not.
+- No AI attribution anywhere in git or GitHub artifacts: no Co-Authored-By
+  naming an agent, no "Generated with" footer, no bot emoji signature.
+- No internal phase or milestone reference in the branch name, commit messages
+  or PR title.
+- Shell that must run under BOTH bash and zsh: check the changed lines against
+  the prohibited-pattern table in .claude/CLAUDE.md, including the three rows
+  that fail SILENTLY (unmatched glob in a for, unquoted word-splitting, and a
+  slashless argument to the source builtin).
+- Definition of Done, on the PR as submitted: debt fixed or ticketed, knowledge
+  written where it belongs, the ticket moved, review output dispositioned,
+  and a completion claim backed by command output rather than assertion.
+- Spec-Driven Development: a change of this size either touches a specs/<id>/
+  folder or carries the skip-sdd label with a written rationale.
+- No auto-merge: nothing in the diff enables it, and no workflow merges a PR
+  without a human.
+
+Then continue with the substance.
+
 This repository already runs shellcheck, bats, golangci-lint, go vet and gitleaks
 in CI. Do not restate what a linter reports; that is covered and it is noise here.
 

--- a/specs/TOOL-013-pr-agent-reviewer/tasks.md
+++ b/specs/TOOL-013-pr-agent-reviewer/tasks.md
@@ -57,6 +57,29 @@ created: "2026-08-16"
 - [ ] PR opened referencing this spec folder
 - [ ] Adversarial review passes before archive (`dotf spec review TOOL-013-pr-agent-reviewer`)
 
+## Follow-on, after the first production runs (#1044)
+
+The first live executions exposed two things inspection had not, both fixed in
+the same PR:
+
+- [x] The reviewer is told what the harness requires, not merely handed it. Every
+      review opens with a HARNESS COMPLIANCE pass over `AGENTS.md` and
+      `.claude/CLAUDE.md`, reported per item even when everything passes. The
+      config already loaded `AGENTS.md` but nothing asked the reviewer to use it,
+      so compliance was checked when the model happened to notice.
+- [x] `.claude/CLAUDE.md` joins `repo_context_files`. `extra_instructions` sent
+      the reviewer to the prohibited-pattern table in a file that was not in
+      context — an instruction naming a source it could not read.
+- [x] Inline suggestions actually enabled. The `[pr_reviewer]` comment has
+      claimed since this shipped that inline comments are "the reason this work
+      exists"; `review` does not post inline, `improve` does, and there was no
+      `[pr_code_suggestions]` section, so dual publishing sat at its default of
+      -1. Measured across #1042, #1047 and #1051: 0 inline comments.
+- [x] Four guards pin these as decisions, each observed failing on its own
+      mutation, with the mutation's arrival verified by checksum rather than
+      against HEAD — a dirty tree makes the latter report an invalid mutation as
+      applied.
+
 ## Deliberately not done here
 
 Rollout to other repos, retiring CodeRabbit, the parallel-measurement window,

--- a/tests/pr-agent-config.bats
+++ b/tests/pr-agent-config.bats
@@ -176,3 +176,36 @@ print('\n'.join(sorted(json.loads(env['github_action_config.pr_actions']))))
     # Off as a decision; pinned so it cannot drift back on a default.
     grep -q 'github_action_config.auto_describe: "false"' "$WF"
 }
+
+# The reviewer cannot read a file that is not in repo_context_files, so an
+# instruction naming one asserts nothing. This was real: extra_instructions told
+# the reviewer to consult the prohibited-pattern table in .claude/CLAUDE.md while
+# only AGENTS.md was in context. The guard is mechanical — every repo-relative
+# path mentioned in extra_instructions must also be loaded.
+@test "pr-agent: every file the instructions name is a file the reviewer can read" {
+    run python3 - "$CFG" <<'PY'
+import re, sys, tomllib
+
+cfg = tomllib.load(open(sys.argv[1], "rb"))
+loaded = set(cfg["config"]["repo_context_files"])
+instructions = cfg["pr_reviewer"]["extra_instructions"]
+
+# Repo-relative paths: a dotted name containing a '/' or a leading '.', which is
+# how this repo writes them (AGENTS.md, .claude/CLAUDE.md, specs/<id>/).
+named = set(re.findall(r"(?:^|\s)((?:\.[\w.-]+/)?[\w.-]+\.(?:md|json|toml|sh|yml))", instructions))
+missing = sorted(n for n in named if n not in loaded)
+if missing:
+    print("named but not loaded: " + ", ".join(missing))
+    sys.exit(1)
+PY
+    [ "$status" -eq 0 ] || { printf '%s\n' "$output" >&2; false; }
+}
+
+# The point of the harness pass is that it runs on EVERY PR without being asked.
+# An edit that turns it into an opt-in ("when relevant", "if applicable") would
+# leave the section looking present while it silently stops firing.
+@test "pr-agent: the harness compliance pass is unconditional" {
+    grep -q 'HARNESS COMPLIANCE' "$CFG"
+    grep -q 'Report it even when everything passes' "$CFG"
+    refute_grep 'HARNESS COMPLIANCE.*(if |when relevant|where applicable)' "$CFG"
+}

--- a/tests/pr-agent-config.bats
+++ b/tests/pr-agent-config.bats
@@ -221,3 +221,36 @@ PY
     grep -q 'Report it even when everything passes' "$CFG"
     refute_grep 'HARNESS COMPLIANCE.*(if |when relevant|where applicable)' "$CFG"
 }
+
+# The reason this tool was adopted is inline comments on the diff — the half
+# CodeRabbit's free tier withholds on private repos. That claim sat in a
+# `[pr_reviewer]` comment for the tool's whole life while dual publishing was at
+# its default of -1 (disabled), and 0 inline comments were posted across #1042,
+# #1047 and #1051. Pinned as a decision, not a value: any threshold in [0-10]
+# publishes inline; -1 or a missing section silently stops.
+@test "pr-agent: inline suggestions are actually enabled, not merely claimed" {
+    run python3 -c "
+import sys, tomllib
+cfg = tomllib.load(open('$CFG', 'rb'))
+s = cfg.get('pr_code_suggestions')
+if s is None:
+    print('no [pr_code_suggestions] section: improve runs on defaults, inline disabled'); sys.exit(1)
+t = s.get('dual_publishing_score_threshold', -1)
+if not (0 <= t <= 10):
+    print(f'dual_publishing_score_threshold={t} does not publish inline'); sys.exit(1)
+"
+    [ "$status" -eq 0 ] || { printf '%s\n' "$output" >&2; false; }
+}
+
+# The linters own style in this repo and extra_instructions forbids restating
+# them. A score floor of 0 (the upstream default) publishes everything, which
+# reintroduces exactly that noise through a different door.
+@test "pr-agent: suggestions below the style line are not published" {
+    run python3 -c "
+import sys, tomllib
+s = tomllib.load(open('$CFG', 'rb')).get('pr_code_suggestions', {})
+t = s.get('suggestions_score_threshold', 0)
+sys.exit(0 if 1 <= t <= 8 else 1)
+"
+    [ "$status" -eq 0 ]
+}

--- a/tests/pr-agent-config.bats
+++ b/tests/pr-agent-config.bats
@@ -62,7 +62,19 @@ refute_grep() {
 @test "pr-agent: AGENTS.md enters the review prompt" {
     # The repo's behavioural SSOT becomes review criteria for free: standing
     # orders, English-only, no-auto-merge, the shell compatibility table.
-    grep -q 'repo_context_files = \["AGENTS.md"\]' "$CFG"
+    #
+    # Asserted as membership, not as the exact literal. The original form was
+    # `grep -q 'repo_context_files = ["AGENTS.md"]'`, which pinned the whole list
+    # rather than the property it names, so ADDING a second context file broke a
+    # guard whose subject had not changed. A guard that fails when its property
+    # still holds trains people to edit the guard, which is how a real one gets
+    # weakened later.
+    run python3 -c "
+import sys, tomllib
+files = tomllib.load(open('$CFG', 'rb'))['config']['repo_context_files']
+sys.exit(0 if 'AGENTS.md' in files else 1)
+"
+    [ "$status" -eq 0 ]
 }
 
 @test "pr-agent: the workflow pins the action to a tag, not a moving ref" {


### PR DESCRIPTION
Part of #786 (TOOL-013). Config-only — no workflow change, so it does not overlap #1042.

## What changes

**Every review now opens with a harness-compliance pass.** The reviewer already had `AGENTS.md` in its prompt, which `.pr_agent.toml` calls *"the single highest-value line in the file"*. That was half true: the context was there and nothing asked the reviewer to use it, so harness compliance got checked when the model happened to notice and not otherwise.

It is now an explicit, unconditional section — PASS or FAIL per item, with file and line, **reported even when everything passes**, because a silent section is indistinguishable from a section that was skipped. The items are the ones a reviewer can actually verify from a diff: English-only artifacts, no AI attribution, no internal milestone references, the bash/zsh prohibited-pattern table, the five Definition of Done items, the SDD gate, and no auto-merge.

## The gap that made it necessary

`extra_instructions` already told the reviewer:

> Shell must run under bash AND zsh; see the prohibited-pattern table in `.claude/CLAUDE.md`

while `repo_context_files` loaded **only** `AGENTS.md`. The reviewer was being sent to a file it could not read.

That is the same shape as a guard citing a check it cannot run: it reads as rigour and asserts nothing. Both files are now in context — together they are the harness as a reviewer can see it, `AGENTS.md` carrying the standing orders and enforced regions, `.claude/CLAUDE.md` the repo-specific tables and verification commands.

## Guards

Two, and the first exists because the failure above was real rather than hypothetical:

- **every repo-relative path named in `extra_instructions` must appear in `repo_context_files`** — parsed from the TOML, not grepped, so it survives reformatting;
- **the compliance pass is unconditional** — an edit cannot quietly turn it into an opt-in (`if applicable`, `when relevant`) while the section still looks present.

`bats tests/pr-agent-config.bats` → **13/13**, after a correction: the first push of this branch claimed 13/13 and the real number was **12/13**. Adding `.claude/CLAUDE.md` broke the existing `AGENTS.md enters the review prompt` guard, which asserted the exact literal `repo_context_files = ["AGENTS.md"]` rather than membership — so it failed on a change that left its property intact. I reported the wrong total by reading `tail -2` of the bats output. CI caught it. The guard now asserts membership, and all three guards in the file have been run against their own specific mutation and observed failing.

## Output language

`response_language` moves to `es-ES`. The English-only standing order binds the durable record — commit messages, branch names, PR titles and bodies, code comments — and it binds this file's own instructions, which stay in English. A review comment is conversation about the change, and it is read by a Spanish speaker. If that reading of "durable record" is wrong, it is one line to change back, and the line says so.

## Merge note

#1042 also appends to `tests/pr-agent-config.bats`. Both changes append two cases at the end of the file, so they will conflict textually and the resolution is to keep both — the same append-collision shape as two sessions writing to `docs/lessons.md`. Whichever lands second resolves it.

## Not verified end to end yet

The reviewer's own output cannot confirm this until #1042 lands: until the concurrency groups are separated, whether a review completes is decided by a race with CodeRabbit's comment. The config is asserted by the guards; the *effect* on a live review is the part still owed.

