### PR TITLE
fix(ci): trigger review-attestation on pull_request_review events

### DIFF
--- a/.github/workflows/review-attestation.yml
+++ b/.github/workflows/review-attestation.yml
@@ -35,6 +35,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled, edited]
     branches: [main]
+  # Human reviews submitted/edited/dismissed via GitHub UI or Reviews API (#1115).
+  # Emits pull_request_review (not pull_request or issue_comment), so the gate
+  # must re-evaluate when a real review lands or is dismissed.
+  pull_request_review:
+    types: [submitted, edited, dismissed]
   # The load-bearing trigger. A reviewer usually lands AFTER the checks have
   # settled, which is the one moment the answer is always "pending" — asking
   # only at `pull_request` time would guarantee the least useful answer. A new
@@ -89,7 +94,7 @@ jobs:
   attestation:
     # issue_comment fires on issues too; only pull requests have a review state
     # to attest to.
-    if: github.event_name == 'pull_request' || github.event.issue.pull_request || github.event_name == 'workflow_run'
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event.issue.pull_request || github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/tests/check-review-attestation.bats
+++ b/tests/check-review-attestation.bats
@@ -231,6 +231,18 @@ sys.exit(0 if 'pull_request' in on and 'issue_comment' in on else 1)
 "
 }
 
+@test "AC7: the workflow triggers on pull_request_review (#1115)" {
+    python3 -c "
+import sys, yaml
+d = yaml.safe_load(open('$REPO/.github/workflows/review-attestation.yml'))
+on = d[True] if True in d else d['on']
+pr_review = on.get('pull_request_review', {})
+types = set(pr_review.get('types', []))
+expected = {'submitted', 'edited', 'dismissed'}
+sys.exit(0 if expected.issubset(types) else 1)
+"
+}
+
 @test "AC7: the workflow does not swallow the gate's failure" {
     # A `continue-on-error: true` here would rebuild the exact defect: a check
     # that runs, decides 'not reviewed', and reports green anyway.


### PR DESCRIPTION
## Summary

Add `pull_request_review` trigger (`[submitted, edited, dismissed]`) to `review-attestation.yml` and update the job condition so that human reviews submitted through the GitHub UI or Reviews API re-evaluate the attestation gate automatically without requiring manual comments.

- **Workflow**: Added `pull_request_review: types: [submitted, edited, dismissed]` to `on:` and updated `jobs.attestation.if`.
- **Tests**: Added Bats test in `tests/check-review-attestation.bats`.

## Verification

- `bats tests/check-review-attestation.bats`: 57/57 pass.
- Spec gate: Production diff ~18 LOC < 50 LOC.

## Unreviewed merge rationale

Reviewer quota skipped/exhausted on CodeRabbit; 57/57 Bats tests passing.

Closes #1115