### PR TITLE
fix(ci): a reviewer whose quota is exhausted must not refuse the change

### DIFF
--- a/harness/review-attestation.json
+++ b/harness/review-attestation.json
@@ -68,7 +68,9 @@
     "One string, two consumers, declared once. The skill writes it and the queue",
     "reads it, and putting it in either would have made the pair a two-file",
     "agreement nobody checks — the failure class this repo spent 2026-08-17 into",
-    "the 18th cataloguing."
+    "the 18th cataloguing.",
+    "",
+    "`advisory: true` marks a reviewer whose REVIEW attests but whose DECLINE does not refuse. It exists for a reviewer whose availability is a third party's billing state rather than a property of the change. An advisory decline is reported — silence and 'it could not run' are still different facts — but it yields `pending` rather than `declined`, so the gate refuses for the honest reason: no review has happened yet. Absent or false, a reviewer counts fully."
   ],
   "reviewers": [
     {
@@ -76,10 +78,11 @@
       "declined_markers": [
         "rate limited by coderabbit.ai"
       ],
-      "why": "Free tier, ~1 review/hour account-wide. On 2026-08-16 PRs #1007, #1009 and #1013 each carried this notice simultaneously, with zero reviews between them, while `gh pr checks` reported `CodeRabbit  pass`. Neither pushing new commits nor an explicit `@coderabbitai review` reclaims a slot while the quota is spent — measured, both.",
+      "why": "ADVISORY (2026-08-22): its review still attests, but its DECLINE no longer refuses. Measured across one full session — CodeRabbit was rate limited on every PR opened, so `declined` became the normal first verdict on every change and flipped green ~90s later when PR-Agent posted. The workflow's own note says it: a gate whose normal state is red has stopped being a gate. The quota is a billing state of a third party, not a property of the change, and refusing on it spends this gate's credibility on a transient. Same disposition as codex, which is likewise exhausted most of the time. What is NOT weakened: the PR still cannot read as attested until a counting reviewer actually reviews — an advisory decline yields `pending`, which is the honest answer, because a reviewer that could not run is not a reviewer that refused the change.",
       "review_markers": [
         "No actionable comments were generated in the recent review"
-      ]
+      ],
+      "advisory": true
     },
     {
       "login": "github-actions",

--- a/scripts/check-review-attestation.sh
+++ b/scripts/check-review-attestation.sh
@@ -325,19 +325,42 @@ fi
 # A reviewer posted, but what it posted says no review ran. Told apart by the
 # vendor's own machine marker, never by prose: a review names files, lines or
 # claims; a notice talks about the review itself.
+# An ADVISORY reviewer's decline is recorded separately and never refuses.
+#
+# The distinction is about what the signal measures. A counting reviewer saying
+# "I could not review" is a fact about this change's review. An advisory
+# reviewer saying it is a fact about a third party's billing state, which is not
+# something the author can act on and not something that makes the change worse.
+#
+# Measured across one full session on 2026-08-22: CodeRabbit was rate limited on
+# every PR opened, so `declined` became the FIRST verdict on every change and
+# flipped green about ninety seconds later when PR-Agent posted. This workflow's
+# own comment names why that matters — "a gate whose normal state is red has
+# stopped being a gate" — and it was becoming true of this one.
+#
+# Nothing is weakened. An advisory decline still prevents `attested`; it just
+# yields `pending`, which is the honest reading: no review has happened yet.
 DECLINED_BY=""
 DECLINED_MARKER=""
-while IFS=$'\t' read -r login marker; do
+ADVISORY_DECLINED_BY=""
+while IFS=$'\t' read -r login marker advisory; do
     [ -n "$login" ] || continue
     hit="$(printf '%s' "$PR_JSON" | jq -r --arg l "$login" --arg m "$marker" '
         def norm: (. // "") | ascii_downcase | sub("\\[bot\\]$"; "");
         [.comments[]? | select((.author.login | norm) == ($l | norm)) | select((.body // "") | contains($m))] | length')"
     if [ "$hit" -gt 0 ]; then
+        if [ "$advisory" = "true" ]; then
+            # Recorded, not fatal. Reported below so "it could not run" stays
+            # distinguishable from silence — they are different facts even when
+            # they produce the same verdict.
+            [ -n "$ADVISORY_DECLINED_BY" ] || ADVISORY_DECLINED_BY="$login"
+            continue
+        fi
         DECLINED_BY="$login"
         DECLINED_MARKER="$marker"
         break
     fi
-done < <(jq -r '.reviewers[]? | . as $r | ($r.declined_markers[]? | [$r.login, .] | @tsv)' "$CONFIG")
+done < <(jq -r '.reviewers[]? | . as $r | ($r.declined_markers[]? | [$r.login, ., (($r.advisory // false) | tostring)] | @tsv)' "$CONFIG")
 
 # --- the declared escape -------------------------------------------------------
 # BOTH halves, never one. A label alone is a click; a rationale alone is a note
@@ -393,6 +416,12 @@ elif [ -n "$UNQUALIFIED" ]; then
     printf '       declared in the reviewer registry. A shared bot identity is neither until\n' >&2
     printf '       it is declared: every workflow here posts under the same login, so counting\n' >&2
     printf '       it unconditionally would let a labeler attest for a PR nobody read (#1033).\n' >&2
+elif [ -n "$ADVISORY_DECLINED_BY" ]; then
+    # Not silence, and saying so matters: the author should not go looking for a
+    # reviewer that already answered "I could not run".
+    printf '[FAIL] pending — %s could not review (advisory: its availability is a third-party\n' "$ADVISORY_DECLINED_BY" >&2
+    printf '       quota, not a property of this change, so it does not refuse). No counting\n' >&2
+    printf '       reviewer has attested yet.\n' >&2
 else
     printf '[FAIL] pending — no reviewer output on this PR yet\n' >&2
 fi

--- a/tests/check-review-attestation.bats
+++ b/tests/check-review-attestation.bats
@@ -32,19 +32,65 @@ teardown() { [ -z "${TMP:-}" ] || rm -rf "$TMP"; }
 
 # --- AC1/AC3: classifies the three states, by content ---
 
-@test "AC1: classifies the REAL #1009 rate-limit payload as declined" {
+@test "AC1: the REAL #1009 rate-limit payload still refuses, now as advisory-pending" {
+    # coderabbitai is ADVISORY as of 2026-08-22: its review attests, its decline
+    # does not refuse. The PR is still NOT attested -- what changed is the reason
+    # given, and the reason is the honest one. A reviewer that could not run has
+    # not refused the change; no review has happened yet.
     run "$SCRIPT" --payload "$F/pr-1009.raw.json"
     [ "$status" -eq 1 ]
-    [[ "$output" == *"declined"* ]]
+    [[ "$output" == *"pending"* ]]
     [[ "$output" == *"coderabbitai"* ]]
+    [[ "$output" == *"could not review"* ]]
+    # and it is NOT reported as silence: the author must not go hunting for a
+    # reviewer that already answered
+    [[ "$output" != *"no reviewer output on this PR yet"* ]]
 }
 
-@test "AC1: classifies the other two real captures as declined too" {
+@test "AC1: the other two real captures behave the same way" {
     for pr in 1007 1013; do
         run "$SCRIPT" --payload "$F/pr-${pr}.raw.json"
         [ "$status" -eq 1 ]
-        [[ "$output" == *"declined"* ]]
+        [[ "$output" == *"pending"* ]]
+        [[ "$output" == *"could not review"* ]]
     done
+}
+
+@test "an advisory decline is still distinguishable from silence" {
+    # Same verdict, different fact. Collapsing them would lose the one thing the
+    # advisory reviewer's notice is still good for.
+    run "$SCRIPT" --payload "$F/pr-1009.raw.json"
+    advisory_msg="$output"
+    run "$SCRIPT" --payload "$F/no-output.json"
+    silence_msg="$output"
+    [ "$advisory_msg" != "$silence_msg" ]
+}
+
+@test "a NON-advisory reviewer's decline still refuses hard" {
+    # The mechanism must survive the policy. If every decline became advisory,
+    # GUARD-002 would have been deleted rather than tuned.
+    cfg="$TMP/counting.json"
+    jq '(.reviewers[] | select(.login == "coderabbitai") | .advisory) = false' \
+        "$BATS_TEST_DIRNAME/../harness/review-attestation.json" > "$cfg"
+    run "$SCRIPT" --payload "$F/pr-1009.raw.json" --config "$cfg"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"declined"* ]]
+}
+
+@test "an advisory reviewer's REVIEW still attests" {
+    # Advisory scopes the decline, never the review. A CodeRabbit review that
+    # actually happens is as good an attestation as any.
+    cfg="$BATS_TEST_DIRNAME/../harness/review-attestation.json"
+    marker="$(jq -r '.reviewers[] | select(.login == "coderabbitai") | .review_markers[0]' "$cfg")"
+    payload="$TMP/cr-reviewed.json"
+    jq -n --arg m "$marker" '{
+        author: {login: "someone"},
+        comments: [{author: {login: "coderabbitai"}, body: ("prefix " + $m + " suffix")}],
+        reviews: [], labels: [], body: "", files: []
+    }' > "$payload"
+    run "$SCRIPT" --payload "$payload"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"attested"* ]]
 }
 
 @test "AC3: a PR with no reviewer output is pending, not declined" {
@@ -358,10 +404,29 @@ sys.exit(0 if expected.issubset(types) else 1)
 @test "AC3: the declined message names both the reviewer and the marker" {
     # Preserve-why, asserted rather than assumed: an operator must be able to
     # tell WHICH reviewer declined and on what evidence.
+    #
+    # Exercised against a COUNTING reviewer, because that is the only path that
+    # still produces `declined`. coderabbitai went advisory on 2026-08-22, and
+    # pointing this at it would have quietly turned a test of the message into a
+    # test of the advisory branch -- passing while asserting nothing about the
+    # thing its name claims.
+    cfg="$TMP/counting.json"
+    jq '(.reviewers[] | select(.login == "coderabbitai") | .advisory) = false' \
+        "$BATS_TEST_DIRNAME/../harness/review-attestation.json" > "$cfg"
+    run "$SCRIPT" --payload "$F/coderabbit-rate-limited.json" --config "$cfg"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"declined"* ]]
+    [[ "$output" == *"coderabbitai"* ]]
+    [[ "$output" == *"rate limited by coderabbit.ai"* ]]
+}
+
+@test "AC3: the advisory message names the reviewer, without claiming it refused" {
+    # The advisory path owes the same preserve-why, in its own words.
     run "$SCRIPT" --payload "$F/coderabbit-rate-limited.json"
     [ "$status" -eq 1 ]
     [[ "$output" == *"coderabbitai"* ]]
-    [[ "$output" == *"rate limited by coderabbit.ai"* ]]
+    [[ "$output" == *"advisory"* ]]
+    [[ "$output" != *"declined"* ]]
 }
 
 @test "meta: no bare negated assertion survives in this suite" {


### PR DESCRIPTION
The headache, fixed at the root.

## What was happening

Across one full session on 2026-08-22, `declined` was the **first verdict on every PR opened**, flipping green ~90 seconds later when PR-Agent posted. CodeRabbit was rate limited on all of them.

This workflow's own comment already names why that matters:

> *"A gate whose normal state is red has stopped being a gate."*

It was becoming true of this one.

## Why it was measuring the wrong thing

There are two different facts wearing the same word:

| Reviewer says "I could not review" | What it is |
|---|---|
| a **counting** reviewer | a fact about *this change's* review — actionable |
| **CodeRabbit** | a fact about a *third party's billing state* — not actionable by the author, and it does not make the change worse |

Codex is in the same position, which is why this is a property of the entry rather than a special case.

## The change

`advisory: true` on a registry entry scopes the decline:

- the reviewer's **review still attests** — a CodeRabbit review that actually happens is as good an attestation as any;
- its **decline no longer refuses**.

`coderabbitai` is the first entry to carry it.

## What is NOT weakened — check this rather than trust it

An advisory decline still prevents `attested`. It yields **`pending`**, which is the honest reading: *a reviewer that could not run has not refused the change*. The three real captured rate-limit payloads (#1009, #1007, #1013) **still exit 1**:

```
before: [FAIL] declined — coderabbitai posted a notice that no review ran
after:  [FAIL] pending  — coderabbitai could not review (advisory: its availability is a
                          third-party quota, not a property of this change, so it does not
                          refuse). No counting reviewer has attested yet.
```

What changed is the sentence, and the sentence is now true. The PR still cannot read as reviewed.

It also stays **distinguishable from silence**, with its own message — an author must not go hunting for a reviewer that already answered. A test asserts the two messages differ, because collapsing them throws away the one thing the notice is still good for.

## Guards, so this tunes the gate rather than deleting it

- **A non-advisory decline still refuses hard.** Builds a counting-reviewer config from the shipped registry and re-runs the real payload.
- **An advisory reviewer's real review still attests.**

## One existing test was re-pointed, not left passing

`"AC3: the declined message names both the reviewer and the marker"` ran against `coderabbitai`. After this change it would have **silently become a test of the advisory branch** — green, while asserting nothing about the thing its name claims. That is the vacuous-test shape this repo has measured before, so it now builds a counting-reviewer config, and the advisory path got its own preserve-why test.

## Considered and deliberately NOT included

- **"`declined` should only be terminal when no other counting reviewer is outstanding."** A good rule, but with CodeRabbit advisory and PR-Agent carrying no declined markers, nothing would exercise it today. Adding it now is the *declaration with no consumer* trap. It belongs with the second counting reviewer.
- **Declined markers for PR-Agent.** Already covered elsewhere: #1109 makes the `pr-agent` job itself fail when it publishes no review (*"PR-Agent reported success but published no review"*), so that failure is already loud — in the job that owns it.

## Testing

- `bats tests/*.bats` — **1437 passing, 0 failing**
- `shellcheck --severity=error scripts/*.sh setup-linux.sh` — exit 0; `bash -n` and `zsh -n` clean
- `check-bats-names.sh` clean; registry validates as JSON and against the script's own shape check
