### PR TITLE
test(bats): convert the last negated assertions and close the ratchet

### DIFF
--- a/tests/bitacora-reconcile.bats
+++ b/tests/bitacora-reconcile.bats
@@ -10,6 +10,8 @@
 # So these tests do not inspect the workflow's text; they EXECUTE the classifier,
 # and the load-bearing ones execute it under `bash -e` (see "the regression").
 
+load 'lib/refute'
+
 setup() {
     SCRIPT="$BATS_TEST_DIRNAME/../scripts/bitacora-reconcile.sh"
     FIX="/tmp/bats_reconcile_$$_${BATS_TEST_NUMBER:-0}"
@@ -47,10 +49,13 @@ teardown() {
     rm -rf "$FIX"
 }
 
-# `grep -s` so this holds when gh was never called at all and the log is absent —
-# which is itself the assertion on the soft-pass paths.
 refute_issue_filed() {
-    ! grep -qs "issue create" "$GH_LOG"
+    # The log may not exist at all — gh was never called — and that absence is
+    # itself the assertion on the soft-pass paths. It is the one case where a
+    # missing file is a pass rather than the error refute_grep treats it as, so
+    # it is stated here instead of being folded into `grep -s`.
+    [ -f "$GH_LOG" ] || return 0
+    refute_grep_fixed 'issue create' "$GH_LOG"
 }
 
 @test "success: notice and exit 0" {

--- a/tests/bitacora-rollout.bats
+++ b/tests/bitacora-rollout.bats
@@ -14,6 +14,8 @@
 # added" would have passed against the broken version too, since the stub would
 # happily answer either form.
 
+load 'lib/refute'
+
 setup() {
     SCRIPT="$BATS_TEST_DIRNAME/../scripts/bitacora-rollout.sh"
     FIX="/tmp/bats_rollout_$$_${BATS_TEST_NUMBER:-0}"
@@ -73,7 +75,7 @@ count_calls() {
     [ "$status" -eq 0 ]
     # `gh project item-add --owner` is the form BITACORA_PAT cannot execute.
     # Nothing in the backfill may reach for it again.
-    ! grep -q '^project ' "$GH_LOG"
+    refute_grep '^project ' "$GH_LOG"
 }
 
 @test "the regression: each open item is added via addProjectV2ItemById" {

--- a/tests/board-pickup.bats
+++ b/tests/board-pickup.bats
@@ -9,6 +9,8 @@
 # Hermetic: a fake `gh` on PATH logs each `issue edit` (repo + number) and answers
 # `issue view --json state` from a controllable fixture, so no network is touched.
 
+load 'lib/refute'
+
 setup() {
     HELPER="$BATS_TEST_DIRNAME/../git-hooks/lib/board-pickup.sh"
     TMP="$(mktemp -d "/tmp/bats_pickup_XXXXXX")"
@@ -68,7 +70,7 @@ run_helper() { ( cd "$REPO" && bash "$HELPER" "$@" ); }
     run run_helper "" "" "1"
     [ "$status" -eq 0 ]
     grep -q "mlorentedev/dotfiles 77" "$GHLOG"
-    ! grep -q "mlorentedev/knowledge" "$GHLOG"
+    refute_grep_fixed "mlorentedev/knowledge" "$GHLOG"
 }
 
 @test "current-repo issue missing: falls back to the knowledge bitacora home" {

--- a/tests/check-doc-paths.bats
+++ b/tests/check-doc-paths.bats
@@ -191,7 +191,10 @@ governed_files() {
     printf 'Generated record naming `scripts/gone.sh`.\n' > "$DOTFILES_DIR/$PROBE_REL"
     git -C "$DOTFILES_DIR" add -N "$PROBE_REL"
 
-    ! instruction_files | grep -qx "$PROBE_REL"
+    local discovered
+    discovered="$(instruction_files)"
+    run grep -qxF "$PROBE_REL" <<<"$discovered"
+    [ "$status" -eq 1 ]
 }
 
 @test "check-doc-paths: auto-discovers instruction files when run without arguments [#1021]" {

--- a/tests/guard-bats-negation.bats
+++ b/tests/guard-bats-negation.bats
@@ -4,43 +4,26 @@
 # bash exempts a command preceded by `!` from `set -e`, and bats runs a @test
 # body under `set -e`.  So `! grep -q X file` anywhere but the LAST line of a
 # @test cannot fail that test — the body's status comes from its last command,
-# and every earlier `!` line is discarded.  Measured: 55 of the suite's 139 such
-# lines were in that position, and one of them was hiding a real violation for
+# and every earlier `!` line is discarded.  Measured 2026-08-23: 139 such lines
+# in 30 files, 53 of them in that position, and one hiding a real violation for
 # months (tests/check-review-attestation.bats, AC5).
 #
 # A `!` on the last line does work — and is one appended assertion away from not
-# working, silently.  So the rule this guard enforces is the whole form, not the
-# dead subset: use tests/lib/refute.bash (refute_grep / refute_grep_fixed), or
-# `run cmd` plus an explicit status check.
+# working, silently.  So the rule is the whole form, not the dead subset: use
+# tests/lib/refute.bash (refute_grep / refute_grep_fixed), or `run cmd` plus an
+# explicit status check.  All 139 are converted; this keeps the count at zero.
+#
+# The quarantine ratchet that carried the not-yet-converted files through the
+# three-PR conversion is gone with the last entry, as designed.  If a batch of
+# them ever has to come back, the shape was: a `file count` list, asserted exact
+# in both directions, so a conversion had to lower its entry in the same commit
+# and a regression could not hide behind an entry that over-counted.
 #
 # This is a bats meta-test rather than a scripts/check-*.sh gate on purpose.
 # check-bats-names.sh has to be a script because bats cannot see its own
 # duplicate @test names (the file is a parse error, so nothing runs).  Here
 # there is no such blindness: a bats file can read its siblings, and the `test`
 # job already runs the suite.
-
-# --- the quarantine list -----------------------------------------------------
-#
-# Files still carrying the bare form, with the exact count each carries today.
-# It is a RATCHET, not a home: the guard fails if a listed file's count changes
-# in EITHER direction, so a conversion must delete or lower its entry in the
-# same commit, and a regression cannot hide behind an entry that over-counts.
-# #1034 empties it; when the last entry goes, so does the list.
-quarantine_list() {
-    cat <<'LIST'
-tests/bitacora-reconcile.bats 1
-tests/bitacora-rollout.bats 1
-tests/board-pickup.bats 1
-tests/check-doc-paths.bats 1
-tests/hermes-setup.bats 1
-tests/install-dotf-ps1.bats 1
-tests/pi-config.bats 4
-tests/pwsh-analyzer-coverage.bats 1
-tests/shell-wrapper-dedup.bats 2
-tests/versions-no-hardcode.bats 2
-tests/windows-defaults.bats 2
-LIST
-}
 
 # Lines whose first non-blank token is `!` — the form bash exempts from set -e.
 # `[ ! -f x ]`, `if ! grep …` and `foo || ! bar` are not this shape and are not
@@ -51,56 +34,31 @@ bare_negation_count() {
     printf '%s\n' "${count:-0}"
 }
 
-quarantined_count() {
-    local rel="$1"
-    quarantine_list | awk -v f="$rel" '$1 == f { print $2; found = 1 }
-                                       END { if (!found) print "-" }'
-}
-
-@test "guard: no bats file outside the quarantine list carries a bare negated assertion" {
+@test "guard: no bats file carries a bare negated assertion" {
     local offenders=() f rel n
     for f in "$BATS_TEST_DIRNAME"/*.bats; do
         rel="tests/$(basename "$f")"
         n="$(bare_negation_count "$f")"
-        [ "$n" -eq 0 ] && continue
-        [ "$(quarantined_count "$rel")" = '-' ] && offenders+=("$rel ($n)")
+        [ "$n" -eq 0 ] || offenders+=("$rel ($n)")
     done
 
     if [ "${#offenders[@]}" -gt 0 ]; then
-        printf 'bare `! cmd` assertions found in files that had none:\n' >&2
+        printf 'bare `! cmd` assertions found:\n' >&2
         printf '  %s\n' "${offenders[@]}" >&2
-        printf 'A `!` line that is not the last line of its @test cannot fail it.\n' >&2
+        printf 'A `!` line that is not the last line of its @test cannot fail it,\n' >&2
+        printf 'and one that is, stops being the last line the moment you append.\n' >&2
         printf "Use tests/lib/refute.bash (load 'lib/refute'), or run + a status check.\n" >&2
-        return 1
-    fi
-}
-
-@test "guard: every quarantined file still carries exactly its recorded count" {
-    local drift=() rel want got
-    while read -r rel want; do
-        [ -n "$rel" ] || continue
-        if [ ! -f "$BATS_TEST_DIRNAME/../$rel" ]; then
-            drift+=("$rel: listed but does not exist")
-            continue
-        fi
-        got="$(bare_negation_count "$BATS_TEST_DIRNAME/../$rel")"
-        [ "$got" = "$want" ] || drift+=("$rel: recorded $want, found $got")
-    done < <(quarantine_list)
-
-    if [ "${#drift[@]}" -gt 0 ]; then
-        printf 'the quarantine list has drifted from the suite:\n' >&2
-        printf '  %s\n' "${drift[@]}" >&2
-        printf 'Converting a file means deleting or lowering its entry in the same commit.\n' >&2
         return 1
     fi
 }
 
 @test "guard: the detector actually detects, on a fixture with a known answer" {
     # A guard that silently matches nothing reports a clean suite forever, and
-    # one that overcounts turns the ratchet into noise. This pins the detector
-    # against a file whose answer is counted by hand: three bare negations, and
-    # six shapes that must NOT count — including a commented-out negation and a
-    # `!` that is merely an argument, which are the plausible false positives.
+    # one that overcounts cries wolf until someone deletes it. This pins the
+    # detector against a file whose answer is counted by hand: three bare
+    # negations, and six shapes that must NOT count — including a commented-out
+    # negation and a `!` that is merely an argument, the plausible false
+    # positives.
     local probe
     probe="$(mktemp)"
     {
@@ -123,12 +81,19 @@ quarantined_count() {
     [ "$n" -eq 3 ]
 }
 
-@test "guard: the quarantine list is sorted and free of duplicate entries" {
-    # Two entries for one file would let a conversion satisfy the stale one and
-    # leave the other unnoticed; sorting keeps the merge conflicts honest when
-    # parallel branches each convert a file.
-    local names
-    names="$(quarantine_list | awk '{ print $1 }')"
-    [ "$names" = "$(printf '%s\n' "$names" | LC_ALL=C sort)" ]
-    [ "$(printf '%s\n' "$names" | wc -l)" -eq "$(printf '%s\n' "$names" | sort -u | wc -l)" ]
+@test "guard: every bats file that calls a refute helper loads the library" {
+    # `load 'lib/refute'` missing is not a silent pass — the call errors — but it
+    # errors at the first @test that reaches it, which may be far from the edit.
+    # Cheaper to say so here, with the file named.
+    local missing=() f
+    for f in "$BATS_TEST_DIRNAME"/*.bats; do
+        grep -qE '^[[:space:]]*refute_grep(_fixed)? ' "$f" || continue
+        grep -qF "load 'lib/refute'" "$f" || missing+=("tests/$(basename "$f")")
+    done
+
+    if [ "${#missing[@]}" -gt 0 ]; then
+        printf "these files call a refute helper without load 'lib/refute':\n" >&2
+        printf '  %s\n' "${missing[@]}" >&2
+        return 1
+    fi
 }

--- a/tests/hermes-setup.bats
+++ b/tests/hermes-setup.bats
@@ -109,7 +109,10 @@ provision() {
 }
 
 @test "guard: setup.sh touches none of the local-deploy surface (comments excluded)" {
-    ! grep -vE '^[[:space:]]*#' "$SETUP" | grep -qE 'setup-linux\.sh|setup-windows\.ps1|mcp-servers\.json'
+    local body
+    body="$(grep -vE '^[[:space:]]*#' "$SETUP")"
+    run grep -nE 'setup-linux\.sh|setup-windows\.ps1|mcp-servers\.json' <<<"$body"
+    [ "$status" -eq 1 ] || { printf 'local-deploy surface referenced:\n%s\n' "$output" >&2; return 1; }
 }
 
 @test "sync wrapper aborts a conflicted rebase (never wedges the clone)" {

--- a/tests/install-dotf-ps1.bats
+++ b/tests/install-dotf-ps1.bats
@@ -6,6 +6,8 @@
 # mirrored here). Behavioral correctness is the direct mirror of install-dotf.sh
 # (bats-tested on Linux) plus a real-release smoke during the WIN-006 verification.
 
+load 'lib/refute'
+
 setup() {
     SCRIPTS_DIR="$BATS_TEST_DIRNAME/../scripts"
     PS1="$SCRIPTS_DIR/install-dotf.ps1"
@@ -69,7 +71,7 @@ setup() {
     grep -qE 'function +Set-DotfBinary' "$PS1"
     grep -qF 'Move-Item' "$PS1"
     # The naive one-shot copy straight onto the live target must be gone.
-    ! grep -qF "Copy-Item -Path \$exe" "$PS1"
+    refute_grep_fixed "Copy-Item -Path \$exe" "$PS1"
 }
 
 @test "setup-windows.ps1 dot-sources install-dotf.ps1 and calls Install-Dotf" {

--- a/tests/pi-config.bats
+++ b/tests/pi-config.bats
@@ -3,6 +3,8 @@
 # plaintext secret in git, and the curated model set stays consistent with
 # its own README (NaN + non-big-3 paid OpenRouter).
 
+load 'lib/refute'
+
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
     export PI_MODELS="$DOTFILES_DIR/ai/pi/models.json"
@@ -15,7 +17,7 @@ setup() {
 }
 
 @test "ai/pi/models.json has no literal API key" {
-    ! grep -qE '"apiKey"[[:space:]]*:[[:space:]]*"sk-' "$PI_MODELS"
+    refute_grep '"apiKey"[[:space:]]*:[[:space:]]*"sk-' "$PI_MODELS"
 }
 
 @test "ai/pi/models.json uses the \${NAN_API_KEY} placeholder, resolved at runtime" {
@@ -31,7 +33,7 @@ setup() {
 # This assertion is the inverse of the one it replaced: that test required the broken
 # form and passed for as long as the bug existed.
 @test "ai/pi/models.json carries no {env:...} placeholder pi cannot resolve [BUG-081b]" {
-    ! grep -qF '{env:' "$PI_MODELS"
+    refute_grep_fixed '{env:' "$PI_MODELS"
 }
 
 @test "ai/pi/models.json is valid JSON" {
@@ -45,11 +47,11 @@ setup() {
 }
 
 @test "ai/pi/settings.json omits the volatile lastChangelogVersion (seed-if-missing)" {
-    ! grep -qF 'lastChangelogVersion' "$PI_SETTINGS"
+    refute_grep_fixed 'lastChangelogVersion' "$PI_SETTINGS"
 }
 
 @test "ai/pi/settings.json enabledModels exclude OpenAI/Google/Anthropic OpenRouter providers" {
-    ! grep -qE 'openrouter/(openai|google|anthropic)/' "$PI_SETTINGS"
+    refute_grep 'openrouter/(openai|google|anthropic)/' "$PI_SETTINGS"
 }
 
 # --- Referential integrity between the two files -------------------------

--- a/tests/pwsh-analyzer-coverage.bats
+++ b/tests/pwsh-analyzer-coverage.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 # Tests for POLISH-003: PSScriptAnalyzer full repository coverage
 
+load 'lib/refute'
+
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
     export CI_YML="$DOTFILES_DIR/.github/workflows/ci.yml"
@@ -11,7 +13,7 @@ setup() {
 }
 
 @test "POLISH-003: lint-powershell does not hardcode static script list" {
-    ! grep -q '\$scripts = @(' "$CI_YML"
+    refute_grep_fixed '$scripts = @(' "$CI_YML"
 }
 
 @test "POLISH-003: repo contains at least 20 powershell scripts subject to analysis" {

--- a/tests/shell-wrapper-dedup.bats
+++ b/tests/shell-wrapper-dedup.bats
@@ -4,6 +4,8 @@
 # (_qq_call) and the oc/ocfull wrappers live once in .zsh/functions.sh;
 # each rc keeps only its thin shell-specific qq/qf/dbg wrapper.
 
+load 'lib/refute'
+
 setup() {
     REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 }
@@ -73,7 +75,14 @@ setup() {
     # (matches shell-alias-collision.bats' ZSH_SOURCED) -- .zsh/functions.zsh
     # and .zsh/nvm.zsh were missing here, so a collision defined in either
     # would have gone undetected by this specific check.
-    ! grep -qE '^(function )?(gp|gpr)\(\)' "$REPO_ROOT/.bashrc" "$REPO_ROOT/.zshrc" "$REPO_ROOT/.zsh/functions.sh" "$REPO_ROOT/.zsh/functions.zsh" "$REPO_ROOT/.zsh/nvm.zsh"
+    #
+    # One file per call, deliberately: refute_grep takes a single file so that a
+    # path which does not exist is a loud error rather than a quiet absence, and
+    # a multi-file grep cannot tell the two apart.
+    local rc
+    for rc in .bashrc .zshrc .zsh/functions.sh .zsh/functions.zsh .zsh/nvm.zsh; do
+        refute_grep '^(function )?(gp|gpr)\(\)' "$REPO_ROOT/$rc"
+    done
 }
 
 # --- AC7: utils.sh sourced declaratively; .profile no longer mutates rc files ---
@@ -83,7 +92,7 @@ setup() {
 }
 
 @test "AC7: .profile no longer appends 'source utils.sh' to ~/.bashrc or ~/.zshrc" {
-    ! grep -qE '>>[[:space:]]*"\$HOME/\.(bashrc|zshrc)"' "$REPO_ROOT/.profile"
+    refute_grep '>>[[:space:]]*"\$HOME/\.(bashrc|zshrc)"' "$REPO_ROOT/.profile"
 }
 
 @test "AC7: version_gte resolves after sourcing functions.sh (bash, via utils.sh)" {

--- a/tests/versions-no-hardcode.bats
+++ b/tests/versions-no-hardcode.bats
@@ -4,17 +4,19 @@
 # or references a *_VERSION key that versions.conf does not define (which would
 # leave the corresponding *_HOME path empty and silently drop the tool off PATH).
 
+load 'lib/refute'
+
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
     export VERSIONS_CONF="$DOTFILES_DIR/versions.conf"
 }
 
 @test ".zshrc has no hard-coded version fallback literal" {
-    ! grep -nE '\$\{[A-Z_]+_VERSION:-[0-9]' "$DOTFILES_DIR/.zshrc"
+    refute_grep '\$\{[A-Z_]+_VERSION:-[0-9]' "$DOTFILES_DIR/.zshrc"
 }
 
 @test ".bashrc has no hard-coded version fallback literal" {
-    ! grep -nE '\$\{[A-Z_]+_VERSION:-[0-9]' "$DOTFILES_DIR/.bashrc"
+    refute_grep '\$\{[A-Z_]+_VERSION:-[0-9]' "$DOTFILES_DIR/.bashrc"
 }
 
 @test "every *_VERSION referenced in .zshrc is defined in versions.conf" {

--- a/tests/windows-defaults.bats
+++ b/tests/windows-defaults.bats
@@ -5,6 +5,7 @@
 # tests/windows-defaults.Tests.ps1 (Pester, Windows-only).
 
 load 'winpath'
+load 'lib/refute'
 
 setup() {
     export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
@@ -42,7 +43,8 @@ setup() {
 # --- HKCU-only invariant (AC: all writes target HKCU:\ only) ---
 
 @test "windows-defaults.ps1 never references HKLM (HKCU-only invariant)" {
-    ! grep -qi 'HKLM' "$PS1_SCRIPT"
+    run grep -in 'HKLM' "$PS1_SCRIPT"
+    [ "$status" -eq 1 ] || { printf 'HKCU-only invariant broken:\n%s\n' "$output" >&2; return 1; }
 }
 
 @test "windows-defaults.ps1 validates -Root stays inside HKCU at runtime" {
@@ -73,7 +75,7 @@ setup() {
 }
 
 @test "windows-defaults.ps1 never restarts explorer.exe itself (anti-scope)" {
-    ! grep -qE 'Stop-Process|taskkill|Restart-Computer' "$PS1_SCRIPT"
+    refute_grep 'Stop-Process|taskkill|Restart-Computer' "$PS1_SCRIPT"
 }
 
 # --- setup-windows.ps1 integration (AC: -WithDefaults flag, OFF by default) ---


### PR DESCRIPTION
Final chunk for #1034. **Stacked on #1206**, which is stacked on #1203 — review those first; this branch shrinks to its own commit as they merge.

## What this does

Converts the last **17 lines in 11 files** and deletes the quarantine ratchet, because it is empty. The suite now contains **zero** bare `!` assertions and the guard asserts a flat zero.

These 17 were all in the last-statement position, where the form *does* work. That is why they were left for last, and why they still had to go: a `!` on the closing line stops being on the closing line the moment someone appends an assertion, and nothing announces the move.

## Per-site decisions worth reading

| Site | Decision |
|---|---|
| `refute_issue_filed` (bitacora-reconcile) | Kept `grep -s` semantics deliberately: the gh log **not existing** is itself the assertion on the soft-pass paths. It is the one place a missing file is a pass rather than the error `refute_grep` treats it as, so it is now an explicit `[ -f "$GH_LOG" ] \|\| return 0` instead of a flag whose reason lived in a comment. |
| `'\$scripts = @('` (pwsh-analyzer-coverage) | `refute_grep_fixed`, not `refute_grep` — `(` is a literal in BRE and an unterminated group in ERE. |
| `! instruction_files \| grep -qx`, `! grep -v … \| grep -qE` | Captured intermediate + `run` + exact status. Keeps `grep -x`'s whole-line semantics, which a substring test on `$output` would have quietly dropped. |
| shell-wrapper-dedup's five-file grep | A loop of one-file calls. A multi-file grep cannot distinguish a path that does not exist from a pattern that is absent, and that distinction is the helper's entire point. |

## Guard changes

- The ratchet and its two tests are deleted with the last entry. The guard's header records the ratchet's shape in case a batch ever has to come back.
- New third case: **every file that calls a refute helper loads the library.** A missing `load 'lib/refute'` is not a silent pass — the call errors — but it errors at the first `@test` that reaches it, which can be far from the edit.

## Verification

```
$ bats tests/*.bats
1456 tests, 0 failures        # exit 0, rebased on main @ b04a6c4

$ grep -rcE '^[[:space:]]*![[:space:]]' tests/*.bats | grep -v ':0$'
(no output)
```
