### PR TITLE
test(ci): catch the multi-line apt form the age guard was blind to

### DIFF
--- a/tests/ci-age-pin.bats
+++ b/tests/ci-age-pin.bats
@@ -19,7 +19,28 @@ setup() {
 @test "ci: no job installs age from a distro package manager" {
     # The failure is silent by construction — apt succeeds, the suite is green,
     # and it exercised a different binary than the one declared.
-    if grep -nE 'apt-get install[^\n]*[^-a-z]age([ "'"'"']|$)' "$CI"; then
+    #
+    # Line continuations are JOINED first, because grep is line-based and the
+    # multi-line form is the idiomatic one for a multi-package apt install:
+    #
+    #     apt-get install -y --no-install-recommends \
+    #         age \
+    #         zsh
+    #
+    # A per-line matcher never sees `install` and `age` together there and
+    # reports clean. tests/Dockerfile.integration is written in exactly that
+    # shape, so it is the likely form of any regression. Found while checking a
+    # reviewer's claim on #1059: the claim itself (that a flagless `apt-get
+    # install age` escapes) was wrong — the regex backtracks and catches it —
+    # but testing the claim surfaced this, which is real.
+    # Comments are dropped BEFORE matching. The step this guard protects carries
+    # a comment explaining the defect, which names `apt-get install age` in prose
+    # — and the first version of this test tripped on it. A guard that fires on
+    # documentation ABOUT the thing rather than the thing is the same false
+    # positive GUARD-002 hit, and it trains people to weaken the guard.
+    local joined
+    joined=$(grep -vE '^[[:space:]]*#' "$CI" | sed -e :a -e '/\\$/N; s/\\\n//; ta')
+    if printf '%s\n' "$joined" | grep -nE 'apt-get[[:space:]]+install\b[^|;&]*\bage\b'; then
         printf 'age must come from the pinned release, not apt — see AGE_VERSION.\n' >&2
         return 1
     fi


### PR DESCRIPTION
Rescues a commit orphaned by a merge race. The change itself was written and mutation-tested during #1059's review triage; it was pushed **one minute after #1059 merged**, so the branch ref advanced and the closed PR never picked it up.

```
#1059 merged:     02:32:29
a6a6b3d pushed:  ~02:33
```

`git ls-remote` and the GitHub ref API both showed `a6a6b3d`; the PR showed `head=1719024f, commits seen: 1`, and no CI ever ran on it. The age fix landed; **this did not.**

## What it fixes

`main`'s guard is line-based, and the idiomatic form for a multi-package apt install is a continuation:

```
apt-get install -y --no-install-recommends \
    age \
    zsh
```

No per-line matcher ever sees `install` and `age` together. **`tests/Dockerfile.integration` is written in exactly that shape**, so it is the likely form of a regression here.

Verified against `main`'s guard in isolation, with the mutation confirmed to have landed first:

```
main guard   vs multiline  -> ESCAPES
this guard   vs multiline  -> CAUGHT
this guard   vs flagged    -> CAUGHT
this guard   vs flagless   -> CAUGHT
this guard   vs comment prose about apt -> correctly NOT caught
```

Continuations are joined before matching, and **comments are stripped first** — the widened matcher immediately tripped on the workflow's own comment explaining the defect in prose. A guard that fires on documentation *about* the thing rather than the thing is the false positive GUARD-002 already hit, and it trains people to weaken the guard.

## Provenance: right instinct, wrong diagnosis, real defect

This came from PR-Agent's review on #1059, classified **REAL**, with a mechanism that was **false**. It claimed a flagless `apt-get install age` escapes because `[^\n]*` eats the space; the regex backtracks and all four flag forms were already caught. **Testing the claim is what found the actual hole** — which the reviewer never named.

That sequence is the argument for TOOL-017 (#1062 / #1063): a flow that auto-applied REAL findings would have swapped a working guard for a worse one and left this open.

## A note on the controls, because it happened again here

My first attempt at the isolation control used `git stash`, which had nothing to stash — so it ran **my** guard while claiming to run `main`'s, and reported `CAUGHT`, i.e. "no gap". Third time tonight that an invalid instrument produced a result indistinguishable from a real one.

The control above is explicit instead: `main`'s guard and workflow extracted verbatim into a temp tree, the mutation verified present before the run. `[AC5]` of #1063 exists for exactly this — **a mutation that does not land must report `did-not-land`, never a clean result.**