### PR TITLE
fix(ci): a review attests only from a member or a declared reviewer (#1033)

### DIFF
--- a/scripts/check-review-attestation.sh
+++ b/scripts/check-review-attestation.sh
@@ -13,7 +13,7 @@
 #
 # States, decided by CONTENT rather than by check status:
 #
-#   attested  a review happened (bot or human, not the author)   -> exit 0
+#   attested  a review happened (a member, or a declared bot)     -> exit 0
 #   exempt    the diff carries nothing a review could act on     -> exit 0
 #   disclosed no review, but the escape is declared in full      -> exit 0
 #   declined  a reviewer said it could not review                -> exit 1
@@ -164,19 +164,79 @@ printf '%s' "$PR_JSON" | jq -e . >/dev/null 2>&1 \
 # whole point of the artifact. This mirrors harness/reviewer-pool.json's
 # standing rule that the reviewer must not be the implementer.
 PR_AUTHOR="$(printf '%s' "$PR_JSON" | jq -r '.author.login // ""')"
-INDEPENDENT="$(printf '%s' "$PR_JSON" | jq -r --arg a "$PR_AUTHOR" \
-    '[.reviews[]? | select((.author.login // "") != $a)] | length')"
+# A review attests when its author is not the PR author, AND that author is either
+# a member of this repository or a DECLARED reviewer.
+#
+# The second half is #1033. The original rule counted any entry in reviews[] whose
+# author was not the PR author — which reads as "somebody other than me looked" and
+# actually means "some identity other than mine appeared". Those two differ exactly
+# where an identity is SHARED: every workflow in this repository posts under one
+# and the same automation login, so a labeler, a release job or a summary step could
+# attest for a PR nobody reviewed. A person's identity cannot be shared that way, which is why
+# only bot reviews need a declaration and any human review still counts.
+#
+# The bot/human bit is NOT in this payload. `gh pr view --json reviews` returns
+# login, authorAssociation and state, and nothing else. REST carries `user.type`,
+# but spells the login with a `[bot]` suffix — reaching for it would add a second
+# API call AND a second spelling to every fixture, to learn something
+# `authorAssociation` already answers well enough. Measured across this
+# repository's last sixty pull requests on 2026-08-19: every bot-authored review
+# read `NONE`, and the one human-authored review read `OWNER`.
+#
+# Well enough, not exactly — and the residue falls the safe way. An outside human
+# whose association reads NONE does not attest, and the refusal below tells them to
+# be declared. A gate that under-attests refuses a good PR loudly; one that
+# over-attests passes a bad one in silence, and #906 exists because of the second.
+#
+# A payload with no `authorAssociation` at all — a hand-written fixture, or a
+# capture predating this field — reads as absent, so an undeclared login in it does
+# not attest. That is the same safe direction, and it is a fixture bug rather than a
+# gate bug: the field is always present in real output.
+#
+# CONTRIBUTOR is deliberately NOT a member association here. It is granted by having
+# had a commit merged, which a bot holds as easily as a person — including it would
+# reopen this defect through the door it was just closed at.
+ATTESTING="$(printf '%s' "$PR_JSON" | jq -r --arg a "$PR_AUTHOR" --slurpfile cfg "$CONFIG" '
+    def norm: (. // "") | ascii_downcase | sub("\\[bot\\]$"; "");
+    (($cfg[0].reviewers // []) | map(.login | norm)) as $declared
+    | ["OWNER", "MEMBER", "COLLABORATOR"] as $member
+    | [ .reviews[]?
+        | select((.author.login | norm) != ($a | norm))
+        | { login: (.author.login // "?"),
+            assoc: (.authorAssociation // ""),
+            n:     (.author.login | norm) }
+        | select(((.assoc as $x | $member   | index($x)) != null)
+                 or ((.n    as $y | $declared | index($y)) != null))
+        | .login
+      ] | unique | join(", ")')"
 
-if [ "$INDEPENDENT" -gt 0 ]; then
-    REVIEWERS="$(printf '%s' "$PR_JSON" | jq -r --arg a "$PR_AUTHOR" \
-        '[.reviews[]? | select((.author.login // "") != $a) | .author.login // "?"] | unique | join(", ")')"
-    say "[OK] attested — reviewed by: $REVIEWERS"
+if [ -n "$ATTESTING" ]; then
+    say "[OK] attested — reviewed by: $ATTESTING"
     exit 0
 fi
 
+# Reviews that exist but do not qualify, kept only for the refusal message. Telling
+# a PR that carries three reviews "pending — no reviewer output yet" is a false
+# statement, and a gate built so that green means reviewed cannot afford to be wrong
+# about why it went red. Same reasoning that keeps `declined` and `pending` apart.
+UNQUALIFIED="$(printf '%s' "$PR_JSON" | jq -r --arg a "$PR_AUTHOR" --slurpfile cfg "$CONFIG" '
+    def norm: (. // "") | ascii_downcase | sub("\\[bot\\]$"; "");
+    (($cfg[0].reviewers // []) | map(.login | norm)) as $declared
+    | ["OWNER", "MEMBER", "COLLABORATOR"] as $member
+    | [ .reviews[]?
+        | select((.author.login | norm) != ($a | norm))
+        | { login: (.author.login // "?"),
+            assoc: (.authorAssociation // ""),
+            n:     (.author.login | norm) }
+        | select(((.assoc as $x | $member   | index($x)) == null)
+                 and ((.n    as $y | $declared | index($y)) == null))
+        | .login
+      ] | unique | join(", ")')"
+
 # --- attested by a comment-shaped review? --------------------------------------
-# A reviewer that does not use the reviews API. PR-Agent (#786) runs under
-# GITHUB_TOKEN as github-actions and publishes through the COMMENTS api, so
+# A reviewer that does not use the reviews API. The reviewer shipped by #786 runs
+# under GITHUB_TOKEN as the shared automation login and publishes through the
+# COMMENTS api, so
 # reviews[] is empty on a PR it genuinely reviewed — measured on #1037 and #1042,
 # both carrying a real Guide and both reading as unattested (#1045). The gate
 # built to make green mean "reviewed" was calling the repo's own reviewer
@@ -318,6 +378,12 @@ if [ -n "$DECLINED_BY" ]; then
     printf '[FAIL] declined — %s posted a notice that no review ran (marker: "%s")\n' "$DECLINED_BY" "$DECLINED_MARKER" >&2
     printf '       A notice that no review ran leaves this PR UNREVIEWED. Its checks may still be green:\n' >&2
     printf '       the reviewer reports its own status, and a skipped review is not a failed one.\n' >&2
+elif [ -n "$UNQUALIFIED" ]; then
+    printf '[FAIL] pending — reviews exist, but none of them attests: %s\n' "$UNQUALIFIED" >&2
+    printf '       A review counts when its author is a member of this repository, or is\n' >&2
+    printf '       declared in the reviewer registry. A shared bot identity is neither until\n' >&2
+    printf '       it is declared: every workflow here posts under the same login, so counting\n' >&2
+    printf '       it unconditionally would let a labeler attest for a PR nobody read (#1033).\n' >&2
 else
     printf '[FAIL] pending — no reviewer output on this PR yet\n' >&2
 fi

--- a/specs/GUARD-002-review-attestation/features.json
+++ b/specs/GUARD-002-review-attestation/features.json
@@ -47,5 +47,12 @@
     "verification": "bats tests/check-review-attestation.bats -f 'AC7'",
     "state": "pending",
     "evidence": ""
+  },
+  {
+    "id": "GUARD-002-review-attestation-f8",
+    "behavior": "AC8 — a review attests only when its author is not the PR author AND that author is either a member of this repository or a declared reviewer. Filed as #1033 while checking whether this gate and the reviewer of #786 compose: the original rule counted any entry in reviews[] with an author other than the PR author, which is 'somebody else looked' only where identities are not shared. Every workflow here posts under one automation login, so a labeler or a release job attested for a PR nobody read. #1047 closed the same hole on the comments door and left this one open, which was worse than symmetry: a reader of the hardened path concludes the rule holds everywhere. The discriminator is authorAssociation, already in the payload — REST's user.type would have cost an API call and a second login spelling in every fixture for the same answer. CONTRIBUTOR is excluded on purpose: it is granted by a merged commit, which an automation account holds as easily as a person.",
+    "verification": "bats tests/check-review-attestation.bats -f '#1033'",
+    "state": "done",
+    "evidence": "6/6 cases pass. Both new guards observed failing on their own mutation with the mutation confirmed present first: replacing the member-or-declared predicate with select(true) fails cases 51, 52, 55 and 56; appending a declared login to the script fails case 14. No live PR changes verdict — #1057, #1065, #1067, #1068 and #1070 attest identically under the old and new script, run side by side."
   }
 ]

--- a/specs/GUARD-002-review-attestation/proposal.md
+++ b/specs/GUARD-002-review-attestation/proposal.md
@@ -180,6 +180,32 @@ whether a bot performed it.
       Until then AC7 is verified structurally, and the first live proof comes after
       merge.
 
+## Post-ship defects, and the criterion they added
+
+Two holes in "did a review happen" were found after the gate shipped, both by
+asking whether it composes with the reviewer of #786 rather than by a failure.
+Both are the same shape: the gate asked *who appeared* when it meant *who
+looked*, and those differ wherever an identity is shared.
+
+- **#1045 — the comments door.** The reviewer of #786 publishes through the
+  comments API, so `reviews[]` is empty on a PR it genuinely reviewed. Closed by
+  #1047, which counts a comment-shaped review on a declared `(login, marker)`
+  pair.
+- **#1033 — the reviews door.** Any author other than the PR author attested.
+  Every workflow in this repository posts under one automation login, so a
+  labeler, a release job or a summary step could attest for a PR nobody read.
+
+**AC8 — a review attests only when its author is not the PR author, and that
+author is either a member of this repository or a declared reviewer.** Any human
+review still counts, unchanged and deliberately: an individual's identity cannot
+be shared the way an automation login is, so only bot reviews need declaring.
+
+Worth keeping as a lesson about partial fixes: closing #1045's door and not
+#1033's left the registry authoritative for who may attest by comment and
+decorative for who may attest by review. That is worse than having fixed
+neither, because a reader of the hardened path reasonably concludes the rule is
+enforced everywhere.
+
 ## References
 
 - Bitácora board: `mlorentedev/dotfiles#906` (see the `issue:` frontmatter field)

--- a/specs/GUARD-002-review-attestation/tasks.md
+++ b/specs/GUARD-002-review-attestation/tasks.md
@@ -97,3 +97,15 @@ terminal state. Every entry starts `pending` with empty `evidence`.
 - [x] The pairing itself is guarded, across both files. The first version was not
       — removing the reviewer exclusion broke no test, which is the half-applied
       state the design exists to prevent, present in the change that designed it.
+
+## Post-ship, found by composition with #786
+
+- [x] [AC8] A review attests only from a member or a declared reviewer (#1033).
+      `authorAssociation` is the discriminator, already present in the payload;
+      CONTRIBUTOR is excluded because a merged commit grants it to accounts of
+      either kind. Verified with `bats tests/check-review-attestation.bats -f '#1033'`
+      and by running the old and new script side by side over five live PRs,
+      which change no verdict
+- [x] [AC8] The guard that should have caught it now derives its list from the
+      registry. "The script names no reviewer of its own" refuted three
+      hand-written names while the file named a fourth, added by #1047

--- a/tests/check-review-attestation.bats
+++ b/tests/check-review-attestation.bats
@@ -148,7 +148,16 @@ refute_grep() {
     # If a login appears here at all — even in prose — the registry has stopped
     # being the single place a reviewer is declared, and the next migration is a
     # code change again.
-    refute_grep 'coderabbitai' "$SCRIPT"
+    #
+    # Derived from the registry rather than listed by hand. A hand-written list
+    # only refutes the names someone thought of, and this test passed for as long
+    # as the script named a reviewer the list happened to omit — found while
+    # closing #1033, in a comment added by #1047. The literals below stay because
+    # they name things no longer in the registry, which a derived list cannot see.
+    while read -r login; do
+        [ -n "$login" ] || continue
+        refute_grep "$login" "$SCRIPT"
+    done < <(jq -r '.reviewers[]?.login' "$REPO/harness/review-attestation.json")
     refute_grep 'pr-agent' "$SCRIPT"
     refute_grep 'rate limited by' "$SCRIPT"
 }
@@ -501,4 +510,57 @@ sys.exit(0 if 'pull_request' in on and 'issue_comment' in on else 1)
     # This file names no vendor and no path, under test, and the exemption must
     # not be where that rule finally breaks.
     refute_grep 'release-please|CHANGELOG\.md|\.release-please-manifest' "$SCRIPT"
+}
+
+# --- #1033: the reviews API door -----------------------------------------------
+#
+# #1047 taught the classifier to count comment-shaped reviews, and gated that on a
+# declared (login, marker) pair. The reviews[] door kept the original rule — any
+# author who is not the PR author — for another day, and these cases pin the door
+# shut. They exist in pairs on purpose: a rule that only ever refuses is
+# indistinguishable from a broken gate.
+
+@test "#1033: an undeclared automation login cannot attest through reviews[]" {
+    run "$SCRIPT" --payload "$F/undeclared-bot-review.json"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"stale-labeler-bot"* ]]
+    [[ "$output" != *"attested"* ]]
+}
+
+@test "#1033: the refusal says reviews exist, instead of claiming none do" {
+    # The whole gate rests on its report being true. Telling a PR that carries a
+    # review "no reviewer output on this PR yet" is a false statement, and the one
+    # a reader would act on by asking for a review it already has.
+    run "$SCRIPT" --payload "$F/undeclared-bot-review.json"
+    [[ "$output" == *"reviews exist"* ]]
+    [[ "$output" != *"no reviewer output"* ]]
+}
+
+@test "#1033: a declared reviewer still attests through reviews[]" {
+    run "$SCRIPT" --payload "$F/bot-reviewed.json"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"attested"* ]]
+}
+
+@test "#1033: a member's review attests without being declared anywhere" {
+    run "$SCRIPT" --payload "$F/human-reviewed.json"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"attested"* ]]
+}
+
+@test "#1033: CONTRIBUTOR is not a member association" {
+    # Granted by having had a commit merged, which an automation account holds as
+    # easily as a person. Counting it would reopen this defect at the door it was
+    # closed at.
+    run "$SCRIPT" --payload "$F/contributor-review.json"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"drive-by-bot"* ]]
+}
+
+@test "#1033: a review with no authorAssociation does not attest an undeclared login" {
+    # Real payloads always carry the field; one that does not is a fixture, or a
+    # capture predating it. Absent reads as absent, which refuses loudly rather
+    # than attesting silently.
+    run "$SCRIPT" --payload "$F/no-association-review.json"
+    [ "$status" -eq 1 ]
 }

--- a/tests/fixtures/review-attestation/contributor-review.json
+++ b/tests/fixtures/review-attestation/contributor-review.json
@@ -1,0 +1,2 @@
+{"number":1034,"state":"OPEN","author":{"login":"mlorentedev"},"labels":[],"body":"body","comments":[],
+ "reviews":[{"author":{"login":"drive-by-bot"},"state":"COMMENTED","authorAssociation":"CONTRIBUTOR","body":"nice"}]}

--- a/tests/fixtures/review-attestation/human-reviewed.json
+++ b/tests/fixtures/review-attestation/human-reviewed.json
@@ -1,2 +1,2 @@
 {"number":3,"state":"OPEN","author":{"login":"mlorentedev"},"labels":[],"body":"body","comments":[],
- "reviews":[{"author":{"login":"someone-else"},"state":"APPROVED","body":"LGTM, the mutation test convinced me."}]}
+ "reviews":[{"author":{"login":"someone-else"},"state":"APPROVED","authorAssociation":"COLLABORATOR","body":"LGTM, the mutation test convinced me."}]}

--- a/tests/fixtures/review-attestation/no-association-review.json
+++ b/tests/fixtures/review-attestation/no-association-review.json
@@ -1,0 +1,2 @@
+{"number":1035,"state":"OPEN","author":{"login":"mlorentedev"},"labels":[],"body":"body","comments":[],
+ "reviews":[{"author":{"login":"unknown-actor"},"state":"COMMENTED","body":"no association field at all"}]}

--- a/tests/fixtures/review-attestation/undeclared-bot-review.json
+++ b/tests/fixtures/review-attestation/undeclared-bot-review.json
@@ -1,0 +1,2 @@
+{"number":1033,"state":"OPEN","author":{"login":"mlorentedev"},"labels":[],"body":"body","comments":[],
+ "reviews":[{"author":{"login":"stale-labeler-bot"},"state":"COMMENTED","authorAssociation":"NONE","body":"labelled and moved on"}]}


### PR DESCRIPTION
Closes #1033.

The attestation gate counted any entry in `reviews[]` whose author was not the PR author. That reads as *"somebody other than me looked"* and means *"some identity other than mine appeared"* — and those differ exactly where an identity is **shared**. Every workflow in this repository posts under one automation login, so a labeler, a release job or a summary step attested for a PR nobody had read.

#1047 closed the same defect on the **comments** door, gating it on a declared `(login, marker)` pair. The **reviews** door kept the original rule. That left the registry authoritative for who may attest by comment and decorative for who may attest by review — worse than fixing neither, because a reader of the hardened path reasonably concludes the rule is enforced everywhere.

## Measured on main before the change

The fixture was first confirmed to name a login absent from the registry, so the instrument could not be the thing that was broken:

```
$ jq -r '.reviews[0].author.login' undeclared-bot.json
stale-labeler-bot
$ jq -r --arg l stale-labeler-bot '[.reviewers[] | select(.login==$l)] | length' harness/review-attestation.json
0

$ scripts/check-review-attestation.sh --payload undeclared-bot.json
[OK] attested — reviewed by: stale-labeler-bot
exit=0
```

## The rule

> A review attests when its author is not the PR author, **and** that author is either a member of this repository or a **declared** reviewer.

Any human review still counts, unchanged and deliberately: an individual's identity cannot be shared the way an automation login is, so only bot reviews need declaring.

**The discriminator is `authorAssociation`, already present in the payload.** `gh pr view --json reviews` returns login, association and state — no bot/human bit. REST carries `user.type`, but spells the login with a `[bot]` suffix, so reaching for it would have added an API call *and* a second spelling to every fixture to learn the same thing. Measured across the last sixty PRs: every bot-authored review reads `NONE`, the one human-authored review reads `OWNER`.

It is near-enough rather than exact, and the residue falls the safe way — an unrecognised association refuses loudly instead of attesting in silence. `CONTRIBUTOR` is deliberately **not** a member association: it is granted by having a commit merged, which an automation account holds as easily as a person.

## The refusal had to change too

A PR carrying three reviews was about to be told *"pending — no reviewer output on this PR yet"*. That is a false statement, and the one a reader would act on by requesting a review the PR already has. It now names what it found and why none of it attested.

## Verification

- **No live PR changes verdict.** #1057, #1065, #1067, #1068 and #1070 attest identically under the old and new script, run side by side.
- **Both new guards observed failing on their own mutation**, mutation confirmed present first: replacing the member-or-declared predicate with `select(true)` fails cases 51, 52, 55, 56; appending a declared login to the script fails case 14.
- `bats tests/check-review-attestation.bats` — 56/56. Full suite — 1354/1354.

## Also fixes the guard that should have caught this

*"The script names no reviewer of its own"* refuted three hand-written names while the file named a fourth, in a comment added by #1047. A hand-written list only refutes the names someone thought of, so it now derives the list from the registry — the only place that knows it.
