### PR TITLE
fix(ci): the attestation check-run must not carry a verdict that will change

### DIFF
--- a/.github/workflows/review-attestation.yml
+++ b/.github/workflows/review-attestation.yml
@@ -251,12 +251,44 @@ jobs:
           # revise and which is the signal branch protection must require.
           # `declined` still fails here and immediately, because a reviewer
           # saying it could not review is actionable the moment it is said.
-          if [ "$CODE" != "0" ] && [ "$KIND" = "pending" ] && [ "$EVENT" = "pull_request" ]; then
+          # WIDENED from `pending` to EVERY kind, and the reason is structural
+          # rather than a preference about strictness.
+          #
+          # A check-run cannot be revised: it belongs to the run that created it,
+          # and runs from issue_comment and workflow_run attach to the default
+          # branch, so they cannot reach it either. On the `pull_request` event
+          # NO verdict is final — the reviewers have not run yet, by
+          # construction. Publishing any failure here writes a provisional value
+          # into an immutable slot, which is the defect #1041 named; restricting
+          # the exemption to `pending` narrowed the window instead of closing it.
+          #
+          # Measured 2026-08-22: `declined` was the first verdict on every PR
+          # opened in a full session, because CodeRabbit's rate-limit notice
+          # lands within seconds. Each one froze red permanently while the commit
+          # status beside it went green — "a gate whose normal state is red has
+          # stopped being a gate", arrived at through the one kind the exemption
+          # did not cover.
+          #
+          # #1184 made that particular verdict rare by marking CodeRabbit
+          # advisory. This closes the shape rather than the instance: any future
+          # counting reviewer that answers fast would reopen it.
+          #
+          # NOTHING IS SOFTENED. The verdict is published to the
+          # `review-attestation` COMMIT STATUS in the step above — revisable by
+          # every later run, and the signal branch protection must require. This
+          # step decides only whether an unrevisable check-run carries a value
+          # that is expected to change. Every other event still fails: by then a
+          # reviewer has had its turn, so the verdict means something.
+          if [ "$CODE" != "0" ] && [ "$EVENT" = "pull_request" ]; then
             echo "$SUMMARY"
             echo
-            echo "Not failed here: no reviewer has posted yet, which is the expected"
-            echo "state this early. The verdict lives on the 'review-attestation'"
-            echo "commit status, which later runs revise as reviewers arrive."
+            echo "Not failed here: this run fires as the PR opens, before any reviewer"
+            echo "has had a turn, so no verdict it computes is final. A check-run cannot"
+            echo "be revised, so it must not carry one that will change."
+            echo
+            echo "The verdict lives on the 'review-attestation' commit status, which"
+            echo "later runs revise as reviewers arrive — and which is the signal to"
+            echo "require in branch protection."
             exit 0
           fi
           if [ "$CODE" != "0" ]; then

--- a/tests/review-attestation-workflow.bats
+++ b/tests/review-attestation-workflow.bats
@@ -97,22 +97,36 @@ if 'workflow_run.head_sha' not in group:
 # posted and the only possible verdict is `pending` — so it froze red on every
 # correct PR, permanently, while the commit status beside it went green. A gate
 # whose normal state is red teaches its readers to scroll past it.
-@test "review-attestation: pending does not freeze the check-run red [#1041]" {
-    grep -q 'KIND" = "pending" \] && \[ "$EVENT" = "pull_request"' "$WF"
+@test "review-attestation: the pull_request run never freezes the check-run red [#1041]" {
+    # WIDENED from `pending` to every kind. A check-run cannot be revised, and on
+    # the pull_request event NO verdict is final -- the reviewers have not run
+    # yet, by construction. Restricting the exemption to `pending` narrowed the
+    # window instead of closing it: measured 2026-08-22, `declined` was the first
+    # verdict on every PR opened in a full session, and each froze red for good.
+    grep -q '\[ "$EVENT" = "pull_request" \]; then' "$WF"
 }
 
-# ...and the softening is exactly that narrow. A reviewer saying it could not
-# review is actionable the moment it is said, on any path.
-@test "review-attestation: declined still fails immediately, on every path [#1041]" {
+# ...and the exemption is scoped to the ONE event that cannot mean anything yet.
+# Every other path still fails: by then a reviewer has had its turn.
+@test "review-attestation: every non-pull_request path still fails [#1041]" {
     run bash -c '
       body=$(sed -n "/Fail the run when the PR is not attested/,\$p" "'"$WF"'")
-      # the exemption must name pending; if it ever names declined, or drops the
-      # event guard, the gate has been widened into silence
-      echo "$body" | grep -q "KIND\" = \"pending\"" || exit 1
-      echo "$body" | grep -q "KIND\" = \"declined\"" && exit 1
+      # the exemption must be guarded on the EVENT; losing that guard would make
+      # the gate never fail anywhere, which is widening it into silence
+      echo "$body" | grep -q "EVENT\" = \"pull_request\"" || exit 1
+      # and the unconditional refusal must survive after it
+      echo "$body" | grep -q "exit \"\$CODE\"" || exit 1
       exit 0
     '
     [ "$status" -eq 0 ]
+}
+
+@test "review-attestation: the verdict still reaches a REVISABLE signal [#1041]" {
+    # The exemption is only defensible because the commit status carries the
+    # verdict and every later run can revise it. If the publish step ever went
+    # away, softening the check-run would become plain silence.
+    grep -q 'statuses' "$WF"
+    grep -q 'Publish the verdict onto the PR head' "$WF"
 }
 
 # The workflow extracts the verdict KIND from the classifier's own structured


### PR DESCRIPTION
Refs #1052 — advances it, does not close it (see the correction below). Follows #1184, which made the symptom rare; this closes the shape.

## The structural defect

**A check-run cannot be revised.** It belongs to the run that created it, and runs from `issue_comment` and `workflow_run` attach to the **default branch**, so they cannot reach it either.

On the `pull_request` event, **no verdict is final** — the reviewers have not run yet, by construction. Publishing any failure there writes a provisional value into an immutable slot.

#1041 named exactly this and fixed it **for `pending` only**. That narrowed the window instead of closing it.

## Measured, not inferred

Across a full session on 2026-08-22, `declined` was the **first verdict on every PR opened** — CodeRabbit's rate-limit notice lands within seconds. Each froze red permanently while the commit status beside it went green:

```
07:29:14  pull_request  failure   ← frozen forever
07:29:30  workflow_run  success   ← the truth, on the revisable signal
```

That is *"a gate whose normal state is red has stopped being a gate"* — the workflow's own words — reached through the one kind the exemption did not cover.

## Why this and not a delay, a timeout, or a `depends on`

All three were considered:

| Proposal | Why not |
|---|---|
| **sleep / delay** | guesses a duration (PR-Agent ~90s, variable), burns CI minutes on every PR, and a slow run still freezes. It moves the race rather than removing it |
| **`depends on`** | cannot cross workflows. The cross-workflow dependency already exists and works: the `workflow_run` trigger on `pr-agent` |
| **timeout** | inapplicable — the job does not hang, it answers too early |

The defect is not timing. It is a mutable value in an immutable slot, so the fix is to stop putting it there.

## Nothing is softened — check this rather than trust it

The verdict is still published to the **`review-attestation` commit status**: revisable by every later run, and the signal branch protection must require. This step now decides only whether an *unrevisable* check-run carries a value expected to change.

**Every other event still fails.** By then a reviewer has had its turn, so the verdict means something.

## The #1041 tests are rewritten, not deleted

The invariant moved; it did not disappear. The old pair asserted *"the exemption names `pending`, and must never name `declined`"* — which this change makes false by design, so leaving them would have blocked a correct fix, and deleting them would have dropped the protection.

The three replacements assert what actually protects the gate:

1. the exemption is guarded on the **event**;
2. the **unconditional refusal survives** after it — losing that guard would widen the gate into silence;
3. the **publish step still exists** — the exemption is only defensible because the commit status carries the verdict, and if that went away, softening the check-run would become plain silence.

## #1052: advanced, NOT closed — a correction

I first wrote `Closes #1052` here. **That was wrong, and `spec-gate` caught it**: #1052 carries an active spec, `GUARD-003-review-loop-determinism`, with **nine** acceptance criteria. I verified one (the `workflow_run` trigger fires) and concluded the ticket was done.

That is precisely the shape [lesson 220](https://github.com/mlorentedev/dotfiles/blob/main/docs/lessons/lesson-220-four-defects-one-shape-a-thing-verified-by-a-proxy.md) describes — *a thing verified by a proxy that lives somewhere else* — committed by the person who wrote it, hours later.

What today's evidence actually establishes:

| AC | State |
|---|---|
| **AC1** re-evaluates with no human action, verified live | ✅ `#1182 attestation run: event=workflow_run conclusion=success` |
| **AC2** the status carries the latest verdict, not the first | ✅ observed going green after PR-Agent posted |
| **AC3** declined/never-ran still ends red after the trigger | ✅ preserved by this PR — every non-`pull_request` path still fails |
| **AC4** re-evaluates the PR the reviewer actually ran on | ❌ **#1128 is the open counterexample**: a `/review` run carries master's SHA |
| AC5-AC9 | guard exists; `dotf pr triage-queue` ships — not audited here |

So the PR now says **`Refs #1052`**. AC4 is exactly #1128, which this PR deliberately does not fold in.

## Considered and NOT folded in

**#1128** — *"a review requested with `/review` never updates the attestation, because the workflow_run carries master's SHA"*. Same file, same class, and the obvious neighbour. But its own ticket says **"What this ticket does not decide: the fix"**, leaving two shapes open that need thought about which preserves the "nothing to judge must not publish" invariant. Folding an undecided design into a PR about check-run semantics would make both harder to review. It is also **latent, not observed** — only the on-demand slash command is affected.

## Testing

- `bats tests/*.bats` — **1438 passing, 0 failing**
- workflow parses as valid YAML; `check-bats-names.sh` clean
- No untrusted event payload is interpolated: every value comes through `env:` from `steps.*.outputs`