### PR TITLE
docs(spec): pin the cross-repo error-code contract for CLI-042

### DIFF
--- a/specs/CLI-042-dotf-agent-run/tasks.md
+++ b/specs/CLI-042-dotf-agent-run/tasks.md
@@ -24,9 +24,18 @@ trigger. The split is declared here so no PR silently absorbs the next:
 | **D** | `dotfiles` | real backends: subprocess and hive probes, the tie-break, end-to-end smoke | AC6 |
 | **E** | `dotfiles` | IaC: hive service unit via `dotf secrets run`, `environment.d` and `mcp_servers.json` cleanup, `dotf doctor` reachability check | AC7, AC8, AC9 |
 
-**A is a hard dependency of D.** It needs its own issue on `mlorentedev/hive`, linked as blocking
-#1190, and a release that `uv tool upgrade` can reach — a PR merged upstream is not a version this
-machine runs.
+**A is a hard dependency of D.** It is tracked as `mlorentedev/hive#384` with its own spec,
+`specs/HIVE-384-nan-worker-and-delegate-verb/` in that repo, and it ships as `feat!` → **4.0.0**.
+What D waits on is not the merge but the **release**: merge → release-please PR → merge → GitHub
+Release → PyPI → `uv tool upgrade hive-vault`. A PR merged upstream is not a version this machine
+runs.
+
+**The seam's error classification is the cross-repo contract, so it is pinned on both sides.** The
+hive verb exits `3` for *pool unavailable* and `1` for *task failed*; this dispatcher advances the
+chain on the first and must not on the second. If either side changes those codes unilaterally, a
+bad answer becomes a silent retry against a different model — the exact failure ADR-032 §2 names.
+The dispatcher must therefore treat an unrecognised exit code as *task failed*, never as
+*unavailable*: the fail-closed direction is the one that does not retry.
 
 ## Setup
 


### PR DESCRIPTION
Follow-up to #1192, which merged while this was being written. Docs only, inside `specs/CLI-042-dotf-agent-run/`.

Two corrections to `tasks.md`:

**1. PR A's dependency was described as work still to be scoped.** It exists: `mlorentedev/hive#384`, with its own spec `specs/HIVE-384-nan-worker-and-delegate-verb/` in that repo, shipping as `feat!` → 4.0.0. And the dependency is stated more precisely, because the imprecision would have cost a day: PR D waits on the **release**, not the merge. The round trip is merge → release-please PR → merge → GitHub Release → PyPI → `uv tool upgrade hive-vault`. A PR merged upstream is not a version this machine runs.

**2. The error classification is a cross-repo contract, so it is now pinned on both sides.** The hive verb exits `3` for *pool unavailable* and `1` for *task failed*; this dispatcher advances the chain on the first and must not on the second. Previously only the hive spec named the codes, which is the shape where two repos agree in prose and disagree in code.

Added with it: **an unrecognised exit code is treated as *task failed*, never as *unavailable*.** That is the fail-closed direction — the one that does not retry a bad answer against a different model, which is the failure ADR-032 §2 exists to prevent.