### PR TITLE
fix(ci): re-evaluate the review gate when our own reviewer finishes (#1052, #1041)

### DIFF
--- a/.github/workflows/review-attestation.yml
+++ b/.github/workflows/review-attestation.yml
@@ -23,6 +23,22 @@ on:
   # by itself without anyone pushing.
   issue_comment:
     types: [created, edited]
+  # The trigger `issue_comment` cannot be. GitHub suppresses workflow events for
+  # comments created with GITHUB_TOKEN, to stop workflows retriggering
+  # themselves — and PR-Agent, the reviewer this repo shipped so CodeRabbit's
+  # quota would stop gating throughput, publishes with GITHUB_TOKEN. Measured
+  # 2026-08-18: its two comments on #1047 triggered ZERO runs here, while two
+  # human comments on other PRs each triggered one within three seconds. So on
+  # a PR where PR-Agent is the only reviewer — CodeRabbit rate-limited, this
+  # repo's ordinary state — the verdict is computed seconds after the PR opens,
+  # the review lands about ninety seconds later, and nothing ever re-asks.
+  #
+  # `workflow_run` is not a comment event and is outside that suppression.
+  # Note it only fires for the copy of this file on the DEFAULT BRANCH, so it
+  # cannot be exercised by the pull request that introduces it (#1052 AC1).
+  workflow_run:
+    workflows: [pr-agent]
+    types: [completed]
 
 concurrency:
   # Same reasoning as spec-gate.yml (BUG-066): metadata-only events must not
@@ -30,7 +46,12 @@ concurrency:
   # label and the body section — which fire `labeled` and `edited` within the
   # same second, and under an unconditional cancel they raced into cancelling
   # each other, leaving a stale failure as the visible check.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  # The workflow_run fallback is load-bearing, not defensive. A workflow_run
+  # payload carries neither number, so without it every such run collapses
+  # into ONE group keyed on the empty string, and `completed` is not in the
+  # exempt list below — so a reviewer finishing on one PR would cancel the
+  # re-evaluation of another. That is the defect #1040 was, one workflow over.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.workflow_run.head_sha }}
   cancel-in-progress: ${{ !contains(fromJSON('["labeled", "unlabeled", "edited", "created"]'), github.event.action) }}
 
 permissions:
@@ -49,7 +70,7 @@ jobs:
   attestation:
     # issue_comment fires on issues too; only pull requests have a review state
     # to attest to.
-    if: github.event_name == 'pull_request' || github.event.issue.pull_request
+    if: github.event_name == 'pull_request' || github.event.issue.pull_request || github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
     steps:
       # Pinned to the BASE branch, never the PR's head. Without this the job
@@ -67,8 +88,42 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
 
+      # A workflow_run payload carries neither `pull_request.number` nor
+      # `issue.number`, so the expression the other two triggers use evaluates to
+      # the empty string. Resolving the pull request from the run's head SHA is
+      # the substance of that trigger, not a detail: a gate that re-evaluates the
+      # WRONG pull request is worse than one that does not re-evaluate at all,
+      # because it publishes a confident verdict about a change nobody reviewed.
+      #
+      # Filtered to OPEN pull requests. A head SHA can belong to several — a
+      # merged one and a later branch reusing it — and attesting a closed PR is
+      # noise at best. When none is open there is nothing to attest, which is a
+      # normal outcome (pr-agent also runs on pushes to branches without a PR)
+      # and is reported rather than failed.
+      - name: Resolve the pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DIRECT: ${{ github.event.pull_request.number || github.event.issue.number }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ -n "$DIRECT" ]; then
+            echo "number=$DIRECT" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          number=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RUN_SHA}/pulls" \
+                     --jq 'map(select(.state == "open")) | .[0].number // empty')
+          if [ -z "$number" ]; then
+            echo "no open pull request for ${RUN_SHA} — nothing to attest"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "re-evaluating PR #${number} because the reviewer finished"
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
       - name: Check review attestation
         id: attest
+        if: steps.pr.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           # Through `env:` and quoted at the use site, never interpolated into
@@ -76,7 +131,7 @@ jobs:
           # attacker-supplied text, so this is belt-and-braces — but the habit is
           # what keeps a future edit from reaching for `.title` or `.body` the
           # same way and meaning it.
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         # No `continue-on-error`: a red check here is the entire product. The
         # script itself distinguishes 1 (not reviewed, and not declared) from 2
         # (could not determine), and both are failures — "could not determine"
@@ -113,6 +168,7 @@ jobs:
           exit 0
 
       - name: Publish the verdict onto the PR head
+        if: steps.pr.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ steps.attest.outputs.sha }}
@@ -131,6 +187,7 @@ jobs:
             -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >/dev/null
 
       - name: Fail the run when the PR is not attested
+        if: steps.pr.outputs.skip != 'true'
         env:
           CODE: ${{ steps.attest.outputs.code }}
           SUMMARY: ${{ steps.attest.outputs.summary }}

--- a/.github/workflows/review-attestation.yml
+++ b/.github/workflows/review-attestation.yml
@@ -164,6 +164,12 @@ jobs:
             echo "code=$code"
             echo "sha=$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid)"
             echo "summary=$(head -1 /tmp/attest.out | cut -c1-130)"
+            # The verdict KIND, from the script's own structured prefix rather
+            # than from prose. `[FAIL] pending` and `[FAIL] declined` both exit
+            # 1, and the next step needs to tell them apart. Guarded: a test
+            # asserts the script still emits these tokens, so the coupling
+            # cannot rot silently into a matcher that matches nothing.
+            echo "kind=$(sed -n 's/^\[[A-Z]*\] \([a-z]*\).*/\1/p' /tmp/attest.out | head -1)"
           } >> "$GITHUB_OUTPUT"
           exit 0
 
@@ -191,6 +197,8 @@ jobs:
         env:
           CODE: ${{ steps.attest.outputs.code }}
           SUMMARY: ${{ steps.attest.outputs.summary }}
+          KIND: ${{ steps.attest.outputs.kind }}
+          EVENT: ${{ github.event_name }}
         # The verdict is repeated here, not just in the step that computed it.
         # A bare `exit "$CODE"` made the RED step say nothing: the diagnostic sat
         # in an earlier, green step, so anyone opening the failure saw an exit
@@ -203,6 +211,29 @@ jobs:
         # #988's error path discarding HTTP 500 and surfacing `invalid character
         # 'I'`: the diagnostic threw away the diagnosis.
         run: |
+          # `pending` on the pull_request path is not a finding, and treating it
+          # as one is #1041. A check-run belongs to the run that created it and
+          # can never be updated; runs from issue_comment and workflow_run attach
+          # to the DEFAULT BRANCH, so they cannot revise it either. The
+          # pull_request run fires seconds after the PR opens, when no reviewer
+          # has posted and the only possible verdict is `pending` — so this
+          # check-run froze red on every correct PR, permanently, and taught its
+          # readers to scroll past the attestation line. A gate whose normal
+          # state is red has stopped being a gate.
+          #
+          # The verdict itself is not softened: it is published to the
+          # `review-attestation` COMMIT STATUS above, which any later run can
+          # revise and which is the signal branch protection must require.
+          # `declined` still fails here and immediately, because a reviewer
+          # saying it could not review is actionable the moment it is said.
+          if [ "$CODE" != "0" ] && [ "$KIND" = "pending" ] && [ "$EVENT" = "pull_request" ]; then
+            echo "$SUMMARY"
+            echo
+            echo "Not failed here: no reviewer has posted yet, which is the expected"
+            echo "state this early. The verdict lives on the 'review-attestation'"
+            echo "commit status, which later runs revise as reviewers arrive."
+            exit 0
+          fi
           if [ "$CODE" != "0" ]; then
             echo "::error title=Review attestation::$SUMMARY"
             echo "$SUMMARY"

--- a/specs/GUARD-003-review-loop-determinism/proposal.md
+++ b/specs/GUARD-003-review-loop-determinism/proposal.md
@@ -1,0 +1,59 @@
+---
+id: "GUARD-003-review-loop-determinism"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-18"
+issue: "mlorentedev/dotfiles#1052"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# GUARD-003-review-loop-determinism
+
+> **Naming**: file lives at `<repo>/specs/GUARD-003-review-loop-determinism/proposal.md`. `GUARD-003-review-loop-determinism` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #1052: GUARD-003: the review gate never re-evaluates when our own reviewer finishes, because GITHUB_TOKEN comments emit no events -->
+
+GUARD-002 answers "did a review actually happen" and answers it correctly. What it cannot do is **notice when the answer changes**. GitHub suppresses workflow events for comments created with `GITHUB_TOKEN` to prevent recursion, and PR-Agent — the reviewer this repository shipped to stop CodeRabbit's quota gating throughput — publishes with `GITHUB_TOKEN`. So our own reviewer can produce a complete review and the gate will never look at it, holding whatever verdict it computed twenty seconds after the PR opened, which is `pending` on every PR. Merging #1047 makes PR-Agent's output *countable*; it does not make it *counted*.
+
+## What
+
+Three observable changes, in a required order.
+
+**The gate re-evaluates when the reviewer finishes.** A `workflow_run` trigger on the `pr-agent` workflow completing. `workflow_run` is not a comment event, so it is outside the `GITHUB_TOKEN` suppression that causes the defect. No external infrastructure: GitHub already emits this event.
+
+**The verdict becomes enforceable rather than advisory.** The `review-attestation` **commit status** joins branch protection's required checks, so a merge is refused mechanically until the gate is green. Never the check-run, which cannot be revised after creation (#1041) — a required check-run frozen at `pending` blocks every PR permanently.
+
+**The triage loop gains a wake-up.** The same `workflow_run` event signals that reviewer output is ready to disposition. `pr-review-triage` already reads the comments, produces a per-item disposition and applies under confirmation; what it lacks is anything telling it the moment has arrived.
+
+## Out of scope
+
+- **Applying reviewer comments without confirmation.** In scope: applying them *with* per-item confirmation, which is what `pr-review-triage` already requires. Out of scope: removing that confirmation. Reviewer output is untrusted data — CodeRabbit's own comments say so — and a non-frontier model's "add this line", applied unattended to `.github/workflows/`, `scripts/check-*`, `harness/` or `secrets/`, is privilege escalation of the same shape as the defect #1019 fixed by pinning the gate's checkout to the base branch.
+- **Auto-merge, in any form.** The loop ends at a pushed commit and a recorded disposition. The merge stays human, repository-wide rule.
+- **Replacing CodeRabbit.** Two reviewers run alongside each other for a bounded window by decision in #786.
+- **A pending-to-declined deadline.** Once the gate re-evaluates on reviewer completion, "pending forever" stops being the common case. Revisit only if measurement says otherwise.
+
+## Risks / open questions
+
+- **`workflow_run` fires for the workflow, not for a pull request.** The event carries the run, and the PR association has to be recovered from it. AC4 exists because a trigger that re-evaluates the wrong PR is worse than no trigger.
+- **Ordering is load-bearing and the wrong order blocks the repository.** `#1047` -> `#1041` -> this trigger -> required-in-branch-protection. Making the gate required before #1041 lands blocks every PR, because the frozen `attestation` check-run is red on all of them.
+- **A trigger must not become a path to green.** It re-evaluates; it never attests. A reviewer that declined, or never ran, still ends red (AC3).
+- **Lane collision, to be arbitrated by the owner.** `.github/workflows/pr-agent.yml` is TOOL-013's surface and held by another session; a third agent is active on harness surfaces. This spec's own surface is `.github/workflows/review-attestation.yml` and `scripts/check-review-attestation.sh`, which is GUARD-002's and unheld.
+
+## Acceptance criteria
+
+- [ ] AC1. A PR-Agent review completing causes the gate to re-evaluate, with no human action and no manual re-run, verified on a live PR rather than by inspection.
+- [ ] AC2. The re-evaluation publishes to the commit status, and the status carries the latest verdict rather than the first.
+- [ ] AC3. A PR whose reviewer declined, or never ran, still ends red after the trigger fires.
+- [ ] AC4. The trigger re-evaluates the pull request the reviewer actually ran on, and no other.
+- [ ] AC5. A guard fails when the gate's workflow loses its `workflow_run` trigger, and has been observed failing on that specific mutation — including confirmation that the mutation reached the file, since an invalid mutation and an absent guard produce the same green.
+- [ ] AC6. The required-check adoption is documented with its ordering constraint, so it cannot be enabled before #1041.
+
+## References
+
+- Bitácora board: `mlorentedev/dotfiles#1052`
+- GUARD-002 (#906, shipped in #1019) — the gate this extends; #1041 and #1045 are its two open defects
+- #786 / TOOL-013 — PR-Agent, the second reviewer whose output triggered this
+- `00_meta/patterns/pattern-verification-fails-toward-unproven.md` — fourth arrival: a second producer of a consumed signal appears, and the consumer was written when there was one

--- a/specs/GUARD-003-review-loop-determinism/tasks.md
+++ b/specs/GUARD-003-review-loop-determinism/tasks.md
@@ -15,7 +15,17 @@ created: "2026-08-18"
 > blocked in sequence, and starting at the wrong end blocks the repository.
 
 
-## Blocked on, before any task here starts
+## Blocked on — corrected after measurement
+
+The original wording said no task here could start until both landed. That was
+wrong about **T1 and T2**, and the correction is worth keeping because it changed
+the schedule. #1047's diff touches `scripts/check-review-attestation.sh`, its
+tests, the registry and six fixtures — and **not the workflow**, which is where
+the trigger lives. And #1041 fixes the frozen *check-run* while the trigger fixes
+the *commit status*: two different signals, not two stages of one. So the trigger
+was disjoint from both and shipped first.
+
+What genuinely blocks:
 
 - [ ] B1. **#1047 merges** — the classifier learns to count comment-shaped review
       output. Until then there is no verdict worth re-evaluating. Held by another
@@ -26,11 +36,11 @@ created: "2026-08-18"
 
 ## Implementation
 
-- [ ] T1. [AC5] Write the guard first: a case asserting the gate's workflow
+- [x] T1. [AC5] Write the guard first: a case asserting the gate's workflow
       declares a `workflow_run` trigger on `pr-agent`. Observe it red before the
       trigger exists, **and assert the mutation reached the file** — an invalid
       mutation and an absent guard produce the same green.
-- [ ] T2. [AC1] [AC4] Add the `workflow_run` trigger and recover the pull request
+- [x] T2. [AC1] [AC4] Add the `workflow_run` trigger and recover the pull request
       from the run payload. A trigger that re-evaluates the wrong PR is worse
       than no trigger, so the recovery is the substance of this task, not the
       trigger line.

--- a/specs/GUARD-003-review-loop-determinism/tasks.md
+++ b/specs/GUARD-003-review-loop-determinism/tasks.md
@@ -1,0 +1,68 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-18"
+---
+
+# Tasks - GUARD-003-review-loop-determinism
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers** (optional, additive — borrowed from `github/spec-kit`, adapt-not-adopt per #141):
+> - `[P]` — this task has **no dependency on another unchecked task**, so it is safe to run in parallel (fan out to a `Workflow`, or just batch). TDD chains (test → implement → refactor of the *same* behavior) are sequential and must NOT carry `[P]`; independent behaviors can.
+> - `[AC<n>]` — this task helps satisfy **acceptance criterion #`<n>`** from `proposal.md`. Lets `/spec check` map coverage deterministically; omit it and the check falls back to semantic judgment.
+>
+> **No task here carries `[P]`.** This spec's ordering is not a preference: it is
+> blocked in sequence, and starting at the wrong end blocks the repository.
+
+
+## Blocked on, before any task here starts
+
+- [ ] B1. **#1047 merges** — the classifier learns to count comment-shaped review
+      output. Until then there is no verdict worth re-evaluating. Held by another
+      session.
+- [ ] B2. **#1041 ships** — the verdict lives on the revisable commit status
+      rather than a check-run frozen at creation. Making the gate required before
+      this blocks every PR.
+
+## Implementation
+
+- [ ] T1. [AC5] Write the guard first: a case asserting the gate's workflow
+      declares a `workflow_run` trigger on `pr-agent`. Observe it red before the
+      trigger exists, **and assert the mutation reached the file** — an invalid
+      mutation and an absent guard produce the same green.
+- [ ] T2. [AC1] [AC4] Add the `workflow_run` trigger and recover the pull request
+      from the run payload. A trigger that re-evaluates the wrong PR is worse
+      than no trigger, so the recovery is the substance of this task, not the
+      trigger line.
+- [ ] T3. [AC2] Confirm the re-evaluation writes the commit status and that the
+      status carries the latest verdict. Depends on B2 having landed the status
+      as the authoritative channel.
+- [ ] T4. [AC3] A declined or absent review still ends red after the trigger
+      fires. Verified by fixture, not by reasoning — the trigger must not become
+      a path to green.
+- [ ] T5. [AC1] Verify on a **live** PR: a PR-Agent run completing flips the gate
+      with no human action and no manual re-run. Inspection does not satisfy AC1.
+- [ ] T6. [AC6] Document the required-check adoption with its ordering
+      constraint, in the gate's own workflow and in the reviewer registry comment
+      block, so the constraint travels with the thing it constrains.
+
+## Closing
+
+- [ ] Every acceptance criterion covered by a verification command whose failure
+      mode has been observed
+- [ ] Lint passes (`shellcheck scripts/check-review-attestation.sh`, `bash -n`)
+- [ ] Tests pass (`bats tests/check-review-attestation.bats`)
+- [ ] No unrelated changes in the diff
+- [ ] `verification.md` filled in with output produced in the session, not recalled
+- [ ] PR opened referencing this spec folder
+- [ ] Adversarial review passes before archive (`dotf spec review GUARD-003-review-loop-determinism`)
+
+## A note on this spec's own surface
+
+The trigger lands in `.github/workflows/review-attestation.yml`, which is
+GUARD-002's surface and currently unheld. It does **not** touch
+`.github/workflows/pr-agent.yml` — that is TOOL-013's, held elsewhere. The
+`workflow_run` trigger names the pr-agent workflow but is declared in the gate's
+own file, so the two lanes stay separate and no coordination is required beyond
+the workflow's name remaining stable. If that name changes, T1's guard fails,
+which is the intended behaviour.

--- a/specs/GUARD-003-review-loop-determinism/verification.md
+++ b/specs/GUARD-003-review-loop-determinism/verification.md
@@ -40,3 +40,47 @@ Before archiving, flag what (if anything) should be promoted to the vault. If al
 - [ ] Folder moved: `specs/GUARD-003-review-loop-determinism/` -> `specs/archive/GUARD-003-review-loop-determinism/`
 - [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
 - [ ] Promotions above executed (if any)
+
+
+## Session evidence — the trigger (T1, T2)
+
+Guards written before the trigger and observed red, with their diagnostics:
+
+```
+not ok 2 ... [AC1]   no workflow_run trigger: our own reviewer finishing wakes nothing
+not ok 3 ... [AC1]   job if: does not admit workflow_run — the trigger would fire and skip
+not ok 4 ... [AC4]   grep 'workflow_run.head_sha' failed
+```
+
+Green after implementation, 6/6. Every guard then run against its own mutation,
+with the mutation's arrival checked by **checksum before and after** rather than
+against `HEAD` — on a dirty tree the latter reports an invalid mutation as
+applied, which is the false green the exercise exists to detect:
+
+| mutation | landed | guards failed |
+|---|---|---|
+| `workflow_run` trigger deleted | yes | 1 |
+| `workflow_run` names `ci` instead of `pr-agent` | yes | 1 |
+| job condition no longer admits `workflow_run` | yes | 1 |
+| concurrency key loses its head_sha discriminator | yes | 1 |
+| PR resolution removed | yes | 1 |
+| **control: a pattern that does not exist** | **no** | 0 (correctly not counted) |
+
+`bats tests/check-review-attestation.bats` — 37/37, no regression.
+`actionlint .github/workflows/review-attestation.yml` — clean.
+
+**AC1 is NOT satisfied by any of this.** `workflow_run` fires only for the copy
+of a workflow on the default branch, so the trigger cannot be exercised by the
+pull request that introduces it. AC1 says "verified on a live PR", and that
+verification is owed after merge, on the next PR that PR-Agent reviews. Recorded
+here rather than ticked, because a criterion that cannot be met yet is not met.
+
+## A defect prevented, worth its own line
+
+The concurrency group was keyed on `pull_request.number || issue.number`. A
+`workflow_run` payload has neither, so every such run would have collapsed into
+one group keyed on the empty string — and `completed` is not in the
+cancel-exempt list, so a reviewer finishing on one PR would have cancelled the
+re-evaluation of another. That is #1040 exactly, one workflow over, arrived by a
+different route, and it would have shipped inside the fix for the defect #1040
+caused.

--- a/specs/GUARD-003-review-loop-determinism/verification.md
+++ b/specs/GUARD-003-review-loop-determinism/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-18"
+---
+
+# Verification - GUARD-003-review-loop-determinism
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/GUARD-003-review-loop-determinism/` -> `specs/archive/GUARD-003-review-loop-determinism/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)

--- a/tests/review-attestation-workflow.bats
+++ b/tests/review-attestation-workflow.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+# GUARD-003 (#1052): the gate's WORKFLOW shape, as distinct from its classifier.
+#
+# Separate from check-review-attestation.bats on purpose. That file asserts what
+# the script decides; this one asserts that the workflow ever asks. The two fail
+# for different reasons and a change to one rarely touches the other.
+#
+# Why this file exists at all: GitHub suppresses workflow events for comments
+# created with GITHUB_TOKEN, to prevent recursion. PR-Agent publishes with
+# GITHUB_TOKEN. Measured 2026-08-18 — two PR-Agent comments on #1047 triggered
+# ZERO gate runs, while two human comments elsewhere each triggered one within
+# three seconds. So `issue_comment` cannot be the trigger that notices our own
+# reviewer, and on a PR where PR-Agent is the only reviewer (CodeRabbit's quota
+# spent, this repo's normal state) the verdict freezes seconds after the PR
+# opens and nothing re-asks.
+
+setup() {
+    REPO="$BATS_TEST_DIRNAME/.."
+    WF="$REPO/.github/workflows/review-attestation.yml"
+}
+
+# Parses the workflow and answers one question, printing nothing on success.
+#
+# `on:` is read as the BOOLEAN True, not the string "on" — YAML 1.1 spells true
+# as y|yes|on|true and PyYAML still honours it. A test that looked up d["on"]
+# would raise KeyError and could be "fixed" by deleting the assertion.
+wf_query() {
+    python3 -c "
+import sys, yaml
+d = yaml.safe_load(open('$WF'))
+triggers = d.get(True, d.get('on', {}))
+$1
+" 
+}
+
+@test "review-attestation: the workflow exists" {
+    [ -f "$WF" ]
+}
+
+@test "review-attestation: re-evaluates when the pr-agent reviewer finishes [AC1]" {
+    run wf_query "
+wr = triggers.get('workflow_run')
+if wr is None:
+    print('no workflow_run trigger: our own reviewer finishing wakes nothing'); sys.exit(1)
+names = wr.get('workflows') or []
+if 'pr-agent' not in names:
+    print(f'workflow_run does not name pr-agent (names={names})'); sys.exit(1)
+if 'completed' not in (wr.get('types') or []):
+    print('workflow_run does not listen for completed'); sys.exit(1)
+"
+    [ "$status" -eq 0 ] || { printf '%s\n' "$output" >&2; false; }
+}
+
+@test "review-attestation: the job admits workflow_run events [AC1]" {
+    run wf_query "
+cond = str(d['jobs']['attestation'].get('if', ''))
+if 'workflow_run' not in cond:
+    print('job if: does not admit workflow_run — the trigger would fire and skip'); sys.exit(1)
+"
+    [ "$status" -eq 0 ] || { printf '%s\n' "$output" >&2; false; }
+}
+
+# A workflow_run payload carries neither pull_request.number nor issue.number,
+# so the expression the other two triggers rely on evaluates to empty. Resolving
+# the PR from the run's head SHA is the substance of the trigger, not a detail:
+# a gate that re-evaluates the wrong pull request is worse than one that does
+# not re-evaluate at all.
+@test "review-attestation: the workflow_run path resolves its pull request [AC4]" {
+    grep -q 'workflow_run.head_sha' "$WF"
+    grep -qE 'commits/.*\/pulls' "$WF"
+}
+
+# A workflow_run payload carries no PR number, so a group key built only from
+# `pull_request.number || issue.number` collapses EVERY workflow_run into one
+# group keyed on the empty string. `completed` is not in the cancel-exempt list,
+# so a reviewer finishing on one PR would cancel the re-evaluation of another —
+# the #1040 defect, one workflow over, arrived by a different route.
+@test "review-attestation: the concurrency key cannot conflate two pull requests [AC4]" {
+    run wf_query "
+group = str(d['concurrency']['group'])
+if 'workflow_run.head_sha' not in group:
+    print('group key has no workflow_run discriminator: all such runs share one group'); sys.exit(1)
+"
+    [ "$status" -eq 0 ] || { printf '%s\n' "$output" >&2; false; }
+}
+
+# The verdict must reach the PR head as a commit status on every path. A
+# workflow_run run is associated with the default branch, exactly like an
+# issue_comment one, so without this it would compute a verdict nothing displays.
+@test "review-attestation: every path still publishes the verdict as a commit status [AC2]" {
+    grep -q 'statuses: write' "$WF"
+    grep -qE 'statuses/\$\{SHA\}' "$WF"
+}

--- a/tests/review-attestation-workflow.bats
+++ b/tests/review-attestation-workflow.bats
@@ -91,3 +91,45 @@ if 'workflow_run.head_sha' not in group:
     grep -q 'statuses: write' "$WF"
     grep -qE 'statuses/\$\{SHA\}' "$WF"
 }
+
+# #1041: a check-run belongs to the run that created it and can never be updated.
+# The pull_request run fires seconds after the PR opens, when no reviewer has
+# posted and the only possible verdict is `pending` — so it froze red on every
+# correct PR, permanently, while the commit status beside it went green. A gate
+# whose normal state is red teaches its readers to scroll past it.
+@test "review-attestation: pending does not freeze the check-run red [#1041]" {
+    grep -q 'KIND" = "pending" \] && \[ "$EVENT" = "pull_request"' "$WF"
+}
+
+# ...and the softening is exactly that narrow. A reviewer saying it could not
+# review is actionable the moment it is said, on any path.
+@test "review-attestation: declined still fails immediately, on every path [#1041]" {
+    run bash -c '
+      body=$(sed -n "/Fail the run when the PR is not attested/,\$p" "'"$WF"'")
+      # the exemption must name pending; if it ever names declined, or drops the
+      # event guard, the gate has been widened into silence
+      echo "$body" | grep -q "KIND\" = \"pending\"" || exit 1
+      echo "$body" | grep -q "KIND\" = \"declined\"" && exit 1
+      exit 0
+    '
+    [ "$status" -eq 0 ]
+}
+
+# The workflow extracts the verdict KIND from the classifier's own structured
+# prefix. That is a coupling between two files, so it is tested against the real
+# strings rather than assumed: a sed that silently matches nothing would make
+# every verdict read as an empty kind, and the exemption above would stop firing.
+@test "review-attestation: the kind extractor matches what the classifier emits [#1041]" {
+    local script="$REPO/scripts/check-review-attestation.sh"
+    for kind in pending declined; do
+        grep -q "\[FAIL\] $kind" "$script" || {
+            printf 'classifier no longer emits "[FAIL] %s"\n' "$kind" >&2; return 1; }
+    done
+    # the extractor itself, run over the real emitted shapes
+    got=$(printf '[FAIL] pending — no reviewer output on this PR yet\n' \
+          | sed -n 's/^\[[A-Z]*\] \([a-z]*\).*/\1/p' | head -1)
+    [ "$got" = "pending" ] || { printf 'extractor produced "%s"\n' "$got" >&2; return 1; }
+    got=$(printf '[FAIL] declined — coderabbitai posted a notice\n' \
+          | sed -n 's/^\[[A-Z]*\] \([a-z]*\).*/\1/p' | head -1)
+    [ "$got" = "declined" ] || { printf 'extractor produced "%s"\n' "$got" >&2; return 1; }
+}


### PR DESCRIPTION
Refs #1052. Closes #1041.

**#1052 is referenced, not closed, deliberately.** The spec gate is right to ask: a PR closing a spec's issue must archive that spec in the same PR. GUARD-003 is not finished — AC1 requires verifying the trigger on a live PR, and `workflow_run` fires only for the copy of a workflow on the default branch, so it cannot be exercised until this merges. Archiving now would record a criterion as met that has never run. The spec stays active, AC1 is verified on the next PR PR-Agent reviews, and it archives after its adversarial review.

Two commits against one file, kept in one PR because they are the same thirty lines of `review-attestation.yml` and separating them would mean a stacked PR for no reviewer benefit.

## Why both, and why now

#1047 taught the classifier to count PR-Agent's comment-shaped review. It merged, and it works — verified end to end on #1051 an hour ago:

```
review-attestation  pass
attested — reviewed by: github-actions
(comment-shaped review: "## PR Reviewer Guide")
```

**That green appeared only because a human commented.** The review had been sitting there and the gate had not looked. Which is the point of the first commit here.

## 1. The gate now re-evaluates when our own reviewer finishes (#1052)

GitHub suppresses workflow events for comments created with `GITHUB_TOKEN`, to stop workflows retriggering themselves. PR-Agent publishes with `GITHUB_TOKEN`. Measured:

| time | PR | author | gate runs triggered |
|---|---|---|---|
| 00:49:02 | #1047 | `github-actions[bot]` (PR-Agent Guide) | **0** |
| 00:49:47 | #1047 | `github-actions[bot]` (Suggestions) | **0** |
| 00:52:27 | #1046 | `mlorentedev` | 1, three seconds later |
| 00:52:27 | #1048 | `mlorentedev` | 1, three seconds later |

On a PR where PR-Agent is the only reviewer — CodeRabbit rate-limited, this repo's ordinary state and the reason PR-Agent exists — the verdict is computed seconds after the PR opens, the review lands about ninety seconds later, and nothing re-asks.

`workflow_run` is not a comment event and is outside that suppression. It is declared in **this** gate's workflow, not in pr-agent's, so the two lanes stay separate; the only coupling is the workflow's name, and a guard fails if it stops matching.

Two things that are substance rather than configuration:

- **The pull request is resolved from the run's head SHA**, filtered to open PRs. A `workflow_run` payload carries no PR number, and a gate that re-evaluates the *wrong* PR publishes a confident verdict about a change nobody reviewed — worse than not re-evaluating.
- **The concurrency key gained that SHA.** Without it every `workflow_run` collapsed into one group keyed on the empty string, with `cancel-in-progress` live, so a reviewer finishing on one PR would cancel the re-evaluation of another. **That is #1040 exactly, one workflow over** — and it would have shipped inside the fix for what #1040 caused.

## 2. A pending verdict no longer freezes the check-run red (#1041)

A check-run belongs to the run that created it and can never be updated; `issue_comment` and `workflow_run` runs attach to the default branch, so they cannot revise it either. The `pull_request` run fires when no reviewer has posted and the only possible verdict is `pending` — so `attestation` went red on every correct PR and stayed red, beside a `review-attestation` status that later went green.

`pending` is no longer a finding **on the pull_request path**, and the softening is exactly that narrow. `declined` still fails immediately everywhere: a reviewer saying it could not review is actionable the moment it is said. The verdict is untouched — it goes to the commit status, which later runs revise and which is what branch protection must require.

## Verification

Guards written **before** the implementation and observed red with their own diagnostics, then 9/9. Every guard run against its own mutation, arrival checked by **checksum before and after** rather than against `HEAD` — on a dirty tree the latter reports an invalid mutation as *applied*, which is the false green the exercise exists to catch:

| mutation | landed | guards failed |
|---|---|---|
| `workflow_run` trigger deleted | yes | 1 |
| trigger names `ci` instead of `pr-agent` | yes | 1 |
| job condition no longer admits `workflow_run` | yes | 1 |
| concurrency key loses its head_sha discriminator | yes | 1 |
| PR resolution removed | yes | 1 |
| pending exemption removed | yes | 2 |
| exemption widened to `declined` | yes | 2 |
| event guard dropped from the exemption | yes | 1 |
| classifier changes its `[FAIL] pending` prefix | yes | 1 |
| **control: a pattern that does not exist** | **no** | 0, correctly not counted |

`bats tests/check-review-attestation.bats` 37/37, no regression. `actionlint` clean.

## What is not verified, and cannot be here

**AC1 is deliberately unticked.** `workflow_run` fires only for the copy of a workflow on the **default branch**, so the trigger cannot be exercised by the pull request that introduces it. Verification on a live PR is owed on the next PR PR-Agent reviews after this merges. A criterion that cannot be met yet is not met, and recording it as pending is the point of the gate this PR is part of.

