### PR TITLE
test(bats): kill negated assertions that cannot fail, and guard the class

### DIFF
--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -237,3 +237,4 @@ tags: [lessons, index, dotfiles]
 | [221 - An allow-list merge makes every new template key a silent no-op](lesson-221-an-allow-list-merge-makes-every-new-template-key-a.md) | 2026-08-22 |  |
 | [222 - A coupling's scope is measured, not inferred from where you saw it fail](lesson-222-a-couplings-scope-is-measured-not-inferred-from-whe.md) | 2026-08-23 |  |
 | [223 - A test updated to keep passing stops being a guard](lesson-223-a-test-updated-to-keep-passing-stops-being-a-guar.md) | 2026-08-23 |  |
+| [224 - A negated assertion is exempt from `set -e`, so it cannot fail a test](lesson-224-a-negated-assertion-is-exempt-from-set-e-so-it-cann.md) | 2026-08-23 |  |

--- a/docs/lessons/lesson-224-a-negated-assertion-is-exempt-from-set-e-so-it-cann.md
+++ b/docs/lessons/lesson-224-a-negated-assertion-is-exempt-from-set-e-so-it-cann.md
@@ -1,0 +1,129 @@
+# Lesson 224 — A negated assertion is exempt from `set -e`, so it cannot fail a test
+
+**Date:** 2026-08-23
+**Area:** tests / bats / guards
+**Severity:** high — 53 assertions across the suite could not fail, and one was hiding a real violation
+
+## What happened
+
+bash exempts any command preceded by `!` from `set -e`. bats runs a `@test` body
+under `set -e` and takes the body's exit status from its **last** command. Put
+those together and `! grep -q X file` in the middle of a test is not an
+assertion — it is a comment that executes.
+
+```bash
+@test "the script names no reviewer" {
+    ! grep -q 'coderabbitai' "$SCRIPT"   # violated: passes anyway
+    grep -q 'reviewers' "$REGISTRY"      # this line alone decides the verdict
+}
+```
+
+Measured on 2026-08-23 over `tests/*.bats`: **139** lines whose first token is
+`!`, in 30 files. **53** of them were in a position where they could not fail
+(not the last statement of their `@test`, and not rescued by an `|| return 1`).
+The other 86 worked only because nothing had been appended below them yet.
+
+The proof is a falsification, not an argument. Take one real assertion —
+`tests/setup-windows.bats`, "does NOT eager-source load-secrets" — and make it
+false by changing the pattern to a string the file certainly contains:
+
+| Form | Result |
+|---|---|
+| `! grep -qF 'param' "$PS1_SCRIPT"` (old, line 81 of 84) | `ok 1` |
+| `refute_grep_fixed 'param' "$PS1_SCRIPT"` (new, same line) | `not ok 1` |
+
+Same file, same position, same falsified claim. One reports green.
+
+This is not theoretical damage. `tests/check-review-attestation.bats` asserted
+that `scripts/check-review-attestation.sh` names no reviewer of its own. The
+script **did** name one, in a comment. The suite was green for as long as the
+violated line was not the last one in its test.
+
+## Why it survives inspection
+
+Three reasons, and each one is worth knowing on its own:
+
+**A bare `false` in the same position IS caught.** The exemption is specific to
+the `!` form, so the obvious sanity check — "does `set -e` work in a bats body?"
+— answers yes and moves on. The rule is narrower than the check.
+
+**It is the shape a careful person reaches for.** `! grep -q` reads as "assert
+absent", which is exactly the intent. Nothing about it looks like a no-op.
+
+**It degrades on edit, silently.** An assertion on the last line works today.
+Appending one more assertion below it — the most ordinary edit there is — kills
+it, with no diff to the line that died.
+
+There is a fourth, nastier variant. Inside a loop, only the last iteration can
+decide anything:
+
+```bash
+for plugin in github code-simplifier … feature-dev; do   # 9 plugins
+    ! grep -qE "\"${plugin}@…\"" "$DOTFILES_DIR/setup-linux.sh"
+done
+```
+
+The `for` is the last statement, so it does carry a status — but that status is
+the last iteration's. Eight of the nine plugins were unchecked, in a test whose
+name promises all nine.
+
+## The fix, and the two vacuous passes hiding inside it
+
+Assertions moved to `tests/lib/refute.bash` (`load 'lib/refute'`), which returns
+non-zero explicitly and prints the offending line with its number. Writing it
+surfaced two more ways to pass without asserting, both inherited by any hand-
+rolled `! grep`:
+
+- **A grep error is not an absence.** An unreadable file or a pattern invalid in
+  the chosen dialect exits `2`, and `! grep` reads that as "not found". This
+  matters precisely when converting: `(` is a literal in BRE and an unterminated
+  group in ERE, so a pattern moved from `grep -q` to `grep -qE` without thought
+  starts erroring — and erroring reads as passing. The helper treats any status
+  above 1 as a failure.
+- **A pattern beginning with `-` is a pattern.** `--vault knowledge` was being
+  handed to grep as options. The helper passes the pattern after `--`.
+
+The dialect is in the function name — `refute_grep` (extended regex) and
+`refute_grep_fixed` (literal) — so the call site has to say which one it means.
+For the non-grep cases, `run cmd` plus an explicit `[ "$status" -eq 1 ]` says the
+same thing; prefer `-eq 1` to `-ne 0`, because `-ne 0` also passes on 127, the
+status of a helper whose name you typo'd.
+
+## The rule
+
+**Never open a statement in a bats test with `!`.** Not in the middle, not on
+the last line — the last line is one appended assertion away from the middle,
+and nothing tells you when it moves.
+
+`tests/guard-bats-negation.bats` enforces this over the whole suite. It carries
+a quarantine list of the files not yet converted with their **exact** counts, and
+fails when a count moves in either direction: a conversion must lower its entry
+in the same commit, and a regression cannot hide behind an entry that
+over-counts. The list is emptied file by file; when the last entry goes, so does
+the list.
+
+The guard also tests its own detector against a fixture with a hand-counted
+answer. A guard that silently matches nothing reports a clean suite forever —
+the same failure it exists to catch, one level up.
+
+## Relation to Lessons 212 and 220
+
+[212](lesson-212-an-invalid-instrument-is-indistinguishable-from-an.md) — an
+invalid instrument is indistinguishable from an absent guard.
+[220](lesson-220-four-defects-one-shape-a-thing-verified-by-a-proxy.md) — a
+thing verified by a proxy that lives somewhere else, with its diagnostic
+question: *what would this still pass on if the thing it checks were broken?*
+
+This is that question answered for an entire suite: **the assertion would still
+pass on anything at all.** The instrument was not merely aimed at a proxy — it
+had no subject. The generalisable move is the one both lessons end on: falsify
+the check deliberately and confirm it goes red. A test never observed failing is
+a claim, not a check.
+
+## Evidence
+
+- `grep -rnE '^\s+!\s' tests/*.bats | wc -l` → 139, in 30 files (2026-08-23)
+- Falsification pair above: `ok 1` on the old form, `not ok 1` on the new one
+- `tests/check-review-attestation.bats` AC5 — the real violation it hid
+- Full suite after conversion: 1453 tests, 0 failures
+- `#1034` — the ticket

--- a/tests/backup-secrets-to-usb.bats
+++ b/tests/backup-secrets-to-usb.bats
@@ -10,6 +10,8 @@
 # We re-assert syntax here too so this file is self-contained as the canonical
 # per-script suite, but the load-bearing additions are the guard tests.
 
+load 'lib/refute'
+
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
     export SCRIPTS_DIR="$DOTFILES_DIR/scripts"
@@ -110,19 +112,6 @@ teardown() {
     # failure mode being ended, so absence must not be quiet.
     grep -q 'log_warning "No DR escrow' "$BACKUP_SCRIPT"
     grep -q "dotf secrets backup" "$BACKUP_SCRIPT"
-}
-
-# `! cmd` is EXEMPT from `set -e`, so a bare `! grep` anywhere but the final line
-# of a @test is silently ignored and the case passes on its last assertion alone.
-# The first assertion below was dead for exactly that reason. Same defect found
-# in tests/check-review-attestation.bats, where it was hiding a real violation.
-refute_grep() {
-    local pattern="$1" file="$2"
-    if grep -qE "$pattern" "$file"; then
-        printf 'expected NOT to find /%s/ in %s, but it is there:\n' "$pattern" "$file" >&2
-        grep -nE "$pattern" "$file" >&2
-        return 1
-    fi
 }
 
 @test "backup-secrets-to-usb.sh keeps the USB payload a declared list, not a recursive sweep" {

--- a/tests/check-review-attestation.bats
+++ b/tests/check-review-attestation.bats
@@ -11,6 +11,8 @@
 # ever stops classifying that file as `declined`, the gate has stopped doing
 # the one thing it was built for.
 
+load 'lib/refute'
+
 setup() {
     REPO="$BATS_TEST_DIRNAME/.."
     SCRIPT="$REPO/scripts/check-review-attestation.sh"
@@ -171,23 +173,6 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *"declined"* ]]
     [[ "$output" == *"pr-agent"* ]]
-}
-
-# refute_grep exists because `! cmd` is EXEMPT from `set -e` in bash. A bare
-# `! grep -q X file` anywhere except the final line of a @test is silently
-# ignored, so the test passes on the strength of its last assertion alone.
-#
-# That is not hypothetical here: this file's AC5 case asserted the script names
-# no reviewer, the script DID name one in a comment, and the suite reported
-# green for as long as the violated assertion was not the last line. Found via a
-# reviewer comment about a different defect in the same predicate.
-refute_grep() {
-    local pattern="$1" file="$2"
-    if grep -qE "$pattern" "$file"; then
-        printf 'expected NOT to find /%s/ in %s, but it is there:\n' "$pattern" "$file" >&2
-        grep -nE "$pattern" "$file" >&2
-        return 1
-    fi
 }
 
 @test "AC5: the script names no reviewer of its own" {
@@ -429,12 +414,10 @@ sys.exit(0 if expected.issubset(types) else 1)
     [[ "$output" != *"declined"* ]]
 }
 
-@test "meta: no bare negated assertion survives in this suite" {
-    # The pitfall that hid a real violation here: `! cmd` is exempt from set -e,
-    # so a failing negation anywhere but the last line of a @test is ignored.
-    # refute_grep is the replacement; this keeps the pattern from creeping back.
-    refute_grep '^[[:space:]]*![[:space:]]*grep' "$BATS_TEST_FILENAME"
-}
+# The "meta: no bare negated assertion survives in this suite" case that used to
+# live here now covers every file in tests/, not just this one: see
+# tests/guard-bats-negation.bats (#1034).  Two guards for one rule is one guard
+# and one thing that quietly disagrees with it.
 
 @test "AC7: the workflow tolerates the gate not yet existing on the base branch" {
     # Chicken-and-egg found in production on #1019: pinning checkout to the base

--- a/tests/claude-settings-template.bats
+++ b/tests/claude-settings-template.bats
@@ -3,6 +3,8 @@
 # The template is the SSOT for the "dotfiles-owned" subset of ~/.claude/settings.json.
 # Per-key merge policy is documented in specs/SDD-002-settings-portability/proposal.md.
 
+load 'lib/refute'
+
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
     export SETTINGS_TEMPLATE="$DOTFILES_DIR/ai/claude/settings.json"
@@ -258,14 +260,14 @@ setup() {
 @test "setup-linux.sh plugin install loop must NOT include plugins removed for zero usage" {
     for plugin in github code-simplifier claude-md-management claude-code-setup \
         ralph-loop code-review commit-commands pr-review-toolkit feature-dev; do
-        ! grep -qE "\"${plugin}@claude-plugins-official\"" "$DOTFILES_DIR/setup-linux.sh"
+        refute_grep "\"${plugin}@claude-plugins-official\"" "$DOTFILES_DIR/setup-linux.sh"
     done
 }
 
 @test "setup-windows.ps1 plugin install loop must NOT include plugins removed for zero usage" {
     for plugin in github code-simplifier claude-md-management claude-code-setup \
         ralph-loop code-review commit-commands pr-review-toolkit feature-dev; do
-        ! grep -qE "\"${plugin}@claude-plugins-official\"" "$DOTFILES_DIR/setup-windows.ps1"
+        refute_grep "\"${plugin}@claude-plugins-official\"" "$DOTFILES_DIR/setup-windows.ps1"
     done
 }
 

--- a/tests/compile-harness.bats
+++ b/tests/compile-harness.bats
@@ -3,6 +3,8 @@
 # Each test runs the real script against an isolated temp git repo + fake vault,
 # so the real AGENTS.md / CLAUDE.md are never touched.
 
+load 'lib/refute'
+
 setup() {
     SCRIPT="$BATS_TEST_DIRNAME/../scripts/compile-harness.sh"
     TMP="/tmp/bats_harness_$$_${BATS_TEST_NUMBER:-0}"
@@ -284,9 +286,9 @@ EOF
 @test "setup-linux.sh no longer deploys skills from the removed ai/skills tree" {
     # assert no ACTIVE code path reads the deleted sources (historical mentions
     # in comments are allowed; the deploy is now compile-harness.sh --deploy)
-    ! grep -qF '"$CURRENT_DIR/ai/skills/' "$BATS_TEST_DIRNAME/../setup-linux.sh"
-    ! grep -qF '"$CURRENT_DIR/ai/opencode/commands' "$BATS_TEST_DIRNAME/../setup-linux.sh"
-    ! grep -qF 'OPENCODE_CMDS_SRC=' "$BATS_TEST_DIRNAME/../setup-linux.sh"
+    refute_grep_fixed '"$CURRENT_DIR/ai/skills/' "$BATS_TEST_DIRNAME/../setup-linux.sh"
+    refute_grep_fixed '"$CURRENT_DIR/ai/opencode/commands' "$BATS_TEST_DIRNAME/../setup-linux.sh"
+    refute_grep_fixed 'OPENCODE_CMDS_SRC=' "$BATS_TEST_DIRNAME/../setup-linux.sh"
 }
 
 @test "AC4: injection past the line cap fails (ai/claude/CLAUDE.md)" {
@@ -397,7 +399,7 @@ run_deploy() {
     [ "$(grep -c '^generated_sha:' "$FAKEHOME/.claude/skills/demo-skill/SKILL.md")" -eq 1 ]
     # opencode command drops name:, keeps description + provenance
     [ -f "$FAKEHOME/.config/opencode/commands/demo-skill.md" ]
-    ! grep -q '^name:' "$FAKEHOME/.config/opencode/commands/demo-skill.md"
+    refute_grep '^name:' "$FAKEHOME/.config/opencode/commands/demo-skill.md"
     grep -q '^description:' "$FAKEHOME/.config/opencode/commands/demo-skill.md"
     grep -qE '^generated_sha: [0-9a-f]{16}' "$FAKEHOME/.config/opencode/commands/demo-skill.md"
     [ "$(grep -c '^generated_from:' "$FAKEHOME/.config/opencode/commands/demo-skill.md")" -eq 1 ]
@@ -442,15 +444,15 @@ EOF
     grep -q '^generated_from: 00_meta/skills/full-skill/SKILL.md' "$F"
 
     # neutral/store-only keys must NOT leak into deployed frontmatter
-    ! grep -qE '^(id|type|status|created|owner|paths|keywords|requires|targets):' "$F"
+    refute_grep '^(id|type|status|created|owner|paths|keywords|requires|targets):' "$F"
 
     # opencode command drops name, keeps description + allowed-tools, drops neutral keys
     OC="$FAKEHOME/.config/opencode/commands/full-skill.md"
     [ -f "$OC" ]
-    ! grep -q '^name:' "$OC"
+    refute_grep '^name:' "$OC"
     grep -q '^description: ' "$OC"
     grep -q '^allowed-tools: ' "$OC"
-    ! grep -qE '^(id|type|status|created|owner|paths|keywords|requires|targets):' "$OC"
+    refute_grep '^(id|type|status|created|owner|paths|keywords|requires|targets):' "$OC"
 }
 
 @test "AC1: --deploy replaces a pre-existing vault symlink with a regular copy" {
@@ -486,8 +488,8 @@ EOF
     grep -q '^name: demo-skill' "$FAKEHOME/.gemini/skills/demo-skill/SKILL.md"
     grep -qE '^generated_sha: [0-9a-f]{16}' "$FAKEHOME/.gemini/skills/demo-skill/SKILL.md"
     [ -f "$FAKEHOME/.gemini/prompts/demo-skill.md" ]
-    ! grep -q '^name:' "$FAKEHOME/.gemini/prompts/demo-skill.md"
-    ! grep -q '^description:' "$FAKEHOME/.gemini/prompts/demo-skill.md"
+    refute_grep '^name:' "$FAKEHOME/.gemini/prompts/demo-skill.md"
+    refute_grep '^description:' "$FAKEHOME/.gemini/prompts/demo-skill.md"
     grep -q 'sha256:' "$FAKEHOME/.gemini/prompts/demo-skill.md"
     grep -q 'Body line one.' "$FAKEHOME/.gemini/prompts/demo-skill.md"
 }
@@ -501,7 +503,7 @@ EOF
     grep -qF -- 'Demo skill for the render pipeline.' "$FAKEHOME/.copilot/copilot-instructions.md"
     grep -qE 'BEGIN HARNESS GENERATED \(sha256:[0-9a-f]{16}\)' "$FAKEHOME/.copilot/copilot-instructions.md"
     # claude-only opt-out absent from the copilot catalog
-    ! grep -q 'claude-only' "$FAKEHOME/.copilot/copilot-instructions.md"
+    refute_grep_fixed 'claude-only' "$FAKEHOME/.copilot/copilot-instructions.md"
 }
 
 @test "AC6: per-skill targets[] limits which agents receive deployed output" {
@@ -633,8 +635,8 @@ EOF
     grep -qF 'nested rule line'      "$REPO/harness/enforced/demo.md"
     grep -qF 'rule line two'         "$REPO/harness/enforced/demo.md"
     # the next same-level section is the boundary and must not leak in
-    ! grep -qF 'unrelated'        "$REPO/harness/enforced/demo.md"
-    ! grep -qF 'Next Section'     "$REPO/harness/enforced/demo.md"
+    refute_grep_fixed 'unrelated'        "$REPO/harness/enforced/demo.md"
+    refute_grep_fixed 'Next Section'     "$REPO/harness/enforced/demo.md"
 }
 
 @test "ENGINE-002: --refresh aborts loudly when the manifest anchor is missing (FM D3)" {
@@ -831,7 +833,7 @@ seed_doctrine_fixture() {
     # neutral-only / deferred keys must NOT leak into the native agent frontmatter.
     # `model` is NO LONGER one of them: it is resolved, not dropped (see the tier
     # tests below), so removing it from this list is the behaviour change.
-    ! grep -qE '^(kind|capabilities|skills|targets):' "$F"
+    refute_grep '^(kind|capabilities|skills|targets):' "$F"
     # the record's own provenance (HARNESS-069, added at --refresh) must not
     # survive alongside deploy's own — render_agent's name/description-only
     # passthrough already drops it, but pin that behavior explicitly
@@ -849,7 +851,7 @@ seed_doctrine_fixture() {
     # model id, never the neutral tier — a harness reading `model: top` would ask
     # its provider for a model called "top"
     grep -q '^model: opus' "$F"
-    ! grep -q '^model: top' "$F"
+    refute_grep '^model: top' "$F"
     # exactly one model line: the resolved one replaces the record's, never joins it
     [ "$(grep -c '^model:' "$F")" -eq 1 ]
 }
@@ -922,7 +924,7 @@ DIAG
     [ -f "$F" ]
     grep -q '^name: curator' "$F"
     # not declaring a tier is not an error — it renders as it always did
-    ! grep -q '^model:' "$F"
+    refute_grep '^model:' "$F"
 }
 
 @test "agents: an unresolvable tier fails the deploy instead of rendering a model-less definition" {
@@ -969,7 +971,7 @@ DIAG
     [ -f "$F" ]
     grep -q '^name: curator' "$F"
     # degraded exactly to the pre-change behaviour — never worse than status quo
-    ! grep -q '^model:' "$F"
+    refute_grep '^model:' "$F"
 }
 
 @test "agents: a dotf too old to know resolve-tier warns rather than embedding its help output" {
@@ -999,8 +1001,8 @@ STALE
     F="$FAKEHOME/.claude/agents/curator.md"
     [ -f "$F" ]
     # the help screen must not have become the model id
-    ! grep -q '^model:' "$F"
-    ! grep -q 'Usage:' "$F"
+    refute_grep '^model:' "$F"
+    refute_grep_fixed 'Usage:' "$F"
 }
 
 @test "agents: skill deploy survives a failed agent render" {
@@ -1041,7 +1043,7 @@ EOF
     # the record declares `capabilities: [read, search, edit]`; the deployed file
     # must carry the harness's NATIVE tool names, never the neutral verbs
     grep -q '^tools: Read, Glob, Bash' "$F"
-    ! grep -qE '^capabilities:' "$F"
+    refute_grep '^capabilities:' "$F"
     [ "$(grep -c '^tools:' "$F")" -eq 1 ]
 }
 
@@ -1052,7 +1054,7 @@ EOF
     run_deploy; [ "$status" -eq 0 ]
     F="$FAKEHOME/.claude/agents/curator.md"
     [ -f "$F" ]
-    ! grep -q '^tools:' "$F"
+    refute_grep '^tools:' "$F"
     # the model line is independent and must still be there
     grep -q '^model: opus' "$F"
 }
@@ -1091,7 +1093,7 @@ HALF
     [[ "$output" == *"predates the resolve-capabilities"* ]]
     F="$FAKEHOME/.claude/agents/curator.md"
     grep -q '^model: opus' "$F"
-    ! grep -q '^tools:' "$F"
+    refute_grep '^tools:' "$F"
 }
 
 @test "BUG-1168: a whitespace-bearing model id blames the map, not a stale dotf" {
@@ -1301,7 +1303,7 @@ HALF2
     run_deploy; [ "$status" -eq 0 ]
     # claude: curator targets it, scribe does not
     grep -q 'curator' "$FAKEHOME/.claude/CLAUDE.md"
-    ! grep -q 'scribe' "$FAKEHOME/.claude/CLAUDE.md"
+    refute_grep_fixed 'scribe' "$FAKEHOME/.claude/CLAUDE.md"
     # opencode: both personas target it
     grep -q 'curator' "$FAKEHOME/.config/opencode/AGENTS.md"
     grep -q 'scribe' "$FAKEHOME/.config/opencode/AGENTS.md"

--- a/tests/guard-bats-negation.bats
+++ b/tests/guard-bats-negation.bats
@@ -110,9 +110,11 @@ quarantined_count() {
 }
 
 @test "guard: the detector actually detects, on a fixture with a known answer" {
-    # A guard that silently matches nothing reports a clean suite forever. This
-    # pins the detector against a file whose answer is counted by hand: three
-    # bare negations, and four shapes that must NOT count.
+    # A guard that silently matches nothing reports a clean suite forever, and
+    # one that overcounts turns the ratchet into noise. This pins the detector
+    # against a file whose answer is counted by hand: three bare negations, and
+    # six shapes that must NOT count — including a commented-out negation and a
+    # `!` that is merely an argument, which are the plausible false positives.
     local probe
     probe="$(mktemp)"
     {
@@ -124,6 +126,8 @@ quarantined_count() {
         printf '    [ ! -f x ]\n'
         printf '    refute_grep a b\n'
         printf '    printf "%%s" "!"\n'
+        printf '    # ! grep -q a b\n'
+        printf '    foo || ! bar\n'
         printf '}\n'
     } > "$probe"
 

--- a/tests/guard-bats-negation.bats
+++ b/tests/guard-bats-negation.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+# GUARD: no bare `! cmd` assertion in the bats suite (#1034).
+#
+# bash exempts a command preceded by `!` from `set -e`, and bats runs a @test
+# body under `set -e`.  So `! grep -q X file` anywhere but the LAST line of a
+# @test cannot fail that test — the body's status comes from its last command,
+# and every earlier `!` line is discarded.  Measured: 55 of the suite's 139 such
+# lines were in that position, and one of them was hiding a real violation for
+# months (tests/check-review-attestation.bats, AC5).
+#
+# A `!` on the last line does work — and is one appended assertion away from not
+# working, silently.  So the rule this guard enforces is the whole form, not the
+# dead subset: use tests/lib/refute.bash (refute_grep / refute_grep_fixed), or
+# `run cmd` plus an explicit status check.
+#
+# This is a bats meta-test rather than a scripts/check-*.sh gate on purpose.
+# check-bats-names.sh has to be a script because bats cannot see its own
+# duplicate @test names (the file is a parse error, so nothing runs).  Here
+# there is no such blindness: a bats file can read its siblings, and the `test`
+# job already runs the suite.
+
+# --- the quarantine list -----------------------------------------------------
+#
+# Files still carrying the bare form, with the exact count each carries today.
+# It is a RATCHET, not a home: the guard fails if a listed file's count changes
+# in EITHER direction, so a conversion must delete or lower its entry in the
+# same commit, and a regression cannot hide behind an entry that over-counts.
+# #1034 empties it; when the last entry goes, so does the list.
+quarantine_list() {
+    cat <<'LIST'
+tests/agents-md.bats 2
+tests/aliases.bats 10
+tests/antigravity.bats 4
+tests/bitacora-reconcile.bats 1
+tests/bitacora-rollout.bats 1
+tests/board-pickup.bats 1
+tests/check-doc-paths.bats 1
+tests/compile-harness-real.bats 2
+tests/docs-drift.bats 2
+tests/hermes-setup.bats 1
+tests/hive-upgrade-timer.bats 4
+tests/install-dotf-ps1.bats 1
+tests/knowledge-crystallize-ps1.bats 2
+tests/nan-scripts-secrets.bats 2
+tests/opencode.bats 23
+tests/pi-config.bats 4
+tests/pwsh-analyzer-coverage.bats 1
+tests/shell-wrapper-dedup.bats 2
+tests/skills-pipeline.bats 4
+tests/utils.bats 6
+tests/vault-health-golden.bats 1
+tests/verify-setup.bats 2
+tests/versions-conf.bats 3
+tests/versions-no-hardcode.bats 2
+tests/windows-defaults.bats 2
+LIST
+}
+
+# Lines whose first non-blank token is `!` — the form bash exempts from set -e.
+# `[ ! -f x ]`, `if ! grep …` and `foo || ! bar` are not this shape and are not
+# matched: they are read by the shell in a context where the status is used.
+bare_negation_count() {
+    local file="$1" count
+    count="$(grep -cE '^[[:space:]]*![[:space:]]' "$file" 2>/dev/null || true)"
+    printf '%s\n' "${count:-0}"
+}
+
+quarantined_count() {
+    local rel="$1"
+    quarantine_list | awk -v f="$rel" '$1 == f { print $2; found = 1 }
+                                       END { if (!found) print "-" }'
+}
+
+@test "guard: no bats file outside the quarantine list carries a bare negated assertion" {
+    local offenders=() f rel n
+    for f in "$BATS_TEST_DIRNAME"/*.bats; do
+        rel="tests/$(basename "$f")"
+        n="$(bare_negation_count "$f")"
+        [ "$n" -eq 0 ] && continue
+        [ "$(quarantined_count "$rel")" = '-' ] && offenders+=("$rel ($n)")
+    done
+
+    if [ "${#offenders[@]}" -gt 0 ]; then
+        printf 'bare `! cmd` assertions found in files that had none:\n' >&2
+        printf '  %s\n' "${offenders[@]}" >&2
+        printf 'A `!` line that is not the last line of its @test cannot fail it.\n' >&2
+        printf "Use tests/lib/refute.bash (load 'lib/refute'), or run + a status check.\n" >&2
+        return 1
+    fi
+}
+
+@test "guard: every quarantined file still carries exactly its recorded count" {
+    local drift=() rel want got
+    while read -r rel want; do
+        [ -n "$rel" ] || continue
+        if [ ! -f "$BATS_TEST_DIRNAME/../$rel" ]; then
+            drift+=("$rel: listed but does not exist")
+            continue
+        fi
+        got="$(bare_negation_count "$BATS_TEST_DIRNAME/../$rel")"
+        [ "$got" = "$want" ] || drift+=("$rel: recorded $want, found $got")
+    done < <(quarantine_list)
+
+    if [ "${#drift[@]}" -gt 0 ]; then
+        printf 'the quarantine list has drifted from the suite:\n' >&2
+        printf '  %s\n' "${drift[@]}" >&2
+        printf 'Converting a file means deleting or lowering its entry in the same commit.\n' >&2
+        return 1
+    fi
+}
+
+@test "guard: the detector actually detects, on a fixture with a known answer" {
+    # A guard that silently matches nothing reports a clean suite forever. This
+    # pins the detector against a file whose answer is counted by hand: three
+    # bare negations, and four shapes that must NOT count.
+    local probe
+    probe="$(mktemp)"
+    {
+        printf '@test "x" {\n'
+        printf '    ! grep -q a b\n'
+        printf '\t! [ -f x ]\n'
+        printf '! true\n'
+        printf '    if ! grep -q a b; then :; fi\n'
+        printf '    [ ! -f x ]\n'
+        printf '    refute_grep a b\n'
+        printf '    printf "%%s" "!"\n'
+        printf '}\n'
+    } > "$probe"
+
+    local n
+    n="$(bare_negation_count "$probe")"
+    rm -f "$probe"
+    [ "$n" -eq 3 ]
+}
+
+@test "guard: the quarantine list is sorted and free of duplicate entries" {
+    # Two entries for one file would let a conversion satisfy the stale one and
+    # leave the other unnoticed; sorting keeps the merge conflicts honest when
+    # parallel branches each convert a file.
+    local names
+    names="$(quarantine_list | awk '{ print $1 }')"
+    [ "$names" = "$(printf '%s\n' "$names" | LC_ALL=C sort)" ]
+    [ "$(printf '%s\n' "$names" | wc -l)" -eq "$(printf '%s\n' "$names" | sort -u | wc -l)" ]
+}

--- a/tests/lib/refute.bash
+++ b/tests/lib/refute.bash
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Shared negative assertions for the bats suite.  Load with: load 'lib/refute'
+#
+# WHY THIS EXISTS
+# ---------------
+# bash exempts any command preceded by `!` from `set -e`, and bats runs a @test
+# body under `set -e`.  So `! grep -q X file` in the MIDDLE of a @test cannot
+# fail that test: the body's exit status is taken from its last command, and
+# every earlier `!` line is discarded.  A bare `false` in the same position IS
+# caught — the exemption is specific to the `!` form, which is why it survives
+# casual inspection.
+#
+# That is not hypothetical.  tests/check-review-attestation.bats asserted that
+# scripts/check-review-attestation.sh names no reviewer; the script DID name one
+# (in a comment), and the suite stayed green for as long as the violated
+# assertion was not the last line of its @test.
+#
+# Two hardenings over a plain `! grep`, both of which turn a vacuous pass into a
+# loud failure:
+#
+#   * a grep ERROR is not an absence.  An unreadable file, or a pattern that is
+#     invalid under the chosen dialect (`(` is a group in ERE and a literal in
+#     BRE, so a BRE pattern moved to -E can start erroring), exits >=2.  `! grep`
+#     reads that as "not found" and passes.  Here it fails and says so.
+#   * the pattern is passed after `--`, so a pattern that begins with `-`
+#     (`--vault knowledge`) is a pattern and not a bundle of grep options.
+#
+# The dialect is explicit in the function name: refute_grep is an extended
+# regex, refute_grep_fixed is a literal string.  Do not "simplify" them into one
+# entry point with a flags argument — the call sites are the place where the
+# author has to state which one they mean.
+
+# refute_grep <ere-pattern> <file>
+# Fails if <file> matches the extended regular expression <ere-pattern>.
+refute_grep() {
+    _refute_grep_impl E "$@"
+}
+
+# refute_grep_fixed <literal> <file>
+# Fails if <file> contains the literal string <literal>.
+refute_grep_fixed() {
+    _refute_grep_impl F "$@"
+}
+
+_refute_grep_impl() {
+    local dialect="$1" pattern="$2" file="$3"
+
+    if [ "$#" -ne 3 ]; then
+        printf 'refute_grep: expected <pattern> <file>, got %d argument(s)\n' \
+            "$(($# - 1))" >&2
+        return 1
+    fi
+
+    local status=0
+    grep "-q${dialect}" -- "$pattern" "$file" >/dev/null 2>&1 || status=$?
+
+    case "$status" in
+        0)
+            printf 'expected NOT to find /%s/ in %s, but it is there:\n' \
+                "$pattern" "$file" >&2
+            grep "-n${dialect}" -- "$pattern" "$file" >&2
+            return 1
+            ;;
+        1)
+            return 0
+            ;;
+        *)
+            printf 'refute_grep: grep exited %s on %s for /%s/ — an error is not an absence\n' \
+                "$status" "$file" "$pattern" >&2
+            return 1
+            ;;
+    esac
+}

--- a/tests/powershell-profile.bats
+++ b/tests/powershell-profile.bats
@@ -2,6 +2,7 @@
 # Tests for powershell/profile.ps1 (structural)
 
 load 'winpath'
+load 'lib/refute'
 
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
@@ -35,11 +36,11 @@ setup() {
     grep -qE 'if \(Get-Command opencode' "$PROFILE_SCRIPT"
     grep -qF 'Set-Alias -Name oc -Value opencode' "$PROFILE_SCRIPT"
     # Regression guard: ensure --pure isn't quietly reintroduced for Windows.
-    ! grep -qE 'function oc\s+\{\s*opencode --pure' "$PROFILE_SCRIPT"
+    refute_grep 'function oc\s+\{\s*opencode --pure' "$PROFILE_SCRIPT"
 }
 
 @test "profile.ps1 no longer defines aider tier functions (sunset)" {
-    ! grep -qE '^function (ai|aic|aia) ' "$PROFILE_SCRIPT"
+    refute_grep '^function (ai|aic|aia) ' "$PROFILE_SCRIPT"
 }
 
 # --- Cross-machine path resolution (ADR-025): no hardcoded repo literal ---
@@ -49,7 +50,7 @@ setup() {
     # still find the repo script. The old literal 'Projects\dotfiles\scripts'
     # broke on any machine whose repo is not under ~/Projects/dotfiles.
     grep -qF '$env:DOTFILES_REPO_DIR' "$PROFILE_SCRIPT"
-    ! grep -qF "'Projects\\dotfiles\\scripts\\nan-debug.sh'" "$PROFILE_SCRIPT"
+    refute_grep_fixed "'Projects\\dotfiles\\scripts\\nan-debug.sh'" "$PROFILE_SCRIPT"
 }
 
 # --- On-demand secrets (ADR-028: no ambient export; wrap AI CLIs via dotf secrets run) ---
@@ -59,13 +60,13 @@ setup() {
     # session. opencode (reads {env:NAN_API_KEY} from opencode.jsonc), pi and agy
     # are wrapped to launch through `dotf secrets run`, so the secret lives only
     # in their child process — never the session.
-    ! grep -qE 'load-secrets\.ps1' "$PROFILE_SCRIPT"
+    refute_grep 'load-secrets\.ps1' "$PROFILE_SCRIPT"
     grep -qE 'function opencode \{ dotf secrets run' "$PROFILE_SCRIPT"
 }
 
 @test "parity: neither .bashrc nor profile.ps1 auto-loads secrets; both wrap the AI CLIs" {
-    ! grep -qE 'source .*load-secrets\.sh' "$DOTFILES_DIR/.bashrc"
-    ! grep -qE 'load-secrets\.ps1' "$PROFILE_SCRIPT"
+    refute_grep 'source .*load-secrets\.sh' "$DOTFILES_DIR/.bashrc"
+    refute_grep 'load-secrets\.ps1' "$PROFILE_SCRIPT"
     grep -qE 'opencode\(\) \{ dotf secrets run' "$DOTFILES_DIR/.bashrc"
     grep -qE 'function opencode \{ dotf secrets run' "$PROFILE_SCRIPT"
 }
@@ -102,7 +103,7 @@ setup() {
 @test "profile.ps1 hc function wraps dotf doctor (CLI-018)" {
     # hc was a healthcheck.ps1 launcher; after CLI-018 it runs dotf doctor.
     grep -A6 '^function hc' "$PROFILE_SCRIPT" | grep -qF 'dotf doctor'
-    ! grep -qF 'healthcheck.ps1' "$PROFILE_SCRIPT"
+    refute_grep_fixed 'healthcheck.ps1' "$PROFILE_SCRIPT"
 }
 
 @test "profile.ps1 valid PowerShell syntax (if pwsh available)" {

--- a/tests/pr-agent-config.bats
+++ b/tests/pr-agent-config.bats
@@ -6,19 +6,12 @@
 # afterwards — a reviewer that quietly rubber-stamps, or that quietly reads
 # credential material.
 
+load 'lib/refute'
+
 setup() {
     REPO="$BATS_TEST_DIRNAME/.."
     CFG="$REPO/.pr_agent.toml"
     WF="$REPO/.github/workflows/pr-agent.yml"
-}
-
-refute_grep() {
-    local pattern="$1" file="$2"
-    if grep -qE "$pattern" "$file"; then
-        printf 'expected NOT to find /%s/ in %s, but it is there:\n' "$pattern" "$file" >&2
-        grep -nE "$pattern" "$file" >&2
-        return 1
-    fi
 }
 
 @test "pr-agent: the config and workflow both exist" {

--- a/tests/refute-lib.bats
+++ b/tests/refute-lib.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# Tests for tests/lib/refute.bash — the negative assertions the whole suite
+# leans on (#1034).
+#
+# A broken assertion helper is worse than no helper: every call site that uses
+# it reports green.  The two cases that matter most here are the ones a plain
+# `! grep` gets wrong — a grep ERROR and a pattern that starts with `-`.
+
+load 'lib/refute'
+
+setup() {
+    TMP="$(mktemp -d)"
+    FIXTURE="$TMP/subject.txt"
+    printf '%s\n' \
+        'alpha' \
+        'beta = 2' \
+        '--vault knowledge --vault knowledge' \
+        'a (parenthesised) phrase' \
+        > "$FIXTURE"
+}
+
+teardown() { rm -rf "$TMP"; }
+
+@test "refute_grep: passes when the extended regex is absent" {
+    refute_grep '^gamma$' "$FIXTURE"
+}
+
+@test "refute_grep: fails when the extended regex is present" {
+    run refute_grep '^beta = [0-9]+$' "$FIXTURE"
+    [ "$status" -eq 1 ]
+}
+
+@test "refute_grep: names the file and prints the offending line" {
+    run refute_grep '^beta' "$FIXTURE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"expected NOT to find"* ]]
+    [[ "$output" == *"subject.txt"* ]]
+    [[ "$output" == *"2:beta = 2"* ]]
+}
+
+@test "refute_grep: a pattern beginning with a dash is a pattern, not options" {
+    run refute_grep '\-\-vault knowledge \-\-vault knowledge' "$FIXTURE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"but it is there"* ]]
+}
+
+@test "refute_grep_fixed: a literal dash-leading string is a pattern too" {
+    run refute_grep_fixed '--vault knowledge --vault knowledge' "$FIXTURE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"but it is there"* ]]
+}
+
+@test "refute_grep_fixed: parentheses are literal, not a group" {
+    run refute_grep_fixed '(parenthesised)' "$FIXTURE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"but it is there"* ]]
+}
+
+@test "refute_grep: a grep error is a failure, not an absence" {
+    # The vacuous pass this whole change exists to kill: an unreadable file
+    # exits 2, and `! grep` reads that as "not found".
+    run refute_grep 'anything' "$TMP/does-not-exist.txt"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"an error is not an absence"* ]]
+}
+
+@test "refute_grep: an invalid extended regex is a failure, not an absence" {
+    # A BRE pattern moved to -E without thought: `(` is a literal in BRE and an
+    # unterminated group in ERE.  grep exits 2, and the assertion must not pass.
+    run refute_grep 'a (parenthesised' "$FIXTURE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"an error is not an absence"* ]]
+}
+
+@test "refute_grep: a wrong argument count fails instead of half-asserting" {
+    run refute_grep '^alpha$'
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"expected <pattern> <file>"* ]]
+}

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 # Tests for setup-linux.sh
 
+load 'lib/refute'
+
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
 }
@@ -74,8 +76,8 @@ setup() {
     # `dotf secrets render` over the registry, and their own runtime resolver).
     grep -qF 'dotf secrets show OPENROUTER_API_KEY' "$DOTFILES_DIR/setup-linux.sh"
     # the eager-source + the old secrets_show twin API are gone
-    ! grep -qE 'load-secrets\.sh" >/dev/null 2>&1' "$DOTFILES_DIR/setup-linux.sh"
-    ! grep -qF 'secrets_show ' "$DOTFILES_DIR/setup-linux.sh"
+    refute_grep 'load-secrets\.sh" >/dev/null 2>&1' "$DOTFILES_DIR/setup-linux.sh"
+    refute_grep_fixed 'secrets_show ' "$DOTFILES_DIR/setup-linux.sh"
 }
 
 @test "setup-linux.sh installs gh if missing" {
@@ -190,7 +192,7 @@ setup() {
 # MCP server list must live in mcp-servers.json, not hardcoded in setup-linux.sh.
 @test "setup-linux.sh MCP registration reads from mcp-servers.json" {
     grep -q 'mcp-servers\.json' "$DOTFILES_DIR/setup-linux.sh"
-    ! grep -qE 'claude mcp add --transport (stdio|http) (drawio|socket|context7|sequential-thinking|hive)' "$DOTFILES_DIR/setup-linux.sh"
+    refute_grep 'claude mcp add --transport (stdio|http) (drawio|socket|context7|sequential-thinking|hive)' "$DOTFILES_DIR/setup-linux.sh"
 }
 
 # MCP registration must check existence before adding, not blindly retry.
@@ -312,8 +314,8 @@ setup() {
 # presence of the cleanup block.
 
 @test "setup scripts no longer register the thedotmack marketplace (MEM-002)" {
-    ! grep -qF 'claude plugin marketplace add thedotmack/claude-mem' "$DOTFILES_DIR/setup-linux.sh"
-    ! grep -qF 'claude plugin marketplace add thedotmack/claude-mem' "$DOTFILES_DIR/setup-windows.ps1"
+    refute_grep_fixed 'claude plugin marketplace add thedotmack/claude-mem' "$DOTFILES_DIR/setup-linux.sh"
+    refute_grep_fixed 'claude plugin marketplace add thedotmack/claude-mem' "$DOTFILES_DIR/setup-windows.ps1"
 }
 
 @test "setup scripts ship the idempotent claude-mem cleanup block (MEM-002)" {

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -2,6 +2,7 @@
 # Tests for setup-windows.ps1 (structural + PSScriptAnalyzer)
 
 load 'winpath'
+load 'lib/refute'
 
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
@@ -55,8 +56,8 @@ setup() {
 }
 
 @test "setup-windows.ps1 no longer deploys Aider configuration (sunset)" {
-    ! grep -q 'Deploying Aider configuration' "$PS1_SCRIPT"
-    ! grep -q 'Installing aider-chat via uv' "$PS1_SCRIPT"
+    refute_grep_fixed 'Deploying Aider configuration' "$PS1_SCRIPT"
+    refute_grep_fixed 'Installing aider-chat via uv' "$PS1_SCRIPT"
 }
 
 @test "setup-windows.ps1 registers MCP servers" {
@@ -77,8 +78,8 @@ setup() {
     # Migrated off the load-secrets eager dot-source (ADR-028). agy's
     # OPENROUTER_API_KEY is baked into mcp_config.json via `dotf secrets show`
     # after Install-Dotf, before the agy block (opencode/pi self-resolve).
-    ! grep -qE '\. \$loadSecretsDeployed' "$PS1_SCRIPT"
-    ! grep -qF 'Eager-load secrets' "$PS1_SCRIPT"
+    refute_grep '\. \$loadSecretsDeployed' "$PS1_SCRIPT"
+    refute_grep_fixed 'Eager-load secrets' "$PS1_SCRIPT"
     grep -qF 'dotf secrets show OPENROUTER_API_KEY' "$PS1_SCRIPT"
 }
 
@@ -133,8 +134,8 @@ setup() {
 
 @test "setup-windows.ps1 detects copilot via Get-Command, not gh extension list" {
     grep -qF "Get-Command copilot" "$PS1_SCRIPT"
-    ! grep -qF "gh extension list" "$PS1_SCRIPT"
-    ! grep -qF "github/gh-copilot" "$PS1_SCRIPT"
+    refute_grep_fixed "gh extension list" "$PS1_SCRIPT"
+    refute_grep_fixed "github/gh-copilot" "$PS1_SCRIPT"
 }
 
 @test "setup-windows.ps1 auto-installs GitHub.Copilot via winget" {
@@ -147,7 +148,7 @@ setup() {
     # init-project.ps1 et al. were retired -> dotf init. setup must clean up old
     # copies, never Copy-Item them.
     grep -q 'init-repo-github-defaults.ps1' "$PS1_SCRIPT"
-    ! grep -qE 'Copy-Item .*init-project\.ps1' "$PS1_SCRIPT"
+    refute_grep 'Copy-Item .*init-project\.ps1' "$PS1_SCRIPT"
 }
 
 @test "setup-windows.ps1 deploys knowledge-crystallize.ps1" {
@@ -161,7 +162,7 @@ setup() {
 # MEM-002: claude-mem-heal.ps1 is retired (ADR-016 Q2). setup-windows.ps1 must
 # NOT deploy it any more.
 @test "setup-windows.ps1 no longer deploys claude-mem-heal.ps1 (MEM-002)" {
-    ! grep -q 'claude-mem-heal.ps1' "$PS1_SCRIPT"
+    refute_grep_fixed 'claude-mem-heal.ps1' "$PS1_SCRIPT"
     [ ! -f "$DOTFILES_DIR/scripts/claude-mem-heal.ps1" ]
 }
 
@@ -211,7 +212,7 @@ setup() {
 # MCP server list must live in mcp-servers.json, not hardcoded in the setup script.
 @test "setup-windows.ps1 MCP registration reads from mcp-servers.json" {
     grep -q 'mcp-servers\.json' "$PS1_SCRIPT"
-    ! grep -Eq 'claude mcp add --transport (stdio|http) (drawio|socket|context7|sequential-thinking|hive)' "$PS1_SCRIPT"
+    refute_grep 'claude mcp add --transport (stdio|http) (drawio|socket|context7|sequential-thinking|hive)' "$PS1_SCRIPT"
 }
 
 # MCP registration must check existence before adding, not blindly retry.
@@ -282,7 +283,7 @@ setup() {
 # idempotent cleanup that uninstalls the plugin + prunes leftover dirs.
 
 @test "setup-windows.ps1 no longer registers the thedotmack marketplace (MEM-002)" {
-    ! grep -qF 'claude plugin marketplace add thedotmack/claude-mem' "$PS1_SCRIPT"
+    refute_grep_fixed 'claude plugin marketplace add thedotmack/claude-mem' "$PS1_SCRIPT"
 }
 
 @test "setup-windows.ps1 ships the idempotent claude-mem cleanup block (MEM-002)" {
@@ -324,7 +325,7 @@ setup() {
     # -ne reconcile would downgrade a newer install. Gate on Test-VersionAtLeast
     # so only a below-minimum opencode triggers an upgrade.
     grep -qF 'Test-VersionAtLeast $installedVer $tool.Version' "$PS1_SCRIPT"
-    ! grep -qF '$installedVer -ne $tool.Version' "$PS1_SCRIPT"
+    refute_grep_fixed '$installedVer -ne $tool.Version' "$PS1_SCRIPT"
     grep -qE 'winget install \$tool\.Id --version \$tool\.Version' "$PS1_SCRIPT"
     # Convergence is verified by re-query, not by winget's exit code: a
     # shadowing install (npm global, scoop) would otherwise produce a false
@@ -365,8 +366,8 @@ setup() {
 @test "setup-windows.ps1 no longer deploys skills from the removed ai\\skills tree (SDD-008)" {
     # the ai\skills / ai\opencode\commands references that remain are historical
     # comments in the Deploy-SkillRecord block, never active Test-Path sources.
-    ! grep -qE '\$skillsSource\s*=\s*"\$DotfilesDir\\ai\\skills"' "$PS1_SCRIPT"
-    ! grep -qE '\$opencodeCmdsSrc\s*=' "$PS1_SCRIPT"
+    refute_grep '\$skillsSource\s*=\s*"\$DotfilesDir\\ai\\skills"' "$PS1_SCRIPT"
+    refute_grep '\$opencodeCmdsSrc\s*=' "$PS1_SCRIPT"
 }
 
 @test "Convert-SkillRecord does not stack a second set of generated_* fields on a record that already carries its own (HARNESS-069)" {
@@ -441,7 +442,7 @@ setup() {
 }
 
 @test "negative parity: setup-linux.sh does not reference PSVersion (BUG-005 is Windows-only)" {
-    ! grep -qF 'PSVersion' "$DOTFILES_DIR/setup-linux.sh"
+    refute_grep_fixed 'PSVersion' "$DOTFILES_DIR/setup-linux.sh"
 }
 
 @test "setup-windows.ps1 deploys SSH config" {
@@ -558,15 +559,15 @@ setup() {
     # AGENTS.md itself may mention 'CORE PRINCIPLE' as documentation text -- that
     # is fine. The bug is using it as a Select-String -Pattern, which post-AI-013
     # never matches the deployed file and emits a spurious [ERROR] every run.
-    ! grep -qF -- '-Pattern "CORE PRINCIPLE"' "$PS1_SCRIPT"
+    refute_grep_fixed '-Pattern "CORE PRINCIPLE"' "$PS1_SCRIPT"
 }
 
 @test "parity: both setup scripts detect copilot via binary, not gh extension" {
     grep -qF "command -v copilot" "$DOTFILES_DIR/setup-linux.sh"
     grep -qF "Get-Command copilot" "$PS1_SCRIPT"
     # Neither should still reference the legacy extension path
-    ! grep -qF "github/gh-copilot" "$DOTFILES_DIR/setup-linux.sh"
-    ! grep -qF "github/gh-copilot" "$PS1_SCRIPT"
+    refute_grep_fixed "github/gh-copilot" "$DOTFILES_DIR/setup-linux.sh"
+    refute_grep_fixed "github/gh-copilot" "$PS1_SCRIPT"
 }
 
 # --- SDD-002: settings.json template merge ---
@@ -581,7 +582,7 @@ setup() {
 @test "SDD-002: setup-windows.ps1 calls Merge-ClaudeSettings (not inline hashtable)" {
     grep -qF 'Merge-ClaudeSettings -TemplatePath' "$PS1_SCRIPT"
     # The legacy inline hook hashtable must be gone
-    ! grep -qE '\$hookEntry\s*=\s*@\{' "$PS1_SCRIPT"
+    refute_grep '\$hookEntry\s*=\s*@\{' "$PS1_SCRIPT"
 }
 
 @test "SDD-002: setup-windows.ps1 references the template path ai\\claude\\settings.json" {
@@ -601,7 +602,7 @@ setup() {
 @test "SDD-002: setup-linux.sh calls merge_claude_settings (not inline HOOK_ENTRY)" {
     grep -qF 'merge_claude_settings "$CLAUDE_SETTINGS_TEMPLATE"' "$DOTFILES_DIR/setup-linux.sh"
     # The legacy inline HOOK_ENTRY jq -n heredoc must be gone
-    ! grep -qF 'HOOK_ENTRY=$(jq -n' "$DOTFILES_DIR/setup-linux.sh"
+    refute_grep_fixed 'HOOK_ENTRY=$(jq -n' "$DOTFILES_DIR/setup-linux.sh"
 }
 
 @test "SDD-002: setup-linux.sh references the template path ai/claude/settings.json" {


### PR DESCRIPTION
Closes part of #1034 (the ticket stays open until the quarantine list is empty — see *Chunking* below).

## The defect

bash exempts any command preceded by `!` from `set -e`. bats runs a `@test` body under `set -e` and takes the body's status from its **last** command. So `! grep -q X file` anywhere but the final line of a test is not an assertion — it executes and is discarded.

A bare `false` in the same position **is** caught. The exemption is specific to the `!` form, which is why it survives casual inspection.

## Scope, measured

`grep -rnE '^\s+!\s' tests/*.bats` → **139 lines in 30 files** (the ticket said 46 in 18; it was written before the suite grew).

| | count |
|---|---|
| Could not fail (not the last statement, not rescued by `\|\| return 1`) | **53** |
| Work today, one appended line from not working | 86 |

The ticket's estimate of 46 is superseded by this measurement; the classifier used is in the commit history of this branch's session, and the guard added here reproduces the count.

## Proof it is real

Falsify one existing assertion — `tests/setup-windows.bats`, *"does NOT eager-source load-secrets"*, at its own line 81 of 84 — by pointing it at a string the target file certainly contains:

| Form | Result |
|---|---|
| `! grep -qF 'param' "$PS1_SCRIPT"` | `ok 1` |
| `refute_grep_fixed 'param' "$PS1_SCRIPT"` | `not ok 1` |

Same file, same line, same falsified claim. One reports green.

Not hypothetical damage: `tests/check-review-attestation.bats` AC5 asserted the script names no reviewer of its own. It **did**, in a comment. The suite was green for as long as the violated line was not last.

## What this PR does

- **`tests/lib/refute.bash`** — one shared `refute_grep` (ERE) / `refute_grep_fixed` (literal), replacing three divergent copies (`backup-secrets-to-usb`, `check-review-attestation`, `pr-agent-config`). Two vacuous passes that all three copies had are closed:
  - **a grep error is not an absence** — exit ≥2 (unreadable file, or a BRE pattern that is invalid as an ERE) was read as "not found". This matters exactly during conversion: `(` is a literal in BRE and an unterminated group in ERE.
  - **a pattern beginning with `-` is a pattern** — `--vault knowledge` was being handed to grep as options. It now goes after `--`.
- **`tests/refute-lib.bats`** — the helper's own tests, both directions, including the two above.
- **`tests/guard-bats-negation.bats`** — suite-wide guard with a per-file **quarantine ratchet**: it fails when a listed file's count moves in *either* direction, so a conversion must lower its entry in the same commit and a regression cannot hide behind an entry that over-counts. It replaces the single-file meta test that lived in `check-review-attestation.bats` (deleted here — two guards for one rule is one guard and one thing that quietly disagrees with it). Its detector is pinned against a fixture with a hand-counted answer, because a guard that silently matches nothing reports a clean suite forever.
- **55 assertions converted** in the five files carrying the load-bearing negatives.
- **`docs/lessons/lesson-224`** + index line.

### Why a bats meta-test and not a `scripts/check-*.sh`

`check-bats-names.sh` has to be a script because bats cannot see its own duplicate `@test` names — the file is a parse error, so nothing runs. There is no such blindness here: a bats file can read its siblings, and the `test` job already runs the suite. No new CI wiring, no production LOC.

## The load-bearing assertions: all satisfied

Every negative the ticket flagged as load-bearing is genuinely true today. Converted and run, they pass:

| Assertion | Verdict |
|---|---|
| `setup-windows.bats` L80-81, `powershell-profile.bats` L62/67-68 — the retired `load-secrets` path is gone (ADR-028 migration guard) | green |
| `compile-harness.bats` L287-288 — setup no longer reads the deleted `ai/skills` tree | green |
| `setup-linux.bats` L315, `claude-settings-template.bats` L261/268 — the removed plugins are not installed | green |

No latent defect surfaced, so nothing to fix or ticket on that axis. Worth stating explicitly, since the expectation going in was the opposite.

One nastier variant found while converting, in `claude-settings-template.bats`: the negation sat inside a `for` over 9 plugins. The loop is the last statement, so it *does* carry a status — the **last iteration's**. Eight of nine plugins were unchecked in a test whose name promises all nine.

## Chunking (declared, so no PR absorbs the next in silence)

| PR | Content | State |
|---|---|---|
| 1 (this) | library + ratchet guard + lesson + the 5 files with the load-bearing negatives (55 lines) | here |
| 2 | the remaining dead assertions | next |
| 3 | the remaining live-but-fragile ones; ratchet to zero, list deleted, #1034 closed | after |

**84 lines remain quarantined in 25 files.** The ratchet refuses to let that number grow meanwhile.

## Verification

```
$ bats tests/*.bats
1453 tests, 0 failures        # exit 0

$ shellcheck scripts/*.sh setup-linux.sh
(no output)

$ ./scripts/check-spec-gate.sh --base-ref main --head-ref HEAD --explain
[OK] Production diff 0 LOC < threshold 50 (below threshold; spec not required)
```

Guard mutation-tested in both directions before commit: adding a bare `!` to a converted file fails test 1 (`tests/setup-linux.bats (1)`), removing one from a quarantined file fails test 2 (`tests/utils.bats: recorded 6, found 5`).
