### PR TITLE
feat(ci): configure CodeRabbit instead of inheriting somebody else's defaults

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,110 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit is the SECOND opinion here, not the first. PR-Agent is the automatic
+# reviewer (.github/workflows/pr-agent.yml, TOOL-013) and runs on every push;
+# CodeRabbit's job is the independent look, and its findings have earned that —
+# on #1172 it caught a privilege escalation through data that the shipped tests,
+# the schema and an adversarial review had all passed over.
+#
+# Every setting below exists because leaving it at its default was measured to
+# cost something. Defaults are not neutral: an unwritten config is a set of
+# decisions somebody else made for a different repository.
+
+language: "en-US"
+early_access: false
+
+tone_instructions: |
+  Be terse. Name the file, the line and the failing input. Prefer one reproducible
+  finding over three plausible ones. This repository values a claim you can run
+  over a claim that reads well.
+
+reviews:
+  # `chill`, not `assertive`. Measured upstream rather than assumed: crossplane
+  # tested assertive and reported "approx 200 comments on one PR […] the signal
+  # to noise ratio isn't good enough" (crossplane/crossplane, 12k stars). The
+  # same trade decided `auto_improve: false` in the PR-Agent workflow here.
+  profile: chill
+
+  # The PR bodies in this repository carry hand-written measurement tables, merge
+  # orders and before/after evidence — the part worth reading. This is the same
+  # decision already recorded for the other tool: the PR-Agent workflow sets
+  # `auto_describe: false` because "describe REWRITES the PR body […] a model
+  # rewriting them destroys exactly that". CodeRabbit brings the same threat
+  # through a different door.
+  high_level_summary: false
+  high_level_summary_placeholder: "@coderabbitai summary"
+  changed_files_summary: false
+  sequence_diagrams: false
+  poem: false
+
+  # Labels and reviewers are the board's business (ADR-018), not a reviewer's.
+  # An auto-applied label here is how #1180 acquired a `skip-sdd` that changed
+  # which gate rules applied.
+  auto_apply_labels: false
+  suggested_labels: false
+  suggested_reviewers: false
+
+  # A closed PR's review is spend with nothing to spend it on.
+  abort_on_close: true
+
+  auto_review:
+    enabled: true
+
+    # THE SETTING THIS FILE EXISTS FOR.
+    #
+    # Default is `true`: CodeRabbit re-reviews after every push, and its own docs
+    # state that "automatic incremental reviews count toward the same
+    # per-developer PR review rate limit as manual PR reviews".
+    #
+    # Measured 2026-08-22: CodeRabbit was rate limited on EVERY pull request
+    # opened across a full session. The work pattern here is many small pushes
+    # per PR, which is precisely the profile that burns the allowance — so the
+    # quota was spent on re-reviews nobody asked for, and gone by the time a
+    # human wanted a second opinion.
+    #
+    # The value is not lost by turning this off, and that is the point. Its best
+    # finding of that session — a privilege escalation through data on #1172 —
+    # came from the FIRST review of the PR, not from an incremental pass. The
+    # first look is kept; the re-reads are on request.
+    #
+    # `@coderabbitai review` when a PR is genuinely ready, which is upstream's
+    # own recommendation for repositories with frequent pushes.
+    auto_incremental_review: false
+
+    # Belt and braces. With incremental review off this should never be reached,
+    # but if it is ever turned back on, a fast-moving branch must not spend the
+    # allowance before the PR is ready. Upstream recommends 1-2 for this profile;
+    # pingcap/docs runs 3.
+    auto_pause_after_reviewed_commits: 1
+
+    # A draft is not asking to be reviewed. The most common setting among the
+    # large repositories surveyed: crossplane, MONAI, biomejs, pingcap, wso2.
+    drafts: false
+
+    # CodeRabbit always includes the default branch, but naming it keeps auto
+    # review working if the default is ever renamed (pingcap/docs records the
+    # same reasoning).
+    base_branches:
+      - "^main$"
+
+  path_instructions:
+    - path: "**/*.sh"
+      instructions: >-
+        Scripts here MUST run under bash AND zsh. Flag any construct that behaves
+        differently: an unescaped bracket in a parameter expansion pattern
+        (`${v#[}` aborts zsh at RUN time and `zsh -n` does not catch it),
+        `echo -e`, `&>`, `local x="$(cmd)"` masking the command's exit status
+        under `set -e`, and unquoted word-splitting, which zsh does not perform.
+    - path: "harness/*.json"
+      instructions: >-
+        These are declarative registries consumed by the render and the gates. A
+        value that reaches rendered output must be checked for characters that
+        could ALTER that output rather than appear in it — a comma in a
+        comma-separated field, a brace in a flow mapping. Flag any new field
+        whose absence would read as a default rather than as a decision.
+    - path: ".github/workflows/*.yml"
+      instructions: >-
+        Flag untrusted event payload interpolated into `run:` (issue/PR titles and
+        bodies, comment bodies, branch names) instead of passed through `env:`.
+        Also flag a verdict published to a check-run that later runs cannot
+        revise.


### PR DESCRIPTION
This repository had **no `.coderabbit.yaml`**, so CodeRabbit ran on defaults. Defaults are not neutral — they are decisions somebody else made for a different repository.

## The one that mattered

```
auto_incremental_review: true    ← default: re-review after EVERY push
```

CodeRabbit's own docs:

> *"Automatic incremental reviews count toward the same per-developer PR review rate limit as manual PR reviews."*

**Measured 2026-08-22:** CodeRabbit was rate limited on *every* pull request opened across a full session.

### A correction, and PR-Agent earned it

This PR originally claimed it **stops** the exhaustion. That claim was too strong, and PR-Agent flagged it: *"Verify that disabling `auto_incremental_review` actually prevents quota exhaustion in production."* Measuring instead of inferring:

| | count |
|---|---|
| PRs **opened** that day | **17** — each one a first review, which this PR keeps |
| commits per PR | 1–3, with few pushes after open — so few incremental re-reviews |

So the dominant consumer was the **number of PRs opened**, not incremental re-review. Disabling incremental removes real waste at the margin; **it does not prevent exhaustion on a 17-PR day.**

What actually handles that is **#1184**, which made CodeRabbit advisory so an exhausted quota stops being treated as a refusal. That was the fix for the symptom; this is an efficiency improvement whose effect I overstated.

It still belongs: a re-review nobody asked for is spend with no return, and the setting was inherited rather than chosen. But the honest claim is *"stops paying for re-reads"*, not *"stops the exhaustion"*.

## Incremental off, first review kept — and the distinction is the point

Turning CodeRabbit off entirely would lose real value. Its best finding of that session — a **privilege escalation through data** on #1172, which the shipped tests, the schema *and* an adversarial review had all passed over — came from the **first** review of the PR, not from an incremental pass.

So: the first look stays automatic, re-reads become `@coderabbitai review`. That is upstream's own recommendation for repositories with frequent pushes.

## The rest is drawn from real configs, not invented

I surveyed `.coderabbit.yaml` in high-signal repositories via `gh search code`:

| Setting | Evidence |
|---|---|
| `profile: chill` | **crossplane** (12k ⭐) tested assertive and recorded *"approx 200 comments on one PR […] the signal to noise ratio isn't good enough"* |
| `drafts: false` | the most common setting among those surveyed — crossplane, MONAI (8.6k ⭐), biomejs, pingcap, wso2, clappr |
| `base_branches` | **pingcap/docs** records why: naming it keeps auto review working if the default branch is ever renamed |
| quota strategy | two exist in the wild — **pingcap/docs** throttles (`auto_pause_after_reviewed_commits: 3`), **infection** and **nextcloud/mail** disable auto-review entirely. This takes the middle: first review yes, incremental no |

## Summaries off — a decision this repo already made once, for the other tool

The PR-Agent workflow sets `auto_describe: false` because *"describe REWRITES the PR body […] a model rewriting them destroys exactly that"* — the bodies here carry hand-written measurement tables and before/after evidence. CodeRabbit brings the same threat through a different door as `high_level_summary`, and that door had no config.

`auto_apply_labels` and `suggested_labels` are off because labels are the board's business (ADR-018) — and because an auto-applied label is how #1180 acquired a `skip-sdd` that changed which gate rules applied to it.

## `path_instructions` encode what this repo keeps re-learning

- **`**/*.sh`** — must run under bash *and* zsh, including the unescaped-bracket pattern that aborts zsh at **run** time while `zsh -n` passes clean (found the hard way today).
- **`harness/*.json`** — a registry value that reaches rendered output must not be able to **alter** it (the #1172 escalation), and a new field whose absence reads as a default rather than a decision (#1156).
- **`.github/workflows/*.yml`** — untrusted event payload interpolated into `run:`, and a verdict published to a check-run later runs cannot revise (#1185).

## SDD skip rationale

`spec-gate` refused at *"Production diff: 110 LOC (>= threshold 50)"*. Measured:

```
total lines:   110      ← what the gate counts
non-comment:    45      ← what the rule says to count
setting keys:   25
```

**This file is under the threshold by the rule merged in #1180 hours ago** — *"the cap counts EXECUTABLE lines; declarative data, schemas and comment blocks are excluded"*. `check-spec-gate.sh`'s `_excluded()` is path-based and has no notion of counting within a file, so every comment line counts as production.

Filed as **#1186**. The label here compensates for a counter that has not caught up with the rule; it is not dodging the rule. A single YAML config file with 25 setting keys is not a change that wants a spec folder.