### PR TITLE
fix(ci): install age from the pinned release on Linux, and verify what it got

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,50 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install age
+      # age comes from the pinned release, not apt — the same reasoning the
+      # Windows job below already applies (BUG-025), arrived at here for a second
+      # reason as well.
+      #
+      # 1. It did not honour the pin. versions.conf says AGE_VERSION=1.3.1;
+      #    `apt-get install age` on ubuntu-24.04 gives 1.1.1, so the Linux suite
+      #    had never once exercised the version this repo declares — for the tool
+      #    that decrypts every secret. Windows tested 1.3.1 and Linux tested
+      #    1.1.1, from one line of the same manifest.
+      # 2. It was slow and getting slower, because it depends on an Ubuntu
+      #    mirror's throughput on the day. Measured 2026-08-18 on one PR: the
+      #    step took 10s, then 66s, then over three minutes on consecutive runs.
+      #    `Fetched 6615 kB in 39s (168 kB/s)` — the packages, not the work.
+      #    GitHub's release CDN is not that mirror.
+      #
+      # zsh still needs apt (not present on the runner image), so `update` stays
+      # for it — but it no longer gates the tool the secrets tests depend on.
+      - name: Install age (pinned release — honours AGE_VERSION, as Windows does)
+        run: |
+          # `. ./versions.conf`, never `. versions.conf`: a slashless argument to
+          # the source builtin is searched on $PATH only. bash falls back to the
+          # cwd and zsh does not, so the bare form silently yields an empty
+          # version and installs `@v`. Prohibited-pattern table, .claude/CLAUDE.md.
+          . ./versions.conf
+          [ -n "${AGE_VERSION:-}" ] || { echo "AGE_VERSION missing from versions.conf" >&2; exit 1; }
+          url="https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-amd64.tar.gz"
+          curl -fsSL "$url" | tar xz
+          sudo install -m0755 age/age age/age-keygen /usr/local/bin/
+          rm -rf age
+          # Fail loudly here if the pin and the binary disagree, rather than
+          # letting the suite report on a version nobody asked for. This is the
+          # assertion whose absence let 1.1.1 run for months.
+          # Compare with a leading `v` stripped from BOTH sides: age prints
+          # `v1.3.1` but 1.2.1 printed `1.2.1`, so pinning the prefix would turn
+          # a correct install red the next time upstream changes its mind about
+          # it. The version is the claim; the `v` is punctuation.
+          got="$(age --version | sed 's/^v//')"
+          [ "$got" = "${AGE_VERSION#v}" ] || { echo "age is $got, expected ${AGE_VERSION#v}" >&2; exit 1; }
+          age-keygen --version >/dev/null
+
+      - name: Install zsh
         run: |
           sudo apt-get update
-          sudo apt-get install -y age zsh
+          sudo apt-get install -y --no-install-recommends zsh
 
       # tests/knowledge-crystallize-go-parity.bats proves `dotf vault crystallize`
       # is byte-identical to the shell oracle on the golden corpus (CLI-021). It

--- a/tests/ci-age-pin.bats
+++ b/tests/ci-age-pin.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# The CI age install must honour versions.conf, on every OS.
+#
+# It did not, for months, and nothing said so: versions.conf declared
+# AGE_VERSION=1.3.1 while the Linux job ran `apt-get install age` and got 1.1.1.
+# Windows tested the pinned version, Linux tested whatever Ubuntu shipped, from
+# one line of the same manifest — for the tool that decrypts every secret in
+# this repo. A pin that one of two consumers ignores is not a pin.
+#
+# Asserted on the workflow text, because nothing here can run GitHub's runner.
+# What is protected is that the version comes from the manifest rather than
+# from a distro's opinion.
+
+setup() {
+    REPO="$BATS_TEST_DIRNAME/.."
+    CI="$REPO/.github/workflows/ci.yml"
+}
+
+@test "ci: no job installs age from a distro package manager" {
+    # The failure is silent by construction — apt succeeds, the suite is green,
+    # and it exercised a different binary than the one declared.
+    if grep -nE 'apt-get install[^\n]*[^-a-z]age([ "'"'"']|$)' "$CI"; then
+        printf 'age must come from the pinned release, not apt — see AGE_VERSION.\n' >&2
+        return 1
+    fi
+}
+
+@test "ci: both age installs resolve the version from versions.conf" {
+    # One per OS. Neither may hardcode a version: a literal here and a value in
+    # versions.conf is the same two-copies problem the manifest exists to end.
+    local n
+    n=$(grep -cE 'AGE_VERSION' "$CI")
+    [ "$n" -ge 2 ] || { printf 'expected >=2 AGE_VERSION references in ci.yml, found %s\n' "$n" >&2; return 1; }
+
+    if grep -nE 'releases/download/v[0-9]+\.[0-9]+\.[0-9]+' "$CI"; then
+        printf 'a hardcoded age version in a download URL — read it from versions.conf\n' >&2
+        return 1
+    fi
+}
+
+@test "ci: the linux install verifies what it got against the pin" {
+    # Downloading the right URL is not the same as running the right binary: a
+    # release could be retagged, a tarball could change layout, and a silent
+    # PATH shadow would leave an older age first. The assertion is what makes
+    # the pin observable rather than merely intended.
+    grep -q 'age --version' "$CI"
+    grep -qE 'AGE_VERSION#v|expected \$\{AGE_VERSION' "$CI"
+}


### PR DESCRIPTION
Reported as "the `Install age` step is slow today". It is — and chasing it found the version pin was not being honoured.

## Two defects, one step

**1. The pin pinned nothing.** `versions.conf` declares `AGE_VERSION=1.3.1`. The Linux job ran `apt-get install age`, which on ubuntu-24.04 gives **1.1.1**.

| where | method | version |
|---|---|---|
| CI Linux | `apt-get install age` | **1.1.1** |
| CI Windows | pinned release | **1.3.1** ✓ |

Same line of the same manifest, two jobs, two different binaries — for the tool that decrypts every secret in this repo. **A pin that one of two consumers ignores is not a pin.**

**2. It was slow because it depends on a mirror's throughput on the day.** Measured across consecutive runs on one PR: **10s → 66s → over three minutes.**

```
Fetched 11.3 MB in 19s (603 kB/s)     <- apt-get update, indices
Fetched 6615 kB in 39s (168 kB/s)     <- the packages
```

11.3 MB of that is indices for repos nothing here needs — Microsoft prod for **arm64, amd64 and armhf**, azure-cli, Chrome. The Windows job does the same job in **2 seconds** from GitHub's release CDN.

## Verified before changing anything

The risk with a version bump is silent, so each assumption was measured rather than assumed:

| assumption | check | result |
|---|---|---|
| the artifact exists | `curl -I` | HTTP 200 |
| tarball layout | `tar tz` | `age/age`, `age/age-keygen` ✓ |
| 1.3.1 works | round-trip encrypt/decrypt | pass |
| **backward compatible** | encrypt with 1.2.1, decrypt with 1.3.1 | **pass** |
| existing artifacts readable | header of every `sensitive/*.age` | `age-encryption.org/v1`, both versions fail only on the key |
| tests assert on age's output | grep | one hit, and it is a **stub**, not the binary |
| anything parses `age --version` | grep | nothing |
| runs under both shells | replayed the step verbatim | bash ✓ zsh ✓ |

## One fragility caught in the replay

age **1.3.1** prints `v1.3.1`; **1.2.1** printed `1.2.1`. My first assertion hardcoded the `v`, which would have turned a *correct* install red the next time upstream changed its mind. It now strips a leading `v` from both sides — the version is the claim, the `v` is punctuation.

## Guards, each observed failing

| mutation | result |
|---|---|
| restore the apt install | test 1 **fails** |
| hardcode the version in the download URL | test 2 **fails** |
| drop the version assertion | test 3 **fails** |

The third exists because downloading the right URL is not the same as running the right binary — a retag, a layout change or a PATH shadow all leave the URL correct and the binary wrong. **That assertion is what makes the pin observable rather than merely intended**, and its absence is why 1.1.1 ran for months.

```
$ bats tests/*.bats
1322 tests, no failures
```

## Deliberately out of scope, each ticketed

Same defect class, wider blast radius — worth their own changes rather than riding this one:

- **`setup-linux.sh` fetches `age/latest`** — a moving target, so what a machine gets depends on the day it ran setup. This one is the sharpest: it ignores the manifest *and* is non-reproducible.
- **`tests/Dockerfile.integration`** installs age from apt on `ubuntu:26.04`.
- **`dotf doctor` has no age version check at all** — it reports pin drift for golangci-lint but not for the tool holding the secrets.

## No collision with anything open

Measured against all five open PRs: none touches `.github/workflows/ci.yml`. #1049 touches `versions.conf` but only `DOTF_VERSION`, 25 lines from `AGE_VERSION`, and this PR does not touch that file at all.

---

## Correction after measuring the fix in CI

This description sold **speed** alongside correctness. The measurement only half supports that, so here is what actually happened:

```
Install age (pinned release):  02:24:39 -> 02:24:39   <1s     (was 10s, then 66s, then 3min+)
Install zsh:                   02:24:39 -> 02:25:45   66s
```

The `age` install went from *part of* a 66s step to **under a second**. But the job's wall time is **unchanged**: the 66s was `apt-get update` plus `zsh`, and `age` was only riding along. Splitting the steps made the cost visible, not smaller.

**So the win here is the pin, not the clock.** The Linux suite now exercises the version the manifest declares, and a mismatch fails loudly at install time. The remaining 66s is apt fetching `zsh` (`zsh-common` alone is 4.17 MB) and is untouched by this change.

Leaving the original text above rather than editing it, because a claim that the evidence narrowed is worth showing narrowed.

## Review disposition (#1059)

| source | disposition | reason |
|---|---|---|
| PR-Agent — "Test regex false negative", classified REAL | **applied, not as proposed** | see below |
| PR-Agent — "Ticket compliance: #1049 partially compliant" | **skip** | spurious association; this PR is unrelated to the release ticket |
| CodeRabbit | **not a review** | *"Review limit reached — you've used all 1 included review"* — a notice, while the `CodeRabbit` check reads `SUCCESS`. The #906 scenario, caught by GUARD-002 |

**On the applied one:** the reviewer's stated mechanism was wrong. It claimed a flagless `apt-get install age` escapes the regex because `[^\n]*` greedily eats the space. The regex backtracks, and all three flag forms were already caught:

```
sudo apt-get install age         -> CAUGHT
sudo apt-get install age zsh     -> CAUGHT
sudo apt-get install -y age zsh  -> CAUGHT
```

But **testing the claim found a real hole it did not name**: `grep` is line-based, and the idiomatic multi-package apt install is a continuation —

```
apt-get install -y --no-install-recommends \
    age \
    zsh
```

— which no per-line matcher ever sees. `tests/Dockerfile.integration` is written in exactly that shape, so it is the likely form of a regression. Fixed in `a6a6b3d` by joining continuations before matching, with comments stripped first (the widened matcher immediately tripped on this workflow's own comment explaining the bug — a guard firing on documentation *about* the thing).

Right instinct, wrong diagnosis, real defect.
