### PR TITLE
fix(setup): jq `// empty` guard silently disabled the whole Claude settings merge

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -1277,13 +1277,18 @@ merge_claude_settings() {
     # from scratch. Measured on this repo's own box — the key sat in the template
     # while the deployed file had no `outputStyle` at all. It belongs with `model`
     # and `effortLevel`: same file, same kind of setting, dotfiles-owned.
-    # `// empty` leaves the existing value alone if a template ever omits it,
-    # rather than writing null and having Claude read an invalid style.
+    # Guarded with `has()`, NOT with `// empty`. In jq a condition that evaluates
+    # to `empty` makes the whole if-expression produce nothing, so `// empty`
+    # here does not mean "leave it alone when absent" — it means the entire merge
+    # yields an empty result, `merged` is empty, and the function bails with
+    # "merge produced empty output, skipping write". A template that ever omits
+    # this one optional key would then deploy NOTHING: not model, not
+    # effortLevel, not permissions, not hooks.
     local merged
     merged=$(jq --argjson tmpl "$template_substituted" '
         .model = $tmpl.model
         | .effortLevel = $tmpl.effortLevel
-        | (if ($tmpl.outputStyle // empty) then .outputStyle = $tmpl.outputStyle else . end)
+        | (if ($tmpl | has("outputStyle")) then .outputStyle = $tmpl.outputStyle else . end)
         | .permissions = (.permissions // {})
         | .permissions.allow = (((.permissions.allow // []) + $tmpl.permissions.allow) | unique)
         | .hooks = (.hooks // {})

--- a/tests/claude-settings-template.bats
+++ b/tests/claude-settings-template.bats
@@ -47,6 +47,39 @@ setup() {
     done
 }
 
+@test "the merge expression survives a template that omits an optional key" {
+    # jq: a condition that evaluates to `empty` makes the WHOLE if-expression
+    # produce nothing, so `if ($tmpl.key // empty) then ... else . end` does not
+    # mean "leave it alone when absent" -- it means the entire merge pipeline
+    # yields an empty result. merge_claude_settings then logs "merge produced
+    # empty output, skipping write" and NO key deploys: not model, not
+    # effortLevel, not permissions, not hooks. `has()` is the guard that means
+    # what the other one looks like it means.
+    #
+    # Extracted from setup-linux.sh so this tests the shipped expression rather
+    # than a copy of it.
+    local expr existing out
+    expr="$(sed -n "/^    merged=\$(jq --argjson tmpl /,/^    ' \"\$target_path\"/p" \
+        "$DOTFILES_DIR/setup-linux.sh" \
+        | sed -e "1s/.*jq --argjson tmpl \"\$template_substituted\" '//" -e "\$d")"
+    [ -n "$expr" ]
+    existing='{"model":"sonnet","userCustom":"preserve me"}'
+
+    # a template WITHOUT the optional key must still merge everything else
+    out="$(printf '%s' "$existing" | jq --argjson tmpl \
+        '{"model":"opus","effortLevel":"xhigh","permissions":{"allow":[]},"hooks":{},"enabledPlugins":{}}' \
+        "$expr" 2>&1)"
+    [ -n "$out" ]
+    [ "$(printf '%s' "$out" | jq -r '.model')" = "opus" ]
+    [ "$(printf '%s' "$out" | jq -r '.userCustom')" = "preserve me" ]
+
+    # and a template WITH it must carry it through
+    out="$(printf '%s' "$existing" | jq --argjson tmpl \
+        '{"model":"opus","effortLevel":"xhigh","outputStyle":"Concise","permissions":{"allow":[]},"hooks":{},"enabledPlugins":{}}' \
+        "$expr" 2>&1)"
+    [ "$(printf '%s' "$out" | jq -r '.outputStyle')" = "Concise" ]
+}
+
 @test "template has outputStyle and both merge policies propagate it" {
     [[ "$(jq -r '.outputStyle' "$SETTINGS_TEMPLATE")" != "null" ]]
     grep -q 'outputStyle' "$DOTFILES_DIR/setup-linux.sh"


### PR DESCRIPTION
Follow-up to #1165, from its own round-2 adversarial review.

## The bug

#1165 added `outputStyle` to `merge_claude_settings`, guarded like this:

```jq
| (if ($tmpl.outputStyle // empty) then .outputStyle = $tmpl.outputStyle else . end)
```

with a comment claiming it "leaves the existing value alone if a template ever omits it". **It does the opposite.** In jq, a condition that evaluates to `empty` makes the whole `if` expression produce nothing — so a template without that one optional key makes the entire merge pipeline yield an empty result.

`merge_claude_settings` then hits its own safety net:

```sh
if [ -z "$merged" ]; then
    log_warning "Claude settings merge produced empty output, skipping write"
    return 0
fi
```

…and **nothing deploys**: not `model`, not `effortLevel`, not `permissions.allow`, not the SessionStart/SessionEnd hooks. A warning, exit 0, and a settings file that never got its dotfiles-owned subset.

Reproduced before fixing:

```console
$ jq --argjson tmpl '{"model":"opus","effortLevel":"xhigh"}' \
     '.model = $tmpl.model | .effortLevel = $tmpl.effortLevel
      | (if ($tmpl.outputStyle // empty) then .outputStyle = $tmpl.outputStyle else . end)' \
     <<<'{"model":"sonnet","userThing":"keep"}'
$ echo "[$?]"   # exit 0, and NO output at all
[0]
```

Latent today because the template does carry the key — which is exactly why it was worth fixing now rather than the first time someone trims the template.

## The fix

`has()` is the guard that means what the other one looks like it means. One line, plus the comment corrected to say why.

## Testing

The test **extracts the jq expression out of `setup-linux.sh`** rather than restating it, so it exercises the shipped merge and cannot drift from it. It asserts both directions:

- a template omitting the key still merges everything else (and preserves unrelated user keys);
- a template carrying it still propagates it.

Fails before the fix, at exactly the assertion that matters:

```
not ok 1 the merge expression survives a template that omits an optional key
#   `[ -n "$out" ]' failed
```

- `bats tests/*.bats` -> **1419 passing, 0 failing**
- `shellcheck setup-linux.sh` clean (one pre-existing SC1091 info), `bash -n` clean

## Provenance

Found by the round-2 adversarial review of #1165 (`nan/deepseek-v4-flash`, from `harness/reviewer-pool.json`), which graded it **THEORETICAL**. Reproducing it upgraded it to real: the failure needs no unusual input, only a template edit.

Not SDD-gated: single-line bug fix with an obvious cause, well under the Discipline Gate's thresholds.
