### PR TITLE
feat(harness): give capabilities the same seam the model tier got

### DIFF
--- a/cli/internal/cmd/harness.go
+++ b/cli/internal/cmd/harness.go
@@ -25,6 +25,7 @@ pattern triggers, and workflow integrations.`,
 	cmd.AddCommand(newHarnessTriggersCmd())
 	cmd.AddCommand(newHarnessSuggestCmd())
 	cmd.AddCommand(newHarnessResolveTierCmd())
+	cmd.AddCommand(newHarnessResolveCapabilitiesCmd())
 	return cmd
 }
 

--- a/cli/internal/cmd/harness_resolve_capabilities.go
+++ b/cli/internal/cmd/harness_resolve_capabilities.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/env"
+	"github.com/mlorentedev/dotfiles/cli/internal/harness"
+)
+
+// newHarnessResolveCapabilitiesCmd is capability-map.json's consumer, and the
+// sibling of resolve-tier: same seam, one field over.
+//
+// It resolves a capability SET rather than one capability at a time, because the
+// two native forms disagree about what a partial answer means. A `csv` field is
+// an allow-list — naming a tool grants it and omitting one denies it — while a
+// `decision-map` grants without denying. A per-capability API would push that
+// distinction onto every caller, and the shell caller is exactly the one least
+// able to carry it.
+func newHarnessResolveCapabilitiesCmd() *cobra.Command {
+	var (
+		harnessName string
+		repoRoot    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "resolve-capabilities <capability>[,<capability>...]",
+		Short: "Resolve neutral capabilities to one harness's native frontmatter line",
+		Long: `resolve-capabilities answers which native tools or permissions a set of neutral
+capabilities means for one harness, reading harness/capability-map.json through
+the validated loader.
+
+It prints a COMPLETE frontmatter line — field and value — because the field name
+differs per harness and a caller should not have to know it:
+
+    cap_line="$(dotf harness resolve-capabilities read,shell --harness claude)"
+    # tools: Read, Glob, Bash
+
+Both declared forms render on one line and both are valid YAML: ` + "`csv`" + ` produces
+a comma list, ` + "`decision-map`" + ` a flow mapping.
+
+Where the map cannot answer — an unmapped capability, an undeclared harness, or a
+map that is absent or schema-invalid — this exits non-zero and writes nothing to
+stdout. It never falls back to a default: an empty tools list is not "no opinion",
+it is a definition granting nothing.`,
+		Example: `  dotf harness resolve-capabilities read,search,edit,shell --harness claude
+  dotf harness resolve-capabilities read,web --harness opencode`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if harnessName == "" {
+				return fmt.Errorf("--harness is required: a capability means different native tools " +
+					"per harness, so resolving one without naming the harness has no answer")
+			}
+			root := repoRoot
+			if root == "" {
+				root = env.ResolveHarnessRoot()
+			}
+			m, err := harness.LoadCapabilityMap(root)
+			if err != nil {
+				return err
+			}
+			line, err := harness.ResolveCapabilities(m, strings.Split(args[0], ","), harnessName)
+			if err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), line)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&harnessName, "harness", "", "harness the capabilities are resolved for (required)")
+	cmd.Flags().StringVar(&repoRoot, "repo-root", "",
+		"root containing harness/capability-map.json (default: the checkout, else DOTFILES_DIR)")
+	return cmd
+}

--- a/cli/internal/cmd/harness_resolve_tier_test.go
+++ b/cli/internal/cmd/harness_resolve_tier_test.go
@@ -200,29 +200,32 @@ func TestHarnessResolveTierFailsLoudWithoutAMap(t *testing.T) {
 	}
 }
 
-// TestHarnessHelpListsResolveTier pins the capability probe in
+// TestHarnessHelpListsSubcommands pins the capability probe in
 // scripts/compile-harness.sh, which decides whether the dotf on PATH is new
-// enough to resolve a tier by grepping `dotf harness --help` for this exact
-// subcommand name.
+// enough by grepping `dotf harness --help` for a subcommand name.
 //
 // The probe exists because the exit status cannot answer the question: a dotf
-// predating the subcommand rejects `--harness` with exit 1, which is
-// indistinguishable from a genuine routing refusal (#1158). Renaming the
-// subcommand without updating that grep would make the probe answer "too old"
-// forever, silently degrading every agent render to no model line — the exact
-// failure this feature removed. This test is the tripwire.
-func TestHarnessHelpListsResolveTier(t *testing.T) {
+// predating a subcommand rejects its flags with exit 1, which is
+// indistinguishable from a genuine refusal (#1158). Renaming one of these
+// without updating that grep would make the probe answer "too old" forever,
+// silently degrading every agent render — a guard that fails OPEN and reports
+// health. This test is the tripwire, and it covers BOTH registries' consumers
+// because the shell now probes for each independently.
+func TestHarnessHelpListsSubcommands(t *testing.T) {
 	stdout, stderr, err := captureRealStreams(t, "harness", "--help")
 	if err != nil {
 		t.Fatalf("harness --help failed: %v (stderr=%q)", err, stderr)
 	}
-	// Same shape the shell greps for: the name at the start of its line in the
-	// command list, followed by whitespace before its summary.
-	if !regexp.MustCompile(`(?m)^\s*resolve-tier\s`).MatchString(stdout + stderr) {
-		t.Errorf("`dotf harness --help` does not list resolve-tier as a command.\n"+
-			"scripts/compile-harness.sh greps for exactly this to decide whether the "+
-			"installed dotf can resolve a tier; without it every agent renders with no "+
-			"model line.\ngot:\n%s", stdout+stderr)
+	out := stdout + stderr
+	for _, sub := range []string{"resolve-tier", "resolve-capabilities"} {
+		// Same shape the shell greps for: the name at the start of its line in
+		// the command list, followed by whitespace before its summary.
+		if !regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(sub) + `\s`).MatchString(out) {
+			t.Errorf("`dotf harness --help` does not list %q as a command.\n"+
+				"scripts/compile-harness.sh greps for exactly this to decide whether the "+
+				"installed dotf can resolve it; without it every agent renders without that "+
+				"field.\ngot:\n%s", sub, out)
+		}
 	}
 }
 

--- a/cli/internal/harness/capability_map.go
+++ b/cli/internal/harness/capability_map.go
@@ -1,0 +1,250 @@
+package harness
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// CapabilityMapFile and CapabilityMapSchemaFile are the repo-relative paths to
+// the compile-time capability registry and its declarative contract (ADR-027 §2,
+// shaped by ADR-035).
+//
+// Not embedded, for the same reason model-map.json is not: an absent map that
+// resolved to a build-time default would grant or deny tool access silently,
+// which is what C15 forbids.
+const (
+	CapabilityMapFile       = "harness/capability-map.json"
+	CapabilityMapSchemaFile = "harness/capability-map.schema.json"
+)
+
+// ValidateCapabilityMap checks doc against schema.
+//
+// Standard keywords are interpreted by santhosh-tekuri/jsonschema, the same
+// draft-2020-12 implementation model-map uses. Unlike model-map this declares no
+// `x-` cross-block rule: model-map's rule plumbing is a package-level closed set
+// bound to that one schema, and generalising it to per-schema rule sets touches a
+// file hardened over six adversarial review rounds. The single cross-block
+// invariant here runs in checkVocabularyCoverage below instead, so the refactor
+// can be its own deliberate change rather than riding along with a new registry.
+func ValidateCapabilityMap(doc, schema []byte) error {
+	compiler := jsonschema.NewCompiler()
+
+	schemaDoc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schema))
+	if err != nil {
+		return fmt.Errorf("parse %s: %w", CapabilityMapSchemaFile, err)
+	}
+	// Opaque, stable resource id: a repo-relative path would be resolved against
+	// the process working directory and leak a per-machine absolute path into
+	// every error message.
+	const schemaURL = "https://mlorentedev.github.io/dotfiles/capability-map.schema.json"
+	if err := compiler.AddResource(schemaURL, schemaDoc); err != nil {
+		return fmt.Errorf("load %s: %w", CapabilityMapSchemaFile, err)
+	}
+	compiled, err := compiler.Compile(schemaURL)
+	if err != nil {
+		return fmt.Errorf("%s is not a valid schema: %w", CapabilityMapSchemaFile, err)
+	}
+
+	d, err := jsonschema.UnmarshalJSON(bytes.NewReader(doc))
+	if err != nil {
+		return fmt.Errorf("parse %s: %w", CapabilityMapFile, err)
+	}
+	if err := compiled.Validate(d); err != nil {
+		return fmt.Errorf("%s does not satisfy %s: %w", CapabilityMapFile, CapabilityMapSchemaFile, err)
+	}
+	return checkVocabularyCoverage(d)
+}
+
+// checkVocabularyCoverage is the rule a stock JSON Schema cannot express: every
+// harness must map every verb the `vocabulary` block declares.
+//
+// A partial harness is the dangerous shape, not an obviously broken one. It
+// validates cleanly, and a persona declaring a verb the harness happens to omit
+// then either fails at deploy or — worse, for a csv allow-list — renders a
+// definition missing exactly the tool it needed, with no error anywhere. The
+// vocabulary block exists so coverage is checked against a declared set rather
+// than against whatever the first harness happened to list.
+func checkVocabularyCoverage(doc any) error {
+	root, ok := doc.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s is not a JSON object", CapabilityMapFile)
+	}
+	vocab := toStrings(root["vocabulary"])
+	if len(vocab) == 0 {
+		return fmt.Errorf("%s declares an empty vocabulary", CapabilityMapFile)
+	}
+	harnesses, ok := root["harnesses"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s declares no harnesses block", CapabilityMapFile)
+	}
+
+	for _, name := range sortedKeys(harnesses) {
+		h, ok := harnesses[name].(map[string]any)
+		if !ok {
+			continue
+		}
+		caps, ok := h["capabilities"].(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s: harness %q declares no capabilities block", CapabilityMapFile, name)
+		}
+		var missing []string
+		for _, v := range vocab {
+			if _, present := caps[v]; !present {
+				missing = append(missing, v)
+			}
+		}
+		if len(missing) > 0 {
+			sort.Strings(missing)
+			return fmt.Errorf(
+				"%s: harness %q maps no native names for %s — every harness must cover the whole "+
+					"declared vocabulary. A partial harness validates cleanly and then renders a "+
+					"definition missing exactly the tool the persona asked for",
+				CapabilityMapFile, name, strings.Join(missing, ", "))
+		}
+		// The reverse: a native name declared for a verb outside the vocabulary
+		// is dead weight that reads as coverage.
+		var extra []string
+		for _, k := range sortedKeys(caps) {
+			if !contains(vocab, k) {
+				extra = append(extra, k)
+			}
+		}
+		if len(extra) > 0 {
+			return fmt.Errorf(
+				"%s: harness %q maps %s, which the vocabulary does not declare — "+
+					"add it to `vocabulary` or drop it, but do not leave a mapping nothing can ask for",
+				CapabilityMapFile, name, strings.Join(extra, ", "))
+		}
+	}
+	return nil
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// LoadCapabilityMap reads the capability registry and validates it against the
+// schema beside it. No fallback and no embedded default: where the map cannot be
+// read, this errors (C15).
+func LoadCapabilityMap(repoRoot string) (map[string]any, error) {
+	mapPath := filepath.Join(repoRoot, CapabilityMapFile)
+	schemaPath := filepath.Join(repoRoot, CapabilityMapSchemaFile)
+
+	doc, err := os.ReadFile(mapPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w\nthis is not an empty capability map — nothing falls back to a default", CapabilityMapFile, err)
+	}
+	schema, err := os.ReadFile(schemaPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w\nthe map cannot be trusted without the contract it declares against", CapabilityMapSchemaFile, err)
+	}
+	if err := ValidateCapabilityMap(doc, schema); err != nil {
+		return nil, err
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(doc, &parsed); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", CapabilityMapFile, err)
+	}
+	return parsed, nil
+}
+
+// ResolveCapabilities renders one harness's complete native value for a set of
+// neutral capabilities, returning the frontmatter line ready to emit.
+//
+// It returns a WHOLE line — "tools: Read, Glob, Bash" — rather than a bare value,
+// because the field name differs per harness and the caller should not have to
+// know it. Both declared forms render on one line and both are valid YAML:
+// `csv` produces a comma list, `decision-map` a YAML flow mapping.
+//
+// The set is resolved as a set, not capability by capability, and that is the
+// point. A `csv` field is an ALLOW-LIST — naming a tool grants it and omitting
+// one denies it — while a `decision-map` grants without denying. Emitting a
+// per-capability token for a caller to concatenate would lose that distinction
+// at exactly the layer that has to preserve it.
+func ResolveCapabilities(m map[string]any, caps []string, harness string) (string, error) {
+	harnesses, ok := m["harnesses"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("%s declares no harnesses block", CapabilityMapFile)
+	}
+	h, ok := harnesses[harness].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf(
+			"harness %q is not declared in %s (declared: %s)\n"+
+				"a harness whose native tool vocabulary has not been verified is absent on purpose — "+
+				"guessing native names would render a definition granting tools that do not exist",
+			harness, CapabilityMapFile, strings.Join(sortedKeys(harnesses), ", "))
+	}
+	field, _ := h["field"].(string)
+	form, _ := h["form"].(string)
+	table, ok := h["capabilities"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("%s: harness %q declares no capabilities block", CapabilityMapFile, harness)
+	}
+
+	// Native names in declaration order per capability, deduped across the set,
+	// first occurrence wins. Deterministic so the rendered file does not churn.
+	var natives []string
+	seen := map[string]bool{}
+	for _, c := range caps {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		raw, present := table[c]
+		if !present {
+			return "", fmt.Errorf(
+				"capability %q is not mapped for harness %q in %s (mapped: %s)",
+				c, harness, CapabilityMapFile, strings.Join(sortedKeys(table), ", "))
+		}
+		for _, n := range toStrings(raw) {
+			if !seen[n] {
+				seen[n] = true
+				natives = append(natives, n)
+			}
+		}
+	}
+	if len(natives) == 0 {
+		return "", fmt.Errorf(
+			"no capabilities requested for harness %q — resolving to an empty %s would render a "+
+				"definition granting nothing, which is not the same as declaring none",
+			harness, field)
+	}
+
+	switch form {
+	case "csv":
+		return fmt.Sprintf("%s: %s", field, strings.Join(natives, ", ")), nil
+	case "decision-map":
+		grant, _ := h["grant"].(string)
+		if strings.TrimSpace(grant) == "" {
+			return "", fmt.Errorf(
+				"%s: harness %q uses form %q but declares no `grant` value — "+
+					"a decision map with no decision to write grants nothing",
+				CapabilityMapFile, harness, form)
+		}
+		// Sorted: a flow mapping has no meaningful order, so a stable one keeps
+		// the rendered file from churning on map iteration.
+		sorted := append([]string(nil), natives...)
+		sort.Strings(sorted)
+		pairs := make([]string, 0, len(sorted))
+		for _, n := range sorted {
+			pairs = append(pairs, fmt.Sprintf("%s: %s", n, grant))
+		}
+		return fmt.Sprintf("%s: {%s}", field, strings.Join(pairs, ", ")), nil
+	default:
+		return "", fmt.Errorf(
+			"%s: harness %q declares form %q, which this resolver does not render",
+			CapabilityMapFile, harness, form)
+	}
+}

--- a/cli/internal/harness/capability_map_test.go
+++ b/cli/internal/harness/capability_map_test.go
@@ -1,0 +1,240 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveCapabilitiesAgainstShippedMap exercises the resolver against the
+// map the repository actually ships, so a fixture cannot drift away from it.
+func TestResolveCapabilitiesAgainstShippedMap(t *testing.T) {
+	root := repoRootForTest(t)
+	m, err := LoadCapabilityMap(root)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		caps        []string
+		harness     string
+		want        string
+		wantErrSubs []string
+	}{
+		{
+			// An allow-list: what is named is granted, what is not is denied.
+			name:    "claude renders a csv allow-list",
+			caps:    []string{"read", "shell"},
+			harness: "claude",
+			want:    "tools: Read, Glob, Bash",
+		},
+		{
+			// Glob serves both read and search; it must appear once, at the
+			// position its first requester put it.
+			name:    "overlapping natives are deduped, first occurrence wins",
+			caps:    []string{"read", "search"},
+			harness: "claude",
+			want:    "tools: Read, Glob, Grep",
+		},
+		{
+			// A decision map grants without denying, and renders as a YAML flow
+			// mapping so it still fits one frontmatter line.
+			name:    "opencode renders a decision map",
+			caps:    []string{"shell", "web"},
+			harness: "opencode",
+			want:    "permission: {bash: allow, webfetch: allow, websearch: allow}",
+		},
+		{
+			name:    "the whole vocabulary resolves for every declared harness",
+			caps:    []string{"read", "search", "edit", "shell", "web"},
+			harness: "claude",
+			want:    "tools: Read, Glob, Grep, Edit, Write, Bash, WebFetch, WebSearch",
+		},
+		{
+			name:        "an unmapped capability names itself and the harness",
+			caps:        []string{"telepathy"},
+			harness:     "claude",
+			wantErrSubs: []string{"telepathy", "claude"},
+		},
+		{
+			// Absent on purpose, not overlooked: guessing native names would
+			// render a definition granting tools that may not exist.
+			name:        "an undeclared harness names what IS declared",
+			caps:        []string{"read"},
+			harness:     "copilot",
+			wantErrSubs: []string{"copilot", "claude", "opencode"},
+		},
+		{
+			name:        "an empty request refuses rather than granting nothing",
+			caps:        []string{""},
+			harness:     "claude",
+			wantErrSubs: []string{"claude"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveCapabilities(m, tt.caps, tt.harness)
+			if len(tt.wantErrSubs) > 0 {
+				if err == nil {
+					t.Fatalf("expected an error, got %q", got)
+				}
+				if got != "" {
+					t.Errorf("failed resolution returned %q; it must return nothing", got)
+				}
+				for _, sub := range tt.wantErrSubs {
+					if !strings.Contains(err.Error(), sub) {
+						t.Errorf("error does not name %q: %v", sub, err)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got  %q\nwant %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCapabilityMapFailsLoudWhenUnreadable is C15 for this registry: an absent,
+// unschema'd or invalid map errors rather than resolving to a permissive default.
+// An empty capability value is not "no opinion" — for a csv allow-list it is a
+// definition granting nothing.
+func TestCapabilityMapFailsLoudWhenUnreadable(t *testing.T) {
+	shippedSchema := func(t *testing.T) string {
+		t.Helper()
+		b, err := os.ReadFile(filepath.Join(repoRootForTest(t), CapabilityMapSchemaFile))
+		if err != nil {
+			t.Fatalf("read shipped schema: %v", err)
+		}
+		return string(b)
+	}
+
+	tests := []struct {
+		name    string
+		seed    func(t *testing.T) string
+		wantSub string
+	}{
+		{
+			name: "no map at all",
+			seed: func(t *testing.T) string { return t.TempDir() },
+		},
+		{
+			name: "a map with no schema beside it",
+			seed: func(t *testing.T) string {
+				dir := t.TempDir()
+				writeCapFixture(t, dir, CapabilityMapFile, minimalCapabilityMap)
+				return dir
+			},
+		},
+		{
+			name: "a map that is not JSON",
+			seed: func(t *testing.T) string {
+				dir := t.TempDir()
+				writeCapFixture(t, dir, CapabilityMapFile, "{ not json")
+				writeCapFixture(t, dir, CapabilityMapSchemaFile, "{}")
+				return dir
+			},
+		},
+		{
+			// The cross-block rule a stock schema cannot express. It validates
+			// against every standard keyword and would then render a claude
+			// definition missing exactly the tool the persona asked for.
+			name: "a harness that does not cover the whole vocabulary",
+			seed: func(t *testing.T) string {
+				dir := t.TempDir()
+				writeCapFixture(t, dir, CapabilityMapSchemaFile, shippedSchema(t))
+				writeCapFixture(t, dir, CapabilityMapFile, partialCapabilityMap)
+				return dir
+			},
+			wantSub: "shell",
+		},
+		{
+			name: "a harness that maps a verb the vocabulary does not declare",
+			seed: func(t *testing.T) string {
+				dir := t.TempDir()
+				writeCapFixture(t, dir, CapabilityMapSchemaFile, shippedSchema(t))
+				writeCapFixture(t, dir, CapabilityMapFile, extraVerbCapabilityMap)
+				return dir
+			},
+			wantSub: "telepathy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadCapabilityMap(tt.seed(t))
+			if err == nil {
+				t.Fatal("expected an error; an unreadable capability map must never load")
+			}
+			if tt.wantSub != "" && !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error does not name %q: %v", tt.wantSub, err)
+			}
+		})
+	}
+}
+
+// TestShippedCapabilityMapCoversEveryDeclaredHarness is the assertion that would
+// have caught a half-filled registry before it reached a deploy.
+func TestShippedCapabilityMapCoversEveryDeclaredHarness(t *testing.T) {
+	root := repoRootForTest(t)
+	m, err := LoadCapabilityMap(root)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	vocab := toStrings(m["vocabulary"])
+	harnesses, _ := m["harnesses"].(map[string]any)
+	if len(harnesses) == 0 {
+		t.Fatal("shipped map declares no harnesses")
+	}
+	for _, name := range sortedKeys(harnesses) {
+		for _, v := range vocab {
+			line, err := ResolveCapabilities(m, []string{v}, name)
+			if err != nil {
+				t.Errorf("shipped map cannot resolve %q for %q: %v", v, name, err)
+				continue
+			}
+			if strings.TrimSpace(line) == "" {
+				t.Errorf("shipped map resolves %q for %q to an empty line", v, name)
+			}
+		}
+	}
+}
+
+func writeCapFixture(t *testing.T, root, rel, content string) {
+	t.Helper()
+	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+const minimalCapabilityMap = `{
+  "$comment": ["fixture"],
+  "version": 1,
+  "vocabulary": ["read"],
+  "harnesses": {"claude": {"field": "tools", "form": "csv", "capabilities": {"read": ["Read"]}}}
+}`
+
+// Type-correct and schema-valid; only the cross-block coverage rule rejects it.
+const partialCapabilityMap = `{
+  "$comment": ["fixture"],
+  "version": 1,
+  "vocabulary": ["read", "shell"],
+  "harnesses": {"claude": {"field": "tools", "form": "csv", "capabilities": {"read": ["Read"]}}}
+}`
+
+const extraVerbCapabilityMap = `{
+  "$comment": ["fixture"],
+  "version": 1,
+  "vocabulary": ["read"],
+  "harnesses": {"claude": {"field": "tools", "form": "csv", "capabilities": {"read": ["Read"], "telepathy": ["Mind"]}}}
+}`

--- a/harness/capability-map.json
+++ b/harness/capability-map.json
@@ -1,0 +1,105 @@
+{
+  "$comment": [
+    "The compile-time capability registry — the second half of ADR-027 section 2's agnosticism pair,",
+    "whose first half is harness/model-map.json. Shape decided by ADR-035 (shape C: $comment for the",
+    "rationale, version for the consumer cadence, a JSON Schema beside it, and a dotf doctor check).",
+    "Validated by cli/internal/harness/capability_map.go, which reads the schema as data.",
+    "",
+    "NOT EMBEDDED, and for the same reason model-map.json is not: an absent map that resolved to a",
+    "build-time default would grant or deny tool access silently. Constraint C15 — a map that cannot",
+    "be read fails loudly, never as empty and never as a permissive default.",
+    "",
+    "THE NATIVE SHAPES GENUINELY DIFFER, which is why this is a map and not a rename. Verified",
+    "2026-08-22 against the shipping tools rather than assumed:",
+    "",
+    "  claude   frontmatter `tools:` — a comma-separated list of native tool names. An ALLOW-LIST:",
+    "           a tool not named is unavailable to the agent. Read off the installed plugin agents,",
+    "           e.g. `tools: Read, Glob, Grep, Bash, Edit`.",
+    "  opencode agent `permission:` — an object keyed read/edit/glob/grep/list/bash/webfetch/",
+    "           websearch/... with values ask|allow|deny (https://opencode.ai/config.json). A",
+    "           DECISION MAP: a key not named falls back to the config default, so naming a",
+    "           capability says nothing about the rest. opencode's own `tools` field is marked",
+    "           '@deprecated Use permission field instead' in that schema, so mapping onto it would",
+    "           ship a deprecation on day one.",
+    "",
+    "That asymmetry is load-bearing. Naming a capability in an allow-list grants it AND denies",
+    "everything else; naming it in a decision map only grants it. So `form` is declared per harness",
+    "and the resolver renders the complete native value for a capability SET, rather than emitting a",
+    "per-capability token for a caller to concatenate blindly.",
+    "",
+    "GROUPINGS ARE DELIBERATELY GENEROUS. An allow-list that is too narrow denies silently — a Claude",
+    "agent granted `read` but not Glob simply cannot glob, with no error anywhere. That is the inverse",
+    "of the model-tier failure, which is loud once resolved, and it argues for mapping a neutral verb",
+    "onto every native tool a competent implementation of that verb needs.",
+    "",
+    "ABSENT HARNESSES ARE ABSENT ON PURPOSE, not by oversight. `pi` and `agy` are `adapter` harnesses",
+    "in model-map.json (#1162): they take runtime flags and render no definition file, so there is no",
+    "field to put a capability value into. `copilot` renders agent definitions but its native tool",
+    "vocabulary cannot be checked from this machine — the binary is not installed — and #1170 already",
+    "holds the same not-verifiable-here question for its model tier. Declaring guessed native names",
+    "would put a route to nowhere here that validates cleanly, which is the class ADR-035 deleted the",
+    "phantom `codex` pool to avoid."
+  ],
+  "version": 1,
+  "vocabulary": [
+    "read",
+    "search",
+    "edit",
+    "shell",
+    "web"
+  ],
+  "harnesses": {
+    "claude": {
+      "field": "tools",
+      "form": "csv",
+      "why": "Agent frontmatter takes a comma-separated allow-list of native tool names.",
+      "capabilities": {
+        "read": [
+          "Read",
+          "Glob"
+        ],
+        "search": [
+          "Grep",
+          "Glob"
+        ],
+        "edit": [
+          "Edit",
+          "Write"
+        ],
+        "shell": [
+          "Bash"
+        ],
+        "web": [
+          "WebFetch",
+          "WebSearch"
+        ]
+      }
+    },
+    "opencode": {
+      "field": "permission",
+      "form": "decision-map",
+      "grant": "allow",
+      "why": "Agent config takes a permission object, not a tool list; `tools` is deprecated upstream. Declared here with a verified native vocabulary even though opencode is not yet an agents.deploy target, because a registry covering one harness is what makes the pipe neutral by mechanism and single-vendor by data.",
+      "capabilities": {
+        "read": [
+          "read",
+          "list"
+        ],
+        "search": [
+          "grep",
+          "glob"
+        ],
+        "edit": [
+          "edit"
+        ],
+        "shell": [
+          "bash"
+        ],
+        "web": [
+          "webfetch",
+          "websearch"
+        ]
+      }
+    }
+  }
+}

--- a/harness/capability-map.schema.json
+++ b/harness/capability-map.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mlorentedev/dotfiles/harness/capability-map.schema.json",
   "title": "capability-map",
-  "description": "The compile-time capability registry (ADR-027 §2, shaped by ADR-035). Validated by cli/internal/harness/capability_map.go, which reads THIS FILE rather than restating its rules — the contract lives here and only its interpreter lives in Go. The `x-` namespace names cross-block rules implemented in Go: it is a closed set, and one this validator does not implement is a loud error rather than the annotation draft 2020-12 would otherwise make it.",
+  "description": "The compile-time capability registry (ADR-027 §2, shaped by ADR-035). Validated by cli/internal/harness/capability_map.go, which reads THIS FILE rather than restating its rules — the contract lives here and only its interpreter lives in Go. Unlike model-map.schema.json this declares NO `x-` cross-block rule: the one cross-block invariant here (every harness covers the declared vocabulary) is checked in the loader instead. model-map's rule plumbing is a package-level closed set bound to that one schema, and generalising it to per-schema rule sets touches a file hardened over six adversarial review rounds — a refactor that deserves its own deliberate change rather than riding along with a new registry.",
   "type": "object",
   "required": [
     "$comment",
@@ -11,7 +11,6 @@
     "harnesses"
   ],
   "additionalProperties": false,
-  "x-capabilitiesCoverVocabulary": true,
   "properties": {
     "$comment": {
       "description": "The measured rationale, including which native shapes were verified and how. The reasoning is the artifact.",

--- a/harness/capability-map.schema.json
+++ b/harness/capability-map.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mlorentedev/dotfiles/harness/capability-map.schema.json",
+  "title": "capability-map",
+  "description": "The compile-time capability registry (ADR-027 §2, shaped by ADR-035). Validated by cli/internal/harness/capability_map.go, which reads THIS FILE rather than restating its rules — the contract lives here and only its interpreter lives in Go. The `x-` namespace names cross-block rules implemented in Go: it is a closed set, and one this validator does not implement is a loud error rather than the annotation draft 2020-12 would otherwise make it.",
+  "type": "object",
+  "required": [
+    "$comment",
+    "version",
+    "vocabulary",
+    "harnesses"
+  ],
+  "additionalProperties": false,
+  "x-capabilitiesCoverVocabulary": true,
+  "properties": {
+    "$comment": {
+      "description": "The measured rationale, including which native shapes were verified and how. The reasoning is the artifact.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
+    "version": {
+      "description": "The consumer cadence marker. This registry resolves at COMPILE time only — there is no run-time half, unlike model-map.json where `tiers` and `chains` resolve at different times.",
+      "type": "integer"
+    },
+    "vocabulary": {
+      "description": "The neutral capability verbs, taken as given from harness/agent-frontmatter.schema.json. Declared here so a harness block can be checked against it rather than against whatever the first harness happened to list.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]*$"
+      }
+    },
+    "harnesses": {
+      "description": "Per-harness native representation. Only harnesses whose native vocabulary was VERIFIED belong here; a guessed entry validates cleanly and routes nowhere.",
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "field",
+          "form",
+          "capabilities"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "field": {
+            "description": "The native frontmatter/config key the resolved value is written to (claude: tools; opencode: permission).",
+            "type": "string",
+            "pattern": "^\\S+$"
+          },
+          "form": {
+            "description": "How the native value is shaped. `csv` is an ALLOW-LIST of tool names — omitting one denies it. `decision-map` is an object of per-key decisions where an unnamed key falls back to a default, so it grants without denying. The distinction changes what a capability set MEANS, which is why the resolver renders a complete value rather than concatenating per-capability tokens.",
+            "type": "string",
+            "enum": [
+              "csv",
+              "decision-map"
+            ]
+          },
+          "grant": {
+            "description": "For form `decision-map` only: the value written for a granted key (e.g. `allow`). Meaningless for `csv`, where presence is the grant.",
+            "type": "string",
+            "pattern": "^\\S+$"
+          },
+          "why": {
+            "type": "string"
+          },
+          "capabilities": {
+            "description": "Neutral verb -> the native names it needs. Deliberately generous: an allow-list that is too narrow denies silently, with no error anywhere.",
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "pattern": "^\\S+$"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/compile-harness.sh
+++ b/scripts/compile-harness.sh
@@ -332,21 +332,25 @@ render_skill() {
 # the binary KNOWS the subcommand is the only question whose answer does not
 # depend on the arguments it failed to parse. TestHarnessHelpListsResolveTier
 # pins the string this greps for, so the probe cannot rot into always-false.
-dotf_knows_resolve_tier() {
-    local help
+# Generalised over the subcommand name, because there are now two consumers of
+# this file's registries and each needs the same "is the binary new enough"
+# question asked about ITS OWN subcommand. TestHarnessHelpListsSubcommands pins
+# both strings from the Go side.
+dotf_knows_subcommand() {
+    local want="$1" help
     help="$(dotf harness --help 2>/dev/null)" || return 1
     # Matched from a here-string rather than through a pipe. `cmd | grep -q`
     # closes the pipe the moment it matches, and under `set -o pipefail` a
     # producer killed by the resulting SIGPIPE makes the pipeline exit 141 —
     # reporting "too old" for a binary that just proved it is current. No pipe,
     # no such failure mode, and the anchored match is unchanged.
-    grep -q '^[[:space:]]*resolve-tier[[:space:]]' <<<"$help"
+    grep -q "^[[:space:]]*${want}[[:space:]]" <<<"$help"
 }
 
 resolve_model_tier() {
     local tier="$1" agent="$2" out
     type -P dotf >/dev/null 2>&1 || return 2
-    dotf_knows_resolve_tier || return 2
+    dotf_knows_subcommand resolve-tier || return 2
     # The resolver's stderr is deliberately NOT swallowed. It is the only place
     # that distinguishes "this tier declares no model for this harness" from
     # "the map itself is unreadable" — naming the ghost pool, the bad keyword or
@@ -356,10 +360,19 @@ resolve_model_tier() {
     if ! out="$(dotf harness resolve-tier "$tier" --harness "$agent" --repo-root "$REPO_ROOT")"; then
         return 1
     fi
-    # A model id is one non-empty token. Belt and braces behind the probe above:
-    # anything with whitespace in it is not a model id, whatever produced it.
+    # A model id is one non-empty token. Behind the capability probe above, a
+    # whitespace-bearing answer can no longer mean "stale binary printing help" —
+    # the resolver ran and answered, so the defect is in the MAP (#1168). Saying
+    # "dotf is too old" here sent the operator to rebuild a binary that is fine,
+    # while the real fault sat in model-map.json. Exit 3, its own outcome, so the
+    # caller can name the value and the file. The schema permits it because its
+    # non-blank pattern anchors only the first character (#1159).
     case "$out" in
-        ''|*[[:space:]]*) return 2 ;;
+        '') return 2 ;;
+        *[[:space:]]*)
+            printf '[ERROR] %s gives tier "%s" on harness "%s" the id "%s" — a model id is one token with no whitespace\n' \
+                "harness/model-map.json" "$tier" "$agent" "$out" >&2
+            return 3 ;;
     esac
     printf '%s\n' "$out"
 }
@@ -388,12 +401,51 @@ agent_model_line() {
                "$tier" "$agent" >&2
            printf '       %s deploys WITHOUT a model line; install/rebuild dotf and re-run --deploy\n' "$name" >&2
            ;;
+        3) # The map answered with something that is not a model id, and
+           # resolve_model_tier already named the value and the file. Still fatal
+           # (bad data, C15) but never "rebuild dotf".
+           return 1 ;;
         *) # The cause is on the line(s) the resolver already printed: an
            # undeclared tier and an unreadable map both land here, and only it
            # knows which. Point at that rather than asserting a cause this frame
            # cannot tell apart.
            printf '[ERROR] resolving tier "%s" for harness "%s" failed; see the resolver error above\n' \
                "$tier" "$agent" >&2
+           return 1 ;;
+    esac
+}
+
+# Print the frontmatter capability line for one record on one harness, or nothing.
+#
+# Exactly the shape of agent_model_line, one field over, and the same three
+# outcomes for the same reasons: a record declaring no capabilities renders
+# without the field, an unavailable resolver warns and degrades, and only a
+# resolver that ran and refused is fatal.
+#
+# The whole LINE comes back from dotf, field name included, because the native
+# field differs per harness — `tools:` for claude, `permission:` for opencode —
+# and this frame has no business knowing which.
+agent_capability_line() {
+    local record="$1" agent="$2" name="$3" caps rc=0 line
+    caps="$(skill_field "$record" capabilities)"
+    [ -n "$caps" ] || return 0
+    # Strip the YAML flow-sequence brackets: the record writes
+    # `capabilities: [read, search]`, the CLI takes a comma list.
+    caps="${caps#[}"; caps="${caps%]}"; caps="${caps// /}"
+    [ -n "$caps" ] || return 0
+    type -P dotf >/dev/null 2>&1 || rc=2
+    if [ "$rc" -eq 0 ] && ! dotf_knows_subcommand resolve-capabilities; then rc=2; fi
+    if [ "$rc" -eq 0 ]; then
+        line="$(dotf harness resolve-capabilities "$caps" --harness "$agent" --repo-root "$REPO_ROOT")" || rc=1
+    fi
+    case "$rc" in
+        0) printf '%s\n' "$line" ;;
+        2) printf '[WARN] cannot resolve capabilities "%s" for harness "%s": dotf is absent, or predates the resolve-capabilities subcommand\n' \
+               "$caps" "$agent" >&2
+           printf '       %s deploys WITHOUT a capability line; install/rebuild dotf and re-run --deploy\n' "$name" >&2
+           ;;
+        *) printf '[ERROR] resolving capabilities "%s" for harness "%s" failed; see the resolver error above\n' \
+               "$caps" "$agent" >&2
            return 1 ;;
     esac
 }
@@ -415,13 +467,13 @@ agent_model_line() {
 # good record just because the machine running CI has no dotf. Empty renders no
 # model line, which is also what a record declaring no tier produces.
 render_agent() {
-    local record="$1" srcpath="$2" model_line="${3:-}" sha
+    local record="$1" srcpath="$2" model_line="${3:-}" cap_line="${4:-}" sha
     sha="$(sha_of "$record")"
-    awk -v gf="$srcpath" -v gs="$sha" -v ml="$model_line" '
+    awk -v gf="$srcpath" -v gs="$sha" -v ml="$model_line" -v cl="$cap_line" '
         /^---[[:space:]]*$/ {
             fm++
             if (fm==1) { print; print "generated: true"; print "generated_from: " gf; print "generated_sha: " gs; next }
-            if (fm==2) { if (ml != "") print ml; print; next }
+            if (fm==2) { if (ml != "") print ml; if (cl != "") print cl; print; next }
         }
         fm==1 { if ($0 ~ /^(name|description):/) print; next }
         { print }
@@ -792,7 +844,8 @@ deploy_prune() {
 # the Action level, deferred to H-045. Mirrors deploy_skills; agent-md render is
 # a single file. ---
 deploy_agents() {
-    local ag_vsub ag_recdir agent render dir ag_dir name outp tmp_agent model_line
+    local ag_vsub ag_recdir agent render dir ag_dir name outp tmp_agent model_line cap_line
+    local failed=()
     ag_vsub="$(jq -r '.agents.vault_subpath' "$MANIFEST")"
     ag_recdir="$REPO_ROOT/$(jq -r '.agents.record_dir' "$MANIFEST")"
     if [[ ! -d "$ag_recdir" ]]; then
@@ -822,21 +875,39 @@ deploy_agents() {
             outp="$HOME/$dir/$name.md"
             [[ -L "$outp" ]] && rm -f "$outp"
             mkdir -p "$(dirname "$outp")"
-            model_line="$(agent_model_line "$ag_dir/AGENT.md" "$agent" "$name")" || return 1
+            # COLLECT, do not abort (#1169). Returning on the first bad record
+            # left every agent behind it undeployed, for a defect in one — and
+            # which ones those were depended on directory iteration order. The
+            # operator now sees the complete list in a single run, the same
+            # reason `dotf pr triage-queue` reports the whole queue. The exit is
+            # still non-zero, and the message says plainly that some agents DID
+            # deploy, because a non-zero exit that half-succeeded must not read
+            # as "nothing happened".
+            if ! model_line="$(agent_model_line "$ag_dir/AGENT.md" "$agent" "$name")"; then
+                failed+=("$agent/$name"); continue
+            fi
+            if ! cap_line="$(agent_capability_line "$ag_dir/AGENT.md" "$agent" "$name")"; then
+                failed+=("$agent/$name"); continue
+            fi
             tmp_agent="$outp.tmp.$$"
-            if ! render_agent "$ag_dir/AGENT.md" "$ag_vsub/$name/AGENT.md" "$model_line" > "$tmp_agent"; then
+            if ! render_agent "$ag_dir/AGENT.md" "$ag_vsub/$name/AGENT.md" "$model_line" "$cap_line" > "$tmp_agent"; then
                 rm -f "$tmp_agent"
                 printf '[ERROR] agent render failed: %s -> %s\n' "$ag_dir/AGENT.md" "$outp" >&2
-                return 1
+                failed+=("$agent/$name"); continue
             fi
             if ! mv "$tmp_agent" "$outp"; then
                 rm -f "$tmp_agent"
                 printf '[ERROR] could not replace %s\n' "$outp" >&2
-                return 1
+                failed+=("$agent/$name"); continue
             fi
             printf '[deploy] agent -> %s\n' "$outp"
         done
     done < <(jq -r '.agents.deploy[] | "\(.agent)\t\(.render)\t\(.dir)"' "$MANIFEST")
+    if [ "${#failed[@]}" -ne 0 ]; then
+        printf '[ERROR] %s agent record(s) failed to render: %s\n' "${#failed[@]}" "${failed[*]}" >&2
+        printf '        every OTHER agent deployed; re-run --deploy after fixing the records above\n' >&2
+        return 1
+    fi
     # 2. presence-level determinism: inject forced skills into each harness's
     #    always-loaded instructions file (uniform injection — no provider hook).
     if jq -e '.agents.presence' "$MANIFEST" >/dev/null 2>&1; then

--- a/specs/HARNESS-077-capability-map/features.json
+++ b/specs/HARNESS-077-capability-map/features.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "HARNESS-077-capability-map-f1",
+    "behavior": "Outcome 1",
+    "verification": "echo 'not implemented' && exit 1",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/HARNESS-077-capability-map/features.json
+++ b/specs/HARNESS-077-capability-map/features.json
@@ -1,8 +1,92 @@
 [
   {
     "id": "HARNESS-077-capability-map-f1",
-    "behavior": "Outcome 1",
-    "verification": "echo 'not implemented' && exit 1",
+    "behavior": "claude renders a csv allow-list from a neutral capability set",
+    "verification": "cd cli && out=$(go test ./internal/harness/ -run '^TestResolveCapabilitiesAgainstShippedMap$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestResolveCapabilitiesAgainstShippedMap/claude_renders_a_csv_allow-list '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-077-capability-map-f2",
+    "behavior": "opencode renders a decision map from the same neutral request",
+    "verification": "cd cli && out=$(go test ./internal/harness/ -run '^TestResolveCapabilitiesAgainstShippedMap$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestResolveCapabilitiesAgainstShippedMap/opencode_renders_a_decision_map '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-077-capability-map-f3",
+    "behavior": "Overlapping natives are deduped, first occurrence wins",
+    "verification": "cd cli && out=$(go test ./internal/harness/ -run '^TestResolveCapabilitiesAgainstShippedMap$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestResolveCapabilitiesAgainstShippedMap/overlapping_natives_are_deduped,_first_occurrence_wins '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-077-capability-map-f4",
+    "behavior": "An unmapped capability names itself and the harness, returning nothing",
+    "verification": "cd cli && out=$(go test ./internal/harness/ -run '^TestResolveCapabilitiesAgainstShippedMap$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestResolveCapabilitiesAgainstShippedMap/an_unmapped_capability_names_itself_and_the_harness '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-077-capability-map-f5",
+    "behavior": "An undeclared harness names what IS declared rather than resolving to empty",
+    "verification": "cd cli && out=$(go test ./internal/harness/ -run '^TestResolveCapabilitiesAgainstShippedMap$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestResolveCapabilitiesAgainstShippedMap/an_undeclared_harness_names_what_IS_declared '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-077-capability-map-f6",
+    "behavior": "An absent, unschema'd, non-JSON or partially-covering capability map fails rather than defaulting (C15)",
+    "verification": "cd cli && out=$(go test ./internal/harness/ -run '^TestCapabilityMapFailsLoudWhenUnreadable$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestCapabilityMapFailsLoudWhenUnreadable/a_harness_that_does_not_cover_the_whole_vocabulary '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-077-capability-map-f7",
+    "behavior": "A record declaring capabilities deploys native tool names, never the neutral verbs",
+    "verification": "out=$(bats tests/compile-harness.bats -f 'resolves neutral capabilities into the rendered frontmatter' 2>&1) && printf '%s' \"$out\" | grep -qE '^ok [0-9]+ .*resolves neutral capabilities into the rendered frontmatter$'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-077-capability-map-f8",
+    "behavior": "A record declaring no capabilities renders without the field",
+    "verification": "out=$(bats tests/compile-harness.bats -f 'a record declaring no capabilities renders without the field' 2>&1) && printf '%s' \"$out\" | grep -qE '^ok [0-9]+ .*renders without the field$'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-077-capability-map-f9",
+    "behavior": "An unmappable capability fails the deploy without truncating the previous definition",
+    "verification": "out=$(bats tests/compile-harness.bats -f 'an unmappable capability fails the deploy' 2>&1) && printf '%s' \"$out\" | grep -qE '^ok [0-9]+ .*without truncating the definition$'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-077-capability-map-f10",
+    "behavior": "A dotf knowing resolve-tier but not resolve-capabilities warns for that field only",
+    "verification": "out=$(bats tests/compile-harness.bats -f 'knows resolve-tier but not resolve-capabilities' 2>&1) && printf '%s' \"$out\" | grep -qE '^ok [0-9]+ .*warns for that field only$'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-077-capability-map-f11",
+    "behavior": "A whitespace-bearing model id blames the map, not a stale dotf (#1168)",
+    "verification": "out=$(bats tests/compile-harness.bats -f 'BUG-1168' 2>&1) && printf '%s' \"$out\" | grep -qE '^ok [0-9]+ .*blames the map, not a stale dotf$'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-077-capability-map-f12",
+    "behavior": "A bad record does not block the agents behind it, and every failure is named in one run (#1169)",
+    "verification": "out=$(bats tests/compile-harness.bats -f 'DESIGN-1169: a bad record' 2>&1) && printf '%s' \"$out\" | grep -qE '^ok [0-9]+ .*does not block the agents behind it$'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-077-capability-map-f13",
+    "behavior": "The real dotf binary proves the two native forms differ and satisfies the capability probe",
+    "verification": "out=$(bats tests/compile-harness-real.bats 2>&1) && printf '%s' \"$out\" | grep -qE '^ok [0-9]+ real dotf: the two native forms really do differ$'",
     "state": "pending",
     "evidence": ""
   }

--- a/specs/HARNESS-077-capability-map/proposal.md
+++ b/specs/HARNESS-077-capability-map/proposal.md
@@ -1,7 +1,7 @@
 ---
 id: "HARNESS-077-capability-map"
 type: spec
-status: draft # draft | implementing | verifying | archived
+status: implementing # draft | implementing | verifying | archived
 created: "2026-08-22"
 issue: "mlorentedev/dotfiles#560"   # repo#NNN — GitHub issue / Project item that tracks this spec
 tags: [spec, proposal, harness, agents, capabilities, agnosticism]
@@ -58,6 +58,15 @@ rather than a per-capability token the render concatenates blindly.
 - Runtime permission enforcement. This renders a declaration; nothing here checks what a running
   agent actually does.
 - `chains`, the dispatcher, `dotf agent run`. Untouched, still level-2 work.
+- **The `dotf doctor` check over this registry**, and #1164's check that a record's declared tier
+  agrees with `model-map.json`. Both are diagnostics over registries rather than parts of the
+  render, they live in the same `cli/internal/doctor/` neighbourhood, and folding them in pushed
+  this diff past ADR-017's ~300-line atomic cap. They ship together as the immediate follow-up.
+- **Unifying the schema custom-rule plumbing.** `model-map`'s `customRules` is a package-level
+  closed set bound to one schema, so a second registry cannot declare an `x-` rule without a
+  refactor of a file hardened over six adversarial review rounds. This registry's one cross-block
+  invariant runs in its loader instead, and the refactor is filed separately so it is deliberate
+  rather than a side effect.
 
 ## Risks / open questions
 
@@ -80,22 +89,20 @@ rather than a per-capability token the render concatenates blindly.
 
 ## Acceptance criteria
 
-- [ ] `dotf harness resolve-capabilities read,search,edit,shell --harness claude` prints a
+- [x] `dotf harness resolve-capabilities read,search,edit,shell --harness claude` prints a
       `tools:`-ready value naming the native Claude tools, exit 0, nothing on stderr.
-- [ ] The same for `--harness opencode` prints its `permission:` object form.
-- [ ] An undeclared capability exits non-zero naming the capability and the harness, and prints
+- [x] The same for `--harness opencode` prints its `permission:` object form.
+- [x] An undeclared capability exits non-zero naming the capability and the harness, and prints
       nothing to stdout.
-- [ ] A harness the map does not cover exits non-zero naming it, rather than resolving to empty.
-- [ ] An absent or schema-invalid `harness/capability-map.json` fails rather than defaulting (C15).
-- [ ] `curator` declaring `capabilities: [read, search, edit, shell]` deploys a `curator.md` whose
+- [x] A harness the map does not cover exits non-zero naming it, rather than resolving to empty.
+- [x] An absent or schema-invalid `harness/capability-map.json` fails rather than defaulting (C15).
+- [x] `curator` declaring `capabilities: [read, search, edit, shell]` deploys a `curator.md` whose
       frontmatter carries the resolved `tools:` line alongside `name`, `description`, `model` and
       `generated_*`.
-- [ ] A record declaring no `capabilities` renders without the field, unchanged.
-- [ ] An absent or too-old `dotf` warns and renders without the field rather than failing the
+- [x] A record declaring no `capabilities` renders without the field, unchanged.
+- [x] An absent or too-old `dotf` warns and renders without the field rather than failing the
       harness deploy, matching #1165.
-- [ ] `dotf doctor` reports on the registry — present, parseable, schema-valid — as it does for
-      `model-map.json`.
-- [ ] Go table tests for the resolver, bats for the render and both degradation shapes, and a
+- [x] Go table tests for the resolver, bats for the render and both degradation shapes, and a
       real-binary case in `tests/compile-harness-real.bats`.
 
 ## References

--- a/specs/HARNESS-077-capability-map/proposal.md
+++ b/specs/HARNESS-077-capability-map/proposal.md
@@ -1,0 +1,111 @@
+---
+id: "HARNESS-077-capability-map"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-22"
+issue: "mlorentedev/dotfiles#560"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, harness, agents, capabilities, agnosticism]
+template_version: "1.0"
+---
+
+# HARNESS-077-capability-map
+
+## Why
+
+`harness/agents/curator/AGENT.md` declares `capabilities: [read, search, edit, shell]` and the
+deployed `~/.claude/agents/curator.md` carries none of it — `render_agent` drops the field. That is
+*exactly* the state `model:` was in before #1165: a neutral declaration nothing reads, promised by
+`harness/agent-frontmatter.schema.json` and not kept.
+
+It is also the half of ADR-027 §2's agnosticism pair that never shipped. #1165 built the compile-time
+consumer for the model tier; this is the same seam, one field over. Until it exists, a persona's
+declared capabilities are decoration, and every harness gets whatever tool access it defaults to.
+
+## What
+
+The neutral capability vocabulary a persona declares reaches the file the harness actually loads.
+
+`harness/capability-map.json` maps each neutral capability to each harness's native representation.
+`dotf harness resolve-capabilities <cap>[,<cap>…] --harness <name>` answers with that harness's
+rendered value, read through a validated loader. `render_agent` emits it, exactly as it now emits
+the resolved `model:` line.
+
+**The map's value is per-harness and shaped for that harness, because the natives genuinely differ.**
+Verified 2026-08-22 against the shipping tools, not assumed:
+
+| Harness | Field | Shape | Semantics |
+|---|---|---|---|
+| `claude` | `tools:` | comma-separated native tool names — `Read, Glob, Grep, Bash, Edit` | **allow-list**: a tool not named is unavailable |
+| `opencode` | `permission:` | object keyed `read`/`edit`/`glob`/`grep`/`list`/`bash`/`webfetch`/`websearch`/… with values `ask`\|`allow`\|`deny` | **decision map**: an unnamed key falls back to the config default |
+
+`opencode`'s `tools` field exists but its own schema marks it *"@deprecated Use 'permission' field
+instead"*, so mapping onto it would ship a deprecation on day one.
+
+**That asymmetry is the whole reason this is a map and not a rename.** Naming a capability in an
+allow-list grants it and denies the rest; naming it in a decision map grants it and says nothing
+about the rest. So the map declares the *complete* native value for a capability set, per harness,
+rather than a per-capability token the render concatenates blindly.
+
+## Out of scope
+
+- Harnesses whose native representation is not verifiable from this machine. `copilot` is not
+  installed (#1170 already holds its model-tier half); `pi` and `agy` are `adapter` harnesses that
+  take runtime flags, not rendered definitions (#1162). Declaring guessed native names would put a
+  route to nowhere into the map that validates cleanly — the class ADR-035 deleted the phantom
+  `codex` pool to avoid.
+- Changing the neutral vocabulary itself. `[read, search, edit, shell, web]` comes from
+  `harness/agent-frontmatter.schema.json` and is taken as given.
+- Runtime permission enforcement. This renders a declaration; nothing here checks what a running
+  agent actually does.
+- `chains`, the dispatcher, `dotf agent run`. Untouched, still level-2 work.
+
+## Risks / open questions
+
+- **`opencode` has no agent-definition deploy target today.** `manifest.json`'s `agents.deploy`
+  holds one entry (`claude`), and opencode receives only a presence-injected instructions file. So
+  the opencode column is declared and unexercised by any deploy until that set grows. It is
+  included anyway because the whole complaint against the current state is that the pipe is neutral
+  by mechanism and Claude-only by data — declaring a second harness with a *verified* native shape
+  is the cheapest honest step against that, and it is what makes the per-harness-shape decision
+  above concrete rather than theoretical.
+- **An allow-list that is wrong denies silently.** If `read` maps to `Read` but the persona also
+  needs `Glob`, the deployed Claude agent simply cannot glob, with no error anywhere. This is the
+  inverse of the model failure #1165 fixed (which was loud once resolved) and it argues for
+  generous, explicitly-reasoned capability groupings rather than minimal ones.
+- **Failure semantics are inherited, not re-decided.** #1165 established the split and it applies
+  unchanged: an unmappable capability or an unreadable map **fails the render** (C15); an absent or
+  too-old `dotf` **warns and degrades** to the prior behaviour, because that is a bootstrap state.
+  The capability probe from #1165 (`dotf harness --help`) generalises — it must name this
+  subcommand too, pinned from the Go side.
+
+## Acceptance criteria
+
+- [ ] `dotf harness resolve-capabilities read,search,edit,shell --harness claude` prints a
+      `tools:`-ready value naming the native Claude tools, exit 0, nothing on stderr.
+- [ ] The same for `--harness opencode` prints its `permission:` object form.
+- [ ] An undeclared capability exits non-zero naming the capability and the harness, and prints
+      nothing to stdout.
+- [ ] A harness the map does not cover exits non-zero naming it, rather than resolving to empty.
+- [ ] An absent or schema-invalid `harness/capability-map.json` fails rather than defaulting (C15).
+- [ ] `curator` declaring `capabilities: [read, search, edit, shell]` deploys a `curator.md` whose
+      frontmatter carries the resolved `tools:` line alongside `name`, `description`, `model` and
+      `generated_*`.
+- [ ] A record declaring no `capabilities` renders without the field, unchanged.
+- [ ] An absent or too-old `dotf` warns and renders without the field rather than failing the
+      harness deploy, matching #1165.
+- [ ] `dotf doctor` reports on the registry — present, parseable, schema-valid — as it does for
+      `model-map.json`.
+- [ ] Go table tests for the resolver, bats for the render and both degradation shapes, and a
+      real-binary case in `tests/compile-harness-real.bats`.
+
+## References
+
+- Bitácora board: mlorentedev/dotfiles#560 (re-scoped to this half by ADR-035 decision 1)
+- `docs/adr/adr-027-cross-harness-agent-pipeline.md` §2 — the agnosticism pair this completes
+- `docs/adr/adr-035-model-map-routing-registry.md` — shape C (`$comment` + `version` + schema +
+  doctor check), the precedent this follows
+- `specs/archive/HARNESS-076-model-map-tier-render/` — the seam this mirrors, one field over
+- Native formats verified 2026-08-22: Claude Code agent frontmatter `tools:` (installed plugin
+  agents); opencode `permission:` enum `ask|allow|deny` and `tools` deprecation
+  (https://opencode.ai/config.json)
+- Related: #1170 (copilot's model half, same not-verifiable-here reason), #1162 (adapter harnesses)

--- a/specs/HARNESS-077-capability-map/tasks.md
+++ b/specs/HARNESS-077-capability-map/tasks.md
@@ -1,0 +1,60 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-22"
+---
+
+# Tasks - HARNESS-077-capability-map
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers** (optional, additive — borrowed from `github/spec-kit`, adapt-not-adopt per #141):
+> - `[P]` — this task has **no dependency on another unchecked task**, so it is safe to run in parallel (fan out to a `Workflow`, or just batch). TDD chains (test → implement → refactor of the *same* behavior) are sequential and must NOT carry `[P]`; independent behaviors can.
+> - `[AC<n>]` — this task helps satisfy **acceptance criterion #`<n>`** from `proposal.md`. Lets `/spec check` map coverage deterministically; omit it and the check falls back to semantic judgment.
+
+## Setup
+
+- [ ] Branch created from main: `feat/HARNESS-077-capability-map`
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+> Replace these with the actual steps for this feature. Keep them small (one commit each) and in TDD order.
+> The `[P]` / `[AC<n>]` markers are optional — see the legend above. Behaviors 1 and 2 below are independent, so their *first* test task carries `[P]`.
+
+- [ ] [P] [AC1] Write failing test for <behavior 1>
+- [ ] [AC1] Implement <module/function> to make it pass
+- [ ] Refactor for clarity (extract, rename, dedupe)
+- [ ] [P] [AC2] Write failing test for <behavior 2>
+- [ ] [AC2] Implement to make it pass
+- [ ] ...
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
+- [ ] Type checks pass
+- [ ] Lint passes
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
+
+Minimal `features.json` skeleton (drop into `<repo>/specs/HARNESS-077-capability-map/features.json`):
+
+```json
+[
+  {
+    "id": "HARNESS-077-capability-map-f1",
+    "behavior": "<one-line copy of an acceptance criterion>",
+    "verification": "<single shell command; exit 0 means pass>",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/HARNESS-077-capability-map/tasks.md
+++ b/specs/HARNESS-077-capability-map/tasks.md
@@ -13,48 +13,40 @@ created: "2026-08-22"
 
 ## Setup
 
-- [ ] Branch created from main: `feat/HARNESS-077-capability-map`
-- [ ] `proposal.md` is complete and acceptance criteria are testable
-- [ ] No open questions left in `proposal.md` "Risks / open questions"
+- [x] Branch created from main: `feat/capability-map`
+- [x] `proposal.md` complete, acceptance criteria testable
+- [x] No open questions left — the two native shapes were verified against the shipping tools, and
+      the scope cut (doctor checks, rule-plumbing refactor) is recorded in Out of scope with reasons
 
 ## Implementation
 
-> Replace these with the actual steps for this feature. Keep them small (one commit each) and in TDD order.
-> The `[P]` / `[AC<n>]` markers are optional — see the legend above. Behaviors 1 and 2 below are independent, so their *first* test task carries `[P]`.
-
-- [ ] [P] [AC1] Write failing test for <behavior 1>
-- [ ] [AC1] Implement <module/function> to make it pass
-- [ ] Refactor for clarity (extract, rename, dedupe)
-- [ ] [P] [AC2] Write failing test for <behavior 2>
-- [ ] [AC2] Implement to make it pass
-- [ ] ...
+- [x] [AC5] Failing Go test: an absent / unschema'd / non-JSON / partial-coverage map all refuse
+- [x] [AC5] `capability_map.go`: loader + `ValidateCapabilityMap` + `checkVocabularyCoverage`
+- [x] [AC1][AC2] Failing Go table test: `csv` renders an allow-list, `decision-map` a flow mapping
+- [x] [AC1][AC2] `ResolveCapabilities` — resolves a SET, returns the whole frontmatter line
+- [x] [AC3][AC4] Failing Go test: unmapped capability and undeclared harness each name themselves
+- [x] [AC3][AC4] Return the loader's phrasing unchanged; do not re-wrap
+- [x] `dotf harness resolve-capabilities` wired under `dotf harness`
+- [x] Generalise the shell capability probe over the subcommand name; retarget the Go tripwire test
+      at BOTH subcommands, since each field probes independently
+- [x] [AC6] Failing bats: `capabilities: [read, search, edit]` renders native `tools:`
+- [x] [AC6] `agent_capability_line` + `render_agent` emits it
+- [x] [AC7] Failing bats: a record declaring no capabilities renders without the field
+- [x] [AC8] Failing bats: a dotf knowing resolve-tier but not resolve-capabilities warns for that
+      field only, and the model line still resolves
+- [x] #1168: a whitespace-bearing model id blames the map, not a stale dotf (own exit status)
+- [x] #1169: collect failing records and report them all, instead of aborting on the first
+- [x] [AC9] Real-binary cases in `tests/compile-harness-real.bats`, including that the two native
+      forms genuinely differ
 
 ## Closing
 
-- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
-- [ ] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
-- [ ] Type checks pass
-- [ ] Lint passes
-- [ ] No unrelated changes in the diff (no scope creep)
-- [ ] `verification.md` filled in
-- [ ] PR opened referencing this spec folder
-
-## Machine-readable features
-
-This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
-
-**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
-
-Minimal `features.json` skeleton (drop into `<repo>/specs/HARNESS-077-capability-map/features.json`):
-
-```json
-[
-  {
-    "id": "HARNESS-077-capability-map-f1",
-    "behavior": "<one-line copy of an acceptance criterion>",
-    "verification": "<single shell command; exit 0 means pass>",
-    "state": "pending",
-    "evidence": ""
-  }
-]
-```
+- [x] Every acceptance criterion covered by at least one test
+- [x] `features.json` entries propagate the runner's exit status and pin tests by unique name
+- [x] `go build` / `go vet` / `GOOS=windows go vet` / `go test ./...` green
+- [x] `golangci-lint run` -> 0 issues at the `versions.conf` pin; `gofmt` clean
+- [x] `shellcheck --severity=error` (CI's level) clean; `bash -n` and `zsh -n` clean
+- [x] `bats tests/*.bats` -> 1429 passing, 0 failing
+- [x] Scope kept to one idea; the doctor checks and the rule-plumbing refactor are filed, not folded
+- [x] `verification.md` filled in with this session's output
+- [x] PR opened referencing this spec folder

--- a/specs/HARNESS-077-capability-map/verification.md
+++ b/specs/HARNESS-077-capability-map/verification.md
@@ -7,36 +7,73 @@ created: "2026-08-22"
 
 ## Evidence
 
-Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+Every acceptance criterion maps to a named test in `features.json`, and all 13 verifier commands
+were executed in this session. AC1-AC5 are Go table tests over the SHIPPED map (not a fixture, so
+it cannot drift from what deploys); AC6-AC8 are bats over the real script; AC9 is the real-binary
+sibling suite.
 
-- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+The two claims worth singling out, because the whole registry rests on them:
+
+- **The native forms genuinely differ**, from the same neutral request. `shell` resolves to
+  `tools: Bash` for claude and `permission: {bash: allow}` for opencode. Asserted against the real
+  binary in `tests/compile-harness-real.bats` "the two native forms really do differ".
+- **The end-to-end payoff.** `curator` declares `capabilities: [read, search, edit]`; the deployed
+  `curator.md` now carries `tools: Read, Glob, Bash` alongside `model: opus`, and no `capabilities:`
+  line. Before this change it carried neither.
 
 ## Test status
 
-- Test suite: `<command> -> <output / coverage %>`
-- Manual smoke test: what was exercised, what was observed
-- No regressions in existing test suite: yes / no (if no, document)
+Run in this session, in this worktree:
+
+- `go build ./... && go vet ./... && GOOS=windows go vet ./... && go test ./...` -> clean
+- `golangci-lint run` -> `0 issues.` (v2.12.2, matching the `versions.conf` pin); `gofmt` clean
+  apart from `internal/doctor/report.go`, which is #1154, pre-existing on main and untouched
+- `shellcheck --severity=error scripts/*.sh setup-linux.sh` -> exit 0 (CI's own severity; the
+  info-level notes on setup-linux.sh are pre-existing and are #1083)
+- `bash -n` and `zsh -n` on `compile-harness.sh` -> clean
+- `./scripts/check-bats-names.sh tests/` -> clean
+- `bats tests/*.bats` -> **1429 passing, 0 failing**
+- All 13 `features.json` verifiers executed and passing; each propagates the runner's exit status
+  and pins its test by unique NAME rather than by `ok N` position (lesson 217, and the round-1
+  review finding on #1165)
 
 ## Decisions made during implementation
 
-Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
-
--
--
+- **The resolver takes a capability SET, not one capability.** A `csv` field is an allow-list —
+  naming a tool grants it and omitting one denies it — while a `decision-map` grants without
+  denying. A per-capability API would push that distinction onto every caller, and the shell caller
+  is the one least able to carry it. So the map returns the complete native value for a set.
+- **The resolver returns the WHOLE frontmatter line**, field name included, because the field
+  differs per harness (`tools:` vs `permission:`) and the render has no business knowing which.
+  This differs deliberately from `resolve-tier`, where the field is always `model:`.
+- **No `x-` cross-block rule for this schema.** `model-map`'s `customRules` is a package-level
+  closed set bound to one schema, and `TestShippedSchemaDeclaresEveryCustomRule` asserts that
+  schema declares every rule in it — so a second registry cannot declare one without refactoring a
+  file hardened over six adversarial review rounds. The one cross-block invariant here
+  (`checkVocabularyCoverage`) runs in the loader instead. Refactoring that plumbing as a side
+  effect of adding a registry is exactly the kind of drive-by change that destabilises hardened
+  code, so it is filed separately.
+- **The capability probe was generalised over the subcommand name.** With two registry consumers,
+  each field must probe independently — a binary new enough for one and not the other is the
+  realistic staleness shape, and it now degrades only the field it cannot resolve. The Go tripwire
+  test was retargeted at both names accordingly.
+- **Scope was cut to hold ADR-017's atomic-PR cap.** The `dotf doctor` check over this registry and
+  #1164's record-vs-map tier check both live in `cli/internal/doctor/`, are diagnostics rather than
+  parts of the render, and pushed the production diff past ~300 lines. They ship together as the
+  immediate follow-up rather than being dropped.
 
 ## Promotion candidates
 
-Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
-
-- [ ] Lesson for the repo's `docs/lessons/`? <yes / no - one line of what>
-- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
-- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+- [ ] Lesson for `docs/lessons/`? no - the transferable finding here (allow-list vs decision-map
+      changes what a partial answer MEANS) is recorded in the registry's own `$comment`, which is
+      where a future reader of the map will actually look.
+- [ ] ADR-worthy? no - ADR-027 §2 already decided this map exists and ADR-035 decided its shape.
+- [ ] Vault pattern? no - single-project so far.
 
 ## Archive checklist
 
 - [ ] `proposal.md` frontmatter set to `status: archived`
-- [ ] Folder moved: `specs/HARNESS-077-capability-map/` -> `specs/archive/HARNESS-077-capability-map/`
-- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
-- [ ] Promotions above executed (if any)
+- [ ] Folder moved to `specs/archive/HARNESS-077-capability-map/`
+- [ ] Bitacora #560 closed with the PR link
+- [ ] `/adversarial-review HARNESS-077-capability-map` run and PASSing (the archive gate refuses
+      without a fresh review signed by a model in `harness/reviewer-pool.json`)

--- a/specs/HARNESS-077-capability-map/verification.md
+++ b/specs/HARNESS-077-capability-map/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-22"
+---
+
+# Verification - HARNESS-077-capability-map
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons/`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/HARNESS-077-capability-map/` -> `specs/archive/HARNESS-077-capability-map/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)

--- a/tests/compile-harness-real.bats
+++ b/tests/compile-harness-real.bats
@@ -71,6 +71,47 @@ setup() {
     done < <(jq -r '.agents.deploy[].agent' "$REPO/harness/manifest.json")
 }
 
+@test "real dotf: harness --help lists resolve-capabilities too" {
+    run "$DOTF" harness --help
+    [ "$status" -eq 0 ]
+    # The render probes for each subcommand independently, so both names must be
+    # listed in the shape scripts/compile-harness.sh greps for.
+    printf '%s\n' "$output" | grep -qE '^[[:space:]]*resolve-capabilities[[:space:]]'
+}
+
+@test "real dotf: resolve-capabilities writes the whole frontmatter line to stdout" {
+    run bash -c "'$DOTF' harness resolve-capabilities read,shell --harness claude --repo-root '$REPO' 2>/dev/null"
+    [ "$status" -eq 0 ]
+    # field name included: the shell must not have to know it differs per harness
+    [ "$output" = "tools: Read, Glob, Bash" ]
+}
+
+@test "real dotf: the two native forms really do differ" {
+    # The claim the whole registry rests on. claude renders an allow-list, and
+    # opencode a decision map, from the SAME neutral request.
+    run bash -c "'$DOTF' harness resolve-capabilities shell --harness claude --repo-root '$REPO' 2>/dev/null"
+    [ "$status" -eq 0 ]
+    [ "$output" = "tools: Bash" ]
+    run bash -c "'$DOTF' harness resolve-capabilities shell --harness opencode --repo-root '$REPO' 2>/dev/null"
+    [ "$status" -eq 0 ]
+    [ "$output" = "permission: {bash: allow}" ]
+}
+
+@test "real dotf: the shipped capability map answers every verb every agent record declares" {
+    local rec caps agent
+    while IFS= read -r agent; do
+        for rec in "$REPO"/harness/agents/*/AGENT.md; do
+            [ -f "$rec" ] || continue
+            caps="$(awk '/^---[[:space:]]*$/{n++; next} n==1 && /^capabilities:/{sub(/^capabilities:[[:space:]]*/,""); print; exit} n>=2{exit}' "$rec")"
+            [ -n "$caps" ] || continue
+            caps="${caps#[}"; caps="${caps%]}"; caps="${caps// /}"
+            run "$DOTF" harness resolve-capabilities "$caps" --harness "$agent" --repo-root "$REPO"
+            [ "$status" -eq 0 ]
+            [ -n "$output" ]
+        done
+    done < <(jq -r '.agents.deploy[].agent' "$REPO/harness/manifest.json")
+}
+
 @test "real dotf: a full deploy renders the resolved model id into the agent file" {
     # End to end through the real script and the real binary: the claim the stub
     # suite can only approximate.
@@ -83,5 +124,8 @@ setup() {
     # curator declares `model: top`; claude's top tier is opus
     grep -q '^model: opus' "$F"
     ! grep -q '^model: top' "$F"
+    # and its neutral capabilities became native tool names
+    grep -qE '^tools: .*Read' "$F"
+    ! grep -q '^capabilities:' "$F"
     rm -rf "$FAKEHOME"
 }

--- a/tests/compile-harness.bats
+++ b/tests/compile-harness.bats
@@ -68,10 +68,20 @@ seed_dotf_stub() {
 # The capability probe: the render greps this for the subcommand name to decide
 # whether the binary is new enough. cli/internal/cmd pins the real help's shape.
 if [ "$1 $2" = "harness --help" ]; then
-    printf 'Available Commands:\n  resolve-tier  Resolve a neutral model tier\n  triggers      x\n'
+    printf 'Available Commands:\n  resolve-tier          Resolve a neutral model tier\n  resolve-capabilities  Resolve neutral capabilities\n  triggers              x\n'
     exit 0
 fi
-# Only the one subcommand the render calls; anything else is a test bug.
+if [ "$1 $2" = "harness resolve-capabilities" ]; then
+    if [ -n "${STUB_CAP_LINE-unset}" ] && [ "${STUB_CAP_LINE-unset}" != "unset" ]; then
+        printf '%s\n' "$STUB_CAP_LINE"; exit 0
+    fi
+    if [ "${STUB_CAP_LINE-unset}" = "unset" ]; then
+        printf 'tools: Read, Glob, Bash\n'; exit 0
+    fi
+    printf 'capability "%s" is not mapped for harness "%s"\n' "$3" "$5" >&2
+    exit 1
+fi
+# Only the subcommands the render calls; anything else is a test bug.
 [ "$1 $2" = "harness resolve-tier" ] || { printf 'stub: unexpected: %s\n' "$*" >&2; exit 127; }
 if [ -n "${STUB_TIER_MODEL:-}" ]; then
     printf '%s\n' "$STUB_TIER_MODEL"
@@ -350,7 +360,8 @@ EOF
 # A test that wants the unresolvable path sets STUB_TIER_MODEL="" before calling.
 run_deploy() {
     run env HOME="$FAKEHOME" PATH="${DEPLOY_PATH:-${STUB_BIN:-}:$PATH}" \
-        STUB_TIER_MODEL="${STUB_TIER_MODEL-opus}" "$SCRIPT" --deploy
+        STUB_TIER_MODEL="${STUB_TIER_MODEL-opus}" \
+        STUB_CAP_LINE="${STUB_CAP_LINE-unset}" "$SCRIPT" --deploy
 }
 
 @test "render: --refresh stamps the committed record with its own provenance (HARNESS-069), no \$HOME write" {
@@ -1020,6 +1031,130 @@ EOF
     # deploy_skills runs BEFORE deploy_agents, so a failed agent render must not
     # cost the skills their deploy — the ordering in cmd_deploy is load-bearing
     [ -f "$FAKEHOME/.claude/skills/demo-skill/SKILL.md" ]
+}
+
+@test "agents: --deploy resolves neutral capabilities into the rendered frontmatter" {
+    seed_agents_fixture
+    run_refresh; [ "$status" -eq 0 ]
+    run_deploy; [ "$status" -eq 0 ]
+    F="$FAKEHOME/.claude/agents/curator.md"
+    # the record declares `capabilities: [read, search, edit]`; the deployed file
+    # must carry the harness's NATIVE tool names, never the neutral verbs
+    grep -q '^tools: Read, Glob, Bash' "$F"
+    ! grep -qE '^capabilities:' "$F"
+    [ "$(grep -c '^tools:' "$F")" -eq 1 ]
+}
+
+@test "agents: a record declaring no capabilities renders without the field" {
+    seed_agents_fixture
+    sed -i '/^capabilities: /d' "$VAULT/00_meta/agents/definitions/curator/AGENT.md"
+    run_refresh; [ "$status" -eq 0 ]
+    run_deploy; [ "$status" -eq 0 ]
+    F="$FAKEHOME/.claude/agents/curator.md"
+    [ -f "$F" ]
+    ! grep -q '^tools:' "$F"
+    # the model line is independent and must still be there
+    grep -q '^model: opus' "$F"
+}
+
+@test "agents: an unmappable capability fails the deploy without truncating the definition" {
+    seed_agents_fixture
+    run_refresh; [ "$status" -eq 0 ]
+    run_deploy; [ "$status" -eq 0 ]
+    F="$FAKEHOME/.claude/agents/curator.md"
+    STUB_CAP_LINE="" run_deploy
+    [ "$status" -ne 0 ]
+    [[ "$output" == *capabilit* ]]
+    # the previous definition survives, same guarantee as the tier path
+    [ -s "$F" ]
+    grep -q '^tools: Read, Glob, Bash' "$F"
+}
+
+@test "agents: a dotf that knows resolve-tier but not resolve-capabilities warns for that field only" {
+    seed_agents_fixture
+    run_refresh; [ "$status" -eq 0 ]
+    # The realistic staleness shape once two subcommands exist: a binary new
+    # enough for one and not the other. Each field probes independently, so the
+    # model line must still resolve.
+    cat > "$STUB_BIN/dotf" <<'HALF'
+#!/usr/bin/env bash
+if [ "$1 $2" = "harness --help" ]; then
+    printf 'Available Commands:\n  resolve-tier  Resolve a neutral model tier\n'
+    exit 0
+fi
+[ "$1 $2" = "harness resolve-tier" ] || { printf 'Error: unknown flag\n' >&2; exit 1; }
+printf 'opus\n'
+HALF
+    chmod +x "$STUB_BIN/dotf"
+    run_deploy
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"predates the resolve-capabilities"* ]]
+    F="$FAKEHOME/.claude/agents/curator.md"
+    grep -q '^model: opus' "$F"
+    ! grep -q '^tools:' "$F"
+}
+
+@test "BUG-1168: a whitespace-bearing model id blames the map, not a stale dotf" {
+    seed_agents_fixture
+    run_refresh; [ "$status" -eq 0 ]
+    # The resolver ran and answered; the answer is just not a model id. Reporting
+    # "dotf is too old" sent the operator to rebuild a binary that was fine.
+    STUB_TIER_MODEL="opus 4" run_deploy
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"model-map.json"* ]]
+    [[ "$output" == *"opus 4"* ]]
+    [[ "$output" != *"predates the resolve-tier"* ]]
+}
+
+@test "DESIGN-1169: a bad record does not block the agents behind it" {
+    seed_agents_fixture
+    # a second persona on a DIFFERENT tier, so the stub can refuse exactly one
+    mkdir -p "$VAULT/00_meta/agents/definitions/scribe"
+    printf -- '---\nname: scribe\ndescription: second persona.\nkind: invocable\nmodel: mid\n---\n\n# Scribe\n' \
+        > "$VAULT/00_meta/agents/definitions/scribe/AGENT.md"
+    run_refresh; [ "$status" -eq 0 ]
+    cat > "$STUB_BIN/dotf" <<'ONEBAD'
+#!/usr/bin/env bash
+if [ "$1 $2" = "harness --help" ]; then
+    printf 'Available Commands:\n  resolve-tier          x\n  resolve-capabilities  x\n'
+    exit 0
+fi
+if [ "$1 $2" = "harness resolve-capabilities" ]; then printf 'tools: Read\n'; exit 0; fi
+if [ "$1 $2" = "harness resolve-tier" ]; then
+    # refuse `mid` only: scribe fails, curator (top) resolves
+    [ "$3" = "mid" ] && { printf 'tier "mid" declares no model for harness "claude"\n' >&2; exit 1; }
+    printf 'opus\n'; exit 0
+fi
+exit 127
+ONEBAD
+    chmod +x "$STUB_BIN/dotf"
+    run_deploy
+    # non-zero, because one record genuinely failed
+    [ "$status" -ne 0 ]
+    # ...and the GOOD record still deployed. Before #1169 this depended on
+    # directory iteration order: `curator` sorts before `scribe`, so aborting on
+    # the first failure would have left curator deployed and any record after
+    # scribe silently skipped.
+    [ -f "$FAKEHOME/.claude/agents/curator.md" ]
+    grep -q '^model: opus' "$FAKEHOME/.claude/agents/curator.md"
+    # the failing one wrote nothing, not even a truncated file
+    [ ! -f "$FAKEHOME/.claude/agents/scribe.md" ]
+    [[ "$output" == *scribe* ]]
+}
+
+@test "DESIGN-1169: every failing record is named in one run, not just the first" {
+    seed_agents_fixture
+    mkdir -p "$VAULT/00_meta/agents/definitions/scribe"
+    printf -- '---\nname: scribe\ndescription: second persona.\nkind: invocable\nmodel: top\n---\n\n# Scribe\n' \
+        > "$VAULT/00_meta/agents/definitions/scribe/AGENT.md"
+    run_refresh; [ "$status" -eq 0 ]
+    STUB_TIER_MODEL="" run_deploy
+    [ "$status" -ne 0 ]
+    # BOTH records appear, so one deploy tells the operator the whole story
+    [[ "$output" == *curator* ]]
+    [[ "$output" == *scribe* ]]
+    # and the summary says plainly that this was not an all-or-nothing failure
+    [[ "$output" == *"every OTHER agent deployed"* ]]
 }
 
 @test "agents: --deploy injects a presence region (forced skills) into every harness instructions file" {


### PR DESCRIPTION
Closes #560, #1168, #1169. Spec: `specs/HARNESS-077-capability-map/`. Third in the sequence after #1165 (tier render) and #1171 (the `agy` contradiction it exposed).

## The gap

```
harness/agents/curator/AGENT.md     ~/.claude/agents/curator.md  (before)
  model: top                    ->    model: opus        # #1165 fixed this
  capabilities: [read, search, edit] ->  «nothing»       # this PR
```

`render_agent` dropped `capabilities` exactly as it dropped `model` until #1165 — a neutral declaration promised by `harness/agent-frontmatter.schema.json` and read by nobody. It is also the half of ADR-027 §2's agnosticism pair that never shipped.

After this PR `curator.md` carries `tools: Read, Glob, Bash` next to `model: opus`.

## Why this is a map and not a rename

The native shapes genuinely differ. Verified 2026-08-22 against the shipping tools, not assumed:

| Harness | Field | Semantics |
|---|---|---|
| `claude` | `tools: Read, Glob, Bash` | **allow-list** — naming a tool grants it **and denies everything unnamed** |
| `opencode` | `permission: {bash: allow}` | **decision map** — an unnamed key falls back to a default, so naming a capability grants it and says *nothing* about the rest |

`opencode`'s own schema marks its `tools` field *"@deprecated Use 'permission' field instead"*, so mapping onto it would ship a deprecation on day one.

Two design consequences fall straight out of that asymmetry:

- **The resolver takes a capability SET, not one at a time.** A per-capability API would push the allow-vs-grant distinction onto every caller, and the shell caller is the one least able to carry it.
- **It returns the whole frontmatter line, field name included**, because the field differs per harness and the render has no business knowing which. This deliberately differs from `resolve-tier`, where the field is always `model:`.

Proof the distinction is real, from the same neutral request, asserted against the real binary:

```console
$ dotf harness resolve-capabilities shell --harness claude
tools: Bash
$ dotf harness resolve-capabilities shell --harness opencode
permission: {bash: allow}
```

## On agnosticism

This declares **two** harnesses, not one. `opencode` has no `agents.deploy` target yet, so its column is unexercised by any deploy — included anyway because the standing complaint against this pipe is that it is neutral by mechanism and single-vendor by data, and a second harness with a *verified* native shape is the cheapest honest step against that. It is also what makes the per-harness-shape decision concrete rather than theoretical.

`pi` and `agy` are absent because they are `adapter` harnesses (#1171) that render no definition file. `copilot` is absent because its native tool vocabulary is not checkable from this machine — the same not-verifiable-here reason as #1170, and guessing would put a route to nowhere into a map that validates cleanly.

## Two tickets folded in, because they live in this loop

- **#1168** — a whitespace-bearing model id was reported as *"dotf is too old"*, sending the operator to rebuild a binary that was fine while the defect sat in `model-map.json`. Behind the capability probe that answer can only mean bad data, so it gets its own exit status and names the value and the file.
- **#1169** — `deploy_agents` aborted on the first unresolvable record, leaving every agent behind it undeployed, and *which ones* depended on directory iteration order. It now collects, deploys everything that resolves, and exits non-zero naming every failure — saying plainly that other agents **did** deploy, so a non-zero exit is not misread as "nothing happened".

The capability probe is also generalised over the subcommand name: with two registry consumers, the realistic staleness shape is a binary new enough for one and not the other, so each field probes independently and degrades only itself.

## Deliberately NOT in this PR

- **The `dotf doctor` check over this registry, and #1164's record-vs-map tier check.** Both are diagnostics in `cli/internal/doctor/` rather than parts of the render, and folding them in pushed the diff past ADR-017's atomic cap. Immediate follow-up, together.
- **Unifying the schema custom-rule plumbing.** `model-map`'s `customRules` is a package-level closed set bound to one schema, and `TestShippedSchemaDeclaresEveryCustomRule` asserts that schema declares every rule in it — so a second registry cannot declare an `x-` rule without refactoring a file hardened over six adversarial review rounds. This registry's one cross-block invariant (`checkVocabularyCoverage`) runs in its loader instead. Refactoring hardened code as a *side effect* of adding a feature is how it gets destabilised, so it is filed to be done deliberately.

## On the diff size — flagging it rather than hiding it

520 production lines, over ADR-017's ~300 guideline. The breakdown, since the raw number overstates the review burden:

| File | Lines | Note |
|---|---|---|
| `capability_map.go` | 250 | 186 are code; the rest is the WHY this repo asks for |
| `capability-map.json` | 105 | data + the `$comment` rationale block |
| `capability-map.schema.json` | 89 | contract, largely descriptions |
| `compile-harness.sh` | 86 | includes the #1168 and #1169 fixes |
| `harness_resolve_capabilities.go` | 78 | 59 are code |

It is one idea — a registry with its consumer — and splitting it would break the rule this sequence established: **no declaration without its consumer in the same PR**, which is precisely how `model-map` came to merge with zero readers and how `agy`'s contradiction survived four review rounds. I cut what was genuinely separable (the doctor checks) rather than slicing this in half.

## Testing

- `go build ./... && go vet ./... && GOOS=windows go vet ./... && go test ./...` — clean
- `golangci-lint run` — `0 issues.` at the `versions.conf` pin; `gofmt` clean (only pre-existing #1154)
- `shellcheck --severity=error` (CI's own level) — exit 0; `bash -n` and `zsh -n` clean
- `bats tests/*.bats` — **1429 passing, 0 failing**
- All **13** `features.json` verifiers executed; each propagates the runner's exit status and pins its test by unique NAME rather than `ok N` position
- `tests/compile-harness-real.bats` grew four cases driving the **real** binary, including the one asserting the two native forms differ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability mapping for Claude and OpenCode harnesses.
  * Added `harness resolve-capabilities` to translate neutral capabilities into harness-specific configuration.
  * Deployment now renders native capability settings into agent frontmatter.

* **Bug Fixes**
  * Improved deployment error handling, preserving successful outputs and reporting all failed agents.
  * Added clearer handling for unavailable tooling and invalid model or capability resolution results.

* **Tests**
  * Added comprehensive validation, resolution, deployment, and real-binary coverage for capability mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->