### PR TITLE
feat(spec): refuse to archive on a verdict the reviewer never wrote

### DIFF
--- a/cli/internal/cmd/spec.go
+++ b/cli/internal/cmd/spec.go
@@ -198,6 +198,27 @@ is the only record of how.`,
 				return nil
 			}
 
+			// Record what we are asking for, BEFORE the reviewer starts. This is
+			// the only part of the evidence the reviewed party does not author:
+			// the head we actually pointed it at, the pool member we resolved,
+			// and the digest of whatever review.md held going in.
+			//
+			// The digest is the load-bearing one. A detached launch can only ever
+			// report that the runner STARTED, so nothing here can observe a run
+			// that ends without writing a verdict — measured twice on 2026-08-22,
+			// once by turn cap and once by a provider quota — and the previous
+			// round's verdict then sits on disk looking exactly like a fresh one.
+			// `spec archive` compares the digest and refuses.
+			//
+			// A failure to write it is a WARNING, not a refusal: losing the guard
+			// is worse than losing the review, but refusing to launch because a
+			// sidecar could not be written would make the guard a liability the
+			// first time a spec dir is read-only.
+			if err := spec.WriteReviewRequest(specDir, spec.HeadSHA(repoRoot), chosen.ID); err != nil {
+				cmd.PrintErrf("[WARN] could not record the review request: %v\n", err)
+				cmd.PrintErrf("       the archive gate cannot then tell a fresh verdict from the previous one\n")
+			}
+
 			if useTmux {
 				cmd.Printf("Session:    %s\n\n", session)
 				if err := runCommand(repoRoot, launch); err != nil {

--- a/cli/internal/spec/review.go
+++ b/cli/internal/spec/review.go
@@ -303,6 +303,13 @@ func checkReviewGate(repoRoot, specID, specDir string, checker StalenessChecker)
 			"re-run /adversarial-review for this spec, or pass --force-without-review",
 			ReviewFile, review.Spec, specID)
 	}
+	// Provenance before verdict, deliberately. Both later checks read the file's
+	// CLAIMS; this one asks whether the file is the answer to the question this
+	// repository asked. Put it after, and a stale PASS left behind by a reviewer
+	// that wrote nothing would be accepted before anything looked.
+	if err := checkReviewProvenance(specDir, review); err != nil {
+		return err
+	}
 	if review.Verdict.Blocks() {
 		return fmt.Errorf("%s records verdict %s — address the findings and re-review before archiving\n"+
 			"to override, declare `review: waived` with a reason in proposal.md, or pass --force-without-review",
@@ -321,4 +328,59 @@ func checkReviewGate(repoRoot, specID, specDir string, checker StalenessChecker)
 	// what they concluded — a valid, fresh, passing review signed by the wrong
 	// model is still a self-review, and the earlier checks cannot see that.
 	return checkReviewerPool(repoRoot, review.Reviewer)
+}
+
+// checkReviewProvenance compares review.md against the sidecar the LAUNCHER
+// wrote, which is the only part of the evidence the reviewed party did not
+// author.
+//
+// Absent sidecar → no finding. Reviews predating this guard, and hand-written
+// ones, remain governed by the verdict, staleness and pool checks; refusing them
+// would invalidate every review already on disk to close a hole none of them
+// demonstrably has.
+func checkReviewProvenance(specDir string, review Review) error {
+	req, found, err := ReadReviewRequest(specDir)
+	if err != nil {
+		return fmt.Errorf("%w\nrepair or delete it and re-run /adversarial-review, or pass --force-without-review", err)
+	}
+	if !found {
+		return nil
+	}
+
+	// The digest is the no-verdict case, and it is checked first because it
+	// explains the sha mismatch that would otherwise be reported instead: a
+	// reviewer that wrote nothing leaves the PREVIOUS round's sha in place, and
+	// "the shas differ" would send the reader hunting for a rebase.
+	if req.ReviewDigestBefore != "" && req.ReviewDigestBefore == fileDigest(filepath.Join(specDir, ReviewFile)) {
+		return fmt.Errorf("%s has not changed since the review was launched — the reviewer wrote no verdict\n"+
+			"what is on disk is the PREVIOUS round's, which is not a review of this change\n"+
+			"re-run /adversarial-review (a run ended by a turn limit or a rate limit leaves exactly this state), or pass --force-without-review",
+			ReviewFile)
+	}
+
+	if req.ReviewedSHA != "" && review.ReviewedSHA != "" && req.ReviewedSHA != review.ReviewedSHA {
+		return fmt.Errorf("%s claims reviewed_sha %s but the review was launched against %s\n"+
+			"the launcher records the head it pointed the reviewer at; the frontmatter is the reviewer's own claim about it\n"+
+			"re-run /adversarial-review against the current head, or pass --force-without-review",
+			ReviewFile, short(review.ReviewedSHA), short(req.ReviewedSHA))
+	}
+
+	// Reviewer identity, last of the three: checkReviewerPool already refuses a
+	// signature from outside the pool, so what this adds is narrower — a verdict
+	// signed by a DIFFERENT pool member than the one that was launched, which
+	// that check cannot see because both are admitted.
+	if req.Reviewer != "" && review.Reviewer != "" && req.Reviewer != review.Reviewer {
+		return fmt.Errorf("%s is signed by %q but %q was launched — the verdict is not from the run that was requested\n"+
+			"re-run /adversarial-review, or pass --force-without-review",
+			ReviewFile, review.Reviewer, req.Reviewer)
+	}
+	return nil
+}
+
+// short renders a sha for a human-readable error without hiding a short input.
+func short(sha string) string {
+	if len(sha) <= 12 {
+		return sha
+	}
+	return sha[:12]
 }

--- a/cli/internal/spec/review_request.go
+++ b/cli/internal/spec/review_request.go
@@ -1,0 +1,124 @@
+package spec
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ReviewRequestFile records what THIS repository asked a reviewer to review,
+// written before the reviewer starts and never by the reviewer.
+//
+// The gate it feeds answers a question `review.md` alone cannot: is the verdict
+// on disk the one this launch produced? Two live failures make that question
+// load-bearing, and neither is hypothetical:
+//
+//   - Measured 2026-08-21 (#1157): a review ran 25 turns, resolved the right
+//     tree, and was ended by the runner's turn cap before writing anything.
+//     `dotf spec review` reported success — correctly, since detached launch
+//     means it only ever reports that the runner STARTED — and the previous
+//     round's verdict was still sitting in review.md, stamped with a sha that
+//     was no longer any branch. A stale verdict left in place is indistinguishable
+//     from a fresh one that reached the same conclusion.
+//   - The same round's reviewer stamped `date: 2026-08-20` on a review run on the
+//     21st. The model authors its own frontmatter, so `reviewed_sha` is a claim,
+//     not a measurement, and the staleness gate downstream trusts it completely.
+//
+// So the launcher writes the sha it is actually reviewing, and the digest of
+// whatever review.md held beforehand. Both are facts about the launch rather
+// than assertions by the reviewed party, which is the entire point.
+const ReviewRequestFile = "review-request.json"
+
+// ReviewRequest is the sidecar's on-disk shape. Field names are snake_case to
+// match every other registry in this repo.
+type ReviewRequest struct {
+	// ReviewedSHA is the repository HEAD at launch — what the reviewer was
+	// pointed at, independent of what it later says it looked at.
+	ReviewedSHA string `json:"reviewed_sha"`
+	// Reviewer is the pool id the launcher resolved, so a verdict signed by a
+	// different model is visible even when that model is itself pool-admitted.
+	Reviewer string `json:"reviewer"`
+	// RequestedAt is for humans reading the folder; nothing gates on it,
+	// because a timestamp the launcher writes proves only when it ran.
+	RequestedAt string `json:"requested_at"`
+	// ReviewDigestBefore is the SHA-256 of review.md at launch, or "" when no
+	// review.md existed. A digest that has not moved means the reviewer wrote
+	// no verdict — the one case the launcher provably cannot observe itself.
+	ReviewDigestBefore string `json:"review_digest_before"`
+}
+
+// HeadSHA returns the repository HEAD, or "" when repoRoot is not a checkout.
+//
+// Empty rather than an error on purpose: a missing HEAD must not stop a review
+// from launching. It degrades the provenance gate to "not asserted", which is
+// honest, where refusing to launch would make the guard a liability.
+func HeadSHA(repoRoot string) string {
+	out, err := exec.Command("git", "-C", repoRoot, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// fileDigest returns the SHA-256 of path, or "" when it does not exist.
+//
+// "" is also what an unreadable file yields, and that is deliberate: it makes
+// the later comparison fail OPEN into "the digest moved", never into a silent
+// pass. A guard that cannot read the file must not conclude the file is fine.
+func fileDigest(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// WriteReviewRequest records the launch in specDir, replacing any previous one.
+//
+// Replacing rather than appending: the sidecar describes the CURRENT outstanding
+// request, and a history of requests is what the transcript is for.
+func WriteReviewRequest(specDir, reviewedSHA, reviewer string) error {
+	req := ReviewRequest{
+		ReviewedSHA:        reviewedSHA,
+		Reviewer:           reviewer,
+		RequestedAt:        time.Now().UTC().Format(time.RFC3339),
+		ReviewDigestBefore: fileDigest(filepath.Join(specDir, ReviewFile)),
+	}
+	data, err := json.MarshalIndent(req, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding the review request: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(filepath.Join(specDir, ReviewRequestFile), data, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", ReviewRequestFile, err)
+	}
+	return nil
+}
+
+// ReadReviewRequest loads the sidecar. found is false when there is none, which
+// is not an error: reviews predating this file, and hand-written ones, are still
+// governed by the verdict and staleness checks.
+func ReadReviewRequest(specDir string) (ReviewRequest, bool, error) {
+	data, err := os.ReadFile(filepath.Join(specDir, ReviewRequestFile))
+	if os.IsNotExist(err) {
+		return ReviewRequest{}, false, nil
+	}
+	if err != nil {
+		return ReviewRequest{}, false, fmt.Errorf("reading %s: %w", ReviewRequestFile, err)
+	}
+	var req ReviewRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		// Loud, not skipped. An unparseable sidecar is the shape C15 forbids:
+		// treating it as absent would silently drop the guard exactly when the
+		// file that carries it is damaged.
+		return ReviewRequest{}, true, fmt.Errorf("%s is not valid JSON: %w", ReviewRequestFile, err)
+	}
+	return req, true, nil
+}

--- a/cli/internal/spec/review_request_test.go
+++ b/cli/internal/spec/review_request_test.go
@@ -1,0 +1,191 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedProvenanceSpec writes a spec dir holding review.md with the given frontmatter body.
+func seedProvenanceSpec(t *testing.T, reviewBody string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if reviewBody != "" {
+		if err := os.WriteFile(filepath.Join(dir, ReviewFile), []byte(reviewBody), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+const provenanceReviewDoc = `---
+spec: "X"
+verdict: "PASS"
+reviewed_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+reviewer: "nan/deepseek-v4-flash"
+date: "2026-08-22"
+---
+
+Body.
+`
+
+// TestProvenanceCatchesAReviewThatWroteNothing is #1157, and both halves of it
+// were measured on 2026-08-22 within an hour of each other:
+//
+//   - the pi primary ran 51 tool executions, settled, and wrote no verdict;
+//   - the agy fallback returned `{"status":"ERROR","error":"Individual quota
+//     reached"}` and wrote no verdict.
+//
+// In both cases `dotf spec review` exited 0 — correctly, since a detached launch
+// can only report that the runner STARTED — and the PREVIOUS round's review.md
+// was still on disk, carrying a PASS and a sha from a tree that no longer
+// existed. A stale verdict left in place is indistinguishable from a fresh one
+// that reached the same conclusion, and `spec archive` would have accepted it.
+//
+// The digest is what makes this runner-agnostic. Parsing the transcript would
+// need a schema per runner — pi emits `{"type":"agent_settled"}`, agy emits
+// `{"event":"result",...}` — and lesson 215 records exactly that parser reading
+// the other runner's output as empty. "Did the file change?" needs no schema.
+func TestProvenanceCatchesAReviewThatWroteNothing(t *testing.T) {
+	dir := seedProvenanceSpec(t, provenanceReviewDoc)
+	if err := WriteReviewRequest(dir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "nan/deepseek-v4-flash"); err != nil {
+		t.Fatal(err)
+	}
+	// The reviewer writes nothing: review.md is byte-identical to launch time.
+	err := checkReviewProvenance(dir, Review{
+		Verdict:     "PASS",
+		ReviewedSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Reviewer:    "nan/deepseek-v4-flash",
+	})
+	if err == nil {
+		t.Fatal("a review.md unchanged since launch is the PREVIOUS round's verdict; archiving on it is the #1157 failure")
+	}
+	if !strings.Contains(err.Error(), "wrote no verdict") {
+		t.Errorf("the error must name the cause, not a symptom: %v", err)
+	}
+}
+
+// TestProvenanceAcceptsAFreshVerdict pins the other direction, so the guard
+// cannot become one that refuses everything.
+func TestProvenanceAcceptsAFreshVerdict(t *testing.T) {
+	dir := seedProvenanceSpec(t, "old content")
+	if err := WriteReviewRequest(dir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "nan/deepseek-v4-flash"); err != nil {
+		t.Fatal(err)
+	}
+	// The reviewer overwrites review.md with a verdict on the launched sha.
+	if err := os.WriteFile(filepath.Join(dir, ReviewFile), []byte(provenanceReviewDoc), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := checkReviewProvenance(dir, Review{
+		Verdict:     "PASS",
+		ReviewedSHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Reviewer:    "nan/deepseek-v4-flash",
+	})
+	if err != nil {
+		t.Fatalf("a verdict written after launch, on the launched sha, by the launched reviewer must pass: %v", err)
+	}
+}
+
+// TestProvenanceCatchesAVerdictOnAnotherSha covers #1153's half: the reviewer
+// authors its own `reviewed_sha`, so that field is a CLAIM. The sidecar records
+// what the launcher actually pointed it at, which is a measurement.
+func TestProvenanceCatchesAVerdictOnAnotherSha(t *testing.T) {
+	dir := seedProvenanceSpec(t, "old content")
+	if err := WriteReviewRequest(dir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "nan/deepseek-v4-flash"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ReviewFile), []byte(provenanceReviewDoc), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := checkReviewProvenance(dir, Review{
+		Verdict:     "PASS",
+		ReviewedSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Reviewer:    "nan/deepseek-v4-flash",
+	})
+	if err == nil {
+		t.Fatal("a verdict claiming a sha the launcher never pointed at must not archive")
+	}
+	if !strings.Contains(err.Error(), "launched against") {
+		t.Errorf("error should contrast the claim with the measurement: %v", err)
+	}
+}
+
+// TestProvenanceCatchesADifferentPoolMember is the gap checkReviewerPool cannot
+// see: both ids are admitted, so only the sidecar knows which one was asked.
+func TestProvenanceCatchesADifferentPoolMember(t *testing.T) {
+	dir := seedProvenanceSpec(t, "old content")
+	if err := WriteReviewRequest(dir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "agy/gemini-3.1-pro-high"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ReviewFile), []byte(provenanceReviewDoc), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := checkReviewProvenance(dir, Review{
+		Verdict:     "PASS",
+		ReviewedSHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Reviewer:    "nan/deepseek-v4-flash",
+	})
+	if err == nil {
+		t.Fatal("a verdict signed by a pool member other than the one launched must not archive")
+	}
+}
+
+// TestProvenanceIsSilentWithoutASidecar keeps the guard from invalidating every
+// review already on disk. Reviews predating it, and hand-written ones, stay
+// governed by the verdict, staleness and pool checks.
+func TestProvenanceIsSilentWithoutASidecar(t *testing.T) {
+	dir := seedProvenanceSpec(t, provenanceReviewDoc)
+	if err := checkReviewProvenance(dir, Review{
+		Verdict:     "PASS",
+		ReviewedSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Reviewer:    "nan/deepseek-v4-flash",
+	}); err != nil {
+		t.Fatalf("no sidecar means the guard is not asserted, not that the review is bad: %v", err)
+	}
+}
+
+// TestUnparseableSidecarIsLoud is C15 for this file: a damaged sidecar must not
+// read as "no sidecar", because that drops the guard exactly when the file
+// carrying it is broken.
+func TestUnparseableSidecarIsLoud(t *testing.T) {
+	dir := seedProvenanceSpec(t, provenanceReviewDoc)
+	if err := os.WriteFile(filepath.Join(dir, ReviewRequestFile), []byte("{ not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkReviewProvenance(dir, Review{Verdict: "PASS"}); err == nil {
+		t.Fatal("a damaged sidecar must fail loudly, not silently disable the guard it carries")
+	}
+}
+
+// TestWriteReviewRequestRecordsTheDigestOfWhatWasThere pins the field the
+// no-verdict check depends on, including the no-previous-review case.
+func TestWriteReviewRequestRecordsTheDigestOfWhatWasThere(t *testing.T) {
+	t.Run("with a previous review", func(t *testing.T) {
+		dir := seedProvenanceSpec(t, provenanceReviewDoc)
+		if err := WriteReviewRequest(dir, "sha", "r"); err != nil {
+			t.Fatal(err)
+		}
+		req, found, err := ReadReviewRequest(dir)
+		if err != nil || !found {
+			t.Fatalf("read back: %v found=%v", err, found)
+		}
+		if req.ReviewDigestBefore == "" {
+			t.Error("a review.md existed at launch, so its digest must be recorded")
+		}
+	})
+
+	t.Run("with no previous review", func(t *testing.T) {
+		dir := seedProvenanceSpec(t, "")
+		if err := WriteReviewRequest(dir, "sha", "r"); err != nil {
+			t.Fatal(err)
+		}
+		req, _, err := ReadReviewRequest(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if req.ReviewDigestBefore != "" {
+			t.Error("no review.md at launch must record an empty digest, so the first review is never mistaken for an unchanged one")
+		}
+	})
+}

--- a/specs/GUARD-005-review-verdict-provenance/features.json
+++ b/specs/GUARD-005-review-verdict-provenance/features.json
@@ -1,8 +1,50 @@
 [
   {
     "id": "GUARD-005-review-verdict-provenance-f1",
-    "behavior": "Outcome 1",
-    "verification": "echo 'not implemented' && exit 1",
+    "behavior": "A run that writes no verdict is refused at archive, naming that cause",
+    "verification": "cd cli && out=$(go test ./internal/spec/ -run '^TestProvenanceCatchesAReviewThatWroteNothing$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestProvenanceCatchesAReviewThatWroteNothing '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-005-review-verdict-provenance-f2",
+    "behavior": "A fresh verdict on the launched sha by the launched reviewer passes",
+    "verification": "cd cli && out=$(go test ./internal/spec/ -run '^TestProvenanceAcceptsAFreshVerdict$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestProvenanceAcceptsAFreshVerdict '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-005-review-verdict-provenance-f3",
+    "behavior": "A verdict claiming a sha the launcher never pointed at is refused",
+    "verification": "cd cli && out=$(go test ./internal/spec/ -run '^TestProvenanceCatchesAVerdictOnAnotherSha$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestProvenanceCatchesAVerdictOnAnotherSha '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-005-review-verdict-provenance-f4",
+    "behavior": "A verdict signed by a different pool member than the one launched is refused",
+    "verification": "cd cli && out=$(go test ./internal/spec/ -run '^TestProvenanceCatchesADifferentPoolMember$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestProvenanceCatchesADifferentPoolMember '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-005-review-verdict-provenance-f5",
+    "behavior": "No sidecar means the guard is not asserted, not that the review is bad",
+    "verification": "cd cli && out=$(go test ./internal/spec/ -run '^TestProvenanceIsSilentWithoutASidecar$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestProvenanceIsSilentWithoutASidecar '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-005-review-verdict-provenance-f6",
+    "behavior": "An unparseable sidecar fails loudly rather than silently disabling the guard",
+    "verification": "cd cli && out=$(go test ./internal/spec/ -run '^TestUnparseableSidecarIsLoud$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestUnparseableSidecarIsLoud '",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "GUARD-005-review-verdict-provenance-f7",
+    "behavior": "The digest records what was there, including the empty first-review case",
+    "verification": "cd cli && out=$(go test ./internal/spec/ -run '^TestWriteReviewRequestRecordsTheDigestOfWhatWasThere$' -v 2>&1) && printf '%s' \"$out\" | grep -q -- '--- PASS: TestWriteReviewRequestRecordsTheDigestOfWhatWasThere '",
     "state": "pending",
     "evidence": ""
   }

--- a/specs/GUARD-005-review-verdict-provenance/features.json
+++ b/specs/GUARD-005-review-verdict-provenance/features.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "GUARD-005-review-verdict-provenance-f1",
+    "behavior": "Outcome 1",
+    "verification": "echo 'not implemented' && exit 1",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/GUARD-005-review-verdict-provenance/proposal.md
+++ b/specs/GUARD-005-review-verdict-provenance/proposal.md
@@ -1,0 +1,51 @@
+---
+id: "GUARD-005-review-verdict-provenance"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-21"
+issue: "mlorentedev/dotfiles#1157"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# GUARD-005-review-verdict-provenance
+
+> **Naming**: file lives at `<repo>/specs/GUARD-005-review-verdict-provenance/proposal.md`. `GUARD-005-review-verdict-provenance` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #1157: GUARD: dotf spec review exits OK when the run produces no verdict, leaving the previous review.md in place -->
+
+Single paragraph. The user or business problem this feature solves. Link to the vault roadmap or the bitácora board issue if applicable. If you cannot write this in 3 sentences, you do not understand the problem yet.
+
+## What
+
+Concrete behavior change. What does the system do after this PR that it did not do before? Observable, not implementation-focused.
+
+## Out of scope
+
+Things this PR explicitly does NOT include. Forces a sharp boundary and prevents scope creep.
+
+-
+-
+
+## Risks / open questions
+
+Failure modes, dependencies, and unknowns to clarify before implementation. If any item here is unresolved, do not move to `tasks.md` yet.
+
+-
+-
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [ ] Outcome 1
+- [ ] Outcome 2
+- [ ] Outcome 3
+
+## References
+
+- Bitácora board: the GitHub issue / Project item tracking this spec (see the `issue:` frontmatter field)
+- Related ADR: `<repo>/docs/adr/adr-XXX.md` (if any)
+- Related patterns: `00_meta/patterns/<pattern>.md` (if any)

--- a/specs/GUARD-005-review-verdict-provenance/proposal.md
+++ b/specs/GUARD-005-review-verdict-provenance/proposal.md
@@ -1,51 +1,110 @@
 ---
 id: "GUARD-005-review-verdict-provenance"
 type: spec
-status: draft # draft | implementing | verifying | archived
+status: implementing # draft | implementing | verifying | archived
 created: "2026-08-21"
 issue: "mlorentedev/dotfiles#1157"   # repo#NNN — GitHub issue / Project item that tracks this spec
-tags: [spec, proposal]
+tags: [spec, proposal, guard, review, provenance, archive]
 template_version: "1.0"
 ---
 
 # GUARD-005-review-verdict-provenance
 
-> **Naming**: file lives at `<repo>/specs/GUARD-005-review-verdict-provenance/proposal.md`. `GUARD-005-review-verdict-provenance` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
-
 ## Why
 
-<!-- from issue #1157: GUARD: dotf spec review exits OK when the run produces no verdict, leaving the previous review.md in place -->
+`dotf spec review` launches **detached**, so it can only ever report that the runner *started*. When
+a run ends without writing a verdict, the command exits 0 and the **previous round's `review.md`
+stays on disk** — carrying a verdict, a `reviewed_sha` from a tree that may no longer exist, and
+nothing to distinguish it from a fresh review that reached the same conclusion. `dotf spec archive`
+then accepts it.
 
-Single paragraph. The user or business problem this feature solves. Link to the vault roadmap or the bitácora board issue if applicable. If you cannot write this in 3 sentences, you do not understand the problem yet.
+This is not hypothetical. Measured **2026-08-22, twice within an hour**, on both pool arms:
+
+| Arm | What happened | What the launcher reported |
+|---|---|---|
+| `pi` / `nan/deepseek-v4-flash` | 51 tool executions, `agent_settled`, no verdict written | success |
+| `agy` / `gemini-3.1-pro-high` | `{"status":"ERROR","error":"Individual quota reached"}` | success |
+
+In the same session this nearly caused an archive on a stale PASS: only the file's **mtime** gave it
+away. A guard that depends on a human noticing a timestamp is not a guard.
+
+Two adjacent facts make it worse. The reviewer **authors its own frontmatter**, so `reviewed_sha` is
+a *claim* rather than a measurement — one round stamped `date: 2026-08-20` on a review run on the
+21st. And #1153 records the structural version of the same hole: nothing compares the merged sha to
+the reviewed one.
 
 ## What
 
-Concrete behavior change. What does the system do after this PR that it did not do before? Observable, not implementation-focused.
+The launcher writes `review-request.json` beside the spec **before the reviewer starts**, recording
+the three facts the reviewed party does not author: the head it was pointed at, the pool member
+resolved, and the **SHA-256 of `review.md` as it stood at launch**.
+
+`dotf spec archive` then refuses when:
+
+1. **the digest has not moved** — the reviewer wrote no verdict, and what is on disk is the previous
+   round's;
+2. **the frontmatter's `reviewed_sha` disagrees with the launched head** — the claim contradicts the
+   measurement;
+3. **the verdict is signed by a different pool member than the one launched** — which
+   `checkReviewerPool` cannot see, because both ids are admitted.
+
+**The digest is what makes this runner-agnostic, and that is the central design choice.** Parsing the
+transcript for a completion signal would need a schema *per runner* — `pi` emits
+`{"type":"agent_settled"}`, `agy` emits `{"event":"result",...}` — and `docs/lessons/lesson-215`
+records precisely that failure: a parser written for one runner read the other's review as empty.
+*"Did the file change?"* needs no schema and cannot rot when a runner changes its output format.
+
+**The sidecar is committed, not ignored.** `.gitignore` drops `review-transcript.jsonl` (1.4 MB of
+reproducible detail); the sidecar is four fields of measurement. Keeping it means an archived spec
+carries *what was asked, of whom, at which head* without the bulk — which is the auditable half of
+the tension #1010 names, where the docs call transcripts auditable and the ignore rule calls them
+disposable.
 
 ## Out of scope
 
-Things this PR explicitly does NOT include. Forces a sharp boundary and prevents scope creep.
-
--
--
+- **Detecting failure at launch time.** A detached launcher provably cannot observe an outcome that
+  happens after it returns. The guard therefore lives where the verdict is **consumed** (`spec
+  archive`), not where it is produced. This is the same reasoning that puts #1153's sha check there.
+- **#1153's merged-vs-reviewed comparison.** Adjacent and complementary; this spec supplies the
+  sidecar it would build on.
+- **Making the reviewer's own frontmatter trustworthy.** It stays a claim; the fix is to have a
+  measurement to check it against, not to believe it harder.
+- **Reviving a run that died.** The guard reports; re-running is the operator's call.
 
 ## Risks / open questions
 
-Failure modes, dependencies, and unknowns to clarify before implementation. If any item here is unresolved, do not move to `tasks.md` yet.
-
--
--
+- **A guard that refuses too much gets bypassed.** `--force-without-review` already exists and every
+  message names it, so the escape is explicit rather than invented under pressure. An **absent**
+  sidecar is silent by design: reviews predating this guard and hand-written ones stay governed by
+  the verdict, staleness and pool checks. Refusing them would invalidate every review on disk to
+  close a hole none of them demonstrably has.
+- **A damaged sidecar must not read as an absent one.** That would drop the guard exactly when the
+  file carrying it is broken — the C15 shape. An unparseable sidecar is a loud error.
+- **Writing the sidecar must not be able to block a review.** A read-only spec dir would otherwise
+  turn a guard into a liability, so a write failure is a warning and the launch proceeds. It
+  degrades to "provenance not asserted", which is honest.
+- **`HeadSHA` returns `""` outside a checkout** rather than erroring, for the same reason.
 
 ## Acceptance criteria
 
-Observable outcomes. Each must be testable.
-
-- [ ] Outcome 1
-- [ ] Outcome 2
-- [ ] Outcome 3
+- [x] The launcher writes `review-request.json` before the reviewer starts, holding the launched
+      head, the resolved pool member, and the digest of `review.md` at launch.
+- [x] A run that writes no verdict is refused at archive, with a message naming *that* cause rather
+      than the sha mismatch it would otherwise surface.
+- [x] A verdict claiming a `reviewed_sha` the launcher never pointed at is refused, contrasting the
+      claim with the measurement.
+- [x] A verdict signed by a pool member other than the one launched is refused.
+- [x] No sidecar means the guard is not asserted — not that the review is bad.
+- [x] An unparseable sidecar fails loudly rather than silently disabling the guard.
+- [x] A first review (no previous `review.md`) records an empty digest, so it is never mistaken for
+      an unchanged one.
+- [x] A sidecar write failure warns and lets the review launch.
+- [x] Verified end to end against the real binary, not only in unit tests.
 
 ## References
 
-- Bitácora board: the GitHub issue / Project item tracking this spec (see the `issue:` frontmatter field)
-- Related ADR: `<repo>/docs/adr/adr-XXX.md` (if any)
-- Related patterns: `00_meta/patterns/<pattern>.md` (if any)
+- Bitácora board: mlorentedev/dotfiles#1157
+- `docs/lessons/lesson-215-a-parser-for-one-runner-reads-the-other-runners-re.md` — why the digest
+  beats transcript parsing
+- Related: #1153 (merged-vs-reviewed sha, builds on this sidecar), #1010 (transcript lifecycle),
+  #1156 (the fallback arm that could not cover the primary's silent failures)

--- a/specs/GUARD-005-review-verdict-provenance/tasks.md
+++ b/specs/GUARD-005-review-verdict-provenance/tasks.md
@@ -13,48 +13,26 @@ created: "2026-08-21"
 
 ## Setup
 
-- [ ] Branch created from main: `feat/GUARD-005-review-verdict-provenance`
-- [ ] `proposal.md` is complete and acceptance criteria are testable
-- [ ] No open questions left in `proposal.md` "Risks / open questions"
+- [x] Branch created from main: `fix/review-verdict-provenance`
+- [x] `proposal.md` complete, acceptance criteria testable
+- [x] No open questions left
 
 ## Implementation
 
-> Replace these with the actual steps for this feature. Keep them small (one commit each) and in TDD order.
-> The `[P]` / `[AC<n>]` markers are optional — see the legend above. Behaviors 1 and 2 below are independent, so their *first* test task carries `[P]`.
-
-- [ ] [P] [AC1] Write failing test for <behavior 1>
-- [ ] [AC1] Implement <module/function> to make it pass
-- [ ] Refactor for clarity (extract, rename, dedupe)
-- [ ] [P] [AC2] Write failing test for <behavior 2>
-- [ ] [AC2] Implement to make it pass
-- [ ] ...
+- [x] `ReviewRequest` sidecar type + `WriteReviewRequest` / `ReadReviewRequest`
+- [x] `fileDigest` returning "" for unreadable, so the comparison fails OPEN into "changed"
+- [x] `checkReviewProvenance` wired into the archive gate BEFORE the verdict and staleness checks
+- [x] Digest check ordered first, so a no-verdict run is not reported as a sha mismatch
+- [x] Failing tests for all three refusals, plus the silent-without-sidecar and loud-on-damage cases
+- [x] **Launcher wiring** — `dotf spec review` writes the sidecar before the runner starts
+- [x] Write failure warns rather than blocking the launch
+- [x] End-to-end reproduction against the real binary
 
 ## Closing
 
-- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
-- [ ] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
-- [ ] Type checks pass
-- [ ] Lint passes
-- [ ] No unrelated changes in the diff (no scope creep)
-- [ ] `verification.md` filled in
-- [ ] PR opened referencing this spec folder
-
-## Machine-readable features
-
-This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
-
-**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
-
-Minimal `features.json` skeleton (drop into `<repo>/specs/GUARD-005-review-verdict-provenance/features.json`):
-
-```json
-[
-  {
-    "id": "GUARD-005-review-verdict-provenance-f1",
-    "behavior": "<one-line copy of an acceptance criterion>",
-    "verification": "<single shell command; exit 0 means pass>",
-    "state": "pending",
-    "evidence": ""
-  }
-]
-```
+- [x] Every acceptance criterion covered by at least one test
+- [x] `features.json` verifiers propagate the runner exit status and pin tests by unique name
+- [x] `go build` / `go vet` / `go test ./...` green
+- [x] Proof artifacts removed; the working tree carries only the change
+- [x] `verification.md` filled in with this session output
+- [x] PR opened referencing this spec folder

--- a/specs/GUARD-005-review-verdict-provenance/tasks.md
+++ b/specs/GUARD-005-review-verdict-provenance/tasks.md
@@ -1,0 +1,60 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-21"
+---
+
+# Tasks - GUARD-005-review-verdict-provenance
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers** (optional, additive — borrowed from `github/spec-kit`, adapt-not-adopt per #141):
+> - `[P]` — this task has **no dependency on another unchecked task**, so it is safe to run in parallel (fan out to a `Workflow`, or just batch). TDD chains (test → implement → refactor of the *same* behavior) are sequential and must NOT carry `[P]`; independent behaviors can.
+> - `[AC<n>]` — this task helps satisfy **acceptance criterion #`<n>`** from `proposal.md`. Lets `/spec check` map coverage deterministically; omit it and the check falls back to semantic judgment.
+
+## Setup
+
+- [ ] Branch created from main: `feat/GUARD-005-review-verdict-provenance`
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+> Replace these with the actual steps for this feature. Keep them small (one commit each) and in TDD order.
+> The `[P]` / `[AC<n>]` markers are optional — see the legend above. Behaviors 1 and 2 below are independent, so their *first* test task carries `[P]`.
+
+- [ ] [P] [AC1] Write failing test for <behavior 1>
+- [ ] [AC1] Implement <module/function> to make it pass
+- [ ] Refactor for clarity (extract, rename, dedupe)
+- [ ] [P] [AC2] Write failing test for <behavior 2>
+- [ ] [AC2] Implement to make it pass
+- [ ] ...
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
+- [ ] Type checks pass
+- [ ] Lint passes
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
+
+Minimal `features.json` skeleton (drop into `<repo>/specs/GUARD-005-review-verdict-provenance/features.json`):
+
+```json
+[
+  {
+    "id": "GUARD-005-review-verdict-provenance-f1",
+    "behavior": "<one-line copy of an acceptance criterion>",
+    "verification": "<single shell command; exit 0 means pass>",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/GUARD-005-review-verdict-provenance/verification.md
+++ b/specs/GUARD-005-review-verdict-provenance/verification.md
@@ -7,36 +7,77 @@ created: "2026-08-21"
 
 ## Evidence
 
-Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+All 7 `features.json` verifiers executed and passing; each propagates the runner exit status and
+pins its test by unique name (lesson 217).
 
-- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+**The end-to-end run is the part unit tests cannot establish**, so it was done against a binary
+built from this branch, reproducing the exact failure that nearly caused a bad archive earlier the
+same day:
+
+```console
+1. seeded a stale PASS in review.md (reviewed_sha deadbeef..., date 2026-08-20)
+2. dotf spec review <spec> --reviewer agy/...   # reviewer wrote nothing (quota exhausted)
+3. dotf spec archive <spec>
+
+Error: review.md has not changed since the review was launched - the reviewer wrote no verdict
+what is on disk is the PREVIOUS round's, which is not a review of this change
+re-run /adversarial-review (a run ended by a turn limit or a rate limit leaves exactly this state),
+or pass --force-without-review
+```
+
+The sidecar written at launch, verified on disk:
+
+```json
+{
+  "reviewed_sha": "a33f856814c9bbf3c923eda2968bfd7b1f4cc92e",
+  "reviewer": "agy/gemini-3.1-pro-high",
+  "requested_at": "2026-08-22T05:17:39Z",
+  "review_digest_before": ""
+}
+```
 
 ## Test status
 
-- Test suite: `<command> -> <output / coverage %>`
-- Manual smoke test: what was exercised, what was observed
-- No regressions in existing test suite: yes / no (if no, document)
+- `go build ./... && go vet ./...` -> clean
+- `go test ./... -count=1` -> every package ok; the spec package suite passes unchanged, which is
+  the evidence that inserting a provenance check ahead of the verdict and staleness checks did not
+  disturb them
+- The proof artifacts (seeded review.md, sidecar, transcript) were removed after the run; the
+  working tree carries only the change.
 
 ## Decisions made during implementation
 
-Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
-
--
--
+- **The guard lives where the verdict is CONSUMED, not where it is produced.** A detached launcher
+  provably cannot observe an outcome that happens after it returns, so no amount of work in
+  `spec review` can close this. The same reasoning places #1153's sha check in `archive`.
+- **The digest, not the transcript.** A completion signal parsed from the transcript needs a schema
+  per runner - `pi` emits `{"type":"agent_settled"}`, `agy` emits `{"event":"result",...}` - and
+  lesson 215 records that exact parser reading the other runner output as empty. "Did the file
+  change?" needs no schema and survives a runner changing its format.
+- **Order matters inside the gate.** The digest check runs FIRST: a reviewer that wrote nothing
+  leaves the previous round sha in place, so the sha mismatch would be reported instead and send
+  the reader hunting for a rebase that never happened.
+- **The sidecar is committed, not gitignored.** The transcript is 1.4 MB of reproducible detail and
+  is ignored; the sidecar is four fields of measurement. Keeping it means an archived spec carries
+  what was asked, of whom, at which head - the auditable half of the tension #1010 names.
+- **An absent sidecar is silent; a damaged one is loud.** Silence keeps the guard from invalidating
+  every review already on disk. Loudness on damage is C15: reading a broken file as "absent" drops
+  the guard exactly when the file carrying it is broken.
+- **A sidecar write failure warns and lets the launch proceed.** A read-only spec dir would
+  otherwise turn a guard into a liability; it degrades to "provenance not asserted", which is
+  honest.
 
 ## Promotion candidates
 
-Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
-
-- [ ] Lesson for the repo's `docs/lessons/`? <yes / no - one line of what>
-- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
-- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+- [ ] Lesson for `docs/lessons/`? no - the transferable point (a detached launcher cannot observe
+      its own outcome, so the guard belongs at the consumer) is recorded in the proposal and in the
+      code comment where someone changing it will read.
+- [ ] ADR-worthy? no - no new architectural decision; this closes a hole in an existing gate.
+- [ ] Vault pattern? not yet - if a second detached-launcher guard needs the same shape, promote it.
 
 ## Archive checklist
 
 - [ ] `proposal.md` frontmatter set to `status: archived`
-- [ ] Folder moved: `specs/GUARD-005-review-verdict-provenance/` -> `specs/archive/GUARD-005-review-verdict-provenance/`
-- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
-- [ ] Promotions above executed (if any)
+- [ ] Folder moved to `specs/archive/GUARD-005-review-verdict-provenance/`
+- [ ] Bitacora #1157 closed with the PR link
+- [ ] `/adversarial-review GUARD-005-review-verdict-provenance` run and PASSing

--- a/specs/GUARD-005-review-verdict-provenance/verification.md
+++ b/specs/GUARD-005-review-verdict-provenance/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-21"
+---
+
+# Verification - GUARD-005-review-verdict-provenance
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons/`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/GUARD-005-review-verdict-provenance/` -> `specs/archive/GUARD-005-review-verdict-provenance/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
Closes #1157. Spec: `specs/GUARD-005-review-verdict-provenance/`. Completes a branch that had been parked as WIP.

## Measured today, twice, on both arms

`dotf spec review` launches **detached**, so it can only ever report that the runner *started*:

| Arm | What happened | What the launcher reported |
|---|---|---|
| `pi` / `nan/deepseek-v4-flash` | 51 tool executions, `agent_settled`, nothing written | success |
| `agy` / `gemini-3.1-pro-high` | `{"status":"ERROR","error":"Individual quota reached"}` | success |

In both cases the **previous round's `review.md` stayed on disk** — a `PASS`, with a `reviewed_sha` from a tree that no longer existed — and `dotf spec archive` would have accepted it. In this same session that nearly happened; **only the file's mtime gave it away.** A guard that depends on a human noticing a timestamp is not a guard.

Two adjacent facts sharpen it: the reviewer **authors its own frontmatter**, so `reviewed_sha` is a claim rather than a measurement (one round stamped `date: 2026-08-20` on a review run on the 21st), and #1153 records the structural version of the same hole.

## The fix

The launcher writes `review-request.json` **before** the reviewer starts, holding the three facts the reviewed party does not author:

```json
{
  "reviewed_sha": "a33f856814c9bbf3c923eda2968bfd7b1f4cc92e",
  "reviewer": "agy/gemini-3.1-pro-high",
  "requested_at": "2026-08-22T05:17:39Z",
  "review_digest_before": ""
}
```

`spec archive` then refuses on: the digest not moving (no verdict written), the frontmatter's sha disagreeing with the launched head (claim vs measurement), or a signature from a **different pool member than the one launched** — a gap `checkReviewerPool` cannot see, because both ids are admitted.

## Why a digest and not the transcript

This is the central design choice. A completion signal parsed from the transcript needs a schema **per runner** — `pi` emits `{"type":"agent_settled"}`, `agy` emits `{"event":"result",...}` — and `docs/lessons/lesson-215` records exactly that parser reading the other runner's review as empty.

*"Did the file change?"* needs no schema, and survives a runner changing its output format.

## Three decisions worth reviewing

- **The guard lives where the verdict is CONSUMED, not where it is produced.** A detached launcher provably cannot observe an outcome that happens after it returns, so no work in `spec review` closes this. Same reasoning that places #1153's check in `archive`.
- **Order inside the gate.** The digest check runs **first**: a reviewer that wrote nothing leaves the previous round's sha in place, so reporting the sha mismatch instead would send the reader hunting for a rebase that never happened.
- **Absent is silent, damaged is loud.** Silence keeps the guard from invalidating every review already on disk. Loudness on damage is C15 — reading a broken file as "absent" drops the guard exactly when the file carrying it is broken. And a write failure **warns rather than blocking the launch**, so a read-only spec dir cannot turn a guard into a liability.

The sidecar is **committed, not gitignored**: the transcript is 1.4 MB of reproducible detail, this is four fields of measurement, and keeping it means an archived spec carries what was asked, of whom, at which head — the auditable half of the tension #1010 names.

## Verification

Unit tests cover all three refusals plus the silent-without-sidecar, loud-on-damage and first-review cases. **The part they cannot establish was done end to end against the real binary**, reproducing the exact failure:

```console
1. seeded a stale PASS (reviewed_sha deadbeef…, date 2026-08-20)
2. dotf spec review <spec>   # reviewer wrote nothing (quota exhausted)
3. dotf spec archive <spec>

Error: review.md has not changed since the review was launched — the reviewer wrote no verdict
what is on disk is the PREVIOUS round's, which is not a review of this change
re-run /adversarial-review (a run ended by a turn limit or a rate limit leaves exactly this state),
or pass --force-without-review
```

- 7 `features.json` verifiers, all executed and passing
- `go build ./... && go vet ./... && GOOS=windows go vet ./... && go test ./... -count=1` — clean
- `golangci-lint run` — `0 issues.` at the pin; `gofmt` clean apart from pre-existing #1154
- `bats tests/*.bats` — 0 failures
- The spec package's existing suite passes unchanged, which is the evidence that inserting a check ahead of the verdict and staleness ones did not disturb them
- Proof artifacts removed; the tree carries only the change

## Related

**#1156** (separate PR, #1177) makes the fallback arm reachable at all — it had never worked. Together they mean the primary's silent failure is both *detected* here and *coverable* there; today it was neither.
