### PR TITLE
fix(prtriage): address 5 Minor findings from mimo-v2.5 review

### DIFF
--- a/cli/internal/cmd/pr.go
+++ b/cli/internal/cmd/pr.go
@@ -53,16 +53,17 @@ computed must not read as an empty one. The message says which.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(c *cobra.Command, _ []string) error {
-			pending, err := prtriage.Fetch(c.Context(), repo, registry)
+			reg, err := prtriage.LoadRegistry(registry)
 			if err != nil {
 				c.PrintErrln("pr triage-queue:", err)
 				return err
 			}
-			marker, err := prtriage.Marker(registry)
+			pending, err := prtriage.FetchWithRegistry(c.Context(), repo, reg)
 			if err != nil {
 				c.PrintErrln("pr triage-queue:", err)
 				return err
 			}
+			marker := reg.Triage.Marker
 			if len(pending) == 0 {
 				_, _ = fmt.Fprintln(c.OutOrStdout(), "[OK] no reviewer output is awaiting a disposition")
 				return nil

--- a/cli/internal/cmd/spec.go
+++ b/cli/internal/cmd/spec.go
@@ -203,7 +203,7 @@ is the only record of how.`,
 				if err := runCommand(repoRoot, launch); err != nil {
 					return fmt.Errorf("starting the tmux session: %w", err)
 				}
-				if err := confirmLaunched(session, transcript); err != nil {
+				if err := confirmLaunched(session, transcript, id, chosen, entries); err != nil {
 					return err
 				}
 				cmd.Printf("[OK] Review running detached. Watch it with:\n\n    tmux attach -t %s\n\n", session)
@@ -278,7 +278,7 @@ var transcriptSink = func(transcript string) []string {
 // fail; it does NOT promise the run will finish. A death at minute three is
 // inherently unwatched in detached mode, and `spec archive` refusing without a
 // review.md stays the backstop for that.
-func confirmLaunched(session, transcript string) error {
+func confirmLaunched(session, transcript, specID string, current spec.ReviewerEntry, entries []spec.ReviewerEntry) error {
 	const (
 		window = 3 * time.Second        // ~6x the slowest observed startup failure
 		step   = 250 * time.Millisecond // cheap enough to poll, coarse enough not to spin
@@ -288,9 +288,16 @@ func confirmLaunched(session, transcript string) error {
 		if sessionAlive(session) {
 			continue
 		}
+		var nextAdvice string
+		for _, e := range entries {
+			if e.ID != current.ID {
+				nextAdvice = fmt.Sprintf("\nOr try another pool member (e.g. if saturated):\n    dotf spec review %s --reviewer %s", specID, e.ID)
+				break
+			}
+		}
 		return fmt.Errorf("the review died on startup — tmux session %q is already gone.\n%s\n"+
-			"Nothing was reviewed and %s was not written; re-run with --foreground to watch it fail live",
-			session, reviewerLastWords(transcript), spec.ReviewFile)
+			"Nothing was reviewed and %s was not written; re-run with --foreground to watch it fail live.%s",
+			session, reviewerLastWords(transcript), spec.ReviewFile, nextAdvice)
 	}
 	return nil
 }

--- a/cli/internal/cmd/spec_review_test.go
+++ b/cli/internal/cmd/spec_review_test.go
@@ -163,6 +163,31 @@ func TestSpecReviewQuotesTheReviewerStderrWhenItDies(t *testing.T) {
 	}
 }
 
+func TestSpecReviewSuggestsAlternativePoolMemberOnDeath(t *testing.T) {
+	root := makeRepo(t)
+	dir := filepath.Join(root, "harness")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pool := `{"pool":[
+		{"id":"nan/deepseek-v4-flash","runner":"pi","provider":"nan","model":"deepseek-v4-flash","role":"primary"},
+		{"id":"nan/mimo-v2.5","runner":"pi","provider":"nan","model":"mimo-v2.5","role":"fallback"}
+	]}`
+	if err := os.WriteFile(filepath.Join(dir, "reviewer-pool.json"), []byte(pool), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seedSpec(t, root, "AI-001-x", "---\nstatus: implementing\n---\n# AI-001-x\n")
+	stubLaunch(t, false)
+
+	_, _, err := execute(t, "spec", "review", "AI-001-x")
+	if err == nil {
+		t.Fatal("expected the dead launch to fail")
+	}
+	if !strings.Contains(err.Error(), "dotf spec review AI-001-x --reviewer nan/mimo-v2.5") {
+		t.Errorf("expected error to suggest the next pool member, got: %v", err)
+	}
+}
+
 func TestSpecReviewAnnouncesALaunchThatSurvived(t *testing.T) {
 	root := makeRepo(t)
 	seedPool(t, root)

--- a/cli/internal/mem/session_start_triage_test.go
+++ b/cli/internal/mem/session_start_triage_test.go
@@ -77,6 +77,12 @@ func TestBriefSkipsTriageWhenProbeIsNil(t *testing.T) {
 	if got := Brief(opts); !strings.Contains(got, "[pr-triage]") {
 		t.Fatalf("a wired probe must reach the agnostic brief, got %q", got)
 	}
+
+	opts.TriageQueue = func() (string, error) { return "", errors.New("timeout querying queue") }
+	got := Brief(opts)
+	if !strings.Contains(got, "[pr-triage]") || !strings.Contains(got, "timeout querying queue") || !strings.Contains(got, "not an empty queue") {
+		t.Fatalf("an error probe must render loud failure in the agnostic brief, got %q", got)
+	}
 }
 
 // The agnostic brief is what opencode, agy and copilot consume. Wiring the probe
@@ -99,5 +105,11 @@ func TestClaudeContextCarriesTriageSection(t *testing.T) {
 	}
 	if got := ClaudeContext(in); !strings.Contains(got, "#1085") {
 		t.Fatalf("inside a git repo the section must render, got %q", got)
+	}
+
+	in.TriageQueue = func() (string, error) { return "", errors.New("gh api unreachable") }
+	got := ClaudeContext(in)
+	if !strings.Contains(got, "[pr-triage]") || !strings.Contains(got, "gh api unreachable") || !strings.Contains(got, "not an empty queue") {
+		t.Fatalf("an error probe must render loud failure in Claude context, got %q", got)
 	}
 }

--- a/cli/internal/prtriage/fetch.go
+++ b/cli/internal/prtriage/fetch.go
@@ -52,7 +52,6 @@ func Fetch(ctx context.Context, repo, registryPath string) ([]Status, error) {
 // FetchWithRegistry asks GitHub for open PRs using a pre-loaded Registry,
 // avoiding redundant disk reads when the caller already has the registry.
 func FetchWithRegistry(ctx context.Context, repo string, reg Registry) ([]Status, error) {
-	const prLimit = 100
 	args := []string{"pr", "list", "--state", "open", "--limit", fmt.Sprintf("%d", prLimit),
 		"--json", "number,title,url,comments"}
 	if repo != "" {
@@ -62,7 +61,12 @@ func FetchWithRegistry(ctx context.Context, repo string, reg Registry) ([]Status
 	if err != nil {
 		return nil, fmt.Errorf("gh pr list: %w", err)
 	}
+	return parseWire(out, reg)
+}
 
+const prLimit = 100
+
+func parseWire(out []byte, reg Registry) ([]Status, error) {
 	var wire []ghPR
 	if err := json.Unmarshal(out, &wire); err != nil {
 		return nil, fmt.Errorf("parse gh output: %w", err)

--- a/cli/internal/prtriage/fetch.go
+++ b/cli/internal/prtriage/fetch.go
@@ -46,8 +46,14 @@ func Fetch(ctx context.Context, repo, registryPath string) ([]Status, error) {
 	if err != nil {
 		return nil, err
 	}
+	return FetchWithRegistry(ctx, repo, reg)
+}
 
-	args := []string{"pr", "list", "--state", "open", "--limit", "100",
+// FetchWithRegistry asks GitHub for open PRs using a pre-loaded Registry,
+// avoiding redundant disk reads when the caller already has the registry.
+func FetchWithRegistry(ctx context.Context, repo string, reg Registry) ([]Status, error) {
+	const prLimit = 100
+	args := []string{"pr", "list", "--state", "open", "--limit", fmt.Sprintf("%d", prLimit),
 		"--json", "number,title,url,comments"}
 	if repo != "" {
 		args = append(args, "--repo", repo)
@@ -60,6 +66,10 @@ func Fetch(ctx context.Context, repo, registryPath string) ([]Status, error) {
 	var wire []ghPR
 	if err := json.Unmarshal(out, &wire); err != nil {
 		return nil, fmt.Errorf("parse gh output: %w", err)
+	}
+
+	if len(wire) >= prLimit {
+		return nil, fmt.Errorf("gh pr list returned %d open PRs (hit boundary limit); queue may be truncated — investigate with gh pr list", prLimit)
 	}
 
 	prs := make([]PR, 0, len(wire))

--- a/cli/internal/prtriage/prtriage_test.go
+++ b/cli/internal/prtriage/prtriage_test.go
@@ -169,7 +169,7 @@ func TestParseWireBoundaryLimit(t *testing.T) {
 		if i > 1 {
 			sb.WriteString(",")
 		}
-		sb.WriteString(fmt.Sprintf(`{"number": %d, "title": "t%d", "url": "u%d", "comments": []}`, i, i, i))
+		fmt.Fprintf(&sb, `{"number": %d, "title": "t%d", "url": "u%d", "comments": []}`, i, i, i)
 	}
 	sb.WriteString("]")
 

--- a/cli/internal/prtriage/prtriage_test.go
+++ b/cli/internal/prtriage/prtriage_test.go
@@ -1,8 +1,10 @@
 package prtriage
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -142,5 +144,40 @@ func TestTheRealRegistryServesBothConsumers(t *testing.T) {
 	}
 	if markers == 0 {
 		t.Fatal("no reviewer declares review_markers: the queue can never see comment-shaped output")
+	}
+}
+
+// 100 open PRs indicates boundary truncation on `gh pr list --limit 100`.
+// It must return a loud error rather than silently returning a truncated queue.
+func TestParseWireBoundaryLimit(t *testing.T) {
+	r := reg()
+
+	// Under 100: success
+	out99 := `[{"number": 1, "title": "t", "url": "u", "comments": [{"author": {"login": "github-actions"}, "body": "## PR Reviewer Guide\nx", "createdAt": "2026-08-20T01:00:00Z"}]}]`
+	got, err := parseWire([]byte(out99), r)
+	if err != nil {
+		t.Fatalf("parseWire with 1 PR returned unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(got))
+	}
+
+	// 100 entries: boundary limit error
+	var sb strings.Builder
+	sb.WriteString("[")
+	for i := 1; i <= 100; i++ {
+		if i > 1 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(fmt.Sprintf(`{"number": %d, "title": "t%d", "url": "u%d", "comments": []}`, i, i, i))
+	}
+	sb.WriteString("]")
+
+	_, err = parseWire([]byte(sb.String()), r)
+	if err == nil {
+		t.Fatal("expected loud error when wire returns 100 items (boundary limit), got nil")
+	}
+	if !strings.Contains(err.Error(), "hit boundary limit") || !strings.Contains(err.Error(), "100") {
+		t.Fatalf("error must cite boundary limit and count, got: %v", err)
 	}
 }

--- a/harness/skills/pr-review-triage/SKILL.md
+++ b/harness/skills/pr-review-triage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/skills/pr-review-triage/SKILL.md
-generated_sha: 3d91cddcae99ac9e
+generated_sha: ac110dd5b55e6992
 id: pr-review-triage-skill
 type: skill
 status: active
@@ -157,6 +157,8 @@ gh pr comment <N> --repo <owner>/<repo> --body-file <file>
 **The heading is a contract, not a formatting choice.** `dotf pr triage-queue` reads it back to decide whether a PR is still pending: a PR is pending when its newest reviewer output is newer than its newest triage record. The string is declared once, in `harness/review-attestation.json` under `triage.marker` — this skill writes it and the queue reads it. Match it exactly, at the start of a line.
 
 **Record the empty case too.** *"CI green, no review findings"* is a disposition and it must be written down like any other — one row saying so is enough. Skipping it because there was nothing to apply leaves the PR in the queue forever, and a queue that never drains is one nobody reads. The queue re-opens by itself the moment a reviewer speaks again, so recording early costs nothing.
+
+**Edit an existing table when re-triaging.** If a `## Review triage` comment already exists from this session, edit it (using `gh pr comment <N> --edit-last` or by comment ID) rather than posting a second identical table, avoiding duplicate comment noise on the PR.
 
 ### 8. Never
 


### PR DESCRIPTION
## Summary

Address the 5 Minor findings from `mimo-v2.5` review of GUARD-004 (#1118) and add alternative pool member advice on reviewer startup failures (#1117):

1. **`fetch.go`**: Added `FetchWithRegistry` and boundary limit check so hitting 100 open PRs errors loudly rather than silently dropping unreviewed PRs (#1118).
2. **`cmd/pr.go`**: Loaded registry once in `dotf pr triage-queue` and passed to `FetchWithRegistry`, eliminating double disk reads (#1118).
3. **`session_start_triage_test.go`**: Added error propagation tests at the assembly layer for both `Brief()` and `ClaudeContext()` (#1118).
4. **`pr-review-triage` skill**: Documented guidance in step 7 to edit existing triage comments when re-triaging rather than posting duplicate tables (#1118).
5. **`cmd/spec.go`**: Added recommendation with exact re-run command for alternative pool members when a reviewer process dies on startup (#1117).

## Verification

- `cd cli && go test ./... && go vet ./...`: All 17 packages pass.
- `bats tests/check-review-attestation.bats tests/ci-age-pin.bats`: All pass.
- Spec gate: Production diff ~35 LOC < 50 LOC.

## Unreviewed merge rationale

Reviewer quota skipped/exhausted on CodeRabbit; all Go and Bats tests pass.

Closes #1118
Closes #1117