### PR TITLE
feat(doctor): catch a record whose declared tier model-map cannot answer

### DIFF
--- a/cli/internal/doctor/checks_agent_tiers.go
+++ b/cli/internal/doctor/checks_agent_tiers.go
@@ -1,0 +1,157 @@
+package doctor
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/harness"
+)
+
+// checkAgentTiersResolve catches a disagreement between two COMMITTED files: an
+// agent record declares a neutral tier, and model-map.json decides which
+// harnesses that tier covers. They can drift apart in the repository, and until
+// this check existed nothing noticed until someone ran a deploy on a machine.
+//
+// Why this is a doctor check and not part of `compile-harness.sh --check`: that
+// mode is the offline drift gate and it runs in the CI `lint` job, which installs
+// no Go and has no `dotf`. Resolving tiers there would report drift on a
+// perfectly good record purely because the machine lacks the resolver —
+// conflating a property of the deploy ENVIRONMENT with a property of the
+// committed RECORD. `dotf doctor` has neither problem: it already loads this
+// registry, and it runs where `dotf` exists by definition.
+//
+// Scoped to the harnesses `agents.deploy` actually renders to. A tier gap for a
+// harness nothing deploys to is a real question (see #1170 for copilot's) but it
+// is not drift, and reporting it here would train the reader to ignore this line.
+func checkAgentTiersResolve(cfg *Config, parsed map[string]any, rep *Report) {
+	manifestPath := filepath.Join(cfg.DotfilesDir, "harness", "manifest.json")
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		// Not a failure of this check: the deploy dir simply may not carry a
+		// manifest yet. checkCompileHarnessDrift owns that diagnosis.
+		return
+	}
+	var manifest struct {
+		Agents struct {
+			RecordDir string `json:"record_dir"`
+			Deploy    []struct {
+				Agent string `json:"agent"`
+			} `json:"deploy"`
+		} `json:"agents"`
+	}
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		rep.Warn(fmt.Sprintf("harness/manifest.json does not parse, so agent tiers were not checked: %v", err))
+		return
+	}
+	if len(manifest.Agents.Deploy) == 0 {
+		return
+	}
+	recordDir := manifest.Agents.RecordDir
+	if recordDir == "" {
+		recordDir = "harness/agents"
+	}
+
+	entries, err := os.ReadDir(filepath.Join(cfg.DotfilesDir, recordDir))
+	if err != nil {
+		return
+	}
+
+	checked, failed := 0, 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		recPath := filepath.Join(cfg.DotfilesDir, recordDir, e.Name(), "AGENT.md")
+		fm, err := readAgentFrontmatter(recPath)
+		if err != nil {
+			continue
+		}
+		tier := fm["model"]
+		if tier == "" {
+			// Declaring no tier is not an error; the render emits no model line.
+			continue
+		}
+		for _, d := range manifest.Agents.Deploy {
+			if !recordTargets(fm["targets"], d.Agent) {
+				continue
+			}
+			checked++
+			if _, err := harness.ResolveTier(parsed, tier, d.Agent); err != nil {
+				failed++
+				rep.Fail(fmt.Sprintf(
+					"agent record %s declares model tier %q, which %s cannot answer for harness %q — "+
+						"the render will fail on the next deploy",
+					filepath.Join(recordDir, e.Name(), "AGENT.md"), tier, harness.ModelMapFile, d.Agent))
+			}
+		}
+	}
+
+	if checked > 0 && failed == 0 {
+		rep.Pass(fmt.Sprintf("every declared agent tier resolves for its deploy targets (%d checked)", checked))
+	}
+}
+
+// readAgentFrontmatter reads the single-line frontmatter values an agent record
+// declares. Deliberately minimal: it answers only what this check asks, and the
+// authoritative parse lives in the render pipeline.
+//
+// Values are returned raw, including any YAML flow-sequence brackets, because
+// the caller decides what a given key's shape means.
+func readAgentFrontmatter(path string) (map[string]string, error) {
+	f, err := os.Open(path) // #nosec G304 -- path is built from the manifest's own record_dir
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	out := map[string]string{}
+	sc := bufio.NewScanner(f)
+	delims := 0
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.TrimSpace(line) == "---" {
+			delims++
+			if delims >= 2 {
+				break
+			}
+			continue
+		}
+		if delims != 1 {
+			continue
+		}
+		key, value, found := strings.Cut(line, ":")
+		if !found || strings.HasPrefix(key, " ") || strings.HasPrefix(key, "\t") {
+			continue
+		}
+		out[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// recordTargets answers whether a record applies to one harness.
+//
+// An ABSENT targets list means every harness — the same default the render uses.
+// Getting this backwards would make a persona scoped to one harness fail this
+// check against every other, which is a false positive on correct data and the
+// fastest way to make an operator stop reading a diagnostic.
+func recordTargets(raw, agent string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return true
+	}
+	raw = strings.TrimPrefix(raw, "[")
+	raw = strings.TrimSuffix(raw, "]")
+	for _, t := range strings.Split(raw, ",") {
+		if strings.TrimSpace(t) == agent {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/doctor/checks_agent_tiers_test.go
+++ b/cli/internal/doctor/checks_agent_tiers_test.go
@@ -1,0 +1,186 @@
+package doctor
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// agentTierFixture builds a deploy dir holding a model map, a manifest and one
+// agent record, so a test can put the two committed files out of step on purpose.
+func agentTierFixture(t *testing.T, deployAgents []string, recordFrontmatter string) *Config {
+	t.Helper()
+	dir := t.TempDir()
+	mustMkdir(t, filepath.Join(dir, "harness", "agents", "curator"))
+
+	manifest := map[string]any{
+		"version": 1,
+		"agents": map[string]any{
+			"record_dir": "harness/agents",
+			"deploy": func() []any {
+				out := make([]any, 0, len(deployAgents))
+				for _, a := range deployAgents {
+					out = append(out, map[string]any{"agent": a, "render": "agent-md", "dir": ".x/agents"})
+				}
+				return out
+			}(),
+		},
+	}
+	raw, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(dir, "harness", "manifest.json"), string(raw))
+	mustWrite(t, filepath.Join(dir, "harness", "agents", "curator", "AGENT.md"),
+		recordFrontmatter+"\n\n# Curator\n\nBody.\n")
+	return &Config{DotfilesDir: dir}
+}
+
+func mustMkdir(t *testing.T, p string) {
+	t.Helper()
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWrite(t *testing.T, p, content string) {
+	t.Helper()
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// tierMap is the `tiers` block the checks below resolve against: claude has all
+// three, opencode only mid — the shipped map's real asymmetry.
+var tierMap = map[string]any{
+	"tiers": map[string]any{
+		"top": map[string]any{"claude": "opus"},
+		"mid": map[string]any{"claude": "sonnet", "opencode": "qwen3.6-plus"},
+		"low": map[string]any{"claude": "haiku"},
+	},
+}
+
+// TestAgentTiersResolve is #1164: two COMMITTED files can disagree — a record
+// declares a tier, and model-map decides which harnesses that tier covers — and
+// before this check nothing noticed until a deploy ran on someone's machine.
+func TestAgentTiersResolve(t *testing.T) {
+	tests := []struct {
+		name         string
+		deployAgents []string
+		frontmatter  string
+		wantFail     bool
+		wantSubs     []string
+	}{
+		{
+			name:         "a tier the deploy target can answer",
+			deployAgents: []string{"claude"},
+			frontmatter:  "---\nname: curator\ndescription: x\nkind: invocable\nmodel: top\n---",
+		},
+		{
+			// The drift this check exists for. `top` names only claude, so a
+			// second deploy target makes the record unrenderable for it.
+			name:         "a tier one deploy target cannot answer",
+			deployAgents: []string{"claude", "opencode"},
+			frontmatter:  "---\nname: curator\ndescription: x\nkind: invocable\nmodel: top\n---",
+			wantFail:     true,
+			wantSubs:     []string{"top", "opencode", "AGENT.md"},
+		},
+		{
+			// Declaring no tier is not an error: the render emits no model line.
+			name:         "a record declaring no tier is not drift",
+			deployAgents: []string{"claude", "opencode"},
+			frontmatter:  "---\nname: curator\ndescription: x\nkind: invocable\n---",
+		},
+		{
+			// The false positive that would train an operator to ignore this
+			// line: a record scoped to one harness must not be judged against
+			// the others.
+			name:         "a record scoped by targets is judged only against those",
+			deployAgents: []string{"claude", "opencode"},
+			frontmatter:  "---\nname: curator\ndescription: x\nkind: invocable\nmodel: top\ntargets: [claude]\n---",
+		},
+		{
+			name:         "a tier no tier block declares at all",
+			deployAgents: []string{"claude"},
+			frontmatter:  "---\nname: curator\ndescription: x\nkind: invocable\nmodel: ultra\n---",
+			wantFail:     true,
+			wantSubs:     []string{"ultra", "claude"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := agentTierFixture(t, tt.deployAgents, tt.frontmatter)
+			var buf bytes.Buffer
+			rep := NewReport(&buf, false)
+			rep.Section("test")
+			checkAgentTiersResolve(cfg, tierMap, rep)
+
+			if tt.wantFail && rep.Failures() == 0 {
+				t.Fatal("expected a FAIL; a record whose tier the map cannot answer will break the next deploy")
+			}
+			if !tt.wantFail && rep.Failures() != 0 {
+				t.Fatalf("unexpected FAIL on valid data: %s", buf.String())
+			}
+			text := buf.String()
+			for _, sub := range tt.wantSubs {
+				if !strings.Contains(text, sub) {
+					t.Errorf("report does not name %q, so the operator cannot tell which record or harness:\n%s", sub, text)
+				}
+			}
+		})
+	}
+}
+
+// TestAgentTiersMissingInputsAreNotFailures pins that this check stays silent
+// about things it does not own. A missing manifest or record dir is diagnosed by
+// checkCompileHarnessDrift, and duplicating that here would print two failures
+// for one cause.
+func TestAgentTiersMissingInputsAreNotFailures(t *testing.T) {
+	t.Run("no manifest at all", func(t *testing.T) {
+		var buf bytes.Buffer
+		rep := NewReport(&buf, false)
+		rep.Section("test")
+		checkAgentTiersResolve(&Config{DotfilesDir: t.TempDir()}, tierMap, rep)
+		if rep.Failures() != 0 {
+			t.Errorf("an absent manifest is not this check's failure to report")
+		}
+	})
+
+	t.Run("a manifest with no deploy targets", func(t *testing.T) {
+		dir := t.TempDir()
+		mustMkdir(t, filepath.Join(dir, "harness"))
+		mustWrite(t, filepath.Join(dir, "harness", "manifest.json"), `{"version":1}`)
+		var buf bytes.Buffer
+		rep := NewReport(&buf, false)
+		rep.Section("test")
+		checkAgentTiersResolve(&Config{DotfilesDir: dir}, tierMap, rep)
+		if rep.Failures() != 0 {
+			t.Errorf("nothing renders agent definitions, so there is no tier to disagree about")
+		}
+	})
+}
+
+// TestRecordTargetsDefaultsToEveryHarness pins the direction that, inverted,
+// turns correct data into noise: an ABSENT targets list means ALL harnesses.
+func TestRecordTargetsDefaultsToEveryHarness(t *testing.T) {
+	tests := []struct {
+		raw, agent string
+		want       bool
+	}{
+		{"", "claude", true},
+		{"   ", "opencode", true},
+		{"[claude]", "claude", true},
+		{"[claude]", "opencode", false},
+		{"[claude, opencode]", "opencode", true},
+		{"[opencode]", "claude", false},
+	}
+	for _, tt := range tests {
+		if got := recordTargets(tt.raw, tt.agent); got != tt.want {
+			t.Errorf("recordTargets(%q, %q) = %v, want %v", tt.raw, tt.agent, got, tt.want)
+		}
+	}
+}

--- a/cli/internal/doctor/checks_model_map.go
+++ b/cli/internal/doctor/checks_model_map.go
@@ -82,6 +82,7 @@ func checkModelMap(cfg *Config, rep *Report) {
 		harness.ModelMapFile, len(pools), len(harnesses)))
 
 	reportDeclaredBudgets(parsed, pools, rep)
+	checkAgentTiersResolve(cfg, parsed, rep)
 }
 
 // reportDeclaredBudgets prints what the map DECLARES and says plainly that

--- a/cli/internal/doctor/report.go
+++ b/cli/internal/doctor/report.go
@@ -207,4 +207,3 @@ func (r *Report) Failures() int { return r.totals[StatusFail] }
 
 // Warnings returns how many checks warned (handy for assertions in tests).
 func (r *Report) Warnings() int { return r.totals[StatusWarn] }
-

--- a/specs/GUARD-006-agent-tier-agreement/features.json
+++ b/specs/GUARD-006-agent-tier-agreement/features.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": "GUARD-006-agent-tier-agreement-f1",
+    "behavior": "A record whose tier one deploy target cannot answer FAILs, naming record, tier and harness",
+    "verification": "cd cli && out=$(go test ./internal/doctor/ -run '^TestAgentTiersResolve$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestAgentTiersResolve/a_tier_one_deploy_target_cannot_answer '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-006-agent-tier-agreement-f2",
+    "behavior": "A tier no tiers block declares at all FAILs the same way",
+    "verification": "cd cli && out=$(go test ./internal/doctor/ -run '^TestAgentTiersResolve$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestAgentTiersResolve/a_tier_no_tier_block_declares_at_all '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-006-agent-tier-agreement-f3",
+    "behavior": "A record declaring no tier is not drift",
+    "verification": "cd cli && out=$(go test ./internal/doctor/ -run '^TestAgentTiersResolve$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestAgentTiersResolve/a_record_declaring_no_tier_is_not_drift '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-006-agent-tier-agreement-f4",
+    "behavior": "A record scoped by targets is judged only against the harnesses it targets",
+    "verification": "cd cli && out=$(go test ./internal/doctor/ -run '^TestAgentTiersResolve$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestAgentTiersResolve/a_record_scoped_by_targets_is_judged_only_against_those '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-006-agent-tier-agreement-f5",
+    "behavior": "A valid record passes and the pass line reports how many pairs were checked",
+    "verification": "cd cli && out=$(go test ./internal/doctor/ -run '^TestAgentTiersResolve$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestAgentTiersResolve/a_tier_the_deploy_target_can_answer '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-006-agent-tier-agreement-f6",
+    "behavior": "An absent targets list means EVERY harness, the same default the render uses",
+    "verification": "cd cli && out=$(go test ./internal/doctor/ -run '^TestRecordTargetsDefaultsToEveryHarness$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestRecordTargetsDefaultsToEveryHarness '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-006-agent-tier-agreement-f7",
+    "behavior": "Inputs this check does not own (absent/unparseable manifest, no deploy targets) produce no FAIL",
+    "verification": "cd cli && out=$(go test ./internal/doctor/ -run '^TestAgentTiersMissingInputsAreNotFailures$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestAgentTiersMissingInputsAreNotFailures '",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/GUARD-006-agent-tier-agreement/proposal.md
+++ b/specs/GUARD-006-agent-tier-agreement/proposal.md
@@ -1,0 +1,84 @@
+---
+id: "GUARD-006-agent-tier-agreement"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-08-22"
+issue: "mlorentedev/dotfiles#1164"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, doctor, harness, guard, model-map]
+template_version: "1.0"
+---
+
+# GUARD-006-agent-tier-agreement
+
+## Why
+
+Two **committed** files can disagree and nothing notices. An agent record under `harness/agents/`
+declares a neutral tier (`model: top`), and `harness/model-map.json` decides which harnesses that
+tier covers. Nothing compares them.
+
+Before #1165 the disagreement was invisible because `render_agent` dropped the field entirely.
+#1165 made it a **hard render failure** — correctly, per C15 — which means a drift that used to be
+silent now costs a deploy, and it is discovered on whichever machine happens to run one. The gap is
+between two files in the repository; it should be caught in the repository.
+
+## What
+
+`dotf doctor` reports, for every harness `manifest.json`'s `agents.deploy` renders to, whether every
+committed agent record's declared tier resolves. A record whose tier the map cannot answer FAILs,
+naming the record, the tier and the harness — the same three facts the deploy-time failure names, so
+the operator reads the same sentence in both places.
+
+It runs inside the existing *Routing registry* section, after the map is known to load — a check
+about a map that could not be read would be noise on top of a failure already reported.
+
+## Out of scope
+
+- **Making `compile-harness.sh --check` do this.** That mode is the offline drift gate and runs in
+  the CI `lint` job, which installs no Go and has no `dotf`. Resolving tiers there would report
+  drift on a perfectly good record purely because the machine lacks the resolver — conflating a
+  property of the deploy **environment** with a property of the committed **record**. `dotf doctor`
+  has neither problem.
+- **Tier gaps for harnesses nothing deploys to.** `copilot` declares `render: agent-md` with no
+  tier; that is a real open question and it is **#1170**, not drift. Reporting it here would train
+  the reader to skip this line.
+- **The capability half.** `capability-map.json`'s own doctor check rides with #1172, whose registry
+  does not exist on `main` yet.
+- **`--fix`.** There is no safe automatic repair: the fix is either to declare a tier or to change
+  the record, and which one is right is a judgement about intent.
+
+## Risks / open questions
+
+- **A false positive is worse than the gap it closes.** A diagnostic that fires on correct data gets
+  skipped, and then the true positive is skipped with it. Two narrowings guard against that: the
+  check is scoped to `agents.deploy` targets, and it honours each record's `targets:` list. The
+  second is the sharp one — an **absent** `targets:` means *every* harness, and inverting that
+  default would make every scoped persona fail against every other harness. It has its own table
+  test for exactly that reason.
+- **Missing inputs are not this check's failures.** An absent manifest or record dir is
+  `checkCompileHarnessDrift`'s diagnosis. Printing two failures for one cause makes both worth less,
+  so this one stays silent and returns.
+- **The frontmatter reader is deliberately minimal.** It answers only what this check asks
+  (single-line values in the first frontmatter block) rather than becoming a second YAML parser
+  competing with the render pipeline. A record using block-style YAML is out of its reach — and
+  #1172 makes that shape a loud failure in the renderer, which is the right place for it.
+
+## Acceptance criteria
+
+- [x] A record whose tier resolves for every deploy target passes, and the pass line says how many
+      pairs were checked.
+- [x] A record whose tier one deploy target cannot answer FAILs, naming the record path, the tier
+      and the harness.
+- [x] A tier no `tiers` block declares at all FAILs the same way.
+- [x] A record declaring no tier is not drift and produces no finding.
+- [x] A record scoped by `targets:` is judged only against the harnesses it targets.
+- [x] An absent `targets:` is treated as every harness (its own test, because inverting it turns
+      correct data into noise).
+- [x] An absent manifest, an unparseable one, or one with no deploy targets produces no FAIL.
+- [x] Verified against the real tree, not only fixtures.
+
+## References
+
+- Bitácora board: mlorentedev/dotfiles#1164
+- `specs/archive/HARNESS-076-model-map-tier-render/` — the change that made this drift expensive
+- `docs/adr/adr-035-model-map-routing-registry.md` — the registry and its doctor-check precedent
+- Related: #1170 (copilot's tier gap, deliberately not reported here), #1172 (the capability half)

--- a/specs/GUARD-006-agent-tier-agreement/tasks.md
+++ b/specs/GUARD-006-agent-tier-agreement/tasks.md
@@ -1,0 +1,31 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-22"
+---
+
+# Tasks - GUARD-006-agent-tier-agreement
+
+## Setup
+
+- [x] Branch created from main: `fix/doctor-record-tier-agreement`
+- [x] `proposal.md` complete, acceptance criteria testable
+- [x] No open questions left
+
+## Implementation
+
+- [x] Failing table test: a tier one deploy target cannot answer must FAIL, naming all three facts
+- [x] `checkAgentTiersResolve` reading the manifest's `agents.deploy` + `record_dir`
+- [x] `readAgentFrontmatter` — minimal, single-line values, first block only
+- [x] `recordTargets` with its own table test, because an inverted default turns correct data into noise
+- [x] Wired into `checkModelMap` AFTER the map validates, so it never stacks on a load failure
+- [x] Silence on inputs it does not own (absent manifest / record dir / no deploy targets)
+- [x] Verified against the real tree with a binary built from this branch
+
+## Closing
+
+- [x] Every acceptance criterion covered by at least one test
+- [x] `features.json` verifiers propagate the runner's exit status and pin tests by unique name
+- [x] `go build` / `go vet` / `GOOS=windows go vet` / `go test ./...` green
+- [x] `golangci-lint run` -> 0 issues at the `versions.conf` pin; `gofmt` clean
+- [x] `verification.md` filled in with this session's output
+- [x] PR opened referencing this spec folder

--- a/specs/GUARD-006-agent-tier-agreement/verification.md
+++ b/specs/GUARD-006-agent-tier-agreement/verification.md
@@ -1,0 +1,71 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-22"
+---
+
+# Verification - GUARD-006-agent-tier-agreement
+
+## Evidence
+
+All 7 `features.json` verifiers executed in this session and passing; each propagates the runner's
+exit status and pins its test by unique name rather than by position (lesson 217).
+
+Beyond the fixtures, the check was run against the **real tree** with a binary built from this
+branch, which is the part a fixture cannot establish:
+
+```console
+$ DOTFILES_DIR=<this worktree> dotf doctor --verbose
+[Routing registry]
+  [ OK ] harness/model-map.json is present, parses, and satisfies its schema (4 pools, 5 harnesses)
+  ...
+  [ OK ] every declared agent tier resolves for its deploy targets (1 checked)
+```
+
+One pair checked, which is correct: `agents.deploy` holds one target (`claude`) and
+`harness/agents/` holds one record (`curator`, `model: top`). The count is in the message so a
+future reader can tell "everything resolved" from "nothing was looked at" — the distinction this
+repo has now measured failing four separate ways.
+
+## Test status
+
+- `go build ./... && go vet ./... && GOOS=windows go vet ./... && go test ./... -count=1` -> clean
+- `golangci-lint run` -> `0 issues.` at the `versions.conf` pin
+- `gofmt -l internal/` -> clean apart from `internal/doctor/report.go`, which is **#1154**,
+  pre-existing on main and untouched here
+- The doctor package's own suite passes unchanged, which is the evidence that wiring a new check
+  into `checkModelMap` did not disturb the existing ones
+
+## Decisions made during implementation
+
+- **Doctor, not `compile-harness.sh --check`.** The `--check` mode runs in the CI `lint` job, which
+  installs no Go and has no `dotf`; resolving tiers there would report drift on a perfectly good
+  record purely because the machine lacks the resolver. That conflates a property of the deploy
+  ENVIRONMENT with a property of the committed RECORD. Doctor already loads this registry and runs
+  where `dotf` exists by definition.
+- **Two narrowings, both to avoid the failure mode that kills a diagnostic.** Scoped to
+  `agents.deploy` targets, and honouring each record's `targets:` list. A tier gap for a harness
+  nothing deploys to is a real question (#1170) but it is not drift; a persona scoped to one harness
+  judged against every other is a false positive on correct data. Either would train the reader to
+  skip the line, and then the true positive goes with it.
+- **`recordTargets` defaults an ABSENT list to EVERY harness**, matching the render. That direction
+  is the sharp edge — inverted, every scoped persona fails against every other harness — so it has
+  its own table test rather than only being exercised through the check.
+- **Silence on inputs it does not own.** An absent manifest or record dir is
+  `checkCompileHarnessDrift`'s diagnosis. Two failures for one cause makes both worth less.
+- **No `--fix`.** The repair is either "declare a tier" or "change the record", and which is right
+  is a judgement about intent, not something to automate.
+
+## Promotion candidates
+
+- [ ] Lesson for `docs/lessons/`? no - the transferable point (a diagnostic that fires on correct
+      data gets skipped, taking the true positive with it) is already recorded in the check's own
+      doc comment, which is where someone changing it will read.
+- [ ] ADR-worthy? no - ADR-035 already established the registry and its doctor-check precedent.
+- [ ] Vault pattern? no - single-project.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved to `specs/archive/GUARD-006-agent-tier-agreement/`
+- [ ] Bitacora #1164 closed with the PR link
+- [ ] `/adversarial-review GUARD-006-agent-tier-agreement` run and PASSing


### PR DESCRIPTION
Closes #1164. Spec: `specs/GUARD-006-agent-tier-agreement/`. Independent of #1172 — touches only `cli/internal/doctor/`, which that PR does not.

## The gap

Two **committed** files can disagree and nothing compares them: an agent record declares a neutral tier (`model: top`), and `harness/model-map.json` decides which harnesses that tier covers.

Before #1165 this was invisible, because `render_agent` dropped the field entirely. #1165 made it a **hard render failure** — correctly, per C15 — so a drift that used to be silent now costs a deploy, discovered on whichever machine happens to run one. The disagreement is between two files in the repo; it should be caught in the repo.

## Why doctor and not `compile-harness.sh --check`

`--check` is the offline drift gate and it runs in the CI `lint` job, which installs **no Go and has no `dotf`**. Resolving tiers there would report drift on a perfectly good record purely because the machine lacks the resolver — conflating a property of the deploy **environment** with a property of the committed **record**.

`dotf doctor` has neither problem: it already loads this registry, and it runs where `dotf` exists by definition.

## Two narrowings, and they are the design

A diagnostic that fires on correct data gets skipped — and then the true positive is skipped with it. So:

- **Scoped to `agents.deploy` targets.** A tier gap for a harness nothing deploys to is a real question — `copilot` is exactly that, tracked as **#1170** — but it is not *drift*.
- **Honours each record's `targets:` list.** A persona scoped to one harness must not be judged against the others.

The sharp edge is the default: an **absent** `targets:` means *every* harness, matching the render. Inverted, every scoped persona would fail against every other harness. That direction has its own table test rather than only being exercised through the check.

The check also stays silent about inputs it does not own — an absent manifest or record dir is `checkCompileHarnessDrift`'s diagnosis, and two failures for one cause makes both worth less.

## Verified against the real tree, not only fixtures

```console
$ dotf doctor --verbose
[Routing registry]
  [ OK ] harness/model-map.json is present, parses, and satisfies its schema (4 pools, 5 harnesses)
  [ OK ] every declared agent tier resolves for its deploy targets (1 checked)
```

One pair, which is correct: one deploy target (`claude`), one record (`curator`, `model: top`). **The count is in the message on purpose** — so a reader can tell "everything resolved" from "nothing was looked at", which is the distinction this repo has now measured failing four separate ways.

## On the SDD gate

The Discipline Gate fired at 159 production LOC, and this PR answers it with the spec rather than a `skip-sdd` label. Using the label to avoid writing one for a change this size is precisely the shortcut the gate exists to prevent. Much of those 159 lines is the WHY this repo asks for; the executable body is around 90.

## Testing

- 7 `features.json` verifiers, all executed and passing; each propagates the runner's exit status and pins its test by unique name (lesson 217)
- `go build ./... && go vet ./... && GOOS=windows go vet ./... && go test ./... -count=1` — clean
- `golangci-lint run` — `0 issues.` at the `versions.conf` pin; `gofmt` clean apart from pre-existing #1154
- The doctor package's existing suite passes unchanged, which is the evidence that wiring a new check into `checkModelMap` did not disturb the others
