### PR TITLE
fix(harness): agy takes its model as a launcher flag, so it is an adapter

### DIFF
--- a/cli/internal/harness/model_map_test.go
+++ b/cli/internal/harness/model_map_test.go
@@ -671,3 +671,89 @@ func TestEnumHandlesNonComparableValues(t *testing.T) {
 		})
 	}
 }
+
+// TestRenderKindAgreesWithTierKeying pins the rule the map's own `$comment`
+// states and that its data contradicted for `agy` (#1162):
+//
+//	"TIERS ARE KEYED BY WHATEVER CONSUMES THE MODEL ID [...] A harness whose
+//	 render is `adapter` keys by its pool."
+//
+// An `adapter` harness takes the model as a launcher flag — `pi --model X`,
+// `agy --model X` — so there is no rendered field to put an id into, and asking
+// for a harness-keyed tier is a question about a field that does not exist.
+// Conversely a harness that DOES render an id must not be declared `adapter`,
+// or ResolveTier would refuse a lookup the render genuinely needs.
+//
+// `agy` was declared `render: agent-md` while the same file's prose grouped it
+// with `pi` as a launcher-flag harness. Nothing caught it because `tiers` had no
+// consumer at all until #1165, and `agy` is not in manifest.json's
+// `agents.deploy`. Verified 2026-08-21 against the launcher: review_launch.go
+// builds `agy --model <id> …`, and `agy agents` lists none.
+// tierlessRenderers are harnesses declared as rendering a model id that no tier
+// names yet, each with the reason the answer is not known. This is a KNOWN
+// BACKLOG, not an approval: a new entry fails the test until someone chooses,
+// so the set can only shrink deliberately. Same idiom as EXEMPT_SUITES in
+// tests/stub-real-pairing.bats.
+//
+//	copilot  render: agent-md is CORRECT — Copilot CLI custom agents take a
+//	         `model:` string in their .agent.md frontmatter (github/copilot-cli
+//	         #2133 confirms it, and that it rejects the array form VS Code
+//	         accepts). What is missing is only WHICH ids this seat accepts, and
+//	         that is not knowable from this machine: the binary is not installed,
+//	         and copilot appears only in manifest.json's agents.presence, never
+//	         agents.deploy. Declaring guessed ids would put a route to nowhere in
+//	         the map that validates cleanly — the class ADR-035 deleted the
+//	         phantom `codex` pool to avoid. Deferred to the Windows box (#1170).
+var tierlessRenderers = map[string]bool{"copilot": true}
+
+func TestRenderKindAgreesWithTierKeying(t *testing.T) {
+	root := repoRootForTest(t)
+	m, err := LoadModelMap(root)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	harnesses, ok := m["harnesses"].(map[string]any)
+	if !ok {
+		t.Fatal("no harnesses block")
+	}
+	tiers, ok := m["tiers"].(map[string]any)
+	if !ok {
+		t.Fatal("no tiers block")
+	}
+
+	// Which harnesses any tier names directly.
+	keyed := map[string]string{}
+	for _, tier := range sortedKeys(tiers) {
+		entry, ok := tiers[tier].(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, name := range sortedKeys(entry) {
+			keyed[name] = tier
+		}
+	}
+
+	for _, name := range sortedKeys(harnesses) {
+		h, ok := harnesses[name].(map[string]any)
+		if !ok {
+			continue
+		}
+		render, _ := h["render"].(string)
+		tier, hasTier := keyed[name]
+
+		if render == "adapter" && hasTier {
+			t.Errorf("harness %q declares render %q but tier %q names it directly.\n"+
+				"An adapter harness takes the model as a launcher flag, so it keys by POOL "+
+				"(%v) and must have no harness-keyed tier entry. Either drop the tier entry "+
+				"or stop calling it an adapter.", name, render, tier, toStrings(h["pools"]))
+		}
+		if render != "adapter" && !hasTier && !tierlessRenderers[name] {
+			t.Errorf("harness %q declares render %q — a kind that renders a model id into a "+
+				"definition file — but no tier names it, so ResolveTier refuses every lookup "+
+				"for it.\nEither give it a tier entry, or declare it an adapter if its model "+
+				"actually arrives as a launcher flag.\nIf the answer genuinely is not known yet, "+
+				"add it to tierlessRenderers with the reason.", name, render)
+		}
+	}
+}

--- a/harness/model-map.json
+++ b/harness/model-map.json
@@ -115,9 +115,9 @@
       "pools": [
         "nan"
       ],
-      "render": "agent-md",
+      "render": "adapter",
       "spawn": "none",
-      "why": "Present in the reviewer pool as the provider-diverse fallback arm, so it belongs in the map that routes to it."
+      "why": "Present in the reviewer pool as the provider-diverse fallback arm, so it belongs in the map that routes to it. render is `adapter`, NOT agent-md (#1162): the model reaches agy as a launcher flag, exactly as it does for pi. Measured 2026-08-21 — cli/internal/spec/review_launch.go builds `agy --model <id> --output-format stream-json …`, and `agy agents` lists none. It was declared agent-md while this file\u0027s own $comment grouped it with pi as a launcher-flag harness; nothing caught the contradiction because tiers had no consumer until #1165."
     }
   },
   "tiers": {


### PR DESCRIPTION
Closes #1162. Second in the sequence that follows #1165 giving `model-map.json` its first consumer.

## The contradiction

`harness/model-map.json` declared:

```json
"agy": { "pools": ["nan"], "render": "agent-md", "spawn": "none" }
```

while the **same file's** `$comment` said:

> TIERS ARE KEYED BY WHATEVER CONSUMES THE MODEL ID […] `nan` keys by POOL, because the harnesses that reach it (`pi`, `agy`) take the model as a launcher flag rather than a rendered field — `pi --model X`, `agy --model X`. […] **A harness whose render is `adapter` keys by its pool.**

Exactly one could be right.

## The prose is right — measured, not reasoned

| Probe | Result |
|---|---|
| `cli/internal/spec/review_launch.go:145` | builds `agy --model <id> --output-format stream-json …` |
| `agy agents` | lists none |
| `manifest.json` | `agy` appears only under `doctrine.deploy` (`.gemini/GEMINI.md`), **never** `agents.deploy` |

Nothing renders an agent definition for `agy`, so there is no field to put a model id into. `render: adapter`, like `pi`.

**Why nothing caught it:** `tiers` had no consumer at all until #1165. Giving the registry a reader is what made the contradiction reachable — the argument for readers over declarations, in miniature.

## The guard

`TestRenderKindAgreesWithTierKeying` holds both directions of the rule the `$comment` states:

- `render: adapter` ⟹ no harness-keyed tier entry (it keys by pool)
- `render` ≠ `adapter` ⟹ some tier must name it, or `ResolveTier` refuses every lookup the render needs

Fails before the fix, naming the harness and both possible remedies.

## A second instance, and why it is *not* the same defect

The test found `copilot` too: `render: agent-md`, no tier anywhere. That one is **not** a contradiction — the render kind is right. Copilot CLI custom agents genuinely take a `model` **string** in their `.agent.md` frontmatter; [github/copilot-cli#2133](https://github.com/github/copilot-cli/issues/2133) establishes it by reporting the CLI *rejecting* the array form VS Code Copilot Chat accepts (*"model: Expected string, received array"*). A field that can be malformed is a field that is read.

What is missing is only **which ids the seat accepts**, and that is not knowable here: the binary is not installed, and `copilot` appears only in `agents.presence`. Declaring guessed ids would put a route to nowhere into the map that validates cleanly — the class ADR-035 deleted the phantom `codex` pool to avoid.

So `copilot` sits in the test's `tierlessRenderers` table with that reason, tracked as **#1170** (narrowed there: the structural half is now answered, only the ids remain, to be recorded at the Windows box). **The table is a known backlog, not an approval** — a new entry fails the test until someone chooses, so the set can only shrink deliberately. Same idiom as `EXEMPT_SUITES` in `tests/stub-real-pairing.bats`.

## Testing

- `go build ./... && go vet ./... && GOOS=windows go vet ./... && go test ./...` — clean
- `golangci-lint run` — `0 issues.` at the `versions.conf` pin; `gofmt` clean
- `bats tests/*.bats` — **1418 passing, 0 failing**
- `dotf doctor` — exit 0 with the changed map; its *Routing registry* section still reports clean
- Behaviour after the fix: `dotf harness resolve-tier mid --harness agy` now refuses, exactly as it does for `pi`, because agy's model arrives on the command line

Not SDD-gated: one data field plus its rationale, and a test. Production diff is well under the Discipline Gate's thresholds.
