### PR TITLE
fix(attestation): recognize CodeRabbit clean-review comment as attestation

### DIFF
--- a/harness/review-attestation.json
+++ b/harness/review-attestation.json
@@ -77,7 +77,9 @@
         "rate limited by coderabbit.ai"
       ],
       "why": "Free tier, ~1 review/hour account-wide. On 2026-08-16 PRs #1007, #1009 and #1013 each carried this notice simultaneously, with zero reviews between them, while `gh pr checks` reported `CodeRabbit  pass`. Neither pushing new commits nor an explicit `@coderabbitai review` reclaims a slot while the quota is spent — measured, both.",
-      "review_markers": []
+      "review_markers": [
+        "No actionable comments were generated in the recent review"
+      ]
     },
     {
       "login": "github-actions",

--- a/tests/check-review-attestation.bats
+++ b/tests/check-review-attestation.bats
@@ -430,6 +430,32 @@ sys.exit(0 if expected.issubset(types) else 1)
     [[ "$output" == *"pending"* ]]
 }
 
+@test "#1122: a clean CodeRabbit review comment attests without reviews[]" {
+    # CodeRabbit opens a formal review only when it has findings. When it has
+    # none, it leaves reviews[] empty and posts "No actionable comments were
+    # generated in the recent review" as a comment. That is a completed review
+    # and must attest identically to one with findings.
+    local tmp_payload="$TMP/coderabbit-clean-review.json"
+    cat <<'EOF' > "$tmp_payload"
+{
+  "author": {"login": "someone"},
+  "reviews": [],
+  "comments": [
+    {
+      "author": {"login": "coderabbitai"},
+      "body": "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\nNo actionable comments were generated in the recent review. 🎉"
+    }
+  ],
+  "labels": [],
+  "body": "## Summary\n\nclean change"
+}
+EOF
+    run "$SCRIPT" --payload "$tmp_payload"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"attested"* ]]
+    [[ "$output" == *"coderabbitai"* ]]
+}
+
 @test "AC: an undeclared bot cannot attest by posting the same marker" {
     # The failure mode this guards is #1033 arriving through the comments door.
     # Matching "a bot commented" would let a labeler or release bot attest; the


### PR DESCRIPTION
## Summary

When CodeRabbit finds no actionable comments in a PR, it posts its verdict as a comment (`"No actionable comments were generated in the recent review. 🎉"`) and leaves `reviews[]` empty. 

- **`review-attestation.json`**: Declared `"No actionable comments were generated in the recent review"` under `coderabbitai.review_markers` so a clean review attests properly rather than reading unreviewed.
- **Tests**: Added Bats test in `tests/check-review-attestation.bats`.

## Verification

- `bats tests/check-review-attestation.bats`: 58/58 pass.
- Spec gate: Production diff 3 LOC < 50 LOC.

## Unreviewed merge rationale

Reviewer quota skipped/exhausted on CodeRabbit; 58/58 Bats tests passing.

Closes #1122