### PR TITLE
fix(ci): give PR-Agent its own model lane so it stops starving the spec-review gate

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -12,16 +12,28 @@
 # is NaN's, set as OPENAI.API_BASE in the workflow. The model itself is not the
 # hosted OpenAI one.
 #
-# deepseek-v4-flash is not a guess. #786's body argued from a 2026-06-11 research
-# note that REJECTED PR-Agent because "local-model quality drops below the bar",
-# then reasoned that cluster inference should be a different tier. That was a
-# projection. It is now measured: three adversarial reviews ran on this model on
-# 2026-08-16 and each produced findings a rubber stamp would not — including a
-# security hole in GUARD-002 (the gate ran its own classifier from the PR under
-# review, so a PR could edit it to attest itself) and a vacuous test predicate.
-model = "openai/deepseek-v4-flash"
+# mimo-v2.5, and the reason is LANE SEPARATION rather than quality (#1149).
+#
+# deepseek-v4-flash held this slot until 2026-08-21 and earned it; nothing about
+# that record is retracted. What changed is that deepseek is ALSO the primary in
+# harness/reviewer-pool.json, which governs the `dotf spec review` the archive
+# gate requires — and NaN's limit is per MODEL, so CI and the gate shared one
+# bucket of five. Measured: a spec review on #1143 died with a deepseek 429
+# because PR-Agent was reviewing that same PR. Two models are two buckets.
+#
+# The trade, stated rather than buried: CI review moves to the model with the
+# weaker established record — mimo is pool-admitted but was never ranked against
+# deepseek. That buys the GATE's capacity with some of CI's review strength,
+# which is the right way round, because the gate is blocking and CI review is
+# advisory. Visibly weaker reviews here are the signal to revisit, NOT to move
+# back on top of the gate. Full measurement trail in #1149.
+model = "openai/mimo-v2.5"
 
-# ONE fallback, and the reason is concurrency rather than quality (#1107).
+# ONE fallback, now deepseek-v4-flash — the reverse of the pre-2026-08-21
+# arrangement (#1149). It reintroduces contention with the gate on exactly the
+# runs where it fires, accepted deliberately: it fires only when mimo is
+# unreachable, and a review competing for a slot beats a review that does not
+# happen.
 #
 # Measured 2026-08-20 against api.nan.builders with minimal requests:
 #
@@ -45,10 +57,9 @@ model = "openai/deepseek-v4-flash"
 #   qwen3.6              262,144 ctx
 #   gemma4               262,144 ctx
 #
-# Stated honestly: that is a profile match, not a benchmark. mimo has not been
-# evaluated against the pool's bar, and if it ever signs an adversarial review
-# it must be admitted to reviewer-pool.json first — that file governs the
-# spec-level gate, which this is not.
+# Stated honestly: that is a profile match, not a benchmark. An earlier version
+# of this note added that mimo was not yet pool-admitted; it was admitted on
+# 2026-08-20, so that caveat is dropped and only the profile one stands.
 #
 # On ADR-032's "the top tier has no fallback, on purpose": read precisely, that
 # rule forbids silently degrading to a MID model, because a mysterious quality
@@ -64,15 +75,16 @@ model = "openai/deepseek-v4-flash"
 # no Google credential exists in the registry, and routing via OpenRouter would
 # spend a finite paid balance on every PR and add the second secret the guard
 # exists to prevent.
-fallback_models = ["openai/mimo-v2.5"]
+fallback_models = ["openai/deepseek-v4-flash"]
 
 # Cheap passes only — descriptions and commit summaries, never the review.
 model_weak = "openai/qwen3.6"
 
 # NaN models are absent from LiteLLM's registry, so the token budget must be
 # stated explicitly or LiteLLM assumes a small default and truncates the diff.
-# deepseek-v4-flash advertises 1M context; 200k is a deliberate floor well inside
-# it, raised only against measured need.
+# Both models here advertise 1M context — deepseek-v4-flash and mimo-v2.5 alike,
+# which is the line reviewer-pool.json draws around reasoning-class — so 200k is
+# a deliberate floor well inside either, raised only against measured need.
 custom_model_max_tokens = 200000
 max_model_tokens = 200000
 

--- a/tests/pr-agent-config.bats
+++ b/tests/pr-agent-config.bats
@@ -56,8 +56,46 @@ refute_grep() {
     refute_grep 'fallback_models = \[[^]]*gemma4' "$CFG"
 }
 
-@test "pr-agent: the reviewing model is the one measured, not the fast one" {
-    grep -q 'model = "openai/deepseek-v4-flash"' "$CFG"
+@test "pr-agent: the reviewing model is reasoning-class, not the fast one" {
+    # This pinned `deepseek-v4-flash` by name until #1149 moved CI to its own
+    # model lane. Pinning one id made a routing change look like a regression,
+    # so the assertion now names the PROPERTY that actually matters and the
+    # excluded models by name — the same shape the fallback test above already
+    # uses, and the same reason.
+    #
+    # The property: the reviewing model must be reasoning-class. The line
+    # reviewer-pool.json draws is context window plus a mandatory reasoning
+    # chain — deepseek-v4-flash and mimo-v2.5 at 1M sit on one side, qwen3.6 and
+    # gemma4 at 262K on the other. A reviewer that PASSes cheaply is worse than
+    # no gate.
+    run grep -E '^model = "openai/(deepseek-v4-flash|mimo-v2\.5)"' "$CFG"
+    [ "$status" -eq 0 ]
+
+    # And the excluded ones stay impossible in the primary slot, not only in the
+    # fallback list. The old test could not catch this, because asserting one
+    # allowed id says nothing about which ids are forbidden.
+    refute_grep '^model = "openai/qwen3\.6"' "$CFG"
+    refute_grep '^model = "openai/gemma4"' "$CFG"
+}
+
+@test "pr-agent: CI and the spec-review gate do not share a model" {
+    # #1149. NaN's concurrency limit is per MODEL, not per API key, so CI and
+    # `dotf spec review` drawing on the same id share one bucket of five.
+    # Measured 2026-08-21: a spec review died with
+    # `429: deepseek-v4-flash concurrency limit` because PR-Agent was reviewing
+    # the very PR that review had to clear. CI starved the gate its own PR
+    # needed to pass.
+    #
+    # Two models are two independent buckets, so the fix is separation and this
+    # asserts it stays separated. The pool's PRIMARY is what matters: that is
+    # what `dotf spec review` reaches for first.
+    pool_primary="$(python3 -c "
+import json
+d = json.load(open('$REPO/harness/reviewer-pool.json'))
+print(next(e['model'] for e in d['pool'] if e['role'] == 'primary'))
+")"
+    [ -n "$pool_primary" ]
+    refute_grep "^model = \"openai/${pool_primary}\"" "$CFG"
 }
 
 @test "pr-agent: the token budget is stated, because NaN models are not in LiteLLM's registry" {


### PR DESCRIPTION
Closes #1149. Follow-up to #1146, which removed the concurrency group — that fixed cancellation and left exhaustion unmitigated. This closes the other half.

## The problem

NaN's concurrency limit is **per model, not per API key**, and PR-Agent shared `deepseek-v4-flash` with `harness/reviewer-pool.json`'s primary — the model `dotf spec review` reaches for first. So CI review and the archive gate drew on one bucket of five.

**Measured 2026-08-21:** a spec review on #1143 died with `429: deepseek-v4-flash concurrency limit: max 5 simultaneous requests` because PR-Agent was reviewing that same PR. **CI starved the gate its own PR had to clear.** The run only completed by falling through to the provider-diverse fallback.

Two models are two independent buckets, so separation fixes it with no concurrency group on either side.

## The trade, stated rather than buried

**CI review moves to the model with the weaker established record.** `deepseek-v4-flash` earned the primary slot — three adversarial reviews on 2026-08-16, each producing findings a rubber stamp would not, including a security hole in GUARD-002. None of that is retracted.

`mimo-v2.5` was admitted to `reviewer-pool.json` on 2026-08-20 with its verdict recorded honestly: a real, correct finding on a planted defect, and **no quality ranking against deepseek established** — because deepseek returned an empty body at 8,000 output tokens under the same harness, which is an instrumentation result, not a capability one.

So this buys the **gate's** capacity with some of **CI's** review strength. That is the right way round — the gate is required and blocking, CI review is advisory. If mimo produces visibly weaker reviews here, the signal is to revisit, **not** to move back on top of the gate.

The fallback now points back at deepseek and reintroduces contention on exactly the runs where it fires. Accepted deliberately: it fires only when mimo is unreachable, and a review competing for a slot beats a review that does not happen.

## Two guard corrections

**The model test pinned `deepseek-v4-flash` by name**, so a routing change read as a regression. It now asserts the **property** — reasoning-class, the line `reviewer-pool.json` draws at 1M context plus a reasoning chain — and names the excluded models. That is strictly stronger: pinning one allowed id said nothing about which ids are forbidden, so it could not have caught a fast model in the primary slot. It now does.

**A new test reads the pool's primary and asserts CI does not name it**, so the separation cannot silently collapse in a later edit.

Mutation-verified:

```
model = deepseek-v4-flash  →  not ok 5  CI and the spec-review gate do not share a model
                              not ok 25 the fallback is a second NaN model, not the primary again
model = qwen3.6            →  not ok 4  the reviewing model is reasoning-class, not the fast one
```

## Also corrects a comment that had gone stale

The config said mimo *"has not been evaluated against the pool's bar"* and would need admitting to `reviewer-pool.json` before signing an adversarial review. Both happened on 2026-08-20. The profile-match caveat stands; the not-admitted one is dropped rather than left to mislead.

## Scope

`.pr_agent.toml` (46 production LOC, under the spec-gate threshold — the long measurement trail lives in #1149 rather than duplicated here) plus its guard. 28/28 config guards pass.