### PR TITLE
fix(spec): the provider-diverse reviewer arm has never worked

### DIFF
--- a/cli/internal/spec/review_launch.go
+++ b/cli/internal/spec/review_launch.go
@@ -36,8 +36,20 @@ const TranscriptFile = "review-transcript.jsonl"
 // launcher's flags, deliberately explicit rather than parsed out of `id`.
 // `secret_id` optionally names the specific credential (or comma-separated list)
 // to inject via `dotf secrets run --only`, preventing broken unrelated secrets
-// from blocking a review (BUG-089, #1025). When absent, falls back to unscoped
-// resolution.
+// from blocking a review (BUG-089, #1025).
+//
+// `auth: "login"` is its mutually exclusive alternative, for a runner that holds
+// its own credentials and needs none injected. `agy` is one: its OAuth token
+// lives in ~/.gemini/antigravity-cli/google_credentials.json and the binary
+// answers with no API key in the environment at all.
+//
+// Declaring NEITHER is what made the fallback arm decorative (#1156). The entry
+// named GEMINI_API_KEY, a secret the registry has never held, so every attempt to
+// use the provider-diverse arm died at `dotf secrets run --only`; nothing noticed
+// because the primary always answered. An empty `secret_id` is not a safe default
+// either — it falls through to an UNSCOPED injection, handing every credential to
+// a process that needs none. TestEveryPoolEntryDeclaresItsAuth requires exactly
+// one of the two, so "no secret" can never again mean "nobody said".
 type ReviewerEntry struct {
 	ID       string `json:"id"`
 	Runner   string `json:"runner"`
@@ -45,6 +57,7 @@ type ReviewerEntry struct {
 	Model    string `json:"model"`
 	Role     string `json:"role"`
 	SecretID string `json:"secret_id,omitempty"`
+	Auth     string `json:"auth,omitempty"`
 }
 
 // ReviewerCommand builds the argv that runs one pooled reviewer non-interactively.
@@ -85,11 +98,18 @@ func ReviewerCommand(e ReviewerEntry, prompt string, timeout time.Duration, repo
 		return nil, fmt.Errorf("pool entry %q has no model to pin — the launcher must not fall back to a runner default", e.ID)
 	}
 
-	base := []string{"dotf", "secrets", "run"}
-	if s := strings.TrimSpace(e.SecretID); s != "" {
-		base = append(base, "--only", s)
+	// A login-authenticated runner is invoked directly. Wrapping it would inject
+	// every credential in the registry into a process that reads none of them,
+	// and would let one unrelated broken entry block the review — the failure
+	// scoping was introduced to prevent, reached from the other direction.
+	var base []string
+	if strings.TrimSpace(e.Auth) != "login" {
+		base = []string{"dotf", "secrets", "run"}
+		if s := strings.TrimSpace(e.SecretID); s != "" {
+			base = append(base, "--only", s)
+		}
+		base = append(base, "--")
 	}
-	base = append(base, "--")
 
 	switch e.Runner {
 	case "pi":

--- a/cli/internal/spec/reviewer_auth_test.go
+++ b/cli/internal/spec/reviewer_auth_test.go
@@ -1,0 +1,137 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLoginAuthReviewerSkipsTheSecretsWrapper is #1156, and the defect was not a
+// missing credential — it was a pool entry declaring the WRONG auth mechanism.
+//
+// `agy` authenticates by login: its OAuth credentials live in
+// ~/.gemini/antigravity-cli/google_credentials.json, and the binary answers with
+// no API key present at all (measured 2026-08-22). The pool nevertheless declared
+// `secret_id: GEMINI_API_KEY`, so the launcher appended `--only GEMINI_API_KEY`
+// and `dotf secrets run` refused with `unknown id or env var "GEMINI_API_KEY"`.
+//
+// So the provider-diverse fallback arm never worked, and nothing noticed because
+// the primary always answered — which is the whole reason a fallback exists.
+//
+// Dropping the secret_id alone would NOT be the fix. An empty SecretID falls
+// through to an unscoped `dotf secrets run --`, injecting every credential into a
+// process that needs none, and one broken unrelated registry entry would then
+// block the review — exactly what BUG-089 introduced scoping to prevent.
+func TestLoginAuthReviewerSkipsTheSecretsWrapper(t *testing.T) {
+	e := ReviewerEntry{
+		ID:     "agy/gemini-3.1-pro-high",
+		Runner: "agy",
+		Model:  "gemini-3.1-pro-high",
+		Auth:   "login",
+	}
+	argv, err := ReviewerCommand(e, "review this", time.Minute, "/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(argv, " ")
+	if strings.Contains(joined, "secrets") {
+		t.Errorf("a login-authenticated runner must not be wrapped in `dotf secrets run`: "+
+			"it needs no credential injected, and an unrelated broken registry entry would block it.\ngot: %s",
+			joined)
+	}
+	if len(argv) == 0 || argv[0] != "agy" {
+		t.Errorf("expected the runner to be invoked directly, got %v", argv)
+	}
+	// The model pin is an independent property and must survive the change.
+	if i := argvIndex(argv, "--model"); i < 0 || argv[i+1] != "gemini-3.1-pro-high" {
+		t.Errorf("model must stay explicitly pinned: %s", joined)
+	}
+}
+
+// TestSecretAuthReviewerKeepsScopedInjection pins the other direction, so the
+// fix above cannot quietly widen every reviewer's credential exposure.
+func TestSecretAuthReviewerKeepsScopedInjection(t *testing.T) {
+	e := ReviewerEntry{
+		ID:       "nan/deepseek-v4-flash",
+		Runner:   "pi",
+		Provider: "nan",
+		Model:    "deepseek-v4-flash",
+		SecretID: "NAN_API_KEY",
+	}
+	argv, err := ReviewerCommand(e, "review this", time.Minute, "/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(argv, " ")
+	if !strings.Contains(joined, "dotf secrets run --only NAN_API_KEY") {
+		t.Errorf("a secret-authenticated runner must keep SCOPED injection (BUG-089): %s", joined)
+	}
+}
+
+// TestEveryPoolEntryDeclaresItsAuth guards the CLASS rather than the instance.
+//
+// The failure was an absence read as a default: the entry named a credential
+// that does not exist, and nothing in the file said whether "no working secret"
+// meant "authenticates by login" or "someone forgot". Every entry must now say
+// which, so a half-declared member cannot be added and then discovered only when
+// a review refuses to start.
+func TestEveryPoolEntryDeclaresItsAuth(t *testing.T) {
+	entries, err := LoadReviewerPoolEntries(shippedRepoRoot(t))
+	if err != nil {
+		t.Fatalf("load pool: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("the shipped pool is empty, so this guard checked nothing")
+	}
+	for _, e := range entries {
+		hasSecret := strings.TrimSpace(e.SecretID) != ""
+		isLogin := strings.TrimSpace(e.Auth) == "login"
+		if hasSecret == isLogin {
+			t.Errorf("pool entry %q declares secret_id=%q auth=%q — it must declare exactly one: "+
+				"a `secret_id` to inject, or `auth: login` to say it needs none. Declaring neither "+
+				"is how the fallback arm came to be decorative (#1156)", e.ID, e.SecretID, e.Auth)
+		}
+	}
+}
+
+// TestShippedPoolHasAnIndependentProviderArm pins the property the pool exists
+// for. ADR-035 leans on provider diversity for the adversarial review's
+// independence claim, and until #1156 that claim rested on an arm that could not
+// start. A pool where every member shares one provider is a single point of
+// failure wearing a fallback's name.
+func TestShippedPoolHasAnIndependentProviderArm(t *testing.T) {
+	entries, err := LoadReviewerPoolEntries(shippedRepoRoot(t))
+	if err != nil {
+		t.Fatalf("load pool: %v", err)
+	}
+	runners := map[string]bool{}
+	for _, e := range entries {
+		runners[e.Runner] = true
+	}
+	if len(runners) < 2 {
+		t.Errorf("every pool member runs on the same runner (%v) — the fallback is a second model, "+
+			"not a second provider family, and shares its failure modes", runners)
+	}
+}
+
+// shippedRepoRoot walks up to the repository root so the guards above read the
+// pool this repo actually ships, rather than a fixture that can drift from it.
+func shippedRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "harness", "reviewer-pool.json")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find harness/reviewer-pool.json walking up from %s", dir)
+		}
+		dir = parent
+	}
+}

--- a/harness/reviewer-pool.json
+++ b/harness/reviewer-pool.json
@@ -49,9 +49,9 @@
       "id": "agy/gemini-3.1-pro-high",
       "runner": "agy",
       "model": "gemini-3.1-pro-high",
-      "secret_id": "GEMINI_API_KEY",
       "role": "fallback",
-      "why": "A second provider family, independent of both NaN and Anthropic — provider diversity rather than merely a different model. Pro tier at high effort; the flash tiers are excluded for the same reason qwen3.6 is. agy has no --provider flag; the model id selects the family."
+      "why": "A second provider family, independent of both NaN and Anthropic — provider diversity rather than merely a different model. Pro tier at high effort; the flash tiers are excluded for the same reason qwen3.6 is. agy has no --provider flag; the model id selects the family. AUTH IS LOGIN, not a key (#1156): agy holds an OAuth token at ~/.gemini/antigravity-cli/google_credentials.json and answers with no API key in the environment at all (measured 2026-08-22). This entry previously named GEMINI_API_KEY, a secret the registry has never declared, so every attempt to use the provider-diverse arm died at `dotf secrets run --only` -- and nothing noticed, because the primary always answered. The arm this pool exists to provide had therefore never run once.",
+      "auth": "login"
     },
     {
       "id": "nan/mimo-v2.5",


### PR DESCRIPTION
Closes #1156.

## The fallback arm has never worked

`harness/reviewer-pool.json` declared `secret_id: GEMINI_API_KEY` for `agy`, so `ReviewerCommand` appended `--only GEMINI_API_KEY`:

```console
$ dotf spec review <spec> --reviewer agy/gemini-3.1-pro-high
Error: --only: unknown id or env var "GEMINI_API_KEY"
Nothing was reviewed and review.md was not written
```

The registry has never held that secret. **The defect was not a missing credential — the entry named a mechanism `agy` does not use.**

`agy` authenticates by **login**. Its OAuth token lives at `~/.gemini/antigravity-cli/google_credentials.json`, and the binary answers with no API key in the environment at all:

```console
$ agy --model gemini-3.1-pro-high --print "reply with exactly OK"
OK
```

So the provider-diverse arm could never start, and **nothing noticed because the primary always answered** — precisely the circumstance a fallback exists for. Measured today while working #1172: the primary produced no verdict twice in a row, and the arm meant to cover that could not be reached.

## Why deleting the `secret_id` is not the fix

An empty `SecretID` falls through to an **unscoped** `dotf secrets run --`, handing every credential in the registry to a process that reads none of them — and letting one unrelated broken entry block the review. That is the failure BUG-089 introduced scoping to prevent, reached from the other direction.

So `auth: "login"` is declared explicitly, and the wrapper is skipped entirely for such a runner. `agy` is now invoked directly.

## Two guards, because the class matters more than the instance

- **Every pool entry declares exactly one of `secret_id` or `auth: login`.** The whole defect was an *absence read as a default*: no working credential, and nothing saying whether that meant "authenticates by login" or "someone forgot". Now it cannot mean "nobody said".
- **The shipped pool must carry more than one runner.** ADR-035 rests the adversarial review's independence claim on provider diversity; a pool whose members share a provider is a single point of failure wearing a fallback's name. Today's pool is `pi`×2 + `agy` — the guard passes, and would have gone on passing while the arm was decorative, which is why the first guard is the load-bearing one.

The opposite direction is pinned too, so this cannot quietly widen every reviewer's credential exposure: a secret-authenticated entry must keep `--only` scoping.

## Verification

```console
$ dotf spec review <spec> --reviewer agy/gemini-3.1-pro-high --dry-run
Reviewer:   agy/gemini-3.1-pro-high (agy, fallback)
$ # occurrences of "secrets" in the built command: 0
```

- 4 new tests: the login path skips the wrapper, the secret path keeps scoped injection, every shipped entry declares its auth, the shipped pool has ≥2 runners
- `go build ./... && go vet ./...` clean; the spec package's existing suite passes unchanged
- **End-to-end**: a real `dotf spec review --reviewer agy/gemini-3.1-pro-high` now *starts* and runs detached — the first time that arm has executed at all

Not SDD-gated: 26 executable production lines (plus a 2-line registry edit), well under the Discipline Gate's 50-LOC threshold, and a bug fix with a measured cause.

## Related

The primary's two silent no-verdict runs today are **#1157** — `dotf spec review` exiting OK while producing no verdict and leaving the previous `review.md` in place. That is a separate defect on a separate branch; this PR makes the fallback reachable so #1157 stops being a single point of failure while it is fixed.
