### PR TITLE
fix(setup): deploy the settings.json env block instead of dropping it

### DIFF
--- a/ai/claude/settings.json
+++ b/ai/claude/settings.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "model": "opus",
+  "model": "opus[1m]",
   "effortLevel": "xhigh",
   "advisorModel": "fable",
   "outputStyle": "Concise",
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL": "1"
   },
   "permissions": {
     "deny": [

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -234,3 +234,4 @@ tags: [lessons, index, dotfiles]
 | [218 - The Go build cache does not see the data file your test reads](lesson-218-the-go-build-cache-does-not-see-the-data-file-your.md) | 2026-08-21 |  |
 | [219 - A stale CLI refuses with the same exit status as a legitimate refusal](lesson-219-a-stale-cli-refuses-with-the-same-exit-status-as-a.md) | 2026-08-21 |  |
 | [220 - Four defects, one shape: a thing verified by a proxy that lives somewhere else](lesson-220-four-defects-one-shape-a-thing-verified-by-a-proxy.md) | 2026-08-22 |  |
+| [221 - An allow-list merge makes every new template key a silent no-op](lesson-221-an-allow-list-merge-makes-every-new-template-key-a.md) | 2026-08-22 |  |

--- a/docs/lessons/lesson-221-an-allow-list-merge-makes-every-new-template-key-a.md
+++ b/docs/lessons/lesson-221-an-allow-list-merge-makes-every-new-template-key-a.md
@@ -1,0 +1,87 @@
+# Lesson 221 — An allow-list merge makes every new template key a silent no-op
+
+**Date:** 2026-08-22
+**Area:** setup / settings deployment
+**Severity:** medium — config that reads as deployed but never was
+
+## What happened
+
+`ai/claude/settings.json` carried `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"`.
+The deployed `~/.claude/settings.json` had **no `env` key at all**. The flag had
+never been live on any machine that was not bootstrapped from scratch.
+
+The cause is `merge_claude_settings` in `setup-linux.sh`: its per-key policy is
+an explicit **allow-list**. It merges `model`, `effortLevel`, `outputStyle`,
+`permissions.allow`, `hooks.SessionStart`, `hooks.SessionEnd` and
+`enabledPlugins`. Anything else in the template is dropped on the floor, without
+a warning, on every existing installation. `setup-windows.ps1` has the same list
+as an if-chain, with the same hole.
+
+This is the **second** time this class landed. The first was `outputStyle`, and
+the code comment written after that incident describes the mechanism exactly.
+The mechanism was documented; the recurrence was not prevented.
+
+## Why the existing guard missed it
+
+`tests/claude-settings-template.bats` did have a test named *"every
+dotfiles-owned top-level key is named in both merge policies"*. It iterated a
+**hand-written** list:
+
+```bash
+for key in model effortLevel outputStyle; do
+```
+
+and its comment asserted that the structured keys — naming `env` explicitly —
+"have their own merge semantics asserted below and are handled by name in both
+scripts". That sentence was false for `env`, and nothing checked it. The test's
+name promised template-wide coverage; its body covered three keys somebody had
+remembered to type.
+
+This is [Lesson 220](lesson-220-four-defects-one-shape-a-thing-verified-by-a-proxy.md)'s
+shape again: **a thing verified by a proxy that lives somewhere else.** The
+proxy was a literal list in the test; the thing was the template. They drift
+apart the moment anyone edits the template, which is the only moment that
+matters.
+
+## The fix
+
+- Both merge policies now handle `env` (object merge, so a machine-local flag
+  survives) and `advisorModel` (template wins).
+- The guard derives its key list **from the template**:
+
+```bash
+while IFS= read -r key; do
+    if [ "$key" = "\$schema" ]; then continue; fi
+    grep -qF -- "\$tmpl.$key" "$DOTFILES_DIR/setup-linux.sh" || return 1
+    grep -qF -- "ContainsKey('$key')" "$DOTFILES_DIR/setup-windows.ps1" || return 1
+done < <(jq -r 'keys[]' "$SETTINGS_TEMPLATE")
+```
+
+Adding a key to the template now fails CI until both policies name it. Proven
+fail-first: injecting a `someNewKey` into the template makes the test fail with
+`setup-linux.sh merge policy never mentions 'someNewKey'`.
+
+`$schema` is exempt **by name** — a stated decision, not a gap.
+
+## The generalisable rule
+
+**A test that enumerates what it checks cannot catch the item nobody thought to
+enumerate.** Where the set under test is data that lives in the repo, derive the
+set from that data. A hand-written list is a second source of truth whose only
+job is to agree with the first one, and it will stop agreeing silently.
+
+Ask of any guard: *what would this still pass on if the thing it checks were
+broken?* This one passed on a template with an undeployable key in it — which is
+precisely the state it was named after preventing.
+
+## Related
+
+- The concrete flag that surfaced this: `CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL`,
+  which Claude Code reads from its **own** process environment (`settings.env`
+  is merged into `process.env` at startup). Without it the `/advisor` command is
+  hidden and `advisorModel` is read but never attaches — a second silent no-op
+  stacked on the first.
+- `model` sits in the same file with a `template wins` policy, so every setup
+  run resets whatever `/model` last saved. A 1M-context default chosen
+  interactively survived exactly until the next deploy. The template now carries
+  `opus[1m]` so the durable record matches the intent.

--- a/docs/lessons/lesson-221-an-allow-list-merge-makes-every-new-template-key-a.md
+++ b/docs/lessons/lesson-221-an-allow-list-merge-makes-every-new-template-key-a.md
@@ -63,6 +63,28 @@ fail-first: injecting a `someNewKey` into the template makes the test fail with
 
 `$schema` is exempt **by name** — a stated decision, not a gap.
 
+### The guard's first version had the defect it was built to prevent
+
+Review caught it. The greps above originally scanned the **whole scripts**, and
+`setup-windows.ps1` says `$tool.ContainsKey('Version')` in its winget loop, far
+from `Merge-ClaudeSettings`. So a template key named `Version` would satisfy the
+Windows half of the guard while the merge ignored it. Measured, on that exact
+state — template carries `Version`, `merge_claude_settings` handles it,
+`Merge-ClaudeSettings` does not:
+
+```
+OLD GUARD (whole-file grep): PASSES   <-- the hole
+NEW GUARD (scoped to bodies): not ok 5
+                              # Merge-ClaudeSettings never mentions 'Version'
+```
+
+The fix extracts both merge function bodies with `sed` and greps inside those.
+The point is not the `sed`: it is that **a guard is a claim about a specific
+region of code, and grepping a whole file quietly widens the region until the
+claim is no longer the one you meant.** Writing a test against the thing you
+care about is not enough; it has to be scoped to it, or the surrounding file
+answers on its behalf. Same shape as the bug in this lesson, one level up.
+
 ## The generalisable rule
 
 **A test that enumerates what it checks cannot catch the item nobody thought to

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -1284,9 +1284,17 @@ merge_claude_settings() {
     fi
 
     # Per-key merge via single jq invocation. Policy table in proposal.md:
-    # model, effortLevel, outputStyle: template wins. permissions.allow: UNION
-    # (deduped). hooks.SessionStart: template wins (replace). enabledPlugins:
-    # object merge (template wins on conflict). All other keys: existing preserved.
+    # model, effortLevel, outputStyle, advisorModel: template wins.
+    # permissions.allow: UNION (deduped). hooks.SessionStart: template wins
+    # (replace). enabledPlugins, env: object merge (template wins on conflict).
+    # All other keys: existing preserved.
+    #
+    # `env` carries feature flags Claude Code reads from its OWN process
+    # environment -- settings.env is Object.assign'd into process.env at
+    # startup, which is how CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL
+    # reaches the gate that decides whether /advisor exists at all. It merges
+    # per-key rather than replacing, so a machine-local flag a user added by
+    # hand survives a redeploy.
     #
     # `outputStyle` joins the template-wins set because the policy is an explicit
     # ALLOW-LIST: a key added to the template and not named here is silently a
@@ -1306,6 +1314,8 @@ merge_claude_settings() {
         .model = $tmpl.model
         | .effortLevel = $tmpl.effortLevel
         | (if ($tmpl | has("outputStyle")) then .outputStyle = $tmpl.outputStyle else . end)
+        | (if ($tmpl | has("advisorModel")) then .advisorModel = $tmpl.advisorModel else . end)
+        | (if ($tmpl | has("env")) then .env = ((.env // {}) + $tmpl.env) else . end)
         | .permissions = (.permissions // {})
         | .permissions.allow = (((.permissions.allow // []) + $tmpl.permissions.allow) | unique)
         | .hooks = (.hooks // {})

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -252,6 +252,19 @@ function Merge-ClaudeSettings {
     if ($template.ContainsKey('model')) { $existing['model'] = $template['model'] }
     if ($template.ContainsKey('effortLevel')) { $existing['effortLevel'] = $template['effortLevel'] }
     if ($template.ContainsKey('outputStyle')) { $existing['outputStyle'] = $template['outputStyle'] }
+    if ($template.ContainsKey('advisorModel')) { $existing['advisorModel'] = $template['advisorModel'] }
+
+    # env: object merge (template wins on conflict). These are feature flags
+    # Claude Code reads from its OWN process environment -- settings.env is
+    # merged into process.env at startup, which is how
+    # CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL reaches the gate deciding
+    # whether /advisor exists. Per-key so a machine-local flag survives.
+    if ($template.ContainsKey('env')) {
+        if (-not $existing.ContainsKey('env')) { $existing['env'] = @{} }
+        foreach ($envKey in $template['env'].Keys) {
+            $existing['env'][$envKey] = $template['env'][$envKey]
+        }
+    }
 
     # permissions.allow: UNION (template + existing, deduped)
     if ($template.ContainsKey('permissions') -and $template['permissions'].ContainsKey('allow')) {

--- a/tests/claude-settings-template.bats
+++ b/tests/claude-settings-template.bats
@@ -18,8 +18,13 @@ setup() {
 
 # --- Top-level keys (the "ours" subset) ---
 
-@test "template has model = opus" {
-    [[ "$(jq -r '.model' "$SETTINGS_TEMPLATE")" == "opus" ]]
+@test "template has model = opus[1m]" {
+    # The `[1m]` suffix selects the 1M-context variant. It matters that the
+    # TEMPLATE carries it, not just the deployed file: the merge policy is
+    # `template wins` for model, so every setup run resets whatever /model
+    # last saved. With a bare "opus" here, a 1M default chosen interactively
+    # survives exactly until the next deploy -- silently.
+    [[ "$(jq -r '.model' "$SETTINGS_TEMPLATE")" == "opus[1m]" ]]
 }
 
 @test "template has effortLevel = xhigh" {
@@ -30,21 +35,73 @@ setup() {
     # The merge policy is an ALLOW-LIST in two places -- a jq expression in
     # setup-linux.sh and an if-chain in setup-windows.ps1. A key added to the
     # template and named in neither is a SILENT no-op on every existing
-    # installation, reaching only machines bootstrapped from scratch. Measured:
-    # outputStyle sat in the template while the deployed settings.json had no
-    # such key at all.
+    # installation, reaching only machines bootstrapped from scratch.
     #
-    # Scoped to the scalar top-level keys. The structured ones (permissions,
-    # hooks, enabledPlugins, env) have their own merge semantics asserted below
-    # and are handled by name in both scripts.
+    # This test used to enumerate `model effortLevel outputStyle` by hand and
+    # claim in a comment that the structured keys were "handled by name in both
+    # scripts". That claim was FALSE for `env`, and nothing checked it: the
+    # template carried CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS while the deployed
+    # settings.json had no `env` key at all -- the same failure outputStyle had
+    # already caused once. A hand-written list cannot catch the key nobody
+    # thought to add to it, so the list now comes FROM THE TEMPLATE: any new
+    # top-level key must be named in both policies or this fails.
     local key
-    for key in model effortLevel outputStyle; do
-        jq -e --arg k "$key" 'has($k)' "$SETTINGS_TEMPLATE" >/dev/null || continue
-        grep -q "\.$key = \$tmpl\.$key\|\$tmpl\.$key" "$DOTFILES_DIR/setup-linux.sh" \
+    while IFS= read -r key; do
+        # `$schema` is editor metadata for JSON language servers. It is never
+        # deployed, so it is exempt BY NAME -- a stated decision, not a gap.
+        if [ "$key" = "\$schema" ]; then continue; fi
+        grep -qF -- "\$tmpl.$key" "$DOTFILES_DIR/setup-linux.sh" \
             || { echo "setup-linux.sh merge policy never mentions '$key'" >&2; return 1; }
-        grep -q "ContainsKey('$key')" "$DOTFILES_DIR/setup-windows.ps1" \
+        grep -qF -- "ContainsKey('$key')" "$DOTFILES_DIR/setup-windows.ps1" \
             || { echo "setup-windows.ps1 merge policy never mentions '$key'" >&2; return 1; }
-    done
+    done < <(jq -r 'keys[]' "$SETTINGS_TEMPLATE")
+}
+
+@test "the merge carries env through and preserves machine-local entries" {
+    # `env` is how a feature flag reaches Claude Code's own process
+    # environment: settings.env is merged into process.env at startup, which is
+    # what makes CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL able to un-hide
+    # /advisor. Asserting the SHIPPED jq expression, not a copy of it.
+    local expr existing out
+    expr="$(sed -n "/^    merged=\$(jq --argjson tmpl /,/^    ' \"\$target_path\"/p" \
+        "$DOTFILES_DIR/setup-linux.sh" \
+        | sed -e "1s/.*jq --argjson tmpl \"\$template_substituted\" '//" -e "\$d")"
+    [ -n "$expr" ]
+
+    existing='{"model":"sonnet","env":{"MACHINE_LOCAL":"keep"}}'
+    out="$(printf '%s' "$existing" | jq --argjson tmpl \
+        '{"model":"opus","effortLevel":"xhigh","permissions":{"allow":[]},"hooks":{},"enabledPlugins":{},"env":{"CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL":"1"}}' \
+        "$expr" 2>&1)"
+    [ -n "$out" ]
+    # template key arrives...
+    [ "$(printf '%s' "$out" | jq -r '.env.CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL')" = "1" ]
+    # ...and the machine-local one is not clobbered
+    [ "$(printf '%s' "$out" | jq -r '.env.MACHINE_LOCAL')" = "keep" ]
+
+    # a target with no env at all must still receive it
+    out="$(printf '%s' '{"model":"sonnet"}' | jq --argjson tmpl \
+        '{"model":"opus","effortLevel":"xhigh","permissions":{"allow":[]},"hooks":{},"enabledPlugins":{},"env":{"A":"1"}}' \
+        "$expr" 2>&1)"
+    [ "$(printf '%s' "$out" | jq -r '.env.A')" = "1" ]
+}
+
+@test "template env enables the advisor tool" {
+    # /advisor is hidden unless this flag is set: the gate reads
+    # CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL from the process env, and
+    # falls back to a server-side flag that is off for this account. Without
+    # it, advisorModel is read but the tool never attaches -- silently.
+    [ "$(jq -r '.env.CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL' "$SETTINGS_TEMPLATE")" = "1" ]
+}
+
+@test "template advisorModel is one of the values Claude Code accepts" {
+    # The CLI validates against ["fable","opus","sonnet"] (plus "off"); anything
+    # else is rejected at startup with "cannot be used as an advisor".
+    local advisor
+    advisor="$(jq -r '.advisorModel // "off"' "$SETTINGS_TEMPLATE")"
+    case "$advisor" in
+        fable|opus|sonnet|off) ;;
+        *) echo "advisorModel '$advisor' is not an accepted value" >&2; return 1 ;;
+    esac
 }
 
 @test "the merge expression survives a template that omits an optional key" {

--- a/tests/claude-settings-template.bats
+++ b/tests/claude-settings-template.bats
@@ -45,15 +45,28 @@ setup() {
     # already caused once. A hand-written list cannot catch the key nobody
     # thought to add to it, so the list now comes FROM THE TEMPLATE: any new
     # top-level key must be named in both policies or this fails.
-    local key
+    # Scoped to the two merge function BODIES, not to the whole scripts. Both
+    # files say `ContainsKey(...)` and `$tmpl.` in unrelated places --
+    # setup-windows.ps1 has `$tool.ContainsKey('Version')` in its winget loop --
+    # so a whole-file grep would let a template key named `Version` satisfy this
+    # guard while Merge-ClaudeSettings ignored it. A guard that passes on the
+    # broken thing is the defect this whole test exists to prevent.
+    local linux_merge windows_merge key
+    linux_merge="$(sed -n '/^merge_claude_settings() {/,/^}/p' "$DOTFILES_DIR/setup-linux.sh")"
+    windows_merge="$(sed -n '/^function Merge-ClaudeSettings {/,/^}/p' "$DOTFILES_DIR/setup-windows.ps1")"
+    # An empty extract would fail every key below, which is the safe direction,
+    # but say so explicitly rather than blaming the first key.
+    [ -n "$linux_merge" ] || { echo "could not extract merge_claude_settings from setup-linux.sh" >&2; return 1; }
+    [ -n "$windows_merge" ] || { echo "could not extract Merge-ClaudeSettings from setup-windows.ps1" >&2; return 1; }
+
     while IFS= read -r key; do
         # `$schema` is editor metadata for JSON language servers. It is never
         # deployed, so it is exempt BY NAME -- a stated decision, not a gap.
         if [ "$key" = "\$schema" ]; then continue; fi
-        grep -qF -- "\$tmpl.$key" "$DOTFILES_DIR/setup-linux.sh" \
-            || { echo "setup-linux.sh merge policy never mentions '$key'" >&2; return 1; }
-        grep -qF -- "ContainsKey('$key')" "$DOTFILES_DIR/setup-windows.ps1" \
-            || { echo "setup-windows.ps1 merge policy never mentions '$key'" >&2; return 1; }
+        printf '%s\n' "$linux_merge" | grep -qF -- "\$tmpl.$key" \
+            || { echo "merge_claude_settings never mentions '$key'" >&2; return 1; }
+        printf '%s\n' "$windows_merge" | grep -qF -- "ContainsKey('$key')" \
+            || { echo "Merge-ClaudeSettings never mentions '$key'" >&2; return 1; }
     done < <(jq -r 'keys[]' "$SETTINGS_TEMPLATE")
 }
 


### PR DESCRIPTION
## What

`merge_claude_settings` applies an **allow-list**: `model`, `effortLevel`, `outputStyle`, `permissions.allow`, `hooks.Session*`, `enabledPlugins`. Every other template key is discarded, without a warning, on any installation not bootstrapped from scratch.

`env` was such a key. Measured on this machine:

```
$ python3 -c "import json; print('env' in json.load(open('~/.claude/settings.json')))"
False
```

The template has carried `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` while the deployed file had **no `env` key at all**, so that flag was never live. `outputStyle` fell in the same hole once already — the comment written after that incident describes the mechanism exactly, but nothing prevented the recurrence.

## Changes

- `setup-linux.sh` / `setup-windows.ps1`: both merge policies now handle `env` (object merge, so a machine-local entry survives a redeploy) and `advisorModel` (template wins).
- `ai/claude/settings.json`: adds `CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL=1`. Claude Code merges `settings.env` into its **own** `process.env` at startup, and that flag gates both the `/advisor` command and whether `advisorModel` ever attaches. Without it the setting is read and silently ignored.
- `ai/claude/settings.json`: `model` becomes `opus[1m]`. The policy is template-wins for `model`, so a 1M-context default chosen through `/model` survived only until the next setup run.
- Lesson 221.

## The guard

The old test was named *"every dotfiles-owned top-level key is named in both merge policies"* and iterated a hand-written list of three keys, while its comment asserted that `env` was "handled by name in both scripts". That claim was false, and nothing checked it — Lesson 220's shape: a thing verified by a proxy that lives somewhere else.

The list now comes from the template, so a key added there fails CI until both scripts name it. `$schema` is exempt by name, as a stated decision.

## Evidence

Fail-first, by injecting an un-merged key into the template:

```
not ok 5 every dotfiles-owned top-level key is named in both merge policies
# setup-linux.sh merge policy never mentions 'someNewKey'
```

Full suite and lint:

```
$ bats tests/*.bats        -> 1441 ok, 0 not ok
$ shellcheck --severity=error setup-linux.sh   -> clean (CI's severity)
$ bash -n setup-linux.sh && jq empty ai/claude/settings.json  -> OK
```

End-to-end, from the deployed `~/.claude/settings.json` alone — no shell env var, no CLI flag:

```
[DEBUG] CA certs: ... settingsEnv keys: CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS,CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL
[DEBUG] [AdvisorTool] Advisor model: fable
[DEBUG] [AdvisorTool] Server-side tool enabled with claude-fable-5 as the advisor model
```

The same run with the flag absent produces no `[AdvisorTool]` line at all — the advisor was inert, silently.

## Notes

- `pwsh` is not installed locally, so the PowerShell lint runs in CI only. The `.ps1` edit mirrors the `enabledPlugins` block already beside it.
- No spec: 29 production lines added, mostly comments, under the spec-gate threshold.