### PR TITLE
test(harness): add schema and drift guards for triggers.json registry

### DIFF
--- a/cli/internal/harness/triggers_test.go
+++ b/cli/internal/harness/triggers_test.go
@@ -340,3 +340,49 @@ name: skill2
 		t.Fatalf("deps[skill1] = %v; want %v", deps["skill1"], expected)
 	}
 }
+
+// TestRealTriggersFileValid guards harness/triggers.json against silent rot or schema deviation (GUARD #1137).
+func TestRealTriggersFileValid(t *testing.T) {
+	cfg, err := ParseTriggers(defaultTriggersJSON)
+	if err != nil {
+		t.Fatalf("ParseTriggers(defaultTriggersJSON) failed: %v", err)
+	}
+	if cfg.Version < 1 {
+		t.Errorf("expected Version >= 1, got %d", cfg.Version)
+	}
+	if len(cfg.Triggers) == 0 {
+		t.Fatal("expected non-empty triggers array")
+	}
+
+	seenIDs := make(map[string]bool)
+	for i, rule := range cfg.Triggers {
+		if rule.ID == "" {
+			t.Errorf("trigger[%d] has empty ID", i)
+		}
+		if seenIDs[rule.ID] {
+			t.Errorf("duplicate trigger ID %q", rule.ID)
+		}
+		seenIDs[rule.ID] = true
+
+		if rule.Pattern == "" {
+			t.Errorf("trigger %q has empty Pattern", rule.ID)
+		}
+		if len(rule.Globs) == 0 && len(rule.Keywords) == 0 {
+			t.Errorf("trigger %q has neither globs nor keywords", rule.ID)
+		}
+	}
+}
+
+// TestTriggersEmbeddedMatchesDiskSSOT guards against drift between harness/triggers.json and embedded copy (#1137).
+func TestTriggersEmbeddedMatchesDiskSSOT(t *testing.T) {
+	root := "../../.."
+	diskPath := filepath.Join(root, "harness", "triggers.json")
+	diskBytes, err := os.ReadFile(diskPath)
+	if err != nil {
+		t.Skipf("skipping drift test outside repository root: %v", err)
+		return
+	}
+	if !reflect.DeepEqual(diskBytes, defaultTriggersJSON) {
+		t.Errorf("embedded triggers.json drifted from %s; re-sync copies", diskPath)
+	}
+}

--- a/tests/triggers-registry.bats
+++ b/tests/triggers-registry.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# GUARD (#1137): triggers.json schema and drift guard.
+#
+# Asserts harness/triggers.json parses, conforms to the TriggerConfig shape,
+# has unique IDs, and does not drift from cli/internal/harness/triggers.json.
+
+setup() {
+    REPO="$BATS_TEST_DIRNAME/.."
+    TRIGGERS="$REPO/harness/triggers.json"
+    EMBEDDED="$REPO/cli/internal/harness/triggers.json"
+}
+
+@test "triggers.json: file exists and is valid JSON" {
+    [ -f "$TRIGGERS" ]
+    jq empty "$TRIGGERS"
+}
+
+@test "triggers.json: version is a positive integer" {
+    local ver
+    ver="$(jq -r '.version' "$TRIGGERS")"
+    [ "$ver" -ge 1 ]
+}
+
+@test "triggers.json: triggers array is non-empty" {
+    local count
+    count="$(jq -r '.triggers | length' "$TRIGGERS")"
+    [ "$count" -ge 1 ]
+}
+
+@test "triggers.json: every trigger entry has non-empty id, pattern, and globs array" {
+    local invalid
+    invalid="$(jq -r '
+        .triggers[] |
+        select(
+            (.id | type != "string" or length == 0) or
+            (.pattern | type != "string" or length == 0) or
+            (.globs | type != "array" or length == 0)
+        ) | .id // "<missing-id>"
+    ' "$TRIGGERS")"
+    [ -z "$invalid" ]
+}
+
+@test "triggers.json: all trigger IDs are unique (no duplicates)" {
+    local total unique
+    total="$(jq -r '.triggers | length' "$TRIGGERS")"
+    unique="$(jq -r '.triggers[].id' "$TRIGGERS" | sort -u | wc -l)"
+    [ "$total" -eq "$unique" ]
+}
+
+@test "triggers.json: embedded Go copy matches root harness/triggers.json byte-for-byte (no drift)" {
+    [ -f "$EMBEDDED" ]
+    cmp -s "$TRIGGERS" "$EMBEDDED"
+}


### PR DESCRIPTION
## Summary

Adds schema validation and drift tests for `harness/triggers.json` (which was the only registry in `harness/` without test coverage):

1. **Bats Guard (`tests/triggers-registry.bats`)**:
   - Asserts `harness/triggers.json` exists and is valid JSON.
   - Asserts `version` is a positive integer.
   - Asserts `.triggers` array is non-empty.
   - Asserts every trigger has non-empty `id`, `pattern`, and `globs` array.
   - Asserts all trigger `id` values are unique (no duplicates).
   - Asserts embedded Go copy (`cli/internal/harness/triggers.json`) matches root `harness/triggers.json` byte-for-byte.

2. **Go Unit Tests (`cli/internal/harness/triggers_test.go`)**:
   - `TestRealTriggersFileValid`: Verifies the embedded config unmarshals to a valid `TriggerConfig`.
   - `TestTriggersEmbeddedMatchesDiskSSOT`: Verifies embedded copy has not drifted from disk SSOT.

## Verification

- Verified all 6 bats tests pass (`bats tests/triggers-registry.bats`).
- Verified all 18 CLI test packages pass (`go test ./...`).
- Full test suite passes (`./scripts/test.sh`).

Closes #1137