### PR TITLE
docs(spec): scaffold CLI-042 for the dotf agent run executor seam

### DIFF
--- a/specs/CLI-042-dotf-agent-run/features.json
+++ b/specs/CLI-042-dotf-agent-run/features.json
@@ -1,8 +1,71 @@
 [
   {
     "id": "CLI-042-dotf-agent-run-f1",
-    "behavior": "Outcome 1",
-    "verification": "echo 'not implemented' && exit 1",
+    "behavior": "AC1 — `dotf agent run` writes one JSON object to stdout carrying status, pool, model, exit, duration_ms and output, with every log line on stderr",
+    "verification": "cd cli && go test ./internal/agent/ -run TestRunEmitsJSONContract",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f2",
+    "behavior": "AC2 — a backend reporting pool-unavailable advances to the next chains entry; one reporting task-failed does not, and the record names the pool and model that answered",
+    "verification": "cd cli && go test ./internal/agent/ -run TestChainAdvancesOnlyOnPoolUnavailable",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f3",
+    "behavior": "AC3 — a dispatch exceeding its timeout kills the worker and releases its semaphore slot without waiting for it, reporting a non-zero exit with a timeout status",
+    "verification": "cd cli && go test ./internal/agent/ -run TestTimeoutReleasesSlotBeforeReap",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f4",
+    "behavior": "AC4 — an unreadable concurrency counter exits non-zero rather than reading as zero in use, and an unidentifiable machine denies every non-local pool",
+    "verification": "cd cli && go test ./internal/agent/ -run TestFailsClosed",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f5",
+    "behavior": "AC4 — help text and error messages state the narrow guarantee ('dotf alone will never be the cause of exhaustion'), never that exhaustion cannot happen",
+    "verification": "cd cli && go test ./internal/agent/ -run TestGuaranteeWordingIsNarrow",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f6",
+    "behavior": "AC5 — a --tier top dispatch with claude:opus unavailable escalates and exits non-zero; it never falls through to a mid-tier model",
+    "verification": "cd cli && go test ./internal/agent/ -run TestTopTierNeverDegrades",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f7",
+    "behavior": "AC6 — the hive backend answers through NaN and reports the pool and model the chain resolved",
+    "verification": "dotf agent run --backend hive --tier mid --role scout --task 'reply with OK' | jq -e '.pool == \"nan\" and .status == \"ok\"'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f8",
+    "behavior": "AC7 — the hive service unit invokes `dotf secrets run -- hive serve`, and the deployed environment.d fragment carries no credential",
+    "verification": "~/.local/bin/bats tests/hive-service-secret-delivery.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f9",
+    "behavior": "AC8 — no configuration this repo deploys still names Ollama or OpenRouter for hive's worker",
+    "verification": "~/.local/bin/bats tests/hive-provider-drop.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f10",
+    "behavior": "AC9 — `dotf doctor` fails when a backend probes present but can serve no model, so 'zero reachable models' is caught at diagnostic time",
+    "verification": "cd cli && go test ./internal/doctor/ -run TestBackendReachability",
     "state": "pending",
     "evidence": ""
   }

--- a/specs/CLI-042-dotf-agent-run/features.json
+++ b/specs/CLI-042-dotf-agent-run/features.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "CLI-042-dotf-agent-run-f1",
+    "behavior": "Outcome 1",
+    "verification": "echo 'not implemented' && exit 1",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CLI-042-dotf-agent-run/proposal.md
+++ b/specs/CLI-042-dotf-agent-run/proposal.md
@@ -1,0 +1,222 @@
+---
+id: "CLI-042-dotf-agent-run"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-23"
+issue: "mlorentedev/dotfiles#1190"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# CLI-042-dotf-agent-run
+
+> **Naming**: file lives at `<repo>/specs/CLI-042-dotf-agent-run/proposal.md`. `CLI-042-dotf-agent-run` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #1190: CLI-042: dotf agent run — the executor seam ADR-032 defines and nothing implements -->
+
+The orchestration stack has a policy layer and no execution layer. `harness/model-map.json` declares
+pools, harnesses, tiers and chains, and `chains` — which resolves at run time and is read only by the
+level-2 dispatcher — has **no reader at all**, because `dotf agent` is `unknown command`. Without this,
+cross-pool delegation is prose: nothing runs a role on a task in another pool, nothing enforces the
+concurrency reserve the map declares, and `pools.deny` is a field no code evaluates. What breaks if we
+do not ship it: the map stays a declaration rather than a layer, the six remaining roster personas
+would be defined with no consumer, and the concurrency semaphore ADR-035 §3 places at level 2 is
+unimplementable because there is no launcher.
+
+## What
+
+`dotf agent run` exists and dispatches. Three observable outputs:
+
+1. **A result record** carrying exit status, output bounded by a cap, and **the pool and model actually
+   used** — resolved by walking `chains` for the requested tier through the existing loader
+   (`cli/internal/harness/model_map.go`, `ResolveChain` / `ResolveTier` / `DeclaredBudget`), never a
+   second parse of the map.
+2. **Distinct exit codes for _pool unavailable_ and _task failed_**, so the first advances the chain
+   and the second does not. Collapsing them turns a bad answer into a silent retry on another model.
+3. **A loud, non-zero refusal** when the concurrency counter cannot be read or the machine's identity
+   cannot be established — in the latter case every non-local pool is denied (ADR-032 §8).
+
+Three contract decisions taken deliberately, recorded here so they are not re-derived:
+
+| Decision | Choice | Why |
+|---|---|---|
+| Dispatch mode | **Synchronous**: blocks, returns R | ADR-032 §2's seam is literally *"run role A on task T, isolated in W, return R"*. Local evidence: `dotf spec review` launches **detached**, which is exactly why GUARD-005 exists — a detached launcher cannot observe its own verdict, so it needed a sidecar plus a downstream assertion. Starting synchronous avoids reopening that hole; `--detach` can be added later, never the reverse. |
+| Backend selection | **Probe, with `--backend` as an override** | ADR-032 §7: machine facts are probed, never stored — an inventory file rots, a probe cannot lie. Consistent with how the map already declares `probe: bin:claude` / `env:NAN_API_KEY`. The flag exists to force a backend and to make tests deterministic. |
+| stdout | **JSON always**; logs to stderr | The consumer of `agent run` is a dispatcher, not a person — the verb exists to be composed. Precedent: `dotf env path` and the agent-mode contract of #700. |
+
+**Backends: two, and the second one has to be repaired first.** Decided 2026-08-22 after the
+measurement in Risks below: a seam validated against a single implementation is a speculative
+interface rather than a seam, so hive stays in v1 and hive's own inability to reach a model enters
+this spec's critical path rather than being deferred. Two further decisions follow from it:
+
+| Decision | Choice | Why |
+|---|---|---|
+| Where the fallback lives | **In the dispatcher. hive is single-shot** — it takes one model as a parameter and either answers or fails. | ADR-032 §2 assigns *pool unavailable → advance the chain* to the dispatcher. A backend that falls back internally bypasses that semantic and makes "the pool and model actually used" unreportable, and it is a second routing authority — the "map, never a director" drift ADR-035 §4 exists to kill. `chains.mid` already declares NaN→NaN (`deepseek-v4-flash` → `mimo-v2.5`). Concrete gain: fallback becomes cross-**backend**, not merely cross-model — if NaN is saturated the chain can reach `claude:sonnet` through subprocess, which an internal hive chain could never do. |
+| How `dotf` reaches hive | **A dispatch verb on the hive side, launched as a subprocess** — not an MCP client in Go. | The seam's hard semantics (kill on timeout, release the slot without waiting) are exactly what the subprocess backend must already implement for `claude -p` / `pi -p`; the hive verb rides that code path verbatim. One mechanism, N providers. An MCP client would add a Go dependency — itself a Discipline Gate trigger, and stdlib-first says no — a protocol handshake that can drift, and a surface bats cannot smoke. **This does not reduce the backend count**: hive stays a probed, first-class backend; argv is only its transport. |
+
+**hive's worker becomes NaN-only.** Ollama and OpenRouter are dropped rather than deprecated
+(owner's decision, 2026-08-22), which aligns the worker with `model-map.json`, whose `$comment`
+already records `openrouter` as retired upstream. This makes the repair a *removal plus a re-route*
+rather than an addition: hive keeps one transport, the OpenAI-compatible one it already uses for
+embeddings and synthesis.
+
+## Out of scope
+
+Things this PR explicitly does NOT include. Forces a sharp boundary and prevents scope creep.
+
+- **The `orca` backend** — *deferred, not rejected*. ADR-032 §2 places three implementations behind
+  this seam and they occupy different niches rather than competing: `orca` on an interactive machine
+  (managed worktrees, supervised workers, DAGs, ask/reply — the **default executor when present**,
+  never the substrate), `subprocess` as the floor bootstrap guarantees, `hive` for headless/CI. Orca
+  is out of v1 on three measured blockers: **#899** (the CLI wrapper is unusable from a plain shell —
+  the AppImage injects `--no-sandbox` into the electron-as-node path), **#462 / #649** (bootstrap does
+  not install it; the installer does not handle `.deb` / AppImage), and **C9** (a GUI desktop
+  application is out of scope for headless/CI). The sentence that makes those blockers rather than
+  conveniences is ADR-032 §8: *an executor that needs a button pressed in an app is not replicable.*
+  The seam is nevertheless designed for three from the start — had Orca been the first backend built,
+  the contract would have been shaped around GUI-resident state and the other two would not fit later.
+- **Ollama and OpenRouter support in hive** — dropped outright, not deprecated (owner's decision,
+  2026-08-22). Consistent with `model-map.json`'s `$comment`, which already records `openrouter` as
+  retired upstream in August 2026.
+- **A Gemini / `agy` arm inside hive** — unroutable by the declared map: no `gemini` pool exists,
+  `agy`'s OAuth-login auth does not fit the `env:` / `bin:` probe shape, and hive's assigned niche is
+  headless/CI, where `~/.gemini` does not exist. Reaching Gemini at dispatch level is a **map** change
+  (a new pool plus a new auth kind for probes) and gets its own ticket.
+- **An MCP client in `dotf`** — deferred with a named trigger: *a second MCP-only backend appears*.
+- **The remaining roster personas** (#562). Executor before personas: six speculative definitions
+  ahead of their first consumer is the trap this arc already walked into once.
+- **`harness/enforced/orchestration.md` and the dispatch hooks** (#561) — held behind #881 until the
+  first `enforced` record has been exercised end to end.
+- **The `list` and `status` verbs** — they follow the dispatcher, and a synchronous `run` does not need
+  them.
+- **Adaptive reservation** — ADR-032 §3 fixes `reserve_interactive` as a static number for v1.
+
+## Risks / open questions
+
+Failure modes, dependencies, and unknowns to clarify before implementation. If any item here is unresolved, do not move to `tasks.md` yet.
+
+- **[MUST RESOLVE BEFORE CODE] hive's worker reaches zero models on this machine.** Measured
+  2026-08-22 via `mcp__hive__worker_status`: *Ollama: offline / unavailable · OpenRouter: no API key ·
+  Available Models: none*. Its provider vocabulary (`auto` / `ollama` / `openrouter-free` /
+  `openrouter`) does not intersect the map's pools (`nan`, `claude`, `copilot`, `opencode`), and
+  `openrouter` is retired upstream (August 2026, per `model-map.json`'s own `$comment`). So the
+  backend cannot consume `chains` and cannot honestly report "the pool and model actually used".
+  Sharpest form: every acceptance criterion must be verifiable by test or smoke check, and a backend
+  with no reachable provider **cannot pass a smoke test today** — unverifiable by construction, not
+  merely risky.
+- **[MUST RESOLVE BEFORE CODE] The repair is a change in another repo.** `hive` is
+  `mlorentedev/hive` (`~/Projects/hive`), shipped as the `hive-vault` PyPI package and installed as a
+  `uv` tool. Fixing the worker is a PR there, gated by its own board, and this spec depends on the
+  version that lands. Knowledge placement holds: the hive change is documented in the hive repo, and
+  only the seam contract lives here.
+- **[RESOLVED 2026-08-22] What the fallback arm actually is — it does not live in hive at all.**
+  Recorded because the reasoning is the artifact. Two different fallback shapes already exist in this
+  repo, for different reasons, and the resolution was not to pick one but to notice that neither
+  belongs inside a backend:
+
+  | Registry | Primary | Fallback | Rationale |
+  |---|---|---|---|
+  | `.pr_agent.toml` (CI) | `nan/mimo-v2.5` | `nan/deepseek-v4-flash` | **Lane separation.** NaN's limit is per model, so two models are two buckets of five. That file's own comment records that a third-provider tier was *considered and dropped* — no Google credential in the registry, and OpenRouter would spend a finite paid balance per PR. |
+  | `harness/reviewer-pool.json` (gate) | `nan/deepseek-v4-flash` | `agy/gemini-3.1-pro-high` | **Provider diversity**, not merely a different model. |
+
+  The Gemini arm is **not reachable over HTTP with a key**: `agy` authenticates by OAuth login
+  (`~/.gemini/antigravity-cli/google_credentials.json`, #1156) and the secrets registry has never
+  declared `GEMINI_API_KEY`. A Python HTTP client inside hive cannot use that token — reaching Gemini
+  would mean hive shelling out to the `agy` binary, as `cli/internal/spec/review_launch.go` does.
+  **Resolution: hive is NaN-only and single-shot; the dispatcher owns the chain** (see What). The
+  Gemini arm is a map-level question, not a backend-level one.
+
+- **[OPEN — must be answered in `tasks.md`, not in code review] Which backend serves a `nan` chain
+  entry when two can.** After the repair, both `subprocess` (via `pi --model <id>`) and `hive` can
+  serve `nan:deepseek-v4-flash`. The probe order and the tie-break are a contract decision, not an
+  implementation detail: they determine which process consumes the pool's slot and what
+  `pool`/`model` reporting means when two transports reach the same model. Proposed default, to be
+  confirmed with the task breakdown: **prefer `subprocess` on an interactive machine and `hive` where
+  no harness binary is present**, with `--backend` overriding both.
+
+- **[OPEN — SRE, and the sharpest detail of the repair] How `NAN_API_KEY` reaches the hive daemon.**
+  With Ollama and OpenRouter gone, the worker needs a NaN credential, and a plaintext key in
+  `~/.config/environment.d/` would violate the secrets doctrine (ADR-028: Bitwarden SSOT, `dotf
+  secrets run` as the only sanctioned way to hand a secret to a process). The sanctioned shape is the
+  **service unit wrapping `dotf secrets run -- hive serve`**, so the value is injected into the child
+  process and never lands in a file or a transcript. This is an acceptance criterion below, not a
+  deployment note.
+- **hive already speaks NaN, just not on the worker path.** `hive/config.py` carries an
+  OpenAI-compatible surface — `embed_base_url` / `embed_api_key` / `synth_model` — whose comment reads
+  *"default config points at NaN"*, plus `http_timeout` and `tool_timeout` (60s each), so deadline
+  machinery exists. On this machine `HIVE_EMBED_BASE_URL` is **unset**: the deployed
+  `~/.config/environment.d/10-hive-vault.conf` carries only `HIVE_VAULT_PATH` and `VAULT_PATH`. This
+  lowers the repair from "add a provider" to "route the worker through the transport hive already
+  has, and deploy its configuration as IaC".
+- **`delegate_task` exposes neither `timeout` nor cancellation**, and ADR-032 §2 rules a backend that
+  cannot enforce a timeout ineligible. Stated as rebuttable rather than blocking: a client-side
+  deadline that kills the process and releases the semaphore slot plausibly satisfies semantics 3–4,
+  at the cost that the remote worker keeps consuming invisibly.
+- **[RESOLVED 2026-08-22] hive has no dispatch CLI verb.** `hive --help` offers only the stdio MCP
+  server, the daemon, the client shim, `service` and `self-upgrade`. Resolution: **add the verb on the
+  hive side** rather than an MCP client in `dotf` (see What). Hive's `client` shim already routes to
+  the daemon, so the verb is cheap there.
+
+- **ADR-032 §2's backend table is falsified on one row, and the amendment is recorded here rather
+  than edited into an accepted ADR** (the ADR-035 convention). The row reads *"`hive.delegate_task` —
+  already has fallback chains and a cost cap"*. Both halves no longer hold: the fallback chain points
+  at providers that do not answer, and the cost cap is meaningless against a flat subscription, where
+  marginal cost is zero and the binding constraint is concurrency.
+
+- **This will exceed the ~300 executable-LOC atomic-PR cap and must ship as a sequence.** Executor,
+  semaphore, probes, two backends and their tests do not fit one PR, and "first step of a multi-PR
+  sequence" is itself a Discipline Gate trigger. `tasks.md` names the split; no PR in it silently
+  absorbs the next.
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [ ] **AC1 — the machine contract holds.** `dotf agent run --role <r> --task <t> --tier mid` writes a
+      single JSON object to **stdout** carrying at least `status`, `pool`, `model`, `exit`,
+      `duration_ms` and `output`, with every log line on **stderr**. Verified by a table-driven Go test
+      and a bats smoke that pipes stdout through a JSON parser with stderr attached.
+- [ ] **AC2 — the two error classes stay distinct.** A backend reporting *pool unavailable* advances
+      to the next `chains` entry for the tier; a backend reporting *task failed* does not, and the
+      emitted record names the pool and model that actually answered. Table-driven test over a fake
+      backend with scripted responses, including the case where the chain is exhausted.
+- [ ] **AC3 — timeout and cancellation are real.** A dispatch that exceeds its timeout kills the
+      worker, releases its semaphore slot **without waiting for it**, and reports a non-zero exit with
+      a `timeout` status. Test with a fake backend that outlives its deadline, asserting the slot is
+      free before the worker is reaped.
+- [ ] **AC4 — it fails closed and loudly, never permissively.** With an unreadable concurrency
+      counter, `dotf agent run` exits non-zero rather than treating it as zero in use; with a machine
+      whose identity cannot be established, every non-local pool is denied. Both cases tested, and
+      both messages state the narrow guarantee — *`dotf` alone will never be the cause of exhaustion* —
+      rather than promising that exhaustion cannot happen.
+- [ ] **AC5 — the top tier never degrades silently.** With `claude:opus` unavailable, a `--tier top`
+      dispatch escalates and exits non-zero; it never falls through to a mid-tier model. Tested.
+- [ ] **AC6 — the hive backend passes a real smoke check.** `dotf agent run --backend hive --tier mid`
+      returns an answer served by NaN and reports `pool=nan` with the model the chain resolved. This is
+      the criterion hive's repair exists to unblock, and it is the one that cannot pass today.
+- [ ] **AC7 — the NaN credential never lands in a file.** The hive service unit invokes
+      `dotf secrets run -- hive serve`, and the deployed `environment.d` fragment contains no
+      credential. Asserted by a test reading the rendered unit and grepping the deployed fragment,
+      verified by consequence (the daemon answers) rather than by printing the value.
+- [ ] **AC8 — the drop of Ollama and OpenRouter is complete, not partial.** No configuration this repo
+      deploys still names them for hive's worker, and `ai/agy/mcp_servers.json`'s `HIVE_OLLAMA_ENDPOINT`
+      is removed in the same change that removes the provider.
+- [ ] **AC9 — "zero reachable models" is caught at diagnostic time, not under dispatch load.**
+      `dotf doctor` reports a backend that probes present but can serve nothing, and fails rather than
+      passing quietly. This is the incident-to-guard emission for the defect that shaped this spec:
+      hive was a declared backend with no reachable provider **for an unknown length of time, and
+      nothing noticed** — the check must be one that would go red if the thing it checks broke again.
+
+## References
+
+- Bitácora board: the GitHub issue / Project item tracking this spec (see the `issue:` frontmatter field)
+- `docs/adr/adr-032-cross-harness-agent-orchestration.md` — §2 the seam and its five semantics, §3
+  `chains` and concurrency, §4 no top-tier fallback, §7 probes and `pools.deny`, §8 replication and
+  fail-safe deny
+- `docs/adr/adr-035-model-map-routing-registry.md` — §3 budget enforcement levels and fail-closed,
+  §4 a declared map, never a director model
+- `harness/model-map.json`, `harness/reviewer-pool.json`, `.pr_agent.toml` — the registries this
+  consumes or mirrors
+- Epic #558; #1124 (the map this consumes); #561, #562, #563 (siblings, out of scope here)

--- a/specs/CLI-042-dotf-agent-run/proposal.md
+++ b/specs/CLI-042-dotf-agent-run/proposal.md
@@ -151,9 +151,12 @@ Failure modes, dependencies, and unknowns to clarify before implementation. If a
   lowers the repair from "add a provider" to "route the worker through the transport hive already
   has, and deploy its configuration as IaC".
 - **`delegate_task` exposes neither `timeout` nor cancellation**, and ADR-032 §2 rules a backend that
-  cannot enforce a timeout ineligible. Stated as rebuttable rather than blocking: a client-side
-  deadline that kills the process and releases the semaphore slot plausibly satisfies semantics 3–4,
-  at the cost that the remote worker keeps consuming invisibly.
+  cannot enforce a timeout ineligible. A client-side deadline that kills the process and releases the
+  slot satisfies semantics 3–4 *for the dispatcher*, but not for the pool: the remote worker keeps
+  consuming a NaN slot the semaphore has already handed back, so the reserve silently over-counts what
+  is free. **Resolution: the hive verb must propagate cancellation and terminate the worker**
+  (`mlorentedev/hive#384`), and AC3 is written so the weaker form fails the criterion rather than
+  redefining it.
 - **[RESOLVED 2026-08-22] hive has no dispatch CLI verb.** `hive --help` offers only the stdio MCP
   server, the daemon, the client shim, `service` and `self-upgrade`. Resolution: **add the verb on the
   hive side** rather than an MCP client in `dotf` (see What). Hive's `client` shim already routes to
@@ -182,10 +185,21 @@ Observable outcomes. Each must be testable.
       to the next `chains` entry for the tier; a backend reporting *task failed* does not, and the
       emitted record names the pool and model that actually answered. Table-driven test over a fake
       backend with scripted responses, including the case where the chain is exhausted.
-- [ ] **AC3 — timeout and cancellation are real.** A dispatch that exceeds its timeout kills the
-      worker, releases its semaphore slot **without waiting for it**, and reports a non-zero exit with
-      a `timeout` status. Test with a fake backend that outlives its deadline, asserting the slot is
-      free before the worker is reaped.
+- [ ] **AC3 — timeout and cancellation are real, and the guarantee is stated at the strength it
+      actually holds.** A dispatch that exceeds its timeout kills the worker, releases its semaphore
+      slot **without waiting for it**, and reports a non-zero exit with a `timeout` status. Test with
+      a fake backend that outlives its deadline, asserting the slot is free before the worker is
+      reaped.
+      **Backend-specific condition, not a caveat to be dropped:** for `subprocess` the killed process
+      *is* the consumer, so the guarantee is exact. For `hive` it is not — killing the local
+      `hive delegate` process does not by itself stop a worker running behind the daemon, which would
+      keep consuming a NaN slot the semaphore has already released. `hive delegate` must therefore
+      **propagate cancellation to the worker and terminate it**; that requirement is stated in
+      `mlorentedev/hive#384` and is part of what makes the backend eligible under ADR-032 §2. Until it
+      is met, the honest statement is *the slot is released locally and the remote worker may outlive
+      it* — and a backend that can only offer that is one whose reserve accounting is a guess. **AC3
+      is not satisfied by the weaker form**: if the hive verb ships without cancellation propagation,
+      the correct outcome is that hive fails the eligibility test, not that AC3 is reworded down.
 - [ ] **AC4 — it fails closed and loudly, never permissively.** With an unreadable concurrency
       counter, `dotf agent run` exits non-zero rather than treating it as zero in use; with a machine
       whose identity cannot be established, every non-local pool is denied. Both cases tested, and

--- a/specs/CLI-042-dotf-agent-run/tasks.md
+++ b/specs/CLI-042-dotf-agent-run/tasks.md
@@ -1,0 +1,125 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-23"
+---
+
+# Tasks - CLI-042-dotf-agent-run
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers** (optional, additive — borrowed from `github/spec-kit`, adapt-not-adopt per #141):
+> - `[P]` — this task has **no dependency on another unchecked task**, so it is safe to run in parallel (fan out to a `Workflow`, or just batch). TDD chains (test → implement → refactor of the *same* behavior) are sequential and must NOT carry `[P]`; independent behaviors can.
+> - `[AC<n>]` — this task helps satisfy **acceptance criterion #`<n>`** from `proposal.md`. Lets `/spec check` map coverage deterministically; omit it and the check falls back to semantic judgment.
+
+## PR sequence
+
+This spec does not fit one PR, and "first step of a multi-PR sequence" is itself a Discipline Gate
+trigger. The split is declared here so no PR silently absorbs the next:
+
+| PR | Repo | Lands | Criteria |
+|---|---|---|---|
+| **A** | `mlorentedev/hive` | worker becomes NaN-only (Ollama + OpenRouter removed); `hive delegate` dispatch verb, single-shot, `--model` and `--timeout` required | unblocks AC6 |
+| **B** | `dotfiles` | `dotf agent run` — flags, JSON contract, chain walk through the existing loader, fake backend | AC1, AC2, AC5 |
+| **C** | `dotfiles` | semaphore, timeout + cancellation, fail-closed refusals | AC3, AC4 |
+| **D** | `dotfiles` | real backends: subprocess and hive probes, the tie-break, end-to-end smoke | AC6 |
+| **E** | `dotfiles` | IaC: hive service unit via `dotf secrets run`, `environment.d` and `mcp_servers.json` cleanup, `dotf doctor` reachability check | AC7, AC8, AC9 |
+
+**A is a hard dependency of D.** It needs its own issue on `mlorentedev/hive`, linked as blocking
+#1190, and a release that `uv tool upgrade` can reach — a PR merged upstream is not a version this
+machine runs.
+
+## Setup
+
+- [ ] Branch created from main: `feat/dotf-agent-run`
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No open questions left in `proposal.md` "Risks / open questions" — **two are still open**: the
+      backend tie-break for a `nan` chain entry, and the secret-delivery shape for the hive daemon
+- [ ] Issue opened on `mlorentedev/hive` for PR A, linked as blocking #1190
+
+## Implementation
+
+### PR B — the command and its contract
+
+- [ ] [P] [AC1] Failing test: `dotf agent run` writes one JSON object to stdout with `status`,
+      `pool`, `model`, `exit`, `duration_ms`, `output`, and nothing but JSON on stdout
+- [ ] [AC1] Implement the command, its flags (`--role`, `--task`, `--tier`, `--cwd`, `--timeout`,
+      `--backend`) and the JSON encoder; every log line goes to stderr
+- [ ] [P] [AC2] Failing test: a fake backend scripted to return *pool unavailable* advances to the
+      next `chains` entry; one scripted to return *task failed* does not
+- [ ] [AC2] Implement the chain walk over `harness.ResolveChain`, and the error classification that
+      keeps the two cases distinct
+- [ ] [AC2] Failing test + implement: chain exhausted — every entry unavailable — is its own outcome,
+      distinguishable from a task failure
+- [ ] [P] [AC5] Failing test: `--tier top` with `claude:opus` unavailable escalates and exits
+      non-zero, and never resolves a mid-tier model
+- [ ] [AC5] Implement the top-tier no-degrade rule
+- [ ] Refactor: the backend interface is the seam — one method, the five semantics, no backend-specific
+      types leaking into the dispatcher
+
+### PR C — the brakes
+
+- [ ] [P] [AC3] Failing test: a fake backend that outlives its deadline is killed, and the semaphore
+      slot is observably free **before** the worker is reaped
+- [ ] [AC3] Implement per-dispatch timeout (required, no silent default) and cancellation
+- [ ] [P] [AC4] Failing test: an unreadable concurrency counter exits non-zero rather than reading as
+      zero in use
+- [ ] [AC4] Failing test: a machine whose identity cannot be established denies every non-local pool
+- [ ] [AC4] Implement the semaphore over `harness.DeclaredBudget`, and both fail-closed paths
+- [ ] [AC4] Assert the wording: help text and error messages state *`dotf` alone will never be the
+      cause of exhaustion*, never that exhaustion cannot happen
+
+### PR D — the real backends
+
+- [ ] [AC6] Failing test: backend probe selects `subprocess` when a harness binary is present and
+      `hive` when it is not; `--backend` overrides both
+- [ ] [AC6] Implement the subprocess backend (`claude -p`, `pi -p`) on the shared process machinery
+- [ ] [AC6] Implement the hive backend as `hive delegate` over the **same** process machinery — argv
+      is its transport, not a second mechanism
+- [ ] [AC6] Resolve and encode the tie-break for a `nan` chain entry servable by both backends
+- [ ] [AC6] End-to-end smoke: `dotf agent run --backend hive --tier mid` answers, and reports
+      `pool=nan` with the model the chain resolved
+
+### PR E — the deployment, as IaC
+
+- [ ] [AC7] Failing test: the rendered hive service unit invokes `dotf secrets run -- hive serve`
+- [ ] [AC7] Implement the unit and its deployment in `setup-linux.sh`, verified idempotent
+      (`changed=0` on re-run)
+- [ ] [AC7] Assert no credential in the deployed `environment.d` fragment; verify the daemon by
+      consequence (it answers), never by printing the value
+- [ ] [P] [AC8] Remove `HIVE_OLLAMA_ENDPOINT` from `ai/agy/mcp_servers.json` and any other config this
+      repo deploys naming Ollama or OpenRouter for hive's worker
+- [ ] [AC8] Assertion that the removal stays removed — the incident-to-guard rule
+- [ ] [P] [AC9] Failing test: `dotf doctor` fails when a backend probes present but can serve nothing
+- [ ] [AC9] Implement the reachability check, so "zero models" is caught at diagnostic time rather
+      than under dispatch load
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
+- [ ] Type checks pass
+- [ ] Lint passes
+- [ ] `GOOS=windows go vet ./...` clean — the Windows leg compiles the same tree
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
+
+Minimal `features.json` skeleton (drop into `<repo>/specs/CLI-042-dotf-agent-run/features.json`):
+
+```json
+[
+  {
+    "id": "CLI-042-dotf-agent-run-f1",
+    "behavior": "<one-line copy of an acceptance criterion>",
+    "verification": "<single shell command; exit 0 means pass>",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/CLI-042-dotf-agent-run/verification.md
+++ b/specs/CLI-042-dotf-agent-run/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-23"
+---
+
+# Verification - CLI-042-dotf-agent-run
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons/`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/CLI-042-dotf-agent-run/` -> `specs/archive/CLI-042-dotf-agent-run/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)

--- a/specs/CLI-042-dotf-agent-run/verification.md
+++ b/specs/CLI-042-dotf-agent-run/verification.md
@@ -9,9 +9,15 @@ created: "2026-08-23"
 
 Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
 
-- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+- [ ] AC1 (JSON contract on stdout, logs on stderr) -> commit `<hash>` / test `<name>`
+- [ ] AC2 (pool-unavailable advances the chain, task-failed does not) -> commit `<hash>` / test `<name>`
+- [ ] AC3 (timeout kills the worker and frees the slot before reaping) -> commit `<hash>` / test `<name>`
+- [ ] AC4 (fails closed on an unreadable counter and an unidentifiable machine) -> commit `<hash>` / test `<name>`
+- [ ] AC5 (the top tier escalates, never degrades) -> commit `<hash>` / test `<name>`
+- [ ] AC6 (the hive backend answers through NaN and reports pool + model) -> commit `<hash>` / test `<name>`
+- [ ] AC7 (`dotf secrets run -- hive serve`; no credential in a deployed file) -> commit `<hash>` / test `<name>`
+- [ ] AC8 (Ollama and OpenRouter fully removed from deployed config) -> commit `<hash>` / test `<name>`
+- [ ] AC9 (`dotf doctor` fails a backend that can serve nothing) -> commit `<hash>` / test `<name>`
 
 ## Test status
 


### PR DESCRIPTION
Scaffolds the spec for `dotf agent run` — the executor seam ADR-032 §2 defines and nothing
implements. Docs only: no production code, no behavior change.

Closes nothing yet; #1190 stays open until the implementation sequence lands.

## Why this spec exists

The orchestration stack is complete on paper and empty in execution. `harness/model-map.json`
declares pools, harnesses, tiers and chains, and `chains` — which resolves at run time and is read
only by the level-2 dispatcher — **has no reader at all**, because `dotf agent` is `unknown command`.
The concurrency semaphore ADR-035 §3 places at level 2 is likewise unimplementable: there is no
launcher for it to bound.

## What the spec decides

ADR-032 fixed the noun and five contract semantics and deliberately left the wire schema and exit
codes to the implementation spec. Those are decided here:

| | Choice | Why |
|---|---|---|
| Dispatch | **synchronous** | `dotf spec review` launches detached, which is precisely why GUARD-005 exists — a detached launcher cannot observe its own verdict. `--detach` can be added later; the reverse is expensive. |
| Backend | **probe, `--backend` overrides** | ADR-032 §7 — probes cannot lie, inventory files rot. |
| stdout | **JSON always** | the consumer is a dispatcher, not a person. |

## Two findings measured while scoping, and what they changed

**1. hive's delegate worker reaches zero models.** `worker_status`, 2026-08-22: Ollama offline,
OpenRouter keyless — and OpenRouter is retired upstream, as `model-map.json`'s own `$comment` already
records. Its provider vocabulary does not intersect the map's pools, so it can neither consume
`chains` nor report the pool and model actually used.

This **falsifies one row of ADR-032 §2's backend table** (*"already has fallback chains and a cost
cap"*): the chains point at providers that do not answer, and a cost cap is meaningless against a
flat subscription where marginal cost is zero. The amendment is recorded in the spec, ADR-035-style,
rather than edited into an accepted ADR.

The scope decision was re-taken with that evidence rather than inherited: hive stays as the second
backend, and its repair enters the critical path as `mlorentedev/hive#384`. A seam validated against
one implementation is a speculative interface.

**2. The fallback does not belong inside a backend.** ADR-032 §2 assigns *pool unavailable → advance
the chain* to the dispatcher. A backend that falls back internally bypasses that semantic, makes
"the pool and model actually used" unreportable, and becomes a second routing authority — the
"map, never a director" drift ADR-035 §4 exists to kill. `chains.mid` already declares NaN→NaN.
Making hive single-shot also turns fallback cross-**backend**: if NaN saturates, the chain can reach
`claude:sonnet` by subprocess, which an internal hive chain could never do.

Consequences recorded in the spec: hive's worker becomes NaN-only (Ollama and OpenRouter dropped
outright), `dotf` reaches it through a dispatch verb over the existing subprocess machinery rather
than by growing an MCP client, and there is no Gemini arm inside hive — that is a map-level change
with its own ticket.

## Scope

Nine acceptance criteria, and a declared five-PR sequence — this does not fit the ~300 executable-LOC
cap, and "first step of a multi-PR sequence" is itself a Discipline Gate trigger. PR A is the hive
repair; B, C and E here do not depend on it.

Out of scope with reasons stated: the `orca` backend (deferred, not rejected — #899, #462/#649, and
C9), the roster personas (#562), `enforced/orchestration.md` (#561, held behind #881), `list` /
`status`, adaptive reservation, and an MCP client in `dotf` (deferred behind a named trigger).

Two open questions are carried explicitly rather than resolved silently: the backend tie-break when
both `subprocess` and `hive` can serve one `nan` chain entry, and the exact service-unit shape for
delivering `NAN_API_KEY` through `dotf secrets run` — the latter is an acceptance criterion, because
a plaintext key in `environment.d` would be a secrets-doctrine violation, not a deployment detail.

## Also filed from this session

`#1191` — the board's `ID` field is empty on every item, so the `new-ticket` skill's duplicate-ID
guard can only ever report "no collision". That guard is the remediation for a defect that has
already happened twice.
