### PR TITLE
fix(spec): compare content instead of ancestry for review staleness

### DIFF
--- a/cli/internal/spec/review.go
+++ b/cli/internal/spec/review.go
@@ -171,7 +171,7 @@ func (gitStaleness) Stale(repoRoot, specID, reviewedSHA string) (bool, bool, str
 		return true, true, fmt.Sprintf("reviewed_sha %s is not a commit in this history (rewritten by a rebase?)", reviewedSHA)
 	}
 
-	args := []string{"-C", repoRoot, "log", "--format=", "--name-only", reviewedSHA + "..HEAD", "--"}
+	args := []string{"-C", repoRoot, "diff", "--name-only", reviewedSHA, "HEAD", "--"}
 	for _, name := range contractFiles {
 		args = append(args, filepath.Join("specs", specID, name))
 	}

--- a/cli/internal/spec/review_test.go
+++ b/cli/internal/spec/review_test.go
@@ -434,6 +434,7 @@ func TestGitStalenessRebaseWithoutContractChangeIsNotStale(t *testing.T) {
 		"proposal.md":     "---\nstatus: verifying\n---\nclean\n",
 		"tasks.md":        "tasks\n",
 		"verification.md": "evidence\n",
+		"features.json":   "[]\n",
 	})
 	gitRun(t, root, "add", "-A")
 	gitRun(t, root, "commit", "-qm", "feat: create spec")

--- a/cli/internal/spec/review_test.go
+++ b/cli/internal/spec/review_test.go
@@ -416,6 +416,50 @@ func TestGitStalenessIgnoresVerificationMd(t *testing.T) {
 	}
 }
 
+// TestGitStalenessRebaseWithoutContractChangeIsNotStale verifies that rebasing
+// a branch when contract files are byte-identical does not falsely mark the
+// review as stale (#1036).
+func TestGitStalenessRebaseWithoutContractChangeIsNotStale(t *testing.T) {
+	root := t.TempDir()
+	gitRun(t, root, "init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(root, "init.txt"), []byte("initial\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, root, "add", "init.txt")
+	gitRun(t, root, "commit", "-qm", "init")
+
+	// Branch out to feature branch and create/commit the spec
+	gitRun(t, root, "checkout", "-b", "feat/my-spec")
+	writeSpec(t, root, "AI-001-x", map[string]string{
+		"proposal.md":     "---\nstatus: verifying\n---\nclean\n",
+		"tasks.md":        "tasks\n",
+		"verification.md": "evidence\n",
+	})
+	gitRun(t, root, "add", "-A")
+	gitRun(t, root, "commit", "-qm", "feat: create spec")
+	reviewedSHA := gitRun(t, root, "rev-parse", "HEAD")
+
+	// Advance main with an unrelated change
+	gitRun(t, root, "checkout", "main")
+	if err := os.WriteFile(filepath.Join(root, "other.txt"), []byte("main work\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, root, "add", "other.txt")
+	gitRun(t, root, "commit", "-qm", "chore: main commit")
+
+	// Rebase feature branch onto main (rewrites the spec commit SHA)
+	gitRun(t, root, "checkout", "feat/my-spec")
+	gitRun(t, root, "rebase", "main")
+
+	stale, known, reason := gitStaleness{}.Stale(root, "AI-001-x", reviewedSHA)
+	if !known {
+		t.Fatalf("git repository must be answerable")
+	}
+	if stale {
+		t.Errorf("review should not be stale after rebase with identical contract files, got reason: %q", reason)
+	}
+}
+
 func TestGitStalenessUnresolvableShaIsStale(t *testing.T) {
 	root, _ := gitSpecRepo(t, "AI-001-x")
 


### PR DESCRIPTION
## Summary

Changes `gitStaleness.Stale` to query content differences with `git diff <reviewed_sha> HEAD -- <contract files>` instead of commit ancestry with `git log`.

When a feature branch is rebased onto `main` without modifying spec contract files, commit SHAs are rewritten but file contents remain byte-identical. `git log` flagged the new commits in the rebased history as changes, falsely marking the review as stale and refusing the archive. `git diff` directly compares tree contents, ensuring that byte-identical contract files are recognized as up to date.

## Verification

- Added regression test `TestGitStalenessRebaseWithoutContractChangeIsNotStale` reproducing the exact rebase scenario against an identical contract tree.
- Observed test failure on `git log` implementation, verified pass on `git diff`.
- All `cli/internal/spec` and full CLI suite tests pass (`go test ./...`).

Closes #1036

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review staleness detection after rebasing branches.
  * Reviews remain valid when unrelated changes are introduced, provided the specification’s contract files are unchanged.

* **Tests**
  * Added coverage for rebased branches with unchanged contract files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->