### PR TITLE
test(bats): convert the remaining dead negated assertions

### DIFF
--- a/tests/agents-md.bats
+++ b/tests/agents-md.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 # Tests for AGENTS.md SDD Discipline Gate enforcement (SDD-001)
 
+load 'lib/refute'
+
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
     export AGENTS_MD="$DOTFILES_DIR/AGENTS.md"
@@ -96,8 +98,8 @@ setup() {
 @test "AGENTS.md does NOT reintroduce the retired work/personal routing axis" {
     # Negative guard: these markers encode the old axis that mis-routed build/operate
     # artifacts to the vault. Their presence is a regression.
-    ! grep -qF 'for work projects' "$AGENTS_MD"
-    ! grep -qF '30-architecture/adr' "$AGENTS_MD"
+    refute_grep_fixed 'for work projects' "$AGENTS_MD"
+    refute_grep_fixed '30-architecture/adr' "$AGENTS_MD"
 }
 
 # --- HARNESS-064: adversarial-review trigger (#879) ---

--- a/tests/aliases.bats
+++ b/tests/aliases.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 # Tests for .zsh/aliases.zsh
 
+load 'lib/refute'
+
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
     export ALIASES_FILE="$DOTFILES_DIR/.zsh/aliases.zsh"
@@ -37,7 +39,7 @@ setup() {
 @test "aliases.zsh no longer defines oc/ocfull (moved to .zsh/functions.sh, REFACTOR-010)" {
     # oc/ocfull are now shared bash/zsh functions in .zsh/functions.sh.
     # Positive coverage lives in tests/shell-wrapper-dedup.bats.
-    ! grep -qE '^alias (oc|ocfull)=' "$ALIASES_FILE"
+    refute_grep '^alias (oc|ocfull)=' "$ALIASES_FILE"
 }
 
 @test "aliases.zsh defines oclog alias for live opencode log tailing" {
@@ -48,7 +50,7 @@ setup() {
 }
 
 @test "aliases.zsh no longer defines aider tier aliases (sunset)" {
-    ! grep -qE '^alias (ai|aic|aia)=' "$ALIASES_FILE"
+    refute_grep '^alias (ai|aic|aia)=' "$ALIASES_FILE"
 }
 
 # --- Copilot CLI v2 aliases (BUG-003: rename from ghcs/ghce) ---
@@ -82,14 +84,14 @@ setup() {
 @test "aliases.zsh no longer defines _qq_call body (moved to .zsh/functions.sh, REFACTOR-010)" {
     # The qq/qf noglob aliases stay here but reference the shared _qq_call,
     # which now lives once in .zsh/functions.sh (sourced by both shells).
-    ! grep -qE '^_qq_call\(\)' "$ALIASES_FILE"
+    refute_grep '^_qq_call\(\)' "$ALIASES_FILE"
 }
 
 @test "aliases.zsh no longer defines ghcs/ghce (renamed in BUG-003)" {
     # Anchor to start-of-line + alias/function definition forms only -- comments
     # mentioning the old names (e.g. "replaces ghcs/ghce wrappers") are fine.
-    ! grep -qE '^(alias ghcs|ghcs\(\)|function ghcs)' "$ALIASES_FILE"
-    ! grep -qE '^(alias ghce|ghce\(\)|function ghce)' "$ALIASES_FILE"
+    refute_grep '^(alias ghcs|ghcs\(\)|function ghcs)' "$ALIASES_FILE"
+    refute_grep '^(alias ghce|ghce\(\)|function ghce)' "$ALIASES_FILE"
 }
 
 # CHORE-001: shell-profile.sh discoverability via `profile-shell` alias.
@@ -118,7 +120,9 @@ setup() {
 }
 
 @test "aliases.zsh gprj does not point to Apps" {
-    ! grep 'alias gprj=' "$ALIASES_FILE" | grep -q 'Apps'
+    run grep 'alias gprj=' "$ALIASES_FILE"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *Apps* ]]
 }
 
 # --- Git shortcuts ---
@@ -190,10 +194,10 @@ setup() {
 
 @test "parity: ghcs/ghce removed from both aliases.zsh and profile.ps1" {
     ps_file="$DOTFILES_DIR/powershell/profile.ps1"
-    ! grep -qE '^(alias ghcs|ghcs\(\)|function ghcs)' "$ALIASES_FILE"
-    ! grep -qE '^(alias ghce|ghce\(\)|function ghce)' "$ALIASES_FILE"
-    ! grep -qE '^\s*function ghcs' "$ps_file"
-    ! grep -qE '^\s*function ghce' "$ps_file"
+    refute_grep '^(alias ghcs|ghcs\(\)|function ghcs)' "$ALIASES_FILE"
+    refute_grep '^(alias ghce|ghce\(\)|function ghce)' "$ALIASES_FILE"
+    refute_grep '^\s*function ghcs' "$ps_file"
+    refute_grep '^\s*function ghce' "$ps_file"
 }
 
 # --- tmux aliases ---

--- a/tests/antigravity.bats
+++ b/tests/antigravity.bats
@@ -6,6 +6,8 @@
 # These tests assume agy is installed AND setup-linux.sh has been run.
 # CI containers without agy binary or post-setup state will skip these tests.
 
+load 'lib/refute'
+
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
     export GEMINI_HOME="$HOME/.gemini"
@@ -32,7 +34,9 @@ setup() {
     cmd=$(jq -r '.mcpServers["hive-vault"].command' "$DOTFILES_DIR/ai/agy/mcp_servers.json")
     [ "$cmd" = "uvx" ]
     # Regression guard: --directory must not return.
-    ! jq -r '.mcpServers["hive-vault"].args | join(" ")' "$DOTFILES_DIR/ai/agy/mcp_servers.json" | grep -qE '\-\-directory'
+    run jq -r '.mcpServers["hive-vault"].args | join(" ")' "$DOTFILES_DIR/ai/agy/mcp_servers.json"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"--directory"* ]]
 }
 
 @test "ai/agy/mcp_servers.json VAULT_PATH is the placeholder, not a hardcoded user path" {
@@ -41,7 +45,7 @@ setup() {
     local vault
     vault=$(jq -r '.mcpServers["hive-vault"].env.VAULT_PATH' "$DOTFILES_DIR/ai/agy/mcp_servers.json")
     [ "$vault" = '${VAULT_PATH}' ]
-    ! grep -qE '/home/[a-z]+/|C:\\\\Users\\\\' "$DOTFILES_DIR/ai/agy/mcp_servers.json"
+    refute_grep '/home/[a-z]+/|C:\\\\Users\\\\' "$DOTFILES_DIR/ai/agy/mcp_servers.json"
 }
 
 @test "setup-linux.sh substitutes \${VAULT_PATH} and preflights vault dir" {
@@ -73,8 +77,8 @@ setup() {
     # No stray "Gemini-specific" / "GEMINI.md" body references in the
     # canonical SSOT (archived specs and the cleanup logic in setup-*.{sh,ps1}
     # are excluded by file scope).
-    ! grep -qF 'Gemini-specific' "$DOTFILES_DIR/ai/agy/AGY.md"
-    ! grep -qF '# GEMINI.md' "$DOTFILES_DIR/ai/agy/AGY.md"
+    refute_grep_fixed 'Gemini-specific' "$DOTFILES_DIR/ai/agy/AGY.md"
+    refute_grep_fixed '# GEMINI.md' "$DOTFILES_DIR/ai/agy/AGY.md"
 }
 
 @test "ANTIGRAVITY_ENDPOINT is set to production in .zshrc" {

--- a/tests/compile-harness-real.bats
+++ b/tests/compile-harness-real.bats
@@ -17,6 +17,8 @@
 # The CI `test` job already sets up Go (actions/setup-go, ci.yml), so this runs
 # there rather than skipping.
 
+load 'lib/refute'
+
 setup() {
     REPO="$BATS_TEST_DIRNAME/.."
     SCRIPT="$REPO/scripts/compile-harness.sh"
@@ -123,9 +125,9 @@ setup() {
     [ -f "$F" ]
     # curator declares `model: top`; claude's top tier is opus
     grep -q '^model: opus' "$F"
-    ! grep -q '^model: top' "$F"
+    refute_grep '^model: top' "$F"
     # and its neutral capabilities became native tool names
     grep -qE '^tools: .*Read' "$F"
-    ! grep -q '^capabilities:' "$F"
+    refute_grep '^capabilities:' "$F"
     rm -rf "$FAKEHOME"
 }

--- a/tests/docs-drift.bats
+++ b/tests/docs-drift.bats
@@ -2,6 +2,8 @@
 # Tests for cross-file docs sync (SDD-005).
 # Catches the drift class that hit BUG-001, BUG-002, and AI-019 → AUDIT-003.
 
+load 'lib/refute'
+
 setup() {
     DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
     AI_COPILOT="$DOTFILES_DIR/ai/copilot/copilot-instructions.md"
@@ -52,6 +54,6 @@ teardown() {
 @test "copilot-instructions: both describe native Agent Skills discovery" {
     grep -qF '~/.copilot/skills/' "$AI_COPILOT"
     grep -qF '~/.copilot/skills/' "$GH_COPILOT"
-    ! grep -qF 'Copilot has no per-skill discovery mechanism' "$AI_COPILOT"
-    ! grep -qF 'Copilot has no per-skill discovery mechanism' "$GH_COPILOT"
+    refute_grep_fixed 'Copilot has no per-skill discovery mechanism' "$AI_COPILOT"
+    refute_grep_fixed 'Copilot has no per-skill discovery mechanism' "$GH_COPILOT"
 }

--- a/tests/guard-bats-negation.bats
+++ b/tests/guard-bats-negation.bats
@@ -28,29 +28,15 @@
 # #1034 empties it; when the last entry goes, so does the list.
 quarantine_list() {
     cat <<'LIST'
-tests/agents-md.bats 2
-tests/aliases.bats 10
-tests/antigravity.bats 4
 tests/bitacora-reconcile.bats 1
 tests/bitacora-rollout.bats 1
 tests/board-pickup.bats 1
 tests/check-doc-paths.bats 1
-tests/compile-harness-real.bats 2
-tests/docs-drift.bats 2
 tests/hermes-setup.bats 1
-tests/hive-upgrade-timer.bats 4
 tests/install-dotf-ps1.bats 1
-tests/knowledge-crystallize-ps1.bats 2
-tests/nan-scripts-secrets.bats 2
-tests/opencode.bats 23
 tests/pi-config.bats 4
 tests/pwsh-analyzer-coverage.bats 1
 tests/shell-wrapper-dedup.bats 2
-tests/skills-pipeline.bats 4
-tests/utils.bats 6
-tests/vault-health-golden.bats 1
-tests/verify-setup.bats 2
-tests/versions-conf.bats 3
 tests/versions-no-hardcode.bats 2
 tests/windows-defaults.bats 2
 LIST

--- a/tests/hive-upgrade-timer.bats
+++ b/tests/hive-upgrade-timer.bats
@@ -3,6 +3,8 @@
 # daily Scheduled Task (Windows). The upgrade policy that feeds the Phase C
 # daemon's restart-on-upgrade (hive#176).
 
+load 'lib/refute'
+
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
 }
@@ -32,7 +34,7 @@ setup() {
 # The ExecStart must be an ABSOLUTE path: a --user oneshot gets a minimal PATH
 # that may omit ~/.local/bin, so a bare `uv` would fail every slot.
 @test "hive-upgrade.service ExecStart is absolute, not a bare uv on PATH" {
-    ! grep -qE '^ExecStart=uv ' "$DOTFILES_DIR/systemd/hive-upgrade.service"
+    refute_grep '^ExecStart=uv ' "$DOTFILES_DIR/systemd/hive-upgrade.service"
     grep -qE '^ExecStart=%h/' "$DOTFILES_DIR/systemd/hive-upgrade.service"
 }
 
@@ -132,7 +134,7 @@ setup() {
 # Register-ScheduledTask (which would default to the windowed Interactive logon).
 @test "setup-windows.ps1 routes the hive-upgrade task through the S4U helper" {
     grep -qF 'Register-HiveScheduledTask -TaskName $hiveUpgradeTask' "$DOTFILES_DIR/setup-windows.ps1"
-    ! grep -qF 'Register-ScheduledTask -TaskName $hiveUpgradeTask' "$DOTFILES_DIR/setup-windows.ps1"
+    refute_grep_fixed 'Register-ScheduledTask -TaskName $hiveUpgradeTask' "$DOTFILES_DIR/setup-windows.ps1"
 }
 
 @test "setup-windows.ps1 hive-upgrade action is windowless (-WindowStyle Hidden)" {
@@ -204,11 +206,11 @@ setup() {
 }
 
 @test "hive-upgrade.ps1 does not collapse no-install into the already-current guard" {
-    ! grep -qF '-not $installed -or' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
+    refute_grep_fixed '-not $installed -or' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
 }
 
 @test "hive-upgrade.ps1 never runs uv tool ... --reinstall" {
-    ! grep -qE '\$uv tool.*--reinstall' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
+    refute_grep '\$uv tool.*--reinstall' "$DOTFILES_DIR/windows/hive-upgrade.ps1"
 }
 
 @test "hive-upgrade.ps1 is ASCII-only (PSScriptAnalyzer CI)" {

--- a/tests/knowledge-crystallize-ps1.bats
+++ b/tests/knowledge-crystallize-ps1.bats
@@ -2,6 +2,7 @@
 # Tests for scripts/knowledge-crystallize.ps1 (structural + PSScriptAnalyzer)
 
 load 'winpath'
+load 'lib/refute'
 
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
@@ -35,7 +36,7 @@ setup() {
     # resolves the key via Get-ClaudeProjectKey (dotf-backed single source).
     grep -q "utils.ps1" "$PS1_SCRIPT"
     grep -q 'Get-ClaudeProjectKey' "$PS1_SCRIPT"
-    ! grep -q 'function Get-EncodedPath' "$PS1_SCRIPT"
+    refute_grep_fixed 'function Get-EncodedPath' "$PS1_SCRIPT"
 }
 
 @test "knowledge-crystallize.ps1 has Get-DecodedPath function" {
@@ -66,7 +67,7 @@ setup() {
     # The bug mapped ':' to '' (delete), producing C-Users-... which Claude never
     # reads. The correct key maps ':' to '-' (C--Users-...). Guard both: the buggy
     # delete pattern is gone, and the decoder expects the double-dash drive key.
-    ! grep -q "Replace.*':'.*''" "$PS1_SCRIPT"
+    refute_grep "Replace.*':'.*''" "$PS1_SCRIPT"
     grep -q "A-Za-z\].*--" "$PS1_SCRIPT"
 }
 

--- a/tests/nan-scripts-secrets.bats
+++ b/tests/nan-scripts-secrets.bats
@@ -7,6 +7,8 @@
 # sourcing the retired `load-secrets` twin. Structural (grep-based) like the
 # other RC/script contract tests in this suite.
 
+load 'lib/refute'
+
 setup() {
     export SCRIPTS_DIR="$BATS_TEST_DIRNAME/../scripts"
     NAN_SCRIPTS=(nan-bench.sh nan-debug.sh nan-quality-bench.sh)
@@ -20,13 +22,13 @@ setup() {
 
 @test "nan-* scripts do not source the retired load-secrets twin" {
     for s in "${NAN_SCRIPTS[@]}"; do
-        ! grep -qE 'load-secrets' "$SCRIPTS_DIR/$s" || { echo "still references load-secrets: $s"; return 1; }
+        refute_grep 'load-secrets' "$SCRIPTS_DIR/$s"
     done
 }
 
 @test "nan-* scripts do not call secrets_refresh (the old twin API)" {
     for s in "${NAN_SCRIPTS[@]}"; do
-        ! grep -q 'secrets_refresh' "$SCRIPTS_DIR/$s" || { echo "still calls secrets_refresh: $s"; return 1; }
+        refute_grep_fixed 'secrets_refresh' "$SCRIPTS_DIR/$s"
     done
 }
 

--- a/tests/opencode.bats
+++ b/tests/opencode.bats
@@ -3,6 +3,8 @@
 # Relational tests per pattern-setup-script-idempotence — verify invariants,
 # not just presence.
 
+load 'lib/refute'
+
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
     export SETUP_SCRIPT="$DOTFILES_DIR/setup-linux.sh"
@@ -26,7 +28,7 @@ setup() {
     # Windows always-overwrite strategy. The staged-substituted tmp file is
     # moved into place on every run (substitution may have changed content);
     # there is no "already in sync" skip path that could mask drift.
-    ! grep -q 'cmp -s "\$OPENCODE_CONFIG_TMP" "\$OPENCODE_CONFIG_DST"' "$SETUP_SCRIPT"
+    refute_grep 'cmp -s "\$OPENCODE_CONFIG_TMP" "\$OPENCODE_CONFIG_DST"' "$SETUP_SCRIPT"
     grep -q 'mv "\$OPENCODE_CONFIG_TMP" "\$OPENCODE_CONFIG_DST"' "$SETUP_SCRIPT"
 }
 
@@ -41,7 +43,7 @@ setup() {
 @test "opencode PATH is baked into repo .zshrc and .bashrc (SSOT, no setup-time mutation)" {
     grep -q 'export PATH="\$HOME/.opencode/bin:\$PATH"' "$DOTFILES_DIR/.zshrc"
     grep -q 'export PATH="\$HOME/.opencode/bin:\$PATH"' "$DOTFILES_DIR/.bashrc"
-    ! grep -q 'ensure_line_in_file.*OPENCODE_PATH_LINE' "$SETUP_SCRIPT"
+    refute_grep 'ensure_line_in_file.*OPENCODE_PATH_LINE' "$SETUP_SCRIPT"
 }
 
 @test "setup-linux.sh upgrades a below-minimum opencode to the versions.conf pin (REFACTOR-011/013)" {
@@ -50,7 +52,7 @@ setup() {
     # != reconcile would downgrade a newer install. Gate on version_gte so only
     # an older opencode triggers an upgrade.
     grep -q 'version_gte "$installed_opencode" "$OPENCODE_VERSION"' "$SETUP_SCRIPT"
-    ! grep -q 'installed_opencode" != "$OPENCODE_VERSION' "$SETUP_SCRIPT"
+    refute_grep_fixed 'installed_opencode" != "$OPENCODE_VERSION' "$SETUP_SCRIPT"
     # Convergence is verified by re-query, not by installer exit code: a
     # shadowing install (npm global) would otherwise produce a false SUCCESS.
     grep -q 'shadows it in PATH' "$SETUP_SCRIPT"
@@ -62,7 +64,7 @@ setup() {
 
 @test "setup-linux.sh opencode install URL uses opencode.ai (not anomalyco fork)" {
     grep -q 'curl -fsSL https://opencode.ai/install' "$SETUP_SCRIPT"
-    ! grep -q 'curl.*anomalyco' "$SETUP_SCRIPT"
+    refute_grep 'curl.*anomalyco' "$SETUP_SCRIPT"
 }
 
 @test "setup-linux.sh opencode block has no new silenced errors (2>/dev/null || true)" {
@@ -73,13 +75,13 @@ setup() {
 # --- Regression: aider sunset ---
 
 @test "setup-linux.sh no longer installs aider" {
-    ! grep -q "uv tool install --python 3.12 aider-chat" "$SETUP_SCRIPT"
-    ! grep -q "# Aider (AI pair programming)" "$SETUP_SCRIPT"
+    refute_grep_fixed "uv tool install --python 3.12 aider-chat" "$SETUP_SCRIPT"
+    refute_grep_fixed "# Aider (AI pair programming)" "$SETUP_SCRIPT"
 }
 
 @test "setup-windows.ps1 no longer installs aider" {
-    ! grep -q "Installing aider-chat via uv" "$DOTFILES_DIR/setup-windows.ps1"
-    ! grep -q "DEPLOY AIDER CONFIGURATION" "$DOTFILES_DIR/setup-windows.ps1"
+    refute_grep_fixed "Installing aider-chat via uv" "$DOTFILES_DIR/setup-windows.ps1"
+    refute_grep_fixed "DEPLOY AIDER CONFIGURATION" "$DOTFILES_DIR/setup-windows.ps1"
 }
 
 @test "setup-linux.sh keeps uv install (used by hive MCP server)" {
@@ -92,23 +94,24 @@ setup() {
 }
 
 @test ".zsh/aliases.zsh no longer has aider tier aliases" {
-    ! grep -qE '^alias (ai|aic|aia)=' "$ALIASES_FILE"
+    refute_grep '^alias (ai|aic|aia)=' "$ALIASES_FILE"
 }
 
 @test "powershell/profile.ps1 no longer has aider tier functions" {
-    ! grep -qE '^function (ai|aic|aia) ' "$DOTFILES_DIR/powershell/profile.ps1"
+    refute_grep '^function (ai|aic|aia) ' "$DOTFILES_DIR/powershell/profile.ps1"
 }
 
 @test "AGENTS.md no longer lists Aider in the agent matrix" {
-    ! grep -qE 'and Aider all read this file' "$AGENTS_MD"
+    refute_grep 'and Aider all read this file' "$AGENTS_MD"
 }
 
 @test "README.md no longer mentions Aider" {
-    ! grep -qi "aider" "$DOTFILES_DIR/README.md"
+    run grep -in 'aider' "$DOTFILES_DIR/README.md"
+    [ "$status" -eq 1 ] || { printf 'README still mentions aider:\n%s\n' "$output" >&2; return 1; }
 }
 
 @test "env-contract.json uv purpose no longer mentions aider" {
-    ! grep -q '"Python tool installs (aider' "$DOTFILES_DIR/env-contract.json"
+    refute_grep_fixed '"Python tool installs (aider' "$DOTFILES_DIR/env-contract.json"
 }
 
 # --- opencode.jsonc structure ---
@@ -137,7 +140,7 @@ setup() {
     grep -q '"deepseek/deepseek-v4-pro":' "$OPENCODE_CFG"
     grep -q '"minimax/minimax-m3":' "$OPENCODE_CFG"
     # No OpenAI/Google/Anthropic OpenRouter model entries.
-    ! grep -qE '"(openai|google|anthropic)/[^"]+":[[:space:]]*\{[[:space:]]*"name"' "$OPENCODE_CFG"
+    refute_grep '"(openai|google|anthropic)/[^"]+":[[:space:]]*\{[[:space:]]*"name"' "$OPENCODE_CFG"
 }
 
 @test "opencode.jsonc has ollama provider (homelab via VPN)" {
@@ -159,11 +162,11 @@ setup() {
         grep -qE "\"$m\":" "$OPENCODE_CFG" || { echo "missing chat model $m" >&2; false; }
     done
     # Non-chat models must NOT appear (would break config load)
-    ! grep -qE '"qwen3-embedding":|"kokoro":|"whisper":' "$OPENCODE_CFG"
+    refute_grep '"qwen3-embedding":|"kokoro":|"whisper":' "$OPENCODE_CFG"
 }
 
 @test "opencode.jsonc no longer references opencode-go (Go subscription cancelled per SDD-007)" {
-    ! grep -q '"opencode-go":' "$OPENCODE_CFG"
+    refute_grep_fixed '"opencode-go":' "$OPENCODE_CFG"
 }
 
 @test "opencode.jsonc mirrors the 3 active MCP servers (hive, context7, sequential-thinking)" {
@@ -171,7 +174,7 @@ setup() {
         grep -qE "\"$srv\":" "$OPENCODE_CFG" || { echo "missing MCP $srv" >&2; false; }
     done
     # drawio + socket intentionally removed (see opencode.jsonc comment)
-    ! grep -qE '^\s*"drawio":|^\s*"socket":' "$OPENCODE_CFG"
+    refute_grep '^\s*"drawio":|^\s*"socket":' "$OPENCODE_CFG"
 }
 
 @test "opencode.jsonc DX keys present (share disabled, autoupdate notify, providers pruned, tool_output, read-only plan agent)" {
@@ -245,15 +248,15 @@ setup() {
 @test "ai/copilot/copilot-instructions.md is a pointer (no template-placeholder bug)" {
     grep -q "First, read \`AGENTS.md\`" "$DOTFILES_DIR/ai/copilot/copilot-instructions.md"
     # Bug fix regression: must not contain the broken placeholder string
-    ! grep -q "the knowledge base (\`~/Projects/knowledge/" "$DOTFILES_DIR/ai/copilot/copilot-instructions.md"
+    refute_grep_fixed "the knowledge base (\`~/Projects/knowledge/" "$DOTFILES_DIR/ai/copilot/copilot-instructions.md"
     # Bug fix regression: must not contain the wrong Apps\knowledge path
-    ! grep -q "Apps\\\\knowledge" "$DOTFILES_DIR/ai/copilot/copilot-instructions.md"
+    refute_grep "Apps\\\\knowledge" "$DOTFILES_DIR/ai/copilot/copilot-instructions.md"
 }
 
 @test ".github/copilot-instructions.md is a pointer (no template-placeholder bug)" {
     grep -q "First, read \[\`AGENTS.md\`\]" "$DOTFILES_DIR/.github/copilot-instructions.md"
-    ! grep -q "the knowledge base (\`~/Projects/knowledge/" "$DOTFILES_DIR/.github/copilot-instructions.md"
-    ! grep -q "Apps\\\\knowledge" "$DOTFILES_DIR/.github/copilot-instructions.md"
+    refute_grep_fixed "the knowledge base (\`~/Projects/knowledge/" "$DOTFILES_DIR/.github/copilot-instructions.md"
+    refute_grep "Apps\\\\knowledge" "$DOTFILES_DIR/.github/copilot-instructions.md"
 }
 
 # --- OpenCode diagnostics integration ---
@@ -271,7 +274,7 @@ setup() {
 }
 
 @test "opencode.jsonc reasoning comment updated off the stale 1.15.10 'renders neither' note (DX-004 AC5)" {
-    ! grep -q 'Opencode (1.15.10) renders neither' "$OPENCODE_CFG"
+    refute_grep_fixed 'Opencode (1.15.10) renders neither' "$OPENCODE_CFG"
     grep -q 'interleaved' "$OPENCODE_CFG"
 }
 
@@ -287,5 +290,5 @@ setup() {
     grep -q 'TUI_SRC="\$CURRENT_DIR/ai/opencode/tui.json"' "$SETUP_SCRIPT"
     grep -q 'cmp -s "\$TUI_SRC" "\$TUI_DST"' "$SETUP_SCRIPT"
     # tui.json carries no secrets: it must NOT go through dotf secrets render
-    ! grep -qE 'dotf secrets render "\$TUI_(SRC|DST)"' "$SETUP_SCRIPT"
+    refute_grep 'dotf secrets render "\$TUI_(SRC|DST)"' "$SETUP_SCRIPT"
 }

--- a/tests/skills-pipeline.bats
+++ b/tests/skills-pipeline.bats
@@ -5,6 +5,8 @@
 # round-trip at the filesystem level. Runs offline (no vault); the integration
 # container exercises the full setup-linux.sh end-to-end.
 
+load 'lib/refute'
+
 setup() {
     REPO="$BATS_TEST_DIRNAME/.."
     SCRIPT="$REPO/scripts/compile-harness.sh"
@@ -36,7 +38,7 @@ stub_copilot() {
     grep -q '^name: spec' "$FAKEHOME/.claude/skills/spec/SKILL.md"
     # opencode: spec command file present (name: dropped — keyed off filename)
     [ -f "$FAKEHOME/.config/opencode/commands/spec.md" ]
-    ! grep -q '^name:' "$FAKEHOME/.config/opencode/commands/spec.md"
+    refute_grep '^name:' "$FAKEHOME/.config/opencode/commands/spec.md"
     # AC1: neither deployed path is a symlink
     [ ! -L "$FAKEHOME/.claude/skills/spec" ]
     [ ! -L "$FAKEHOME/.config/opencode/commands/spec.md" ]
@@ -51,7 +53,8 @@ stub_copilot() {
     for f in "$FAKEHOME"/.claude/skills/*/SKILL.md; do
         [ -f "$f" ] || continue
         fm="$(awk '/^---[[:space:]]*$/{n++; next} n==1{print} n>=2{exit}' "$f")"
-        ! echo "$fm" | grep -qE '^(paths|keywords|requires|id|type|status|created|owner|targets):'
+        run grep -nE '^(paths|keywords|requires|id|type|status|created|owner|targets):' <<<"$fm"
+        [ "$status" -eq 1 ] || { printf 'store-only frontmatter left in %s:\n%s\n' "$f" "$output" >&2; return 1; }
     done
 }
 
@@ -70,7 +73,7 @@ stub_copilot() {
     [ "$status" -eq 0 ]
     [ -f "$FAKEHOME/.gemini/skills/spec/SKILL.md" ]
     [ -f "$FAKEHOME/.gemini/prompts/spec.md" ]
-    ! grep -q '^name:' "$FAKEHOME/.gemini/prompts/spec.md"   # frontmatter stripped
+    refute_grep '^name:' "$FAKEHOME/.gemini/prompts/spec.md"   # frontmatter stripped
 }
 
 @test "HANDOFF-001: /handoff deploys cross-agent (claude + opencode + agy) with its checklist" {
@@ -131,7 +134,7 @@ stub_copilot() {
     run env HOME="$FAKEHOME" "$SCRIPT" --deploy
     [ "$status" -eq 0 ]
     grep -qF -- '**spec**' "$FAKEHOME/.copilot/copilot-instructions.md"
-    ! grep -qF -- '**crystallize**' "$FAKEHOME/.copilot/copilot-instructions.md"
+    refute_grep_fixed '**crystallize**' "$FAKEHOME/.copilot/copilot-instructions.md"
 }
 
 @test "HARNESS-051: copilot gets native /spec and /handoff skills" {

--- a/tests/utils.bats
+++ b/tests/utils.bats
@@ -50,7 +50,8 @@ setup() {
 }
 
 @test "command_exists returns false for missing command" {
-    ! command_exists __nonexistent_cmd_xyz__
+    run command_exists __nonexistent_cmd_xyz__
+    [ "$status" -eq 1 ]
 }
 
 @test "file_exists finds real file" {
@@ -58,7 +59,8 @@ setup() {
 }
 
 @test "file_exists returns false for missing file" {
-    ! file_exists "/nonexistent/file_xyz.txt"
+    run file_exists "/nonexistent/file_xyz.txt"
+    [ "$status" -eq 1 ]
 }
 
 @test "dir_exists finds real directory" {
@@ -66,7 +68,8 @@ setup() {
 }
 
 @test "dir_exists returns false for missing directory" {
-    ! dir_exists "/nonexistent/dir_xyz"
+    run dir_exists "/nonexistent/dir_xyz"
+    [ "$status" -eq 1 ]
 }
 
 @test "symlink_valid detects valid symlink" {
@@ -84,7 +87,8 @@ setup() {
     echo "content" > "$target"
     ln -sf "$target" "$link"
     rm -f "$target"
-    ! symlink_valid "$link"
+    run symlink_valid "$link"
+    [ "$status" -eq 1 ]
     rm -f "$link"
 }
 
@@ -95,12 +99,14 @@ setup() {
 
 @test "var_is_set returns false for unset variable" {
     unset TEST_UNSET_VAR 2>/dev/null
-    ! var_is_set TEST_UNSET_VAR
+    run var_is_set TEST_UNSET_VAR
+    [ "$status" -eq 1 ]
 }
 
 @test "var_is_set returns false for empty variable" {
     TEST_EMPTY_VAR=""
-    ! var_is_set TEST_EMPTY_VAR
+    run var_is_set TEST_EMPTY_VAR
+    [ "$status" -eq 1 ]
 }
 
 # --- String helpers ---

--- a/tests/vault-health-golden.bats
+++ b/tests/vault-health-golden.bats
@@ -23,6 +23,8 @@
 # ticket + deliberate recapture rather than a silent "cleanup" folded into
 # an unrelated change.
 
+load 'lib/refute'
+
 setup() {
     HERE="$BATS_TEST_DIRNAME/golden/vault-health"
     export GVH_ORACLE_SH="$BATS_TEST_DIRNAME/../scripts/vault-health.sh"
@@ -167,7 +169,7 @@ assert_golden() {
     # recaptured (tests/golden/vault-health/capture.sh) to match — so this test
     # now pins the FIXED shape, and a regression back to double-passing the
     # flag is what would turn it red.
-    ! grep -q -- '--vault knowledge --vault knowledge' \
+    refute_grep_fixed '--vault knowledge --vault knowledge' \
         "$HERE/cases/all-pass/expected/obsidian-argv"
     grep -qx -- '--no-sandbox orphans --vault knowledge' \
         "$HERE/cases/all-pass/expected/obsidian-argv"

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -2,6 +2,8 @@
 # verify-setup.bats - Integration tests verifying setup-linux.sh side effects
 # Run inside the container built from tests/Dockerfile.integration
 
+load 'lib/refute'
+
 setup() {
     if [ -z "$DOTFILES_INTEGRATION_TEST" ]; then
         skip "only runs inside integration test container"
@@ -193,7 +195,7 @@ setup() {
     # setup-linux.sh strips frontmatter with sed '/^---$/,/^---$/d'
     for prompt in "$HOME/.gemini/prompts"/*.md; do
         [ -f "$prompt" ] || continue
-        ! head -1 "$prompt" | grep -q '^---$'
+        [ "$(head -1 "$prompt")" != '---' ] || { printf 'frontmatter left in %s\n' "$prompt" >&2; return 1; }
     done
 }
 
@@ -314,7 +316,7 @@ setup() {
     [ ! -f "$HOME/.config/opencode/commands/crystallize.md" ]
     # rendered command carries provenance + drops name: (opencode keys off filename)
     grep -qE '^generated_sha: [0-9a-f]{16}' "$HOME/.config/opencode/commands/audit.md"
-    ! grep -q '^name:' "$HOME/.config/opencode/commands/audit.md"
+    refute_grep '^name:' "$HOME/.config/opencode/commands/audit.md"
 }
 
 @test "no MCP servers registered (claude CLI absent)" {

--- a/tests/versions-conf.bats
+++ b/tests/versions-conf.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 # Tests for versions.conf format and sourcing
 
+load 'lib/refute'
+
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
     export VERSIONS_CONF="$DOTFILES_DIR/versions.conf"
@@ -19,12 +21,12 @@ setup() {
 }
 
 @test "versions.conf contains no export statements" {
-    ! grep -q '^export ' "$VERSIONS_CONF"
+    refute_grep '^export ' "$VERSIONS_CONF"
 }
 
 @test "versions.conf contains no quoted values" {
-    ! grep -qE '^[A-Z_]+=".+"' "$VERSIONS_CONF"
-    ! grep -qE "^[A-Z_]+='.+'" "$VERSIONS_CONF"
+    refute_grep '^[A-Z_]+=".+"' "$VERSIONS_CONF"
+    refute_grep "^[A-Z_]+='.+'" "$VERSIONS_CONF"
 }
 
 @test "versions.conf sets JAVA_VERSION" {


### PR DESCRIPTION
Chunk 2 of 3 for #1034. **Stacked on #1203** (`fix/bats-dead-negated-assertions`) — review that one first; this branch contains its commits and will shrink to its own two once #1203 merges.

## What this does

Converts the 14 remaining files that carried an assertion in a position where it could not fail, and empties their entries from the ratchet in `tests/guard-bats-negation.bats`.

**67 lines converted.** The mechanical `! grep -q{E,F}` cases went straight to `refute_grep` / `refute_grep_fixed`. The rest needed a decision per site, and those decisions are the reviewable part:

| Shape | Conversion | Why not the obvious one |
|---|---|---|
| `! grep -q '# Aider (AI pair programming)'` | `refute_grep_fixed` | **BRE to ERE is not always faithful.** `( ) { } + ? \|` are literals in BRE and operators in ERE. Moved to `-E` this pattern is an unterminated group: grep exits 2, and a bare `! grep` reads exit 2 as an absence. `.`, `*`, `^`, `\$` mean the same in both, so those stayed regexes. |
| `! jq … \| grep -qE`, `! grep … \| grep -q` | `run <producer>` + assert on `$output` | A pipeline cannot be a `refute_grep` call. The new form also pins the producer's own exit status, which the old one discarded. |
| `! command_exists`, `! var_is_set`, … | `run <predicate>` + `[ "$status" -eq 1 ]` | `-eq 1`, not `-ne 0`: 127 is the status of a helper whose name was typo'd, and `-ne 0` passes on it. |
| `! grep -qi "aider"` | `run grep -in` + exact status | The helper deliberately has no flag passthrough; the dialect is in its name. Two case-insensitive sites do not justify a third entry point. |
| `! grep … \|\| { echo …; return 1; }` (2 sites) | `refute_grep` | These two were **live** — the `\|\|` rescued them. They lose the hand-rolled message because the helper already prints the file and the offending line. |

Two pre-existing `grep --` forms surfaced as loud arg-count failures instead of silent passes. That is the helper's contract working: `refute_grep` passes the pattern after `--` itself, so a caller-supplied `--` is a third argument and it says so.

## Remaining after this

**17 lines in 11 files**, all currently in the last-statement position where the form does work. They convert in chunk 3, because a `!` on the last line is one appended assertion away from dead and nothing announces the move.

## Verification

```
$ bats tests/*.bats
1453 tests, 0 failures        # exit 0

$ ./scripts/check-spec-gate.sh --base-ref main --head-ref HEAD --explain
[OK] Production diff 0 LOC < threshold 50 (below threshold; spec not required)
```
