### PR TITLE
docs(runbooks): document parallel PR-Agent concurrency and batch triage workflow

### DIFF
--- a/docs/runbooks/guide-pr-agent-reviewer.md
+++ b/docs/runbooks/guide-pr-agent-reviewer.md
@@ -66,27 +66,44 @@ busy session exhausts it — six PRs in one session received no review at all
 
 Three things now stand between that and a silent green:
 
-1. `auto_improve = false` halves what this workflow asks for.
-2. A job-level concurrency group serialises inference repo-wide and **queues**
-   rather than cancelling — ADR-032's *"queues or escalates, never degrades
-   silently"*. Note the ceiling: GitHub holds one pending run per group, so in a
-   burst of three or more the extras are cancelled rather than queued. Visibly.
+1. `auto_improve = false` halves what this workflow asks for (#1107).
+2. **Parallel execution across NaN slots without GHA job locks (#1135)**:
+   A job-level GHA concurrency group previously throttled runs to 1 and cancelled
+   in-between jobs due to GHA's max pending queue depth of 1. By removing the
+   global GHA lock and relying on per-PR concurrency (`group: pr-agent-${{ pr.number }}`),
+   batches of PRs review concurrently across NaN's 10 slots.
 3. `fallback_models = ["openai/mimo-v2.5"]` — a second NaN model with its own
-   bucket of five, which is what makes it a fallback rather than a rename.
+   bucket of five, which is what makes it an automatic fallback under LiteLLM
+   if `deepseek-v4-flash` is saturated.
 
 The multiplier that matters is still the **push**, not the PR: the workflow fires
 on every push to the branch, so a PR with five pushes is five reviews of the full
 diff. The per-PR concurrency group collapses a burst of pushes into one review of
 the settled state.
 
+## High-Velocity Batch PR & Triage Workflow
+
+To maximize developer velocity without sacrificing review hygiene:
+
+1. **Sprint Phase (Parallel PR creation)**:
+   The developer or agent opens multiple PRs in series for distinct atomic tickets.
+   No local pre-push lock blocks PR creation while previous PRs await review.
+2. **Async CI Phase (Parallel review)**:
+   GitHub Actions and PR-Agent review each PR in parallel in the cloud across
+   available NaN slots. Non-slash comments (`## Review triage`, discussions) are
+   strictly filtered out (`startsWith(comment.body, '/')`), preventing review loops (#1134).
+3. **Triage Sweep Phase (`dotf pr triage-queue`)**:
+   Before closing a session or merging, the agent queries `dotf pr triage-queue`.
+   The agent evaluates findings, applies fixes via TDD, pushes updates, and posts
+   the `## Review triage` table on each PR until the queue reports `[OK] 0 pending`.
+
 ## Operating it
 
-- **Nothing to trigger.** It fires on the PR event. Slash commands (`/review`,
-  `/describe`, `/improve`) work as comments on an open PR.
-- **Read the output as a comment, not a review.** PR-Agent posts an *issue
-  comment*; it does not submit a formal GitHub review. `gh pr view N --json
-  reviews` will not show it. This is why it cannot currently attest under
-  GUARD-002 — see #1033.
+- **Nothing to trigger.** It fires automatically on the `pull_request` event (`opened`, `synchronize`).
+  Slash commands (`/review`, `/describe`, `/improve`) work as comments on an open PR.
+- **Attestation under GUARD-002**: PR-Agent posts an issue comment carrying the
+  `## PR Reviewer Guide` marker, which `check-review-attestation.sh` recognizes
+  as a valid review attestation (`[OK] attested`).
 - **Changing the reviewing model** is one line in `.pr_agent.toml`. There is one
   fallback, `openai/mimo-v2.5`, and the reason is **concurrency, not quality**:
   the limit is per model, so a second NaN model has its own bucket of five.

--- a/harness/skills/pr-review-triage/SKILL.md
+++ b/harness/skills/pr-review-triage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/skills/pr-review-triage/SKILL.md
-generated_sha: ac110dd5b55e6992
+generated_sha: 1bb26bdb5271dfb3
 id: pr-review-triage-skill
 type: skill
 status: active
@@ -53,6 +53,13 @@ gh pr checks <N> --repo <owner>/<repo> --watch --interval 30
 ```
 
 Watch it once rather than polling in a loop. If a reviewer bot is still pending after the checks settle, wait for that one specific thing — a triage run against half the comments produces a disposition table you will have to redo.
+
+### 1b. Batch Workflow (High-Velocity PR Creation)
+
+When resolving multiple backlog items in a single session:
+- **Do not block local progress waiting for reviews.** Open each atomic PR in series and let CI and autonomous reviewers (PR-Agent) process them asynchronously in parallel.
+- Non-slash comments (`## Review triage`, conversation) are filtered out at the workflow level, so posting triage tables does not trigger review loops or consume inference quota.
+- **Batch sweep before closing:** Run `dotf pr triage-queue` to list all PRs whose reviews have finished across the batch, then iterate through each pending PR, apply needed fixes via TDD, push updates, and record `## Review triage`.
 
 ### 2. Report CI honestly
 


### PR DESCRIPTION
## Summary

Updates `docs/runbooks/guide-pr-agent-reviewer.md` and syncs the `pr-review-triage` skill with the high-velocity batch PR workflow:

1. **Parallel Execution Architecture**: Explains why the global GHA job-level concurrency lock was removed (#1135) to allow batches of PRs to review concurrently across NaN's 10 available slots (5 deepseek + 5 mimo fallback under LiteLLM).
2. **Comment Filter Protection**: Documents how `startsWith(comment.body, '/')` stops `## Review triage` tables and conversational comments from triggering review loops (#1134).
3. **High-Velocity Batch PR & Triage Workflow**: Formulates the 3-phase model (Sprint Phase -> Parallel Async CI -> Triage Sweep via `dotf pr triage-queue`).

## Verification

- Recompiled and refreshed harness skills via `./scripts/compile-harness.sh --refresh`.
- All repository test suites pass.