### PR TITLE
docs(lessons): a stacked PR costs a reviewer and re-conflicts on every squash

### DIFF
--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -238,3 +238,4 @@ tags: [lessons, index, dotfiles]
 | [222 - A coupling's scope is measured, not inferred from where you saw it fail](lesson-222-a-couplings-scope-is-measured-not-inferred-from-whe.md) | 2026-08-23 |  |
 | [223 - A test updated to keep passing stops being a guard](lesson-223-a-test-updated-to-keep-passing-stops-being-a-guar.md) | 2026-08-23 |  |
 | [224 - A negated assertion is exempt from `set -e`, so it cannot fail a test](lesson-224-a-negated-assertion-is-exempt-from-set-e-so-it-cann.md) | 2026-08-23 |  |
+| [225 - A stacked PR costs a reviewer, and re-conflicts on every squash](lesson-225-a-stacked-pr-costs-a-reviewer-and-re-conflicts-on-e.md) | 2026-08-23 |  |

--- a/docs/lessons/lesson-225-a-stacked-pr-costs-a-reviewer-and-re-conflicts-on-e.md
+++ b/docs/lessons/lesson-225-a-stacked-pr-costs-a-reviewer-and-re-conflicts-on-e.md
@@ -1,0 +1,49 @@
+# Lesson 225 — A stacked PR costs a reviewer, and re-conflicts on every squash
+
+**Date:** 2026-08-23
+**Area:** git / CI / review process
+**Severity:** medium — two of three PRs in a chain were read by one reviewer agent instead of two, and nothing said so
+
+## What happened
+
+#1034 was split into three PRs, each stacked on the previous: #1203 (base `main`), #1206 (base #1203's branch), #1207 (base #1206's branch). The chunking itself was right — 139 conversions do not belong in one diff. The *stacking* was the part that cost, in two ways that were both invisible until they bit.
+
+**1. Every squash-merge re-conflicts the rest of the chain.** This repo squash-merges. A squash replaces the parent PR's commits with one new commit, so the child's commits stop being ancestors of `main`. GitHub then auto-retargets the child to `main`, and the parent's entire diff reappears in it as new work:
+
+| Event | Consequence |
+|---|---|
+| #1203 merged as `c660613` | #1206 retargeted to `main`, `mergeable: false, state: dirty` |
+| #1206 merged as `1e21d26` | #1207 retargeted to `main`, `mergeable: false, state: dirty` |
+
+Both were fixed the same way — `git rebase --onto origin/main <old-parent-tip> <branch>`, which replays only the branch's own commits — and both were reported by the human as *"hay conflictos"* before anyone had thought to look. The conflict is not a merge problem to be solved once; it is a scheduled event, one per merge in the chain.
+
+**2. CodeRabbit does not review a stacked PR at all.** Not a quota window that reopens later — configuration:
+
+> Review skipped — auto reviews are disabled on base/target branches other than the default branch.
+
+So #1206 and #1207 were read by **one** reviewer agent (PR-Agent), while #1203 was read by two. Every check was green on all three, and nothing on the PR page distinguished "one reviewer approved" from "two did". This is a fourth distinct mechanism by which a green check does not mean reviewed, after the three in [Lesson 213](lesson-213-a-reviewer-that-reports-success-while-publishing.md) and the release-branch auto-pause in #1196.
+
+## Why the mistake is easy
+
+Stacking is the obvious answer to "these PRs depend on each other", and here they *looked* dependent: chunks 2 and 3 both used the library that chunk 1 introduced.
+
+They were not. Measured after the fact: chunk 2 and chunk 3 touched **disjoint sets of test files**. Their only shared surface was one line-range in the guard's quarantine list. Only chunk 1 had to land first, because it added `tests/lib/refute.bash`. Chunks 2 and 3 could have been cut from `main` *after* chunk 1 merged, as two independent PRs — no retargeting, no rebase per merge, two reviewers each.
+
+The tell was available before the first stack was created: *do these branches modify the same files, or merely rely on the same already-merged code?*
+
+## The rule
+
+**Stack only when the diffs overlap; otherwise serialise off `main`.** Depending on a merged artifact is not a reason to stack — it is a reason to wait for the merge.
+
+When stacking is genuinely required:
+
+- **Budget one rebase per merge in the chain**, and do it immediately after the parent lands, not when someone reports a conflict. `git rebase --onto origin/main <old-parent-tip> <branch>` is the form; a plain `git rebase main` replays the parent's commits too and conflicts against itself.
+- **Say in the PR body that the reviewer coverage is halved.** A stacked PR's `## Review triage` should record *"read by one reviewer agent only, by configuration"* explicitly. Disclosure over silence, the same posture as merging unreviewed.
+- **Prefer disjoint files over a shared ratchet.** The one line the chunks contended over was the quarantine list. A per-file marker would have made even that independent — worth considering the next time a ratchet spans a multi-PR conversion.
+
+## Evidence
+
+- #1203 (`c660613`), #1206 (`1e21d26`), #1207 (`f6b4d36`) — the chain
+- `mergeable_state: dirty` observed twice, once after each parent merge
+- CodeRabbit's skip notice on #1206 and #1207; its full review on #1203
+- #1196 — the release-branch variant of the same "green but unreviewed" class


### PR DESCRIPTION
Documentation only. Captures the two costs the #1034 chain paid, in-session per Standing Order #3.

- **A squash of the parent re-conflicts the child, once per merge.** Observed twice: #1203 merged → #1206 `dirty`; #1206 merged → #1207 `dirty`. Both times the human saw it before anyone thought to look for it. The fix is `git rebase --onto origin/main <old-parent-tip> <branch>` — a plain `git rebase main` replays the parent's commits and conflicts against itself.
- **CodeRabbit does not review a stacked PR at all**, by configuration: *"auto reviews are disabled on base/target branches other than the default branch"*. #1206 and #1207 were read by one reviewer agent while #1203 was read by two, with every check green and nothing on the page saying so. Fourth distinct mechanism in this class, after the three in lesson 213 and the release-branch auto-pause in #1196.

The part worth keeping: **the stacking was avoidable.** Chunks 2 and 3 touched disjoint test files and shared only one line-range in the guard's quarantine list. Depending on a *merged* artifact is a reason to wait for the merge, not to stack.

Open question this PR does not answer: whether the CodeRabbit skip deserves its own ticket alongside #1196. Left to the human.

## Verification

```
$ ./scripts/check-doc-paths.sh   # exit 0
$ bats tests/*.bats              # via pre-commit, green
```
