### PR TITLE
fix(ci): filter pr-agent issue_comment trigger to slash commands only

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -104,7 +104,8 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false
         && !startsWith(github.event.pull_request.head.ref, 'release-please--')) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request
-        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        && startsWith(github.event.comment.body, '/'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Serialise inference repo-wide: QUEUE, never cancel (#1107).


### PR DESCRIPTION
## Summary

Updates `.github/workflows/pr-agent.yml` to require `startsWith(github.event.comment.body, '/')` on `issue_comment` triggers.

Previously, any comment by an OWNER/MEMBER/COLLABORATOR (such as `## Review triage` tables or discussion replies) triggered the PR-Agent workflow, spinning up a Docker container and consuming NaN inference slots needlessly, risking an endless review-triage loop.

With this change:
- Automatic reviews on PR open and pushes (`pull_request` events) continue to work normally.
- On-demand slash commands (`/review`, `/describe`, `/improve`) continue to work.
- Discussion and `## Review triage` comments are cleanly ignored.

## Verification

- Verified workflow condition expression in `.github/workflows/pr-agent.yml`.
- All repository test suites pass (`./scripts/test.sh` and `go test ./...`).

Closes #1134