### PR TITLE
fix(setup): derive the harness mirror from the manifest, not a hardcoded list

### DIFF
--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -236,3 +236,4 @@ tags: [lessons, index, dotfiles]
 | [220 - Four defects, one shape: a thing verified by a proxy that lives somewhere else](lesson-220-four-defects-one-shape-a-thing-verified-by-a-proxy.md) | 2026-08-22 |  |
 | [221 - An allow-list merge makes every new template key a silent no-op](lesson-221-an-allow-list-merge-makes-every-new-template-key-a.md) | 2026-08-22 |  |
 | [222 - A coupling's scope is measured, not inferred from where you saw it fail](lesson-222-a-couplings-scope-is-measured-not-inferred-from-whe.md) | 2026-08-23 |  |
+| [223 - A test updated to keep passing stops being a guard](lesson-223-a-test-updated-to-keep-passing-stops-being-a-guar.md) | 2026-08-23 |  |

--- a/docs/lessons/lesson-223-a-test-updated-to-keep-passing-stops-being-a-guar.md
+++ b/docs/lessons/lesson-223-a-test-updated-to-keep-passing-stops-being-a-guar.md
@@ -8,7 +8,7 @@
 
 `dotf doctor` reported, persistently:
 
-```
+```text
 [Harness + skill drift]
   [FAIL] harness/skill drift (run: compile-harness.sh --refresh, then re-deploy)
 ```
@@ -83,7 +83,7 @@ all. The integration guard went red on its very first CI run — not on the bug 
 was written for, but on a latent one underneath it. In one setup run, 22 seconds
 apart and in the same process:
 
-```
+```text
 [SUCCESS] jq installed
 [WARNING] Claude Code CLI, npx, or jq not found, skipping MCP server registration
 ```
@@ -99,7 +99,7 @@ check asks about, or the two will disagree and both will look right.** Tracked a
 
 ## Evidence
 
-```
+```console
 $ bash ~/.dotfiles/scripts/compile-harness.sh --check
 [ERROR] /home/manu/.dotfiles/ai/orca/ORCA.md: need exactly 1 BEGIN + 1 END HARNESS marker (found /)
 [check] FAIL: harness drift detected

--- a/docs/lessons/lesson-223-a-test-updated-to-keep-passing-stops-being-a-guar.md
+++ b/docs/lessons/lesson-223-a-test-updated-to-keep-passing-stops-being-a-guar.md
@@ -1,0 +1,91 @@
+# Lesson 223 — A test updated to keep passing stops being a guard
+
+**Date:** 2026-08-23
+**Area:** guards / deploy / harness
+**Severity:** medium — a permanent red check whose printed remedy cannot clear it
+
+## What happened
+
+`dotf doctor` reported, persistently:
+
+```
+[Harness + skill drift]
+  [FAIL] harness/skill drift (run: compile-harness.sh --refresh, then re-deploy)
+```
+
+Running the printed remedy from the repo exits **0** — `[check] OK: no harness drift`.
+So the operator follows the instruction, sees green, re-runs the doctor, and is
+still red, with nothing in the message pointing at the cause.
+
+The cause needed three facts, none of which is visible from the failure text:
+
+1. `harness/manifest.json` declares three injection targets: `AGENTS.md`,
+   `ai/claude/CLAUDE.md`, and — added by `#1176` — `ai/orca/ORCA.md`.
+2. `setup-linux.sh` mirrored a **hardcoded pair** into `~/.dotfiles`. The third
+   target never got a copy line, so the deploy dir never had the file.
+3. `checkCompileHarnessDrift` (`cli/internal/doctor/checks_deploy.go:611`) runs
+   the script **from `$DOTFILES_DIR`**, not from the repo. The two scripts are
+   byte-identical; only the root differs. The mirror's run evaluated a target
+   whose file was absent and failed on the marker count.
+
+## The part worth carrying forward
+
+There was already a guard for exactly this. `tests/compile-harness-rootresolve.bats`
+assembles a non-git copy of "exactly what `--check` reads" and asserts it passes.
+It was written *because* this failure mode had happened before — its header says
+so: *"setup copied none of the latter three, so `--check` exited 2 and section 12
+reported a false drift FAIL."*
+
+And `#1176` **edited that test** to add `ai/orca/ORCA.md` to its hand-copied list.
+The commit message records it plainly: *"include orca in rootresolve test"*.
+
+So the test went on passing, by doing by hand precisely the copy that the deploy
+did not do. The guard was adjusted to accommodate the gap instead of exposing it.
+Nothing was hidden and nothing was careless — the test needed that file to run at
+all, and adding it is the obvious local fix. That is what makes the shape worth
+naming: **the change that keeps a guard green is not always the change that keeps
+it a guard.**
+
+The structural cause underneath: the target list existed in **three** places —
+the manifest, `setup-linux.sh`'s copy block, and the test's assembly block. A list
+restated three times can only diverge, and it diverged silently in the one copy
+that had no assertion attached.
+
+## Rule
+
+- When a change makes an existing test need new setup, ask what the test was
+  protecting **before** adding the setup. If the new fixture line is doing work
+  the production path is supposed to do, the test is now describing a bug rather
+  than catching one.
+- **Derive lists, never restate them.** The fix reads targets from the manifest in
+  both the deploy block and the test, so the next entry is mirrored by
+  construction. There is no place left for the list to disagree with itself.
+- A guard that builds its own copy of the world can only test logic, never
+  delivery. Assert the outcome where it actually lands too — here,
+  `verify-setup.bats` now asserts every manifest target exists in the real
+  `$DOTFILES_DIR` after a real setup run, which is the half no unit test reaches.
+- **When a check fails, verify the remedy it prints actually clears it.** A red
+  check with an unactionable message trains the operator to ignore the check,
+  which costs more than the original defect. "Target absent" and "target present
+  but disagrees" need different messages; collapsing them is what produced this.
+
+## Evidence
+
+```
+$ bash ~/.dotfiles/scripts/compile-harness.sh --check
+[ERROR] /home/manu/.dotfiles/ai/orca/ORCA.md: need exactly 1 BEGIN + 1 END HARNESS marker (found /)
+[check] FAIL: harness drift detected
+
+$ ./scripts/compile-harness.sh --check
+[check] OK: no harness drift
+
+$ diff scripts/compile-harness.sh ~/.dotfiles/scripts/compile-harness.sh   # identical
+
+# after the fix, mirroring derived from the manifest:
+$ dotf doctor
+[Harness + skill drift]
+  (5 checks, all ok)
+Results: 147 passed, 0 failed, 4 warned, 6 skipped
+```
+
+Tracked as `#1200`.

--- a/docs/lessons/lesson-223-a-test-updated-to-keep-passing-stops-being-a-guar.md
+++ b/docs/lessons/lesson-223-a-test-updated-to-keep-passing-stops-being-a-guar.md
@@ -46,9 +46,16 @@ all, and adding it is the obvious local fix. That is what makes the shape worth
 naming: **the change that keeps a guard green is not always the change that keeps
 it a guard.**
 
-The structural cause underneath: the target list existed in **three** places —
-the manifest, `setup-linux.sh`'s copy block, and the test's assembly block. A list
-restated three times can only diverge, and it diverged silently in the one copy
+The structural cause underneath: the target list existed in **four** places — the
+manifest, `setup-linux.sh`'s copy block, `compile-harness-rootresolve.bats`'s
+assembly block, and `setup-linux.bats`, which asserted each literal `safe_copy`
+line by `grep -qF`. The fourth only surfaced when the fix removed those lines and
+CI went red on it, which is its own small lesson: **a test that asserts the
+presence of a hardcoded list can only check that the entries someone remembered
+are there, never that the list is complete.** It was green throughout, on a list
+missing the entry that mattered.
+
+A list restated four times can only diverge, and it diverged silently in the copy
 that had no assertion attached.
 
 ## Rule
@@ -68,6 +75,27 @@ that had no assertion attached.
   check with an unactionable message trains the operator to ignore the check,
   which costs more than the original defect. "Target absent" and "target present
   but disagrees" need different messages; collapsing them is what produced this.
+
+## What the new guard found on its first run
+
+Worth recording, because it is the argument for writing the outcome assertion at
+all. The integration guard went red on its very first CI run — not on the bug it
+was written for, but on a latent one underneath it. In one setup run, 22 seconds
+apart and in the same process:
+
+```
+[SUCCESS] jq installed
+[WARNING] Claude Code CLI, npx, or jq not found, skipping MCP server registration
+```
+
+Both lines are true. `jq` is downloaded to `$HOME/.local/bin`, which the rc files
+put on `PATH` and the running setup process does not have. So `command -v jq`
+is false immediately after a successful install, and every step gated on it —
+MCP server registration among them — is silently skipped on precisely the fresh
+machine that needs it. The success message reports the *download*; the later
+check asks about the *lookup*. **"Installed" has to mean the same thing the next
+check asks about, or the two will disagree and both will look right.** Tracked as
+`#1202`; worked around here by resolving the binary path explicitly.
 
 ## Evidence
 

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -558,16 +558,36 @@ fi
 # (healthcheck section 12) can verify drift offline from ~/.dotfiles. The engine
 # resolves its root from its own location, and the rootresolve regression test
 # models exactly this complete non-git copy: scripts/ (compile-harness.sh) +
-# AGENTS.md + ai/claude/CLAUDE.md + harness/. setup copied none of the latter
-# three, so --check exited 2 (manifest not found) and section 12 reported a false
-# drift FAIL. This runs AFTER --refresh so the snapshot matches the refreshed
-# repo state (else the repo<->deploy drift sub-check would then see drift).
+# harness/ + every file harness/manifest.json declares as an injection target.
+# This runs AFTER --refresh so the snapshot matches the refreshed repo state
+# (else the repo<->deploy drift sub-check would then see drift).
+#
+# The target list is DERIVED from the manifest, never restated here. It was a
+# hardcoded pair (AGENTS.md + ai/claude/CLAUDE.md) until #1200: adding
+# ai/orca/ORCA.md as a third target (#1176) needed a copy line nobody wrote, so
+# --check evaluated a target the mirror had never received and reported a drift
+# FAIL whose own printed remedy could not clear it — running --refresh from the
+# repo exits 0, because the repo has the file. Deriving the list means the next
+# manifest entry is mirrored by construction rather than by remembering.
 if [ "$CURRENT_DIR" != "$DOTFILES_DIR" ]; then
     ensure_directory "$DOTFILES_DIR/harness"
     cp -rf "$CURRENT_DIR/harness/." "$DOTFILES_DIR/harness/" 2>/dev/null || true
-    safe_copy "$CURRENT_DIR/AGENTS.md" "$DOTFILES_DIR/" 2>/dev/null || true
-    ensure_directory "$DOTFILES_DIR/ai/claude"
-    safe_copy "$CURRENT_DIR/ai/claude/CLAUDE.md" "$DOTFILES_DIR/ai/claude/" 2>/dev/null || true
+    if command -v jq >/dev/null 2>&1 && [ -f "$CURRENT_DIR/harness/manifest.json" ]; then
+        # Read line by line: `for f in $(jq ...)` does not word-split in zsh,
+        # which would yield ONE target containing every path (see CLAUDE.md's
+        # prohibited-pattern table — this row fails silently).
+        jq -r '.targets[].file' "$CURRENT_DIR/harness/manifest.json" 2>/dev/null \
+        | while IFS= read -r _harness_target; do
+            [ -n "$_harness_target" ] || continue
+            [ -f "$CURRENT_DIR/$_harness_target" ] || continue
+            _harness_target_dir="$(dirname "$DOTFILES_DIR/$_harness_target")"
+            ensure_directory "$_harness_target_dir"
+            safe_copy "$CURRENT_DIR/$_harness_target" "$_harness_target_dir/" 2>/dev/null || true
+        done
+        unset _harness_target _harness_target_dir
+    else
+        log_warning "jq or harness/manifest.json unavailable — harness targets not mirrored to $DOTFILES_DIR; 'dotf doctor' will report harness drift"
+    fi
 fi
 
 # Claude Code

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -572,11 +572,22 @@ fi
 if [ "$CURRENT_DIR" != "$DOTFILES_DIR" ]; then
     ensure_directory "$DOTFILES_DIR/harness"
     cp -rf "$CURRENT_DIR/harness/." "$DOTFILES_DIR/harness/" 2>/dev/null || true
-    if command -v jq >/dev/null 2>&1 && [ -f "$CURRENT_DIR/harness/manifest.json" ]; then
+    # Resolve jq by path, not by name. The installer above downloads it to
+    # ~/.local/bin, which the rc files put on PATH but THIS process may not have
+    # — measured in the integration container, where setup logs "jq installed"
+    # and then "jq not found" 22 seconds later in the same run. A `command -v`
+    # test alone therefore skips the mirror right after a successful install.
+    _jq=""
+    if command -v jq >/dev/null 2>&1; then
+        _jq="jq"
+    elif [ -x "$HOME/.local/bin/jq" ]; then
+        _jq="$HOME/.local/bin/jq"
+    fi
+    if [ -n "$_jq" ] && [ -f "$CURRENT_DIR/harness/manifest.json" ]; then
         # Read line by line: `for f in $(jq ...)` does not word-split in zsh,
         # which would yield ONE target containing every path (see CLAUDE.md's
         # prohibited-pattern table — this row fails silently).
-        jq -r '.targets[].file' "$CURRENT_DIR/harness/manifest.json" 2>/dev/null \
+        "$_jq" -r '.targets[].file' "$CURRENT_DIR/harness/manifest.json" 2>/dev/null \
         | while IFS= read -r _harness_target; do
             [ -n "$_harness_target" ] || continue
             [ -f "$CURRENT_DIR/$_harness_target" ] || continue
@@ -588,6 +599,7 @@ if [ "$CURRENT_DIR" != "$DOTFILES_DIR" ]; then
     else
         log_warning "jq or harness/manifest.json unavailable — harness targets not mirrored to $DOTFILES_DIR; 'dotf doctor' will report harness drift"
     fi
+    unset _jq
 fi
 
 # Claude Code

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -590,10 +590,23 @@ if [ "$CURRENT_DIR" != "$DOTFILES_DIR" ]; then
         "$_jq" -r '.targets[].file' "$CURRENT_DIR/harness/manifest.json" 2>/dev/null \
         | while IFS= read -r _harness_target; do
             [ -n "$_harness_target" ] || continue
-            [ -f "$CURRENT_DIR/$_harness_target" ] || continue
+            # A declared target the checkout does not have is a broken checkout,
+            # and skipping it silently reproduces the very defect this block
+            # fixes: the mirror ends up incomplete and `--check` fails later on
+            # a marker count that names neither the manifest nor the missing
+            # file. Name it here, where the cause is still visible. Setup does
+            # not abort — it is idempotent and long, and one absent target must
+            # not cost a machine the rest of its provisioning — but the warning
+            # is loud and `verify-setup.bats` fails on the resulting gap.
+            if [ ! -f "$CURRENT_DIR/$_harness_target" ]; then
+                log_warning "harness/manifest.json declares a target the checkout does not have: $_harness_target — not mirrored, 'dotf doctor' will report harness drift"
+                continue
+            fi
             _harness_target_dir="$(dirname "$DOTFILES_DIR/$_harness_target")"
             ensure_directory "$_harness_target_dir"
-            safe_copy "$CURRENT_DIR/$_harness_target" "$_harness_target_dir/" 2>/dev/null || true
+            if ! safe_copy "$CURRENT_DIR/$_harness_target" "$_harness_target_dir/" 2>/dev/null; then
+                log_warning "failed to mirror harness target $_harness_target to $_harness_target_dir — 'dotf doctor' will report harness drift"
+            fi
         done
         unset _harness_target _harness_target_dir
     else

--- a/tests/compile-harness-rootresolve.bats
+++ b/tests/compile-harness-rootresolve.bats
@@ -12,19 +12,39 @@ setup() {
 teardown() { rm -rf "$TMP"; }
 
 @test "compile-harness --check works from a non-git copy (root resolved from SCRIPT_DIR)" {
-    # Assemble a complete, NON-git copy of exactly what --check reads.
-    mkdir -p "$TMP/scripts" "$TMP/ai/claude" "$TMP/ai/orca"
+    # Assemble a complete, NON-git copy of exactly what --check reads. The
+    # target list is DERIVED from the manifest, never hand-listed here: this
+    # test used to name the targets literally, so #1176 added ai/orca/ORCA.md
+    # to BOTH the manifest and this line while setup-linux.sh never learned to
+    # mirror it. The test then passed by doing by hand what the deploy did not
+    # do, and hid the drift FAIL it exists to catch (#1200).
+    mkdir -p "$TMP/scripts"
     cp "$REPO/scripts/compile-harness.sh" "$TMP/scripts/"
-    cp "$REPO/AGENTS.md" "$TMP/"
-    cp "$REPO/ai/claude/CLAUDE.md" "$TMP/ai/claude/"
-    cp "$REPO/ai/orca/ORCA.md" "$TMP/ai/orca/"
     cp -r "$REPO/harness" "$TMP/"
+    while IFS= read -r target; do
+        [ -n "$target" ] || continue
+        mkdir -p "$TMP/$(dirname "$target")"
+        cp "$REPO/$target" "$TMP/$target"
+    done < <(jq -r '.targets[].file' "$REPO/harness/manifest.json")
     [ ! -d "$TMP/.git" ]   # genuinely not a git repo
 
     # Run from an unrelated CWD to prove root resolution is CWD-independent.
     run bash -c "cd / && '$TMP/scripts/compile-harness.sh' --check"
     [ "$status" -eq 0 ]
     echo "$output" | grep -q 'no harness drift'
+}
+
+@test "every manifest target is a file the repo actually has" {
+    # The manifest is the source the deploy copy list derives from, so an entry
+    # naming a path that does not exist would silently mirror nothing and leave
+    # --check to fail on the absence, one layer removed from the cause.
+    while IFS= read -r target; do
+        [ -n "$target" ] || continue
+        [ -f "$REPO/$target" ] || {
+            echo "manifest.json declares a target the repo does not have: $target"
+            return 1
+        }
+    done < <(jq -r '.targets[].file' "$REPO/harness/manifest.json")
 }
 
 @test "compile-harness without its harness/ dir fails gracefully (no crash)" {

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -422,27 +422,51 @@ setup() {
 # (~/.dotfiles), and the engine resolves its root from its own location. That
 # offline check needs the harness inputs mirrored into the deploy dir -- exactly
 # the complete non-git copy the rootresolve regression test models: scripts/
-# (compile-harness.sh, already copied) + AGENTS.md + ai/claude/CLAUDE.md +
-# harness/. setup copied none of the latter three, so --check exited 2 (manifest
-# not found) and section 12 reported a false drift FAIL. These guards lock the
-# mirror in, AND assert it runs AFTER --refresh so the snapshot matches the
-# refreshed repo state (else the repo<->deploy drift sub-check would see drift).
+# (compile-harness.sh, already copied) + harness/ + every file
+# harness/manifest.json declares as an injection target. setup copied none of
+# them, so --check exited 2 (manifest not found) and section 12 reported a false
+# drift FAIL. These guards lock the mirror in, AND assert it runs AFTER --refresh
+# so the snapshot matches the refreshed repo state (else the repo<->deploy drift
+# sub-check would see drift).
 
 @test "setup-linux.sh mirrors harness/ into the deploy dir (drift fix)" {
     grep -qF 'cp -rf "$CURRENT_DIR/harness/." "$DOTFILES_DIR/harness/"' "$DOTFILES_DIR/setup-linux.sh"
 }
 
-@test "setup-linux.sh mirrors AGENTS.md into the deploy dir (drift fix)" {
-    grep -qF 'safe_copy "$CURRENT_DIR/AGENTS.md" "$DOTFILES_DIR/"' "$DOTFILES_DIR/setup-linux.sh"
+@test "setup-linux.sh derives the mirrored target list from harness/manifest.json" {
+    # This used to assert two literal `safe_copy` lines, one per target. That
+    # made the test a FOURTH restatement of the manifest's list -- alongside the
+    # manifest itself, the deploy block, and compile-harness-rootresolve.bats --
+    # and it could only ever assert that the targets someone remembered were
+    # copied, never that the list was complete. #1200: a third target was added
+    # to the manifest with no copy line, and this test stayed green while
+    # `dotf doctor` failed permanently.
+    #
+    # Assert the derivation instead. The OUTCOME -- every declared target
+    # actually present in $DOTFILES_DIR -- is asserted by verify-setup.bats
+    # against a real deploy, which is the half source-text grep cannot reach.
+    # Patterns must not start with `-`: grep reads a leading dash as an OPTION
+    # and exits 2 (usage error), which a boolean assertion cannot tell apart
+    # from 1 (not found) — the test would report "the derivation is missing"
+    # when grep never looked at the file.
+    grep -qF '.targets[].file' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF '"$CURRENT_DIR/harness/manifest.json"' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF 'safe_copy "$CURRENT_DIR/$_harness_target" "$_harness_target_dir/"' \
+        "$DOTFILES_DIR/setup-linux.sh"
+}
+
+@test "setup-linux.sh resolves jq by path, not only by name (#1202)" {
+    # The installer downloads jq to ~/.local/bin, which this process's PATH may
+    # not carry: the integration container logs "jq installed" and "jq not
+    # found" 22 seconds apart in one run. A `command -v jq` test alone silently
+    # skips the mirror right after a successful install, so the derivation
+    # no-ops and every manifest target goes missing without an error.
+    grep -qF '[ -x "$HOME/.local/bin/jq" ]' "$DOTFILES_DIR/setup-linux.sh"
 }
 
 @test "setup-linux.sh installs the GUARD memory-sink git-hooks (#418 deploy + wire)" {
     grep -qF '. ./scripts/install-git-hooks.sh' "$DOTFILES_DIR/setup-linux.sh"
     grep -qF 'install_git_hooks' "$DOTFILES_DIR/setup-linux.sh"
-}
-
-@test "setup-linux.sh mirrors ai/claude/CLAUDE.md into the deploy dir (drift fix)" {
-    grep -qF 'safe_copy "$CURRENT_DIR/ai/claude/CLAUDE.md" "$DOTFILES_DIR/ai/claude/"' "$DOTFILES_DIR/setup-linux.sh"
 }
 
 @test "setup-linux.sh harness mirror runs AFTER compile-harness --refresh (ordering guard)" {

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -487,3 +487,51 @@ setup() {
     [ -z "$output" ]
 }
 
+# =============================================================================
+# Section: harness injection targets are mirrored into the deploy dir
+#
+# `dotf doctor` runs `compile-harness.sh --check` from $DOTFILES_DIR, so every
+# file harness/manifest.json declares as a target must exist there. #1176 added
+# ai/orca/ORCA.md to the manifest without a copy line in setup-linux.sh, and the
+# result was a permanent doctor FAIL whose printed remedy could not clear it:
+# running --refresh from the repo exits 0, because the repo has the file (#1200).
+#
+# This asserts the OUTCOME on a real deploy, which is the half no unit test can
+# reach — tests/compile-harness-rootresolve.bats builds its own tmp mirror, so
+# it passed throughout by hand-copying the file setup never delivered.
+# =============================================================================
+
+@test "every harness manifest target exists in the deploy dir" {
+    [ -f "$DOTFILES_DIR/harness/manifest.json" ]
+    command -v jq >/dev/null 2>&1 || {
+        echo "jq is absent, so the target list cannot be read"
+        return 1
+    }
+    local missing="" checked=0
+    while IFS= read -r target; do
+        [ -n "$target" ] || continue
+        checked=$((checked + 1))
+        [ -f "$DOTFILES_DIR/$target" ] || missing="$missing $target"
+    done < <(jq -r '.targets[].file' "$DOTFILES_DIR/harness/manifest.json")
+    # An empty list would make every assertion below vacuously true, which is
+    # how a guard reports "all clear" on a manifest it never read.
+    [ "$checked" -gt 0 ] || {
+        echo "read zero targets from manifest.json — the guard checked nothing"
+        return 1
+    }
+    [ -z "$missing" ] || {
+        echo "manifest targets missing from $DOTFILES_DIR:$missing"
+        echo "setup-linux.sh must mirror every harness/manifest.json target"
+        return 1
+    }
+}
+
+@test "compile-harness --check passes from the deploy dir" {
+    # The assertion dotf doctor makes, made directly: a green --check here is
+    # what a green [Harness + skill drift] section means.
+    [ -x "$DOTFILES_DIR/scripts/compile-harness.sh" ]
+    run bash "$DOTFILES_DIR/scripts/compile-harness.sh" --check
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'no harness drift'
+}
+

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -537,6 +537,14 @@ setup() {
     # The assertion dotf doctor makes, made directly: a green --check here is
     # what a green [Harness + skill drift] section means.
     [ -x "$DOTFILES_DIR/scripts/compile-harness.sh" ]
+    # `--check` requires jq ON PATH (`type -P jq || exit 2`), and setup installs
+    # it to ~/.local/bin without putting that on this process's PATH (#1202).
+    # SKIP rather than inject the path: injecting would make this test green on
+    # a machine where `dotf doctor` is red, which is the failure mode
+    # docs/lessons/lesson-223 is about. A named skip says which condition was
+    # hit; once #1202 lands, this starts running here on its own.
+    command -v jq >/dev/null 2>&1 || \
+        skip "jq is not on PATH, so --check exits 2 before it can answer about drift (#1202)"
     run bash "$DOTFILES_DIR/scripts/compile-harness.sh" --check
     [ "$status" -eq 0 ]
     echo "$output" | grep -q 'no harness drift'

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -503,16 +503,23 @@ setup() {
 
 @test "every harness manifest target exists in the deploy dir" {
     [ -f "$DOTFILES_DIR/harness/manifest.json" ]
-    command -v jq >/dev/null 2>&1 || {
-        echo "jq is absent, so the target list cannot be read"
+    # Resolve jq the same way setup does: it is installed to ~/.local/bin, which
+    # is not necessarily on this process's PATH (#1202).
+    local jq_bin=""
+    if command -v jq >/dev/null 2>&1; then
+        jq_bin="jq"
+    elif [ -x "$HOME/.local/bin/jq" ]; then
+        jq_bin="$HOME/.local/bin/jq"
+    else
+        echo "jq is absent from PATH and ~/.local/bin, so the list cannot be read"
         return 1
-    }
+    fi
     local missing="" checked=0
     while IFS= read -r target; do
         [ -n "$target" ] || continue
         checked=$((checked + 1))
         [ -f "$DOTFILES_DIR/$target" ] || missing="$missing $target"
-    done < <(jq -r '.targets[].file' "$DOTFILES_DIR/harness/manifest.json")
+    done < <("$jq_bin" -r '.targets[].file' "$DOTFILES_DIR/harness/manifest.json")
     # An empty list would make every assertion below vacuously true, which is
     # how a guard reports "all clear" on a manifest it never read.
     [ "$checked" -gt 0 ] || {


### PR DESCRIPTION
fix(setup): derive the harness mirror from the manifest, not a hardcoded list

`dotf doctor` reported a permanent `[FAIL] harness/skill drift` whose printed
remedy could not clear it: running `compile-harness.sh --refresh` from the repo
exits 0, because the repo has every file the manifest declares.

The doctor runs the script from `$DOTFILES_DIR` (checks_deploy.go:611), and the
deploy dir was missing one of the three targets. `harness/manifest.json` gained
`ai/orca/ORCA.md` as a target without a matching copy line in `setup-linux.sh`,
whose mirroring block listed `AGENTS.md` and `ai/claude/CLAUDE.md` literally. The
two scripts are byte-identical; only the root they resolve differs.

The target list is now read from the manifest in both the deploy block and the
root-resolution test, so a new entry is mirrored by construction. It previously
lived in three places and could only diverge.

Guards, in the same change:
- `verify-setup.bats` asserts every manifest target exists in the real
  `$DOTFILES_DIR` after setup runs, and refuses to pass on an empty target list
  — the half no unit test reaches, since the root-resolution test builds its own
  temporary mirror and passed throughout by hand-copying the missing file.
- A manifest entry naming a path the repo does not have now fails directly,
  rather than surfacing one layer removed as a marker-count error.

Verified: mirror `--check` exits 0, `dotf doctor` 147 passed / 0 failed (was
146/1), bats 81 passed across the harness suites, shellcheck clean, `bash -n`
and `zsh -n` both parse.

Closes #1200

Full detail, evidence and the guard rationale are in the commit body and in `docs/lessons/lesson-223`.

Closes #1200

## SDD skip rationale

The gate counts **59 production LOC** in `setup-linux.sh` and refuses at the 50 threshold. Measured against the rule the repository actually merged in #1180 — *"the cap counts EXECUTABLE lines; declarative data, schemas and comment blocks are excluded"* — the same diff is **28 lines**:

```console
$ git diff main HEAD -- setup-linux.sh | grep -E '^\+|^-' | grep -vE '^\+\+\+|^---' | wc -l
59
$ git diff main HEAD -- setup-linux.sh | grep -E '^\+|^-' | grep -vE '^\+\+\+|^---' \
    | sed 's/^[+-]//' | grep -vE '^\s*#' | grep -vE '^\s*$' | wc -l
28
```

The 31-line difference is WHY comments: why the target list is derived rather than restated, why `jq` is resolved by path, and why an absent target warns instead of aborting. `scripts/check-spec-gate.sh`'s `_excluded()` is path-based and has no notion of counting executable lines within a kept file, so writing that reasoning down is what pushed this over the threshold.

This is **#1186**, open and unfixed: the executable-lines rule is documented in `AGENTS.md` and in the vault pattern, and enforced by nothing. Using the escape with this rationale is the same compensation the CodeRabbit config PR made when it hit the identical counter, cited there against the same ticket.

A spec folder would be the wrong instrument here regardless: this is a bugfix closing #1200 with its guard in the same change, not a feature needing a proposal.
