### PR TITLE
feat(harness): admit mimo-v2.5 to the reviewer pool, with the verdict stated honestly

### DIFF
--- a/harness/reviewer-pool.json
+++ b/harness/reviewer-pool.json
@@ -29,7 +29,11 @@
     "",
     "This is the load-bearing slice of H-044, not a replacement for it. H-044's",
     "model-map.json maps a neutral tier (top|mid|low) to a provider per agent — a",
-    "different shape. Kept in a separate file so H-044 need not migrate this one."
+    "different shape. Kept in a separate file so H-044 need not migrate this one.",
+    "",
+    "Order is meaning, not arrangement: the first entry is the launcher's default and the rest are tried in sequence. The provider-diverse fallback comes BEFORE the second NaN model deliberately — it answers a NaN outage, while a sibling model only answers NaN saturation, and the weaker guarantee should not be reached for first.",
+    "",
+    "On saturation, measured 2026-08-20: NaN's concurrency limit is PER MODEL, not per API key (8 concurrent to deepseek gives 5x200 + 3x429, while mimo answers 200 during that saturation). So a spec review launched while the PR reviewer is saturating deepseek WILL fail, and falling through to another entry is the correct response rather than a bug. Do not 'fix' that by promoting the NaN sibling above the provider-diverse entry — it would trade an outage-proof fallback for a saturation-proof one and lose the stronger property. This file is read once per spec, so slow is fine; that is why availability does not outrank independence here."
   ],
   "pool": [
     {
@@ -46,6 +50,15 @@
       "model": "gemini-3.1-pro-high",
       "role": "fallback",
       "why": "A second provider family, independent of both NaN and Anthropic — provider diversity rather than merely a different model. Pro tier at high effort; the flash tiers are excluded for the same reason qwen3.6 is. agy has no --provider flag; the model id selects the family."
+    },
+    {
+      "id": "nan/mimo-v2.5",
+      "runner": "pi",
+      "provider": "nan",
+      "model": "mimo-v2.5",
+      "role": "fallback",
+      "why": "Admitted 2026-08-20 after the evaluation this file's bar requires, and the verdict is recorded honestly rather than as a pass. What WAS established: given the same planted-defect shell snippet, mimo returned a real, correct finding — the `((count++))` exit-1-under-set-e case from this repo's own prohibited-pattern table. It is reasoning-class by profile (1M context, reasoning chain) against qwen3.6 and gemma4's 262K, which is the line this pool draws. What was NOT established: a quality RANKING against deepseek. deepseek never produced content under the same harness — it spent 29,299 characters of reasoning and returned finish_reason=length with an EMPTY body at 8,000 output tokens, so there was nothing to compare against. That is an instrumentation result, not a capability one, and it is stated here so nobody reads this entry as 'mimo matched deepseek'. It is admitted as a SECOND fallback, after the provider-diverse one, because provider diversity remains the stronger property.",
+      "operational_note": "Reasoning models here emit reasoning_content BEFORE content. Under-provisioning max_tokens returns an empty body with finish_reason=length and no error — the same shape as a review that silently did not happen (lesson 213). Provision generously and check finish_reason; deepseek did not answer within 8,000 output tokens on a small prompt."
     }
   ]
 }


### PR DESCRIPTION
The pool's bar is that *"a reviewer that PASSes cheaply is worse than no gate"*. Admitting a model therefore means running the evaluation and **recording what it showed**, not asserting a pass.

## What the evaluation established

Given the same planted-defect shell snippet, **mimo returned a real and correct finding**: the `((count++))` exit-1-under-`set -e` case — which is one of the rows in this repo's own prohibited-pattern table. It is reasoning-class by profile (1M context, reasoning chain) against `qwen3.6` and `gemma4`'s 262K, which is the line this pool draws.

## What it did NOT establish, and the entry says so

**A quality ranking against deepseek.** deepseek produced no content under the same harness:

```
finish_reason: length
reasoning chars: 29299
content: (EMPTY)          <- at max_tokens = 8000
```

There was nothing to compare against. That is an **instrumentation** result, not a capability one, and leaving it unsaid would let the entry be read as *"mimo matched deepseek"*. It does not say that.

That failure is worth keeping, so it is recorded as an `operational_note`: these models emit `reasoning_content` **before** `content`, so under-provisioning `max_tokens` returns an empty body with `finish_reason=length` **and no error** — the same shape as a review that silently did not happen (lesson 213, shipped today).

## Order is meaning, not arrangement

```
primary   nan/deepseek-v4-flash
fallback  agy/gemini-3.1-pro-high     <- provider diversity
fallback  nan/mimo-v2.5               <- same cluster
```

mimo goes **after** the provider-diverse entry. A sibling model on the same cluster answers NaN **saturation**; gemini answers a NaN **outage**. Reaching for the weaker guarantee first would be a downgrade.

## And a note so nobody "fixes" the right behaviour

Measured 2026-08-20: the concurrency limit is **per model, not per API key** — 8 concurrent to deepseek gives 5×200 + 3×429, while mimo answers 200 during that saturation. So a spec review launched while the PR reviewer is saturating deepseek **will fail**, and falling through to the next entry is the correct response rather than a bug.

The `$comment` says explicitly not to fix that by promoting the NaN sibling above gemini: it would trade an outage-proof fallback for a saturation-proof one. This file is read **once per spec** — its own words — so availability does not outrank independence here.

## Verification

- `go build ./...`, `go test ./internal/spec/...` — pass (the pool loader and launch tests read this file)
- `bats tests/*.bats` — **0 failures**
- `reviewer-pool.json` parses; three entries, roles and order as intended
- `spec-gate`: 0 production LOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified fallback ordering for provider-diverse recovery, model saturation, and outages.
  - Added a second fallback model with configuration and evaluation guidance.
  - Documented handling for reasoning output limits and empty responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->