### PR TITLE
fix(ci): fail the review job when it published no review

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -201,3 +201,52 @@ jobs:
           # on demand still behaves. What changes is that it no longer runs
           # unasked on every push.
           github_action_config.auto_improve: "false"
+
+      # A review that did not happen must not report success (#1107).
+      #
+      # PR-Agent swallows a failed inference into a clean exit. Measured on run
+      # 32325012314: green job, no review, because the model returned
+      # `litellm.RateLimitError: deepseek-v4-flash concurrency limit: max 5
+      # simultaneous requests`. Six PRs in one session were affected. ADR-032
+      # already forbids it — the top tier "queues or escalates, NEVER degrades
+      # silently" — so this makes the degrade loud and does nothing else.
+      #
+      # `fallback_models` names mimo-v2.5 for CONCURRENCY (per-model limit,
+      # measured), never to soften the quality bar. The marker comes from the
+      # registry, over the API since this job has no checkout, at the BASE ref
+      # since a PR supplying it could redefine it. Presence, not recency:
+      # `persistent_comment` edits an existing comment. See #1107.
+      - name: Fail if no review was published
+        # Only the paths that actually run `/review`. An issue_comment invoking
+        # `/describe` or `/improve` legitimately publishes no Guide, and failing
+        # those would teach the reader to ignore this check.
+        if: >
+          always() && (github.event_name == 'pull_request'
+            || (github.event_name == 'issue_comment'
+                && contains(github.event.comment.body, '/review')))
+        env:
+          # `github.token`, not `secrets.GITHUB_TOKEN`: identical value, but it is
+          # the automatic token rather than a declared repository secret, so the
+          # "exactly one secret" guard keeps counting what it was written to count.
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          marker=$(gh api "repos/${GITHUB_REPOSITORY}/contents/harness/review-attestation.json?ref=${BASE_REF}" \
+            --jq '.content' | base64 -d \
+            | jq -r '.reviewers[] | select(.login == "github-actions") | .review_markers[0]')
+          if [ -z "$marker" ] || [ "$marker" = "null" ]; then
+            echo "::error::no review marker declared for github-actions in harness/review-attestation.json"
+            exit 1
+          fi
+          found=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq "[.[] | select(.body | contains(\"${marker}\"))] | length")
+          if [ "$found" -gt 0 ]; then
+            echo "review published (marker: ${marker})"
+            exit 0
+          fi
+          echo "::error::PR-Agent reported success but published no review (no comment carries \"${marker}\")."
+          echo "::error::Most likely cause: NaN concurrency exhaustion — the cluster allows 5 simultaneous"
+          echo "::error::requests, shared with pi, qq and hive embeddings. See #1107."
+          exit 1

--- a/tests/pr-agent-config.bats
+++ b/tests/pr-agent-config.bats
@@ -439,3 +439,27 @@ if bad:
 "
     [ "$status" -eq 0 ] || { printf '%s\n' "$output" >&2; false; }
 }
+
+# #1107: PR-Agent swallowed a RateLimitError into a clean exit, so six PRs in one
+# session carried a green `review` job and no review. ADR-032 forbids exactly
+# that — "queues or escalates, NEVER degrades silently" — so the job must fail
+# when it published nothing.
+@test "pr-agent: the workflow fails when no review was published" {
+    grep -q 'name: Fail if no review was published' "$REPO/.github/workflows/pr-agent.yml" \
+        || { echo "the no-review guard step is gone; a silent degrade is back (#1107)" >&2; false; }
+}
+
+# The heading is declared once, in the reviewer registry, and read by three
+# consumers now: the attestation classifier, `dotf pr triage-queue`, and this
+# guard. Restating it in the workflow would rebuild the two-file agreement
+# nobody checks that the registry exists to prevent.
+@test "pr-agent: the no-review guard reads its marker from the registry, not a literal" {
+    run grep -c 'contents/harness/review-attestation.json' "$REPO/.github/workflows/pr-agent.yml"
+    [ "$status" -eq 0 ] && [ "$output" -ge 1 ] \
+        || { echo "the guard no longer reads the marker from the registry" >&2; false; }
+
+    # And it must read the BASE ref: this repository is public, so a PR able to
+    # supply the marker would redefine it to something it does post.
+    grep -q 'BASE_REF:' "$REPO/.github/workflows/pr-agent.yml" \
+        || { echo "the guard must resolve the registry at the base ref, not the PR head" >&2; false; }
+}


### PR DESCRIPTION
Refs #1107.

## What happens

PR-Agent swallows a failed review into a clean exit, in **two different shapes**, both ending with a green `review` job and no review:

**1 — explicit quota error** (run `32325012314`, #1100):
```
litellm.RateLimitError: deepseek-v4-flash concurrency limit: max 5 simultaneous requests.
Failed to review PR: Failed to generate prediction with any model of ['openai/deepseek-v4-flash']
```

**2 — silent hang** (run `32326444322`, #1101): the container's last line is `PR diff` at `02:57:13`, and the job completes at `03:03:18` — six minutes of nothing, no error at all.

**Six PRs in one working session** were affected: #1096, #1100, #1101, #1103, #1104, #1105. It took a log dive to find, because the checks list said pass.

The NaN cluster allows **5 concurrent requests**, shared with pi's TUI, `qq` and hive embeddings, so parallel PR activity exhausts it. One attempt per run, no retry configured. This recurs whenever the repository is busy.

## Why the check tests the outcome, not the error

The two shapes are the argument. A guard grepping the log for `RateLimitError` would have caught #1100 and **missed #1101 entirely** — there was no error to find, only silence. Asking *"did a review get published?"* catches both, and any third shape nobody has seen yet.

Two other hypotheses were tested and refuted before this one: not the merge commit at head (every PR in both the working and failing sets has `parents=2`, so `push_trigger_ignore_merge_commits` is not it), and not run cancellation (the runs report `success`).

## What this deliberately does not do

ADR-032 already forbids the behaviour — the top tier *"queues or escalates, **never degrades silently**"*. This makes the degrade loud. That is all.

**It does not make the reviewer more available.** That is #1110's job, now merged: `auto_improve` off, inference serialised repo-wide, and `fallback_models = ["openai/mimo-v2.5"]` — added for **concurrency**, since the limit is per model, and explicitly not to soften the quality bar. `harness/reviewer-pool.json` still excludes qwen3.6 and gemma4 by name because *"a reviewer that PASSes cheaply is worse than no gate"*, and this PR does not touch that.

This PR is the other half: when both models are exhausted anyway, the absence must be loud.

**The attestation gate was never the problem.** `check-review-attestation.sh` runs the comment-shaped attestation *before* the declined check, deliberately — a real PR-Agent review already outranks a CodeRabbit quota notice. There was simply no review to outrank it.

## Three load-bearing details

| Choice | Why |
|---|---|
| Marker read from the **registry** | It is declared once for what is now three consumers. Restating it here rebuilds the two-file agreement it exists to prevent |
| Read over the **API**, not a checkout | This job deliberately has none; adding one to read a 4 KB file would be the larger change |
| Read at the **base ref** | This repo is public. A PR able to supply the marker would redefine it to a string it does post |

`issue_comment` runs invoking `/describe` or `/improve` are skipped — they legitimately publish no review, and failing them would teach the reader to ignore the check.

`github.token` rather than `secrets.GITHUB_TOKEN`, so the existing *"exactly one secret"* assertion keeps counting what it was written to count. **That test caught the first draft of this PR.**

## Verification

Both new guards **observed failing** before being trusted:

```
$ sed -i 's/name: Fail if no review was published/name: something else/' ...
not ok 24 pr-agent: the workflow fails when no review was published

$ sed -i 's|contents/harness/review-attestation.json|HARDCODED|' ...
not ok 25 pr-agent: the no-review guard reads its marker from the registry, not a literal
```

- `bats tests/*.bats` — **0 failures**
- Workflow YAML parses; `spec-gate` passes at 49 LOC


---

## Rebased onto #1110

Both PRs touched `.github/workflows/pr-agent.yml` and `tests/pr-agent-config.bats`, so this was rebased after #1110 merged. Resolved by keeping both sides in full — #1110's `auto_improve: false`, its job-level concurrency group and its two fallback guards, plus this PR's step and its two guards.

The rebase caught a claim this PR made that #1110 had just falsified: the step's comment said *"`fallback_models` stays empty"*. Corrected in place rather than merged as written.

All four guards re-verified by mutation after the rebase — removing the fallback and renaming the step each turn their guard red, and the full suite is green.
