### PR TITLE
feat(spec): scaffold features.json during dotf spec init

### DIFF
--- a/cli/internal/cmd/spec.go
+++ b/cli/internal/cmd/spec.go
@@ -417,7 +417,7 @@ agent) or by hand. Do not skip the Why.`,
 			}
 
 			cmd.Printf("\n[OK] Created: specs/%s\n", id)
-			cmd.Printf("     proposal.md, tasks.md, verification.md\n")
+			cmd.Printf("     proposal.md, tasks.md, verification.md, features.json\n")
 			if issueNum > 0 {
 				cmd.Printf("     Work-gate linked: issue #%d\n", issueNum)
 			}

--- a/cli/internal/spec/drift_test.go
+++ b/cli/internal/spec/drift_test.go
@@ -32,6 +32,7 @@ func TestEmbeddedTemplatesMatchVault(t *testing.T) {
 		"proposal.md":     "spec-proposal.md",
 		"tasks.md":        "spec-tasks.md",
 		"verification.md": "spec-verification.md",
+		"features.json":   "spec-features.json",
 	}
 	for embedded, vaultName := range pairs {
 		want, err := os.ReadFile(filepath.Join(tmplDir, vaultName))

--- a/cli/internal/spec/spec.go
+++ b/cli/internal/spec/spec.go
@@ -20,9 +20,9 @@ import (
 // templateNames are the spec files rendered into specs/<id>/, in a stable
 // order. proposal.md is special-cased (it carries the issue: frontmatter and
 // the ## Why provenance comment); the others are pure placeholder substitution.
-var templateNames = []string{"proposal.md", "tasks.md", "verification.md"}
+var templateNames = []string{"proposal.md", "tasks.md", "verification.md", "features.json"}
 
-//go:embed templates/proposal.md templates/tasks.md templates/verification.md
+//go:embed templates/proposal.md templates/tasks.md templates/verification.md templates/features.json
 var templatesFS embed.FS
 
 // idPattern is the canonical feature-id grammar: an AREA-NNN ticket whose AREA

--- a/cli/internal/spec/spec_test.go
+++ b/cli/internal/spec/spec_test.go
@@ -76,6 +76,11 @@ func TestRenderSubstitutesAndFixesIssueFrontmatter(t *testing.T) {
 	if !strings.Contains(proposal, "## Why\n\n<!-- from issue #358: Port init-spec -->\n") {
 		t.Errorf("Why comment not injected in the expected position:\n%s", proposal)
 	}
+
+	features := files["features.json"]
+	if !strings.Contains(features, `"id": "CLI-007-dot-spec-init-f1"`) {
+		t.Errorf("features.json missing substituted id:\n%s", features)
+	}
 }
 
 // TestRenderStampsCreatedInAllFiles guards the CodeRabbit-found bug (dotfiles#359):
@@ -118,7 +123,7 @@ func TestScaffoldWritesFilesAndGuardsClobber(t *testing.T) {
 	if warn != "" {
 		t.Errorf("unexpected warning: %q", warn)
 	}
-	for _, name := range []string{"proposal.md", "tasks.md", "verification.md"} {
+	for _, name := range []string{"proposal.md", "tasks.md", "verification.md", "features.json"} {
 		p := filepath.Join(root, "specs", "CLI-007-dot-spec-init", name)
 		if _, err := os.Stat(p); err != nil {
 			t.Errorf("expected %s to exist: %v", p, err)

--- a/cli/internal/spec/templates/features.json
+++ b/cli/internal/spec/templates/features.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "<feature-id>-f1",
+    "behavior": "Outcome 1",
+    "verification": "echo 'not implemented' && exit 1",
+    "state": "pending",
+    "evidence": ""
+  }
+]


### PR DESCRIPTION
## Summary

Updates `dotf spec init` to scaffold `features.json` alongside `proposal.md`, `tasks.md`, and `verification.md`.

Previously, `dotf spec init` scaffolded only the 3 markdown files, while the spec archive gate requires all 4 contract files (`proposal.md`, `tasks.md`, `features.json`). This caused newly initialized specs to fail the archive gate until `features.json` was manually created.

## Verification

- Added `cli/internal/spec/templates/features.json` and registered it in embedded FS / template names.
- Updated `spec_test.go` to assert `features.json` is rendered with substituted spec ID and scaffolded to disk.
- Updated `drift_test.go` to assert parity between embedded `features.json` and vault template SSOT.
- Ran all `cli/internal/spec` and `cli/internal/cmd` tests (`go test ./...`).

Closes #1076