### PR TITLE
fix(ci): remove job-level concurrency lock in pr-agent workflow

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -108,25 +108,6 @@ jobs:
         && startsWith(github.event.comment.body, '/'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Serialise inference repo-wide: QUEUE, never cancel (#1107).
-    #
-    # This is a SECOND group, at job level, and it does not replace the
-    # workflow-level one above — the two answer different questions. The
-    # workflow group is per-PR and cancels, so a burst of pushes still collapses
-    # to one review of the settled state (#1042). This one is repo-wide and does
-    # not cancel, so two PRs never ask NaN for inference at the same time.
-    #
-    # ADR-032 names the rule: the top tier "queues or escalates, NEVER degrades
-    # silently". Queuing is the sanctioned behaviour, and it is what was missing:
-    # the cluster's 5 slots were being spent by our own parallel CI, so a review
-    # failed rather than waited.
-    #
-    # It cannot guarantee a free slot — pi, qq and hive draw on the same pool —
-    # but it caps this workflow's demand at one, leaving the rest for interactive
-    # use instead of racing it.
-    concurrency:
-      group: pr-agent-nan-inference
-      cancel-in-progress: false
     steps:
       # `The-PR-Agent/pr-agent`, not `qodo-ai/pr-agent` as #786's body says: the
       # project has been renamed and the old path now redirects. Pinned to a tag


### PR DESCRIPTION
## Summary

Removes the job-level `concurrency: group: pr-agent-nan-inference` lock from `.github/workflows/pr-agent.yml`.

The workflow-level concurrency group (`group: pr-agent-${{ pr.number }}-${{ event_name }}`) already collapses burst pushes per PR. Removing the global lock allows parallel PRs to be reviewed concurrently across NaN's 10 available slots (5 deepseek + 5 mimo fallback) without GitHub Actions cancelling intermediate runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated pull request processing to allow independent requests to proceed without being held in a shared queue.
  - This may improve the responsiveness and throughput of automated review assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->