### PR TITLE
fix(ci): align the pr-agent trigger list with PR-Agent's own event gate

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -15,7 +15,21 @@ name: pr-agent
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    # `synchronize` is deliberately ABSENT, and the omission must stay aligned
+    # with github_action_config.pr_actions below — see #1053. PR-Agent applies
+    # its own event gate whose default excludes synchronize, so listing it here
+    # started a runner and a Docker build on every push and then reviewed
+    # nothing. Measured on #1048: 4 pull_request runs, 1 artifact published.
+    #
+    # The cost was never inference — pushes are free of model calls. It was a
+    # `review: SUCCESS` on a push-triggered run, which reads as "the reviewer
+    # looked at your new commits" and means "the action started and declined to
+    # act". GUARD-002 exists because that kind of green is worse than a red.
+    #
+    # Reviewing every push is a defensible choice, but it is a different one:
+    # it re-reads the whole diff each time, so it belongs behind
+    # handle_push_trigger with push_commands naming only the cheap tools.
+    types: [opened, reopened, ready_for_review]
   # Slash commands (/review, /describe, /improve) on an existing PR.
   issue_comment:
     types: [created]
@@ -70,3 +84,16 @@ jobs:
           # where whole-registry injection means one broken item mapping can take
           # down authentication for everything.
           CONFIG__PUBLISH_OUTPUT_PROGRESS: false
+          # Stated rather than defaulted, so the two event lists that must agree
+          # are both visible. The default already excludes synchronize; leaving
+          # that implicit is what let the workflow's own trigger list drift away
+          # from it unnoticed (#1053).
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review"]'
+          # `describe` REWRITES the PR body. The bodies in this repo carry
+          # hand-written measurement tables, merge orders and before/after
+          # evidence — the part worth reading — and a model rewriting them
+          # destroys exactly that. Also removes one of the three inference calls
+          # per PR. Turned off as a decision, not left off by accident.
+          github_action_config.auto_describe: "false"
+          github_action_config.auto_review: "true"
+          github_action_config.auto_improve: "true"

--- a/tests/pr-agent-config.bats
+++ b/tests/pr-agent-config.bats
@@ -137,3 +137,42 @@ sys.exit(0 if 'ci:mlorentedev/dotfiles' in n['consumers'] else 1)
     printf '%s\n' "$group" | grep -q 'github.event.pull_request.number'
     printf '%s\n' "$group" | grep -q 'github.event.issue.number'
 }
+
+@test "pr-agent: the workflow's trigger list agrees with PR-Agent's own pr_actions" {
+    # #1053. Two event lists in one file that must agree, and nothing compared
+    # them: the workflow asked for `synchronize`, PR-Agent's pr_actions default
+    # excludes it, so every push started a runner, built the Docker action and
+    # reviewed nothing. Measured on #1048 — 4 pull_request runs, 1 artifact.
+    #
+    # The cost was never inference; pushes make no model calls. It was that the
+    # run reported `review: SUCCESS`, which reads as "your new commits were
+    # reviewed" and means "the action declined to act". GUARD-002 exists because
+    # that green is worse than a red one.
+    #
+    # Asserted as set equality, not substring presence: a list that gains an
+    # event the other lacks is the drift, in either direction.
+    local wf_types pr_actions
+    wf_types=$(python3 -c "
+import yaml, json
+d = yaml.safe_load(open('$WF'))
+print('\n'.join(sorted(d[True]['pull_request']['types'])))
+")
+    pr_actions=$(python3 -c "
+import yaml, json
+d = yaml.safe_load(open('$WF'))
+env = d['jobs']['review']['steps'][-1]['env']
+print('\n'.join(sorted(json.loads(env['github_action_config.pr_actions']))))
+")
+    if [ "$wf_types" != "$pr_actions" ]; then
+        printf 'workflow types and github_action_config.pr_actions disagree:\n' >&2
+        diff <(printf '%s\n' "$wf_types") <(printf '%s\n' "$pr_actions") >&2
+        return 1
+    fi
+}
+
+@test "pr-agent: describe does not rewrite the PR body" {
+    # A model rewriting a body that carries hand-written measurement tables,
+    # merge orders and before/after evidence destroys the part worth reading.
+    # Off as a decision; pinned so it cannot drift back on a default.
+    grep -q 'github_action_config.auto_describe: "false"' "$WF"
+}


### PR DESCRIPTION
The workflow triggered on `synchronize`; PR-Agent's own `pr_actions` gate does not include it. Every push to an open PR started a runner, built the Docker action, and reviewed nothing.

## Measured

```
PR #1048 (feat/gov-004-agents-md-diet)
  pull_request runs on the branch:  4
  PR-Agent artifacts published:     1
```

Three of four runs produced no output.

## What it actually cost — a figure worth correcting

Not inference. Pushes make **no model calls**, so the circulating "~15 calls for a five-push PR" was wrong: it is **~3 per PR**.

What it cost was a runner and a Docker build per push — and something worse than minutes. A push-triggered run reports:

```
review: SUCCESS
```

which reads as *"your new commits were reviewed"* and means *"the action started and declined to act"*. **GUARD-002 exists because that green is worse than a red one.** Anyone pushing a fix and checking the reviewer would have read a green that asserted nothing.

## Class

Two event lists, one file, must agree, nothing compared them — and the disagreement is invisible because the run succeeds. Same shape as #1040 (a concurrency key conflating two event types) and #1045 (`reviews[]` standing in for "someone looked"), one layer down.

Both lists are now **explicit**. Leaving one to a library default is what let them drift unnoticed.

## Also: `describe` is off, as a decision

`describe` **rewrites the PR body**. The bodies in this repo carry hand-written measurement tables, merge orders and before/after evidence — the part worth reading — and a model rewriting them destroys exactly that. It also removes one of three inference calls per PR.

Turned off deliberately and pinned, not left off by accident.

## Reviewing every push stays available

It is a defensible choice, but a *different* one: it re-reads the whole diff each time and re-posts a persistent comment. It belongs behind `handle_push_trigger` with `push_commands` naming only the cheap tools — not as a silent entry in a trigger list that the action then ignores.

## Guards — each observed failing first

| mutation | result |
|---|---|
| re-add `synchronize` to the workflow only | test 14 **fails**, `< synchronize` |
| add `review_requested` to `pr_actions` only | test 14 **fails**, `> review_requested` |
| set `auto_describe` back to `true` | test 15 **fails** |

Asserted as **set equality**, not substring presence: drift in either direction is the defect, and only one direction was the bug actually observed.

## Not in this PR

PR-Agent has **never posted an inline comment** — `improve` was never configured, while `[pr_reviewer]`'s comment claims inline output is the reason the tool exists. Measured: 0 inline across #1042, #1047, #1051. That is `.pr_agent.toml`, which #1044 is currently editing, so the config block was handed there rather than opened as a competing PR.

## Merge note

#1044 also appends to `tests/pr-agent-config.bats`. Same insertion point, different cases — resolution is "keep both".

Closes #1053.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated automated pull-request processing to run when requests are opened, reopened, or marked ready for review.
  * Disabled automatic pull-request description rewriting while retaining automated review and improvement features.

* **Tests**
  * Added validation to ensure workflow triggers match the configured pull-request actions.
  * Added coverage confirming automatic description rewriting remains disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

**Correction (post-open):** an earlier version of this description and #1053 stated PR-Agent's default `pr_actions` as four events including `review_requested`. Upstream v0.42.0 — the pinned tag — has **three**: `['opened', 'reopened', 'ready_for_review']`. The workflow change in this PR already writes the correct three, so only the prose was wrong. Caught by another session reading upstream's `configuration.toml` at the tag rather than taking my summary.
