### PR TITLE
feat(cli): dotf agent run dispatches over the tier chain

### DIFF
--- a/cli/cmd/dotf/main.go
+++ b/cli/cmd/dotf/main.go
@@ -13,6 +13,10 @@ var version = "dev"
 
 func main() {
 	if err := cmd.New(version).Execute(); err != nil {
-		os.Exit(1)
+		// Not a bare 1: `dotf agent run` distinguishes "no pool could serve
+		// this" from "the task failed", and that distinction has to survive the
+		// process boundary or a composer cannot act on it. Everything else is
+		// untagged and still exits 1.
+		os.Exit(cmd.ExitCode(err))
 	}
 }

--- a/cli/internal/agent/agent.go
+++ b/cli/internal/agent/agent.go
@@ -1,0 +1,129 @@
+// Package agent is the execution layer ADR-032 §2 defines: "run role A on task
+// T, isolated in W, return R". It owns the seam and the chain walk; it does not
+// own the routing map. The caller resolves `chains` through
+// harness.ResolveChain and hands the result in, so the registry keeps one
+// reader and this package keeps no opinion about where a chain comes from.
+package agent
+
+import (
+	"context"
+	"time"
+)
+
+// Status is a dispatch outcome carried as a VALUE, not as an error type.
+//
+// The reason is the cross-repo contract: this classification crosses a process
+// boundary (a `hive delegate` exit code, a subprocess exit code) and a JSON
+// boundary (the record on stdout). Exception types do not survive either, so
+// the vocabulary has to be data on both sides. `mlorentedev/hive#395` fixed the
+// same shape upstream for the same reason.
+type Status string
+
+const (
+	// StatusOK — the backend ran the task and it succeeded.
+	StatusOK Status = "ok"
+	// StatusTaskFailed — the backend ran the task and it failed. This does NOT
+	// advance the chain: retrying a genuine failure on a different model turns a
+	// bad answer into a silent second opinion (ADR-032 §2).
+	StatusTaskFailed Status = "task_failed"
+	// StatusPoolUnavailable — the backend could not reach the pool at all, so
+	// the task never ran. This advances the chain. It is never a final status:
+	// the dispatcher resolves it to the next entry, or to chain_exhausted.
+	StatusPoolUnavailable Status = "pool_unavailable"
+	// StatusChainExhausted — every entry in the chain reported unavailable, so
+	// nothing ran anywhere. Distinct from task_failed on purpose: one means "no
+	// answer exists", the other means "the answer was wrong".
+	StatusChainExhausted Status = "chain_exhausted"
+	// StatusEscalated — the top tier's only entry was unavailable and the
+	// dispatcher refused to degrade (ADR-032 §4). Distinct from chain_exhausted
+	// because no chain was exhausted; a fallback was declined.
+	StatusEscalated Status = "escalated"
+	// StatusDryRun — the routing was resolved and deliberately not executed.
+	StatusDryRun Status = "dry_run"
+)
+
+// TierTop is the tier that must never degrade. Named rather than inlined
+// because the no-fallback rule reads as arbitrary at its use site otherwise.
+const TierTop = "top"
+
+// OutputCap bounds the captured output the record carries, per ADR-032 §2's
+// "captured output bounded by an output cap". A dispatcher composing many
+// records must not have one verbose worker blow up the consumer, and stdout
+// here is parsed by a machine, not scrolled by a person.
+const OutputCap = 64 * 1024
+
+// Request is what the dispatcher hands a backend for ONE chain entry. Pool and
+// Model are already resolved: a backend chooses nothing about routing.
+type Request struct {
+	Pool    string
+	Model   string
+	Role    string
+	Task    string
+	Cwd     string
+	Timeout time.Duration
+}
+
+// Response is what a backend reports for one attempt. Backends return the four
+// dispatch-level statuses (ok, task_failed, pool_unavailable, dry_run); the two
+// chain-level ones (chain_exhausted, escalated) are the dispatcher's to emit.
+type Response struct {
+	Status Status
+	Exit   int
+	Output string
+}
+
+// Backend is the seam. One method, the five semantics of ADR-032 §2, and no
+// backend-specific type in either direction — that is what keeps subprocess,
+// hive and (later) orca interchangeable rather than merely coexisting.
+//
+// It returns no error: a transport failure IS one of the statuses, and a
+// backend that could report a failure two different ways would let the
+// dispatcher's classification be bypassed.
+type Backend interface {
+	Dispatch(ctx context.Context, req Request) Response
+}
+
+// Classify maps a backend's reported status onto the dispatcher's vocabulary,
+// failing CLOSED: anything unrecognised is a task failure, never an
+// unavailability.
+//
+// The direction matters and is pinned on both sides of the seam. Reading an
+// unknown code as "unavailable" would advance the chain and spend a second
+// pool on a task that may already have been answered — and, where the pool
+// bills, already been paid for. Reading it as "failed" merely stops.
+func Classify(s Status) Status {
+	switch s {
+	case StatusOK, StatusTaskFailed, StatusPoolUnavailable, StatusDryRun:
+		return s
+	default:
+		return StatusTaskFailed
+	}
+}
+
+// ExitCode is the process exit status for a final record status. It is the
+// coarse class; the record's `status` field carries the fine one.
+//
+// 0/1/3 mirror `hive delegate` deliberately (0 answered, 1 task failed, 3 pool
+// unavailable). One vocabulary across the seam means a composer that already
+// speaks to hive speaks to this without a translation table — and a translation
+// table is where the two would drift.
+func ExitCode(s Status) int {
+	switch s {
+	case StatusOK, StatusDryRun:
+		return 0
+	case StatusChainExhausted, StatusEscalated:
+		return 3
+	default:
+		return 1
+	}
+}
+
+// capOutput bounds output at OutputCap and says so in-band. Truncating without
+// a marker produces a record that reads as a complete short answer, which is
+// worse than a long one.
+func capOutput(s string) (string, bool) {
+	if len(s) <= OutputCap {
+		return s, false
+	}
+	return s[:OutputCap], true
+}

--- a/cli/internal/agent/agent.go
+++ b/cli/internal/agent/agent.go
@@ -8,6 +8,7 @@ package agent
 import (
 	"context"
 	"time"
+	"unicode/utf8"
 )
 
 // Status is a dispatch outcome carried as a VALUE, not as an error type.
@@ -118,12 +119,22 @@ func ExitCode(s Status) int {
 	}
 }
 
-// capOutput bounds output at OutputCap and says so in-band. Truncating without
-// a marker produces a record that reads as a complete short answer, which is
-// worse than a long one.
+// capOutput bounds output at OutputCap and reports the truncation to its
+// caller, which records it in the record's `truncated` field. Truncating
+// without that marker produces a record that reads as a complete short answer,
+// which is worse than a long one.
+//
+// The cut moves back to a rune boundary. OutputCap counts bytes, and a model's
+// output is not ASCII: cutting mid-rune leaves orphan bytes that decode as
+// U+FFFD, so the record would report corruption where it meant to report a
+// limit.
 func capOutput(s string) (string, bool) {
 	if len(s) <= OutputCap {
 		return s, false
 	}
-	return s[:OutputCap], true
+	cut := OutputCap
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut], true
 }

--- a/cli/internal/agent/dispatch.go
+++ b/cli/internal/agent/dispatch.go
@@ -75,6 +75,7 @@ func Dispatch(ctx context.Context, opts Options, be Backend) Record {
 			// a broken registry silently, which is how a map stays broken.
 			rec.Status = StatusTaskFailed
 			rec.Output = err.Error()
+			rec.Exit = ExitCode(rec.Status)
 			rec.DurationMS = elapsed(started, now())
 			return rec
 		}

--- a/cli/internal/agent/dispatch.go
+++ b/cli/internal/agent/dispatch.go
@@ -1,0 +1,135 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Options is one dispatch request, with its route already resolved.
+//
+// Chain arrives resolved rather than being read here: harness.ResolveChain is
+// the map's one reader, and a second parse in this package would be a second
+// place the routing rules are true — the failure model-map.json exists to end.
+type Options struct {
+	Tier    string
+	Role    string
+	Task    string
+	Cwd     string
+	Chain   []string
+	Timeout time.Duration
+	// Now is injectable so duration is an exact expectation under test. A test
+	// asserting `duration_ms >= 0` cannot fail, which is not a test.
+	Now func() time.Time
+}
+
+// Attempt is one entry of the walk. Kept in the record because a chain that
+// silently skipped two pools and answered on the third is indistinguishable,
+// from the outside, from one that answered immediately.
+type Attempt struct {
+	Pool   string `json:"pool"`
+	Model  string `json:"model"`
+	Status Status `json:"status"`
+}
+
+// Record is the machine contract on stdout: one JSON object, always.
+type Record struct {
+	Status     Status    `json:"status"`
+	Tier       string    `json:"tier"`
+	Pool       string    `json:"pool"`
+	Model      string    `json:"model"`
+	Exit       int       `json:"exit"`
+	DurationMS int64     `json:"duration_ms"`
+	Output     string    `json:"output"`
+	Truncated  bool      `json:"truncated"`
+	Attempts   []Attempt `json:"attempts,omitempty"`
+}
+
+// Dispatch walks the chain and returns the record. It never returns an error:
+// every outcome is a status, because the caller's job is to encode the record,
+// not to decide what a failure means.
+func Dispatch(ctx context.Context, opts Options, be Backend) Record {
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	started := now()
+	rec := Record{Tier: opts.Tier}
+
+	// ADR-032 §4: the top tier queues or escalates, it never degrades. The rule
+	// is applied to behaviour unconditionally rather than inferred from the map
+	// happening to declare one entry today — a rule that holds only because of
+	// the current data is not a rule.
+	chain := opts.Chain
+	noFallback := opts.Tier == TierTop
+	if noFallback && len(chain) > 1 {
+		chain = chain[:1]
+	}
+
+	for _, entry := range chain {
+		pool, model, err := splitEntry(entry)
+		if err != nil {
+			// A malformed entry is a defect in the map, not an unavailable pool.
+			// Treating it as unavailable would advance the chain and route around
+			// a broken registry silently, which is how a map stays broken.
+			rec.Status = StatusTaskFailed
+			rec.Output = err.Error()
+			rec.DurationMS = elapsed(started, now())
+			return rec
+		}
+
+		resp := attempt(ctx, opts, be, Request{
+			Pool: pool, Model: model, Role: opts.Role, Task: opts.Task,
+			Cwd: opts.Cwd, Timeout: opts.Timeout,
+		})
+		status := Classify(resp.Status)
+		rec.Attempts = append(rec.Attempts, Attempt{Pool: pool, Model: model, Status: status})
+
+		if status == StatusPoolUnavailable {
+			continue
+		}
+		rec.Status, rec.Pool, rec.Model, rec.Exit = status, pool, model, resp.Exit
+		rec.Output, rec.Truncated = capOutput(resp.Output)
+		rec.DurationMS = elapsed(started, now())
+		return rec
+	}
+
+	// Nothing ran anywhere. The two ways to arrive here are different facts and
+	// get different names: the top tier DECLINED a fallback, a lower tier ran
+	// OUT of them.
+	if noFallback {
+		rec.Status = StatusEscalated
+	} else {
+		rec.Status = StatusChainExhausted
+	}
+	rec.Exit = ExitCode(rec.Status)
+	rec.DurationMS = elapsed(started, now())
+	return rec
+}
+
+// attempt gives the backend the per-dispatch deadline. The timeout is required
+// by ADR-032 §2, and required means the backend receives it — enforcing the
+// kill and the slot release is PR C's, but a deadline that never reaches the
+// backend would make the flag a lie today.
+func attempt(ctx context.Context, opts Options, be Backend, req Request) Response {
+	if opts.Timeout <= 0 {
+		return Response{Status: StatusTaskFailed, Exit: 1,
+			Output: "no timeout was set for this dispatch; a backend that cannot be bounded is not eligible"}
+	}
+	dctx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	defer cancel()
+	return be.Dispatch(dctx, req)
+}
+
+func splitEntry(entry string) (pool, model string, err error) {
+	pool, model, ok := strings.Cut(entry, ":")
+	if !ok || strings.TrimSpace(pool) == "" || strings.TrimSpace(model) == "" {
+		return "", "", fmt.Errorf(
+			"chain entry %q is not `pool:model` — the chain cannot be walked past a route that names nothing",
+			entry)
+	}
+	return pool, model, nil
+}
+
+func elapsed(from, to time.Time) int64 { return to.Sub(from).Milliseconds() }

--- a/cli/internal/agent/dispatch_test.go
+++ b/cli/internal/agent/dispatch_test.go
@@ -1,0 +1,262 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// scriptedBackend answers a fixed response per `pool:model` entry and records
+// the order it was asked in. `seen` is the load-bearing half: the claim AC2
+// makes is about which entries were ATTEMPTED, and a test that only checked the
+// final record would pass on a dispatcher that walked the whole chain and
+// reported the last success.
+type scriptedBackend struct {
+	byEntry map[string]Response
+	seen    []string
+}
+
+func (b *scriptedBackend) Dispatch(_ context.Context, req Request) Response {
+	key := req.Pool + ":" + req.Model
+	b.seen = append(b.seen, key)
+	if r, ok := b.byEntry[key]; ok {
+		return r
+	}
+	return Response{Status: StatusPoolUnavailable}
+}
+
+// fixedClock advances a fixed step per reading, so duration_ms is an exact
+// expectation rather than the vacuous `>= 0` that cannot fail.
+func fixedClock(step time.Duration) func() time.Time {
+	base := time.Unix(0, 0)
+	var n int64
+	return func() time.Time {
+		t := base.Add(time.Duration(n) * step)
+		n++
+		return t
+	}
+}
+
+func TestDispatch_ChainWalk(t *testing.T) {
+	tests := []struct {
+		name       string
+		tier       string
+		chain      []string
+		script     map[string]Response
+		wantStatus Status
+		wantPool   string
+		wantModel  string
+		wantExit   int
+		wantSeen   []string
+	}{
+		{
+			name:  "pool unavailable advances to the next entry",
+			tier:  "mid",
+			chain: []string{"claude:sonnet", "nan:deepseek-v4-flash"},
+			script: map[string]Response{
+				"claude:sonnet":         {Status: StatusPoolUnavailable},
+				"nan:deepseek-v4-flash": {Status: StatusOK, Output: "answered"},
+			},
+			wantStatus: StatusOK,
+			wantPool:   "nan",
+			wantModel:  "deepseek-v4-flash",
+			wantExit:   0,
+			wantSeen:   []string{"claude:sonnet", "nan:deepseek-v4-flash"},
+		},
+		{
+			name:  "task failed does not advance",
+			tier:  "mid",
+			chain: []string{"claude:sonnet", "nan:deepseek-v4-flash"},
+			script: map[string]Response{
+				"claude:sonnet":         {Status: StatusTaskFailed, Exit: 2, Output: "boom"},
+				"nan:deepseek-v4-flash": {Status: StatusOK, Output: "must never be reached"},
+			},
+			wantStatus: StatusTaskFailed,
+			wantPool:   "claude",
+			wantModel:  "sonnet",
+			wantExit:   1,
+			wantSeen:   []string{"claude:sonnet"},
+		},
+		{
+			name:  "every entry unavailable is chain exhausted, not a task failure",
+			tier:  "mid",
+			chain: []string{"claude:sonnet", "nan:deepseek-v4-flash", "nan:mimo-v2.5"},
+			script: map[string]Response{
+				"claude:sonnet":         {Status: StatusPoolUnavailable},
+				"nan:deepseek-v4-flash": {Status: StatusPoolUnavailable},
+				"nan:mimo-v2.5":         {Status: StatusPoolUnavailable},
+			},
+			wantStatus: StatusChainExhausted,
+			wantExit:   3,
+			wantSeen:   []string{"claude:sonnet", "nan:deepseek-v4-flash", "nan:mimo-v2.5"},
+		},
+		{
+			name:  "an unrecognised backend status is a task failure, never an advance",
+			tier:  "mid",
+			chain: []string{"claude:sonnet", "nan:deepseek-v4-flash"},
+			script: map[string]Response{
+				"claude:sonnet": {Status: Status("who knows"), Exit: 9},
+			},
+			wantStatus: StatusTaskFailed,
+			wantPool:   "claude",
+			wantModel:  "sonnet",
+			wantExit:   1,
+			wantSeen:   []string{"claude:sonnet"},
+		},
+		{
+			name:  "a malformed chain entry fails closed rather than being skipped",
+			tier:  "mid",
+			chain: []string{"claude-sonnet", "nan:deepseek-v4-flash"},
+			script: map[string]Response{
+				"nan:deepseek-v4-flash": {Status: StatusOK, Output: "must never be reached"},
+			},
+			wantStatus: StatusTaskFailed,
+			wantExit:   1,
+			wantSeen:   nil,
+		},
+		{
+			name:       "dry run reports the resolved route and exits zero",
+			tier:       "mid",
+			chain:      []string{"claude:sonnet"},
+			script:     map[string]Response{"claude:sonnet": {Status: StatusDryRun}},
+			wantStatus: StatusDryRun,
+			wantPool:   "claude",
+			wantModel:  "sonnet",
+			wantExit:   0,
+			wantSeen:   []string{"claude:sonnet"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			be := &scriptedBackend{byEntry: tc.script}
+			rec := Dispatch(context.Background(), Options{
+				Tier:    tc.tier,
+				Role:    "reviewer",
+				Task:    "check this",
+				Chain:   tc.chain,
+				Timeout: time.Minute,
+				Now:     fixedClock(5 * time.Millisecond),
+			}, be)
+
+			if rec.Status != tc.wantStatus {
+				t.Errorf("status = %q, want %q", rec.Status, tc.wantStatus)
+			}
+			if rec.Pool != tc.wantPool {
+				t.Errorf("pool = %q, want %q", rec.Pool, tc.wantPool)
+			}
+			if rec.Model != tc.wantModel {
+				t.Errorf("model = %q, want %q", rec.Model, tc.wantModel)
+			}
+			if got := ExitCode(rec.Status); got != tc.wantExit {
+				t.Errorf("exit = %d, want %d", got, tc.wantExit)
+			}
+			if strings.Join(be.seen, ",") != strings.Join(tc.wantSeen, ",") {
+				t.Errorf("attempted %v, want %v", be.seen, tc.wantSeen)
+			}
+		})
+	}
+}
+
+// AC5. The rule is behavioural and unconditional, so it is asserted against a
+// two-entry top chain that the map does not currently declare: a test that only
+// used today's single-entry `chains.top` would pass on a dispatcher with no rule
+// at all, and would go quiet the day someone added a fallback to the map.
+func TestDispatch_TopTierNeverDegrades(t *testing.T) {
+	be := &scriptedBackend{byEntry: map[string]Response{
+		"claude:opus":           {Status: StatusPoolUnavailable},
+		"nan:deepseek-v4-flash": {Status: StatusOK, Output: "a mid-tier answer"},
+	}}
+
+	rec := Dispatch(context.Background(), Options{
+		Tier:    TierTop,
+		Role:    "architect",
+		Task:    "decide",
+		Chain:   []string{"claude:opus", "nan:deepseek-v4-flash"},
+		Timeout: time.Minute,
+		Now:     fixedClock(5 * time.Millisecond),
+	}, be)
+
+	if rec.Status != StatusEscalated {
+		t.Errorf("status = %q, want %q", rec.Status, StatusEscalated)
+	}
+	if got := ExitCode(rec.Status); got == 0 {
+		t.Errorf("exit = 0; the top tier being unservable must not read as success")
+	}
+	if len(be.seen) != 1 || be.seen[0] != "claude:opus" {
+		t.Errorf("attempted %v; the top tier must never reach a second entry", be.seen)
+	}
+	if strings.Contains(rec.Output, "mid-tier answer") {
+		t.Errorf("output carries a mid-tier answer: %q", rec.Output)
+	}
+}
+
+func TestDispatch_RecordsDurationAndAttempts(t *testing.T) {
+	be := &scriptedBackend{byEntry: map[string]Response{
+		"claude:sonnet":         {Status: StatusPoolUnavailable},
+		"nan:deepseek-v4-flash": {Status: StatusOK, Output: "answered"},
+	}}
+
+	rec := Dispatch(context.Background(), Options{
+		Tier:    "mid",
+		Chain:   []string{"claude:sonnet", "nan:deepseek-v4-flash"},
+		Timeout: time.Minute,
+		Now:     fixedClock(5 * time.Millisecond),
+	}, be)
+
+	if rec.DurationMS != 5 {
+		t.Errorf("duration_ms = %d, want 5 (clock steps 5ms per reading)", rec.DurationMS)
+	}
+	if len(rec.Attempts) != 2 {
+		t.Fatalf("attempts = %d, want 2 — a skipped entry that leaves no trace is undiagnosable", len(rec.Attempts))
+	}
+	if rec.Attempts[0].Pool != "claude" || rec.Attempts[0].Status != StatusPoolUnavailable {
+		t.Errorf("attempts[0] = %+v, want the claude entry reported unavailable", rec.Attempts[0])
+	}
+	if rec.Attempts[1].Model != "deepseek-v4-flash" || rec.Attempts[1].Status != StatusOK {
+		t.Errorf("attempts[1] = %+v, want the nan entry reported ok", rec.Attempts[1])
+	}
+}
+
+func TestDispatch_OutputIsCappedAndSaysSo(t *testing.T) {
+	be := &scriptedBackend{byEntry: map[string]Response{
+		"claude:sonnet": {Status: StatusOK, Output: strings.Repeat("x", OutputCap+100)},
+	}}
+
+	rec := Dispatch(context.Background(), Options{
+		Tier: "mid", Chain: []string{"claude:sonnet"}, Timeout: time.Minute,
+		Now: fixedClock(time.Millisecond),
+	}, be)
+
+	if len(rec.Output) != OutputCap {
+		t.Errorf("output length = %d, want %d", len(rec.Output), OutputCap)
+	}
+	if !rec.Truncated {
+		t.Error("truncated = false; a capped output that does not say so reads as a complete short answer")
+	}
+}
+
+// The timeout is required per dispatch (ADR-032 §2), and "required" has to mean
+// the backend actually receives a deadline — a parsed-but-inert flag is the
+// silent lie. PR C adds the kill; this asserts the deadline exists at all.
+func TestDispatch_BackendReceivesADeadline(t *testing.T) {
+	var hadDeadline bool
+	be := backendFunc(func(ctx context.Context, _ Request) Response {
+		_, hadDeadline = ctx.Deadline()
+		return Response{Status: StatusOK}
+	})
+
+	Dispatch(context.Background(), Options{
+		Tier: "mid", Chain: []string{"claude:sonnet"}, Timeout: 30 * time.Second,
+		Now: fixedClock(time.Millisecond),
+	}, be)
+
+	if !hadDeadline {
+		t.Error("backend context carried no deadline; the per-dispatch timeout is inert")
+	}
+}
+
+type backendFunc func(context.Context, Request) Response
+
+func (f backendFunc) Dispatch(ctx context.Context, req Request) Response { return f(ctx, req) }

--- a/cli/internal/agent/dispatch_test.go
+++ b/cli/internal/agent/dispatch_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 // scriptedBackend answers a fixed response per `pool:model` entry and records
@@ -48,7 +49,11 @@ func TestDispatch_ChainWalk(t *testing.T) {
 		wantPool   string
 		wantModel  string
 		wantExit   int
-		wantSeen   []string
+		// wantRecExit is the record's own exit field. Kept separate from
+		// wantExit so a path that forgets to set it cannot borrow the
+		// derived value and look correct.
+		wantRecExit int
+		wantSeen    []string
 	}{
 		{
 			name:  "pool unavailable advances to the next entry",
@@ -58,11 +63,12 @@ func TestDispatch_ChainWalk(t *testing.T) {
 				"claude:sonnet":         {Status: StatusPoolUnavailable},
 				"nan:deepseek-v4-flash": {Status: StatusOK, Output: "answered"},
 			},
-			wantStatus: StatusOK,
-			wantPool:   "nan",
-			wantModel:  "deepseek-v4-flash",
-			wantExit:   0,
-			wantSeen:   []string{"claude:sonnet", "nan:deepseek-v4-flash"},
+			wantStatus:  StatusOK,
+			wantPool:    "nan",
+			wantModel:   "deepseek-v4-flash",
+			wantExit:    0,
+			wantRecExit: 0,
+			wantSeen:    []string{"claude:sonnet", "nan:deepseek-v4-flash"},
 		},
 		{
 			name:  "task failed does not advance",
@@ -72,11 +78,12 @@ func TestDispatch_ChainWalk(t *testing.T) {
 				"claude:sonnet":         {Status: StatusTaskFailed, Exit: 2, Output: "boom"},
 				"nan:deepseek-v4-flash": {Status: StatusOK, Output: "must never be reached"},
 			},
-			wantStatus: StatusTaskFailed,
-			wantPool:   "claude",
-			wantModel:  "sonnet",
-			wantExit:   1,
-			wantSeen:   []string{"claude:sonnet"},
+			wantStatus:  StatusTaskFailed,
+			wantPool:    "claude",
+			wantModel:   "sonnet",
+			wantExit:    1,
+			wantRecExit: 2,
+			wantSeen:    []string{"claude:sonnet"},
 		},
 		{
 			name:  "every entry unavailable is chain exhausted, not a task failure",
@@ -87,9 +94,10 @@ func TestDispatch_ChainWalk(t *testing.T) {
 				"nan:deepseek-v4-flash": {Status: StatusPoolUnavailable},
 				"nan:mimo-v2.5":         {Status: StatusPoolUnavailable},
 			},
-			wantStatus: StatusChainExhausted,
-			wantExit:   3,
-			wantSeen:   []string{"claude:sonnet", "nan:deepseek-v4-flash", "nan:mimo-v2.5"},
+			wantStatus:  StatusChainExhausted,
+			wantExit:    3,
+			wantRecExit: 3,
+			wantSeen:    []string{"claude:sonnet", "nan:deepseek-v4-flash", "nan:mimo-v2.5"},
 		},
 		{
 			name:  "an unrecognised backend status is a task failure, never an advance",
@@ -98,11 +106,12 @@ func TestDispatch_ChainWalk(t *testing.T) {
 			script: map[string]Response{
 				"claude:sonnet": {Status: Status("who knows"), Exit: 9},
 			},
-			wantStatus: StatusTaskFailed,
-			wantPool:   "claude",
-			wantModel:  "sonnet",
-			wantExit:   1,
-			wantSeen:   []string{"claude:sonnet"},
+			wantStatus:  StatusTaskFailed,
+			wantPool:    "claude",
+			wantModel:   "sonnet",
+			wantExit:    1,
+			wantRecExit: 9,
+			wantSeen:    []string{"claude:sonnet"},
 		},
 		{
 			name:  "a malformed chain entry fails closed rather than being skipped",
@@ -111,20 +120,22 @@ func TestDispatch_ChainWalk(t *testing.T) {
 			script: map[string]Response{
 				"nan:deepseek-v4-flash": {Status: StatusOK, Output: "must never be reached"},
 			},
-			wantStatus: StatusTaskFailed,
-			wantExit:   1,
-			wantSeen:   nil,
+			wantStatus:  StatusTaskFailed,
+			wantExit:    1,
+			wantRecExit: 1,
+			wantSeen:    nil,
 		},
 		{
-			name:       "dry run reports the resolved route and exits zero",
-			tier:       "mid",
-			chain:      []string{"claude:sonnet"},
-			script:     map[string]Response{"claude:sonnet": {Status: StatusDryRun}},
-			wantStatus: StatusDryRun,
-			wantPool:   "claude",
-			wantModel:  "sonnet",
-			wantExit:   0,
-			wantSeen:   []string{"claude:sonnet"},
+			name:        "dry run reports the resolved route and exits zero",
+			tier:        "mid",
+			chain:       []string{"claude:sonnet"},
+			script:      map[string]Response{"claude:sonnet": {Status: StatusDryRun}},
+			wantStatus:  StatusDryRun,
+			wantPool:    "claude",
+			wantModel:   "sonnet",
+			wantExit:    0,
+			wantRecExit: 0,
+			wantSeen:    []string{"claude:sonnet"},
 		},
 	}
 
@@ -151,6 +162,13 @@ func TestDispatch_ChainWalk(t *testing.T) {
 			}
 			if got := ExitCode(rec.Status); got != tc.wantExit {
 				t.Errorf("exit = %d, want %d", got, tc.wantExit)
+			}
+			// The record's own `exit` field, not just the derived one. They are
+			// two different things and a caller reads the field: a record saying
+			// `"status":"task_failed","exit":0` contradicts itself, and the
+			// process exiting 1 beside it does not repair the record.
+			if rec.Exit != tc.wantRecExit {
+				t.Errorf("rec.Exit = %d, want %d (status %q)", rec.Exit, tc.wantRecExit, rec.Status)
 			}
 			if strings.Join(be.seen, ",") != strings.Join(tc.wantSeen, ",") {
 				t.Errorf("attempted %v, want %v", be.seen, tc.wantSeen)
@@ -234,6 +252,42 @@ func TestDispatch_OutputIsCappedAndSaysSo(t *testing.T) {
 	}
 	if !rec.Truncated {
 		t.Error("truncated = false; a capped output that does not say so reads as a complete short answer")
+	}
+}
+
+// The cap counts bytes and a model's output is not ASCII, so the cut can land
+// inside a rune.
+//
+// The fixture's rune WIDTH is the whole test. An ASCII one cannot see the bug at
+// all — every byte is a boundary. Neither can a two-byte one: OutputCap is
+// 65536, which is even, so a run of "é" always divides exactly and the cut lands
+// on a boundary by arithmetic rather than by the code being correct. That
+// version of this test passed against the byte-slicing cap it was written to
+// catch. A three-byte rune is the smallest that misses: 65536 mod 3 == 1, so the
+// cut lands one byte into a rune and something must step it back.
+func TestDispatch_OutputIsCutOnARuneBoundary(t *testing.T) {
+	multibyte := strings.Repeat("€", OutputCap) // 3 bytes each
+	be := &scriptedBackend{byEntry: map[string]Response{
+		"claude:sonnet": {Status: StatusOK, Output: multibyte},
+	}}
+
+	rec := Dispatch(context.Background(), Options{
+		Tier: "mid", Chain: []string{"claude:sonnet"}, Timeout: time.Minute,
+		Now: fixedClock(time.Millisecond),
+	}, be)
+
+	if !rec.Truncated {
+		t.Fatal("truncated = false on an output twice the cap")
+	}
+	if len(rec.Output) > OutputCap {
+		t.Errorf("output length = %d, exceeds the cap %d", len(rec.Output), OutputCap)
+	}
+	if !utf8.ValidString(rec.Output) {
+		t.Error("output is not valid UTF-8: the cut split a rune, so the record reports corruption " +
+			"where it meant to report a limit")
+	}
+	if strings.ContainsRune(rec.Output, utf8.RuneError) {
+		t.Error("output carries U+FFFD; an orphan byte was kept rather than the cut being moved back")
 	}
 }
 

--- a/cli/internal/agent/dryrun.go
+++ b/cli/internal/agent/dryrun.go
@@ -1,0 +1,24 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+)
+
+// DryRun resolves a route and deliberately does not execute it.
+//
+// It is a first-class backend, not a test double: inspecting which pool and
+// model a tier resolves to on this machine is worth doing without spending a
+// slot of a shared quota, and it stays useful after the real backends land.
+// The scripted fake the tests use is Go-test-only and reachable only through
+// the seam — a `--backend` value that exists to make tests pass is a surface
+// users can reach by accident.
+type DryRun struct{}
+
+func (DryRun) Dispatch(_ context.Context, req Request) Response {
+	return Response{
+		Status: StatusDryRun,
+		Output: fmt.Sprintf("would dispatch role %q to %s:%s (no request was sent)",
+			req.Role, req.Pool, req.Model),
+	}
+}

--- a/cli/internal/cmd/agent.go
+++ b/cli/internal/cmd/agent.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/agent"
+	"github.com/mlorentedev/dotfiles/cli/internal/env"
+	"github.com/mlorentedev/dotfiles/cli/internal/harness"
+)
+
+// newAgentCmd is the RUN side of the orchestration stack, and it takes its own
+// noun for a reason ADR-032 §2 states: `dotf harness` is the compile side —
+// idempotent and offline — while this spawns processes and consumes quota.
+// Folding them into one verb would put those two under one permission and one
+// mental model.
+func newAgentCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "agent",
+		Short: "Run work on another model, pool or harness",
+		Long: `agent is the execution layer over harness/model-map.json.
+
+Where ` + "`dotf harness`" + ` renders definitions, ` + "`dotf agent`" + ` dispatches work: it walks
+the ordered fallback the map declares for a tier and reports which pool and model
+actually answered.`,
+		SilenceUsage: true,
+		RunE:         func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+	}
+	c.AddCommand(newAgentRunCmd())
+	return c
+}
+
+func newAgentRunCmd() *cobra.Command {
+	var (
+		role, task, tier, cwd, backendName, repoRoot string
+		timeout                                      time.Duration
+	)
+
+	c := &cobra.Command{
+		Use:   "run",
+		Short: "Dispatch one task to the first pool in a tier's chain that can serve it",
+		Long: `run dispatches ONE task synchronously and writes ONE JSON object to stdout.
+
+Every log line goes to stderr, so stdout is safe to pipe into a parser:
+
+    dotf agent run --role reviewer --task "..." --tier mid --backend dry-run --timeout 2m | jq .status
+
+The record carries status, tier, pool, model, exit, duration_ms, output and the
+attempts the walk made. Status is the fine-grained truth and the process exit
+code is the coarse class, mirroring ` + "`hive delegate`" + ` so one vocabulary spans the
+seam: 0 answered, 1 the task failed, 3 no pool could serve it.
+
+A pool reporting itself unavailable advances to the next entry in the chain; a
+task that ran and failed does NOT — retrying a real failure on another model
+turns a bad answer into a silent second opinion. The top tier never degrades: if
+its pool cannot serve, this escalates and exits non-zero rather than quietly
+answering from a weaker model.`,
+		Example: `  dotf agent run --role reviewer --task "review this diff" --tier mid --backend dry-run --timeout 2m
+  dotf agent run --role architect --task "decide" --tier top --backend dry-run --timeout 5m`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if role == "" || task == "" {
+				return fmt.Errorf("--role and --task are both required: a dispatch with no task has nothing to run, " +
+					"and one with no role has no way to be scheduled")
+			}
+			if tier == "" {
+				return fmt.Errorf("--tier is required (top|mid|low): the chain to walk is declared per tier in %s, "+
+					"and guessing one would route work to a model nobody chose", harness.ModelMapFile)
+			}
+			if timeout <= 0 {
+				return fmt.Errorf("--timeout is required and must be positive: ADR-032 §2 makes a bounded dispatch " +
+					"part of the contract, and a backend that cannot be bounded is not eligible")
+			}
+			backend, err := resolveBackend(backendName)
+			if err != nil {
+				return err
+			}
+
+			root := repoRoot
+			if root == "" {
+				root = env.ResolveHarnessRoot()
+			}
+			m, err := harness.LoadModelMap(root)
+			if err != nil {
+				return err
+			}
+			chain, err := harness.ResolveChain(m, tier)
+			if err != nil {
+				return err
+			}
+
+			rec := agent.Dispatch(cmd.Context(), agent.Options{
+				Tier: tier, Role: role, Task: task, Cwd: cwd,
+				Chain: chain, Timeout: timeout,
+			}, backend)
+
+			// The record reaches stdout whatever the outcome: its consumer is a
+			// dispatcher, and an error path that emits nothing forces that
+			// consumer to parse stderr prose to learn what happened.
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetEscapeHTML(false)
+			if err := enc.Encode(rec); err != nil {
+				return err
+			}
+			if code := agent.ExitCode(rec.Status); code != 0 {
+				return withExitCode(code, summarise(rec))
+			}
+			return nil
+		},
+	}
+
+	c.Flags().StringVar(&role, "role", "", "role to run the task as (required)")
+	c.Flags().StringVar(&task, "task", "", "the task text handed to the model (required)")
+	c.Flags().StringVar(&tier, "tier", "", "neutral tier whose chain is walked: top|mid|low (required)")
+	c.Flags().StringVar(&cwd, "cwd", "", "working copy the task runs against (default: the current directory)")
+	c.Flags().DurationVar(&timeout, "timeout", 0, "per-dispatch deadline, e.g. 90s or 5m (required)")
+	c.Flags().StringVar(&backendName, "backend", "", "backend to dispatch through (required until probing lands)")
+	c.Flags().StringVar(&repoRoot, "repo-root", "",
+		"root containing harness/model-map.json (default: the checkout, else DOTFILES_DIR)")
+	return c
+}
+
+// resolveBackend picks the implementation behind the seam.
+//
+// Probing (ADR-032 §7) selects it automatically once a real backend exists;
+// until then the flag is required, and its absence is a loud refusal rather
+// than a default. Defaulting to dry-run would be the worst of the options: a
+// dispatch that silently ran nothing and exited 0.
+func resolveBackend(name string) (agent.Backend, error) {
+	switch name {
+	case "dry-run":
+		return agent.DryRun{}, nil
+	case "":
+		return nil, fmt.Errorf("--backend is required: the only backend implemented today is `dry-run`, " +
+			"which resolves the route without dispatching. The subprocess and hive backends, and the probe " +
+			"that would pick one for you, are not built yet")
+	default:
+		return nil, fmt.Errorf("unknown backend %q: the only backend implemented today is `dry-run`", name)
+	}
+}
+
+// summarise is the human line on stderr. The JSON already carries the truth; a
+// person reading a failing &&-chain should not have to pipe it through a parser
+// to learn which pool declined.
+func summarise(rec agent.Record) error {
+	switch rec.Status {
+	case agent.StatusChainExhausted:
+		return fmt.Errorf("no pool in the %s chain could serve this dispatch (%d attempted)", rec.Tier, len(rec.Attempts))
+	case agent.StatusEscalated:
+		return fmt.Errorf("the %s tier could not be served and does not fall back: escalate rather than "+
+			"re-run at a lower tier", rec.Tier)
+	default:
+		return fmt.Errorf("task failed on %s:%s (exit %d)", rec.Pool, rec.Model, rec.Exit)
+	}
+}

--- a/cli/internal/cmd/agent_test.go
+++ b/cli/internal/cmd/agent_test.go
@@ -1,0 +1,265 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/harness"
+)
+
+// AC1. This is a stdout contract, so it is tested through captureRealStreams
+// rather than execute(): the consumer is a dispatcher reading a pipe, and a
+// record written to stderr is an empty string at that call site while looking
+// perfectly fine in a merged capture (BUG-070 #915).
+func TestAgentRun_WritesOneJSONObjectToStdout(t *testing.T) {
+	root := repoRootForTest(t)
+
+	stdout, stderr, err := captureRealStreams(t,
+		"agent", "run",
+		"--role", "reviewer",
+		"--task", "review this diff",
+		"--tier", "mid",
+		"--backend", "dry-run",
+		"--timeout", "90s",
+		"--repo-root", root,
+	)
+	if err != nil {
+		t.Fatalf("agent run: %v (stderr: %s)", err, stderr)
+	}
+
+	var rec struct {
+		Status     string `json:"status"`
+		Tier       string `json:"tier"`
+		Pool       string `json:"pool"`
+		Model      string `json:"model"`
+		Exit       int    `json:"exit"`
+		DurationMS *int64 `json:"duration_ms"`
+		Output     string `json:"output"`
+	}
+	dec := json.NewDecoder(strings.NewReader(stdout))
+	if err := dec.Decode(&rec); err != nil {
+		t.Fatalf("stdout is not a JSON object: %v\nstdout was: %q", err, stdout)
+	}
+	// Exactly ONE object: a second value on the stream would make the contract
+	// "a JSON stream", which a `| jq .status` consumer does not implement.
+	if dec.More() {
+		t.Errorf("stdout carries more than one JSON value: %q", stdout)
+	}
+
+	if rec.Status != "dry_run" {
+		t.Errorf("status = %q, want %q", rec.Status, "dry_run")
+	}
+	if rec.Tier != "mid" {
+		t.Errorf("tier = %q, want %q", rec.Tier, "mid")
+	}
+	// The mid chain's first entry is claude:sonnet in the shipped map; asserting
+	// the resolved route is the point of the record.
+	if rec.Pool == "" || rec.Model == "" {
+		t.Errorf("record names no route: pool=%q model=%q", rec.Pool, rec.Model)
+	}
+	// duration_ms must be PRESENT, not merely non-negative. A pointer
+	// distinguishes "absent" from "zero"; `>= 0` would be an assertion that
+	// cannot fail.
+	if rec.DurationMS == nil {
+		t.Error("duration_ms is absent from the record")
+	}
+	if rec.Output == "" {
+		t.Error("output is empty; the dry run reports nothing about the route it resolved")
+	}
+	if strings.Contains(stderr, "{") {
+		t.Errorf("stderr carries JSON, so stdout is not the whole contract: %q", stderr)
+	}
+}
+
+// The refusals are the other half of the machine contract: each one must reach
+// stderr and leave stdout EMPTY, because a consumer that parses stdout on a
+// failed dispatch would otherwise read a truncated object.
+func TestAgentRun_RefusalsLeaveStdoutEmpty(t *testing.T) {
+	root := repoRootForTest(t)
+	base := []string{"agent", "run", "--repo-root", root}
+
+	tests := []struct {
+		name    string
+		args    []string
+		errSubs []string
+	}{
+		{
+			name:    "no task",
+			args:    []string{"--role", "reviewer", "--tier", "mid", "--backend", "dry-run", "--timeout", "1m"},
+			errSubs: []string{"--role and --task"},
+		},
+		{
+			name:    "no tier",
+			args:    []string{"--role", "r", "--task", "t", "--backend", "dry-run", "--timeout", "1m"},
+			errSubs: []string{"--tier is required"},
+		},
+		{
+			name:    "no timeout",
+			args:    []string{"--role", "r", "--task", "t", "--tier", "mid", "--backend", "dry-run"},
+			errSubs: []string{"--timeout is required", "not eligible"},
+		},
+		{
+			name:    "no backend",
+			args:    []string{"--role", "r", "--task", "t", "--tier", "mid", "--timeout", "1m"},
+			errSubs: []string{"--backend is required", "dry-run"},
+		},
+		{
+			name:    "unknown backend",
+			args:    []string{"--role", "r", "--task", "t", "--tier", "mid", "--timeout", "1m", "--backend", "orca"},
+			errSubs: []string{"unknown backend", "orca"},
+		},
+		{
+			name:    "undeclared tier",
+			args:    []string{"--role", "r", "--task", "t", "--tier", "colossal", "--backend", "dry-run", "--timeout", "1m"},
+			errSubs: []string{"colossal"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, _, err := captureRealStreams(t, append(base, tc.args...)...)
+			if err == nil {
+				t.Fatal("expected a refusal, got none")
+			}
+			if strings.TrimSpace(stdout) != "" {
+				t.Errorf("stdout is not empty on a refusal: %q", stdout)
+			}
+			for _, sub := range tc.errSubs {
+				if !strings.Contains(err.Error(), sub) {
+					t.Errorf("error %q does not name %q", err.Error(), sub)
+				}
+			}
+			if ExitCode(err) != 1 {
+				t.Errorf("exit = %d, want 1: a refusal before dispatch must not read as `pool unavailable`",
+					ExitCode(err))
+			}
+		})
+	}
+}
+
+// A map the schema refuses never reaches the walk at all, and that is the
+// intended layering: the schema stops a broken chain being written, and the
+// dispatcher's own fail-closed branch (agent.Dispatch, covered in that package)
+// is the second line for a chain that did not come from a validated map.
+//
+// What this pins at the command layer is the consequence: no record, empty
+// stdout, exit 1 — never exit 3, which a composer would read as "busy, try the
+// next pool" and retry against a registry that is broken for every pool.
+func TestAgentRun_AMapTheSchemaRefusesStopsBeforeDispatch(t *testing.T) {
+	root := t.TempDir()
+	writeMapFixture(t, root, mapFixtureWithMidChain(`["nan-deepseek-v4-flash"]`))
+	copySchemaFixture(t, root)
+
+	stdout, _, err := captureRealStreams(t,
+		"agent", "run", "--role", "r", "--task", "t", "--tier", "mid",
+		"--backend", "dry-run", "--timeout", "1m", "--repo-root", root,
+	)
+	if err == nil {
+		t.Fatal("a chain entry that names no route was dispatched without complaint")
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Errorf("stdout is not empty for a dispatch that never happened: %q", stdout)
+	}
+	if got := ExitCode(err); got != 1 {
+		t.Errorf("exit = %d, want 1: a broken registry must not read as a busy pool", got)
+	}
+}
+
+// The happy path against a FIXTURE map rather than the shipped one, so the
+// record's route is an exact expectation. The shipped-map test above proves the
+// command works against reality; this one proves it reports the route it was
+// given rather than one it invented.
+func TestAgentRun_ReportsTheRouteTheMapDeclares(t *testing.T) {
+	root := t.TempDir()
+	writeMapFixture(t, root, mapFixtureWithMidChain(`["nan:mimo-v2.5"]`))
+	copySchemaFixture(t, root)
+
+	stdout, _, err := captureRealStreams(t,
+		"agent", "run", "--role", "reviewer", "--task", "t", "--tier", "mid",
+		"--backend", "dry-run", "--timeout", "1m", "--repo-root", root,
+	)
+	if err != nil {
+		t.Fatalf("agent run: %v", err)
+	}
+
+	var rec struct {
+		Pool     string `json:"pool"`
+		Model    string `json:"model"`
+		Attempts []struct {
+			Pool   string `json:"pool"`
+			Model  string `json:"model"`
+			Status string `json:"status"`
+		} `json:"attempts"`
+	}
+	if jsonErr := json.Unmarshal([]byte(stdout), &rec); jsonErr != nil {
+		t.Fatalf("stdout is not a record: %v (%q)", jsonErr, stdout)
+	}
+	if rec.Pool != "nan" || rec.Model != "mimo-v2.5" {
+		t.Errorf("route = %s:%s, want nan:mimo-v2.5", rec.Pool, rec.Model)
+	}
+	if len(rec.Attempts) != 1 || rec.Attempts[0].Status != "dry_run" {
+		t.Errorf("attempts = %+v, want one dry_run attempt", rec.Attempts)
+	}
+}
+
+func mapFixtureWithMidChain(chain string) string {
+	return `{
+  "$comment": ["fixture"],
+  "version": 1,
+  "pools": {"nan": {"auth": "subscription", "probe": "env:NAN_API_KEY"}},
+  "harnesses": {"pi": {"pools": ["nan"], "render": "adapter"}},
+  "tiers": {"mid": {"pi": "mimo-v2.5"}},
+  "chains": {"mid": ` + chain + `},
+  "services": {}
+}`
+}
+
+// copySchemaFixture puts the SHIPPED schema beside the fixture map, so the
+// fixture is held to the contract the repository actually enforces. A relaxed
+// copy would let a test pass on a map production would reject.
+func copySchemaFixture(t *testing.T, root string) {
+	t.Helper()
+	src := filepath.Join(repoRootForTest(t), harness.ModelMapSchemaFile)
+	body, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read shipped schema: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, harness.ModelMapSchemaFile), body, 0o644); err != nil {
+		t.Fatalf("write schema fixture: %v", err)
+	}
+}
+
+func TestExitCode(t *testing.T) {
+	if got := ExitCode(nil); got != 0 {
+		t.Errorf("ExitCode(nil) = %d, want 0", got)
+	}
+	if got := ExitCode(errors.New("plain")); got != 1 {
+		t.Errorf("ExitCode(untagged) = %d, want 1", got)
+	}
+	tagged := withExitCode(3, errors.New("no pool could serve"))
+	if got := ExitCode(tagged); got != 3 {
+		t.Errorf("ExitCode(tagged 3) = %d, want 3", got)
+	}
+	// The tag must survive wrapping: main() sees whatever cobra hands back.
+	if got := ExitCode(errors.Join(errors.New("context"), tagged)); got != 3 {
+		t.Errorf("ExitCode(wrapped) = %d, want 3 — the class is lost if it does not survive a wrap", got)
+	}
+	if !strings.Contains(tagged.Error(), "no pool could serve") {
+		t.Errorf("tagged error lost its message: %q", tagged.Error())
+	}
+}
+
+func writeMapFixture(t *testing.T, root, body string) {
+	t.Helper()
+	path := filepath.Join(root, "harness")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "model-map.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}

--- a/cli/internal/cmd/exit.go
+++ b/cli/internal/cmd/exit.go
@@ -1,0 +1,36 @@
+package cmd
+
+import "errors"
+
+// codedError carries a process exit status alongside a message, so a command
+// can distinguish outcomes that are all "non-zero" to cobra.
+//
+// The alternative already in this tree — os.Exit inside RunE, as
+// `dotf secrets run` does — costs a re-exec harness in the test file, because
+// os.Exit kills the test runner. This stays in-process and therefore testable
+// without one.
+type codedError struct {
+	code int
+	err  error
+}
+
+func (e *codedError) Error() string { return e.err.Error() }
+func (e *codedError) Unwrap() error { return e.err }
+
+// withExitCode tags an error with the status the process should exit with.
+func withExitCode(code int, err error) error { return &codedError{code: code, err: err} }
+
+// ExitCode is what main() exits with. Anything untagged is 1, which is both the
+// previous behaviour and the fail-closed direction: a composer reading an
+// unrecognised non-zero code must treat it as "the task failed", never as "the
+// pool was busy, try the next one".
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var ce *codedError
+	if errors.As(err, &ce) {
+		return ce.code
+	}
+	return 1
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -34,6 +34,7 @@ func New(version string) *cobra.Command {
 	root.AddCommand(newSecretsCmd())
 	root.AddCommand(newUpdateCmd())
 	root.AddCommand(newHarnessCmd())
+	root.AddCommand(newAgentCmd())
 	root.AddCommand(newDeployCmd())
 	root.AddCommand(newPrCmd())
 	root.AddCommand(newSearchCmd())

--- a/cli/internal/cmd/stdout_contract_test.go
+++ b/cli/internal/cmd/stdout_contract_test.go
@@ -97,6 +97,17 @@ func TestStdoutContracts(t *testing.T) {
 			wantSub:  "opus",
 			consumer: `compile-harness.sh: model_id="$(dotf harness resolve-tier "$tier" --harness "$agent")"`,
 		},
+		{
+			// The whole point of `agent run` is to be composed: its consumer is
+			// a dispatcher piping stdout into a parser, never a person reading
+			// a terminal. A record on stderr would parse as empty input, which
+			// jq reports as a null rather than as an error — a dispatch that
+			// silently reads as "no answer" instead of failing.
+			name:     "agent run — the record is piped into a JSON parser by its caller",
+			args:     []string{"agent", "run", "--role", "reviewer", "--task", "probe", "--tier", "mid", "--backend", "dry-run", "--timeout", "30s"},
+			wantSub:  `"status":"dry_run"`,
+			consumer: `a dispatcher: dotf agent run ... | jq -r .status`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cli/internal/harness/model_map_chains_test.go
+++ b/cli/internal/harness/model_map_chains_test.go
@@ -1,0 +1,104 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The top tier's no-fallback rule is a SHAPE rule here and a BEHAVIOUR rule in
+// the dispatcher. This holds the shape half.
+//
+// The second case is the load-bearing one and is not obvious: naming `top`
+// under `chains.properties` exempts it from `additionalProperties`, so a
+// `maxItems` added without the sibling `$ref` would leave `chains.top` with no
+// type, no minimum and no `pool:model` pattern — a strictly weaker key that
+// LOOKS like an added constraint. It was written that way first, and this test
+// is what the mistake earned.
+func TestChainsTopIsCappedWithoutLosingTheChainShape(t *testing.T) {
+	schema := readShippedSchema(t)
+
+	tests := []struct {
+		name    string
+		chains  string
+		wantErr string
+	}{
+		{
+			name:   "one entry is the declared shape",
+			chains: `{"top": ["claude:opus"], "mid": ["nan:qwen3.6"]}`,
+		},
+		{
+			name:    "a second top entry is a declared fallback the top tier does not have",
+			chains:  `{"top": ["claude:opus", "nan:deepseek-v4-flash"], "mid": ["nan:qwen3.6"]}`,
+			wantErr: "maxItems",
+		},
+		{
+			name:    "a top entry that is not pool:model is still rejected",
+			chains:  `{"top": ["claude-opus"], "mid": ["nan:qwen3.6"]}`,
+			wantErr: "pattern",
+		},
+		{
+			name:    "a top that is not an array at all is still rejected",
+			chains:  `{"top": "claude:opus", "mid": ["nan:qwen3.6"]}`,
+			wantErr: "array",
+		},
+		{
+			name:    "an empty top is not 'no fallback', it is nowhere to go",
+			chains:  `{"top": [], "mid": ["nan:qwen3.6"]}`,
+			wantErr: "minItems",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateModelMap([]byte(mapWithChains(tc.chains)), schema)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("valid map rejected: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("map accepted; want a rejection naming %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("rejection does not name %q: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func mapWithChains(chains string) string {
+	return `{
+  "$comment": ["fixture"],
+  "version": 1,
+  "pools": {
+    "nan": {"auth": "subscription", "probe": "env:NAN_API_KEY"},
+    "claude": {"auth": "subscription", "probe": "bin:claude"}
+  },
+  "harnesses": {"claude": {"pools": ["claude"], "render": "agent-md"}},
+  "tiers": {"top": {"claude": "opus"}},
+  "chains": ` + chains + `,
+  "services": {}
+}`
+}
+
+func readShippedSchema(t *testing.T) []byte {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		p := filepath.Join(dir, ModelMapSchemaFile)
+		if b, err := os.ReadFile(p); err == nil {
+			return b
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find %s walking up from the test directory", ModelMapSchemaFile)
+		}
+		dir = parent
+	}
+}

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -239,3 +239,4 @@ tags: [lessons, index, dotfiles]
 | [223 - A test updated to keep passing stops being a guard](lesson-223-a-test-updated-to-keep-passing-stops-being-a-guar.md) | 2026-08-23 |  |
 | [224 - A negated assertion is exempt from `set -e`, so it cannot fail a test](lesson-224-a-negated-assertion-is-exempt-from-set-e-so-it-cann.md) | 2026-08-23 |  |
 | [225 - A stacked PR costs a reviewer, and re-conflicts on every squash](lesson-225-a-stacked-pr-costs-a-reviewer-and-re-conflicts-on-e.md) | 2026-08-23 |  |
+| [226 - Naming a key under `properties` exempts it from `additionalProperties`, so adding a constraint there can loosen the schema](lesson-226-naming-a-key-under-properties-exempts-it-from-additio.md) | 2026-08-23 |  |

--- a/docs/lessons/lesson-226-naming-a-key-under-properties-exempts-it-from-additio.md
+++ b/docs/lessons/lesson-226-naming-a-key-under-properties-exempts-it-from-additio.md
@@ -1,0 +1,117 @@
+# Lesson 226 — Naming a key under `properties` exempts it from `additionalProperties`, so adding a constraint there can loosen the schema
+
+**Date:** 2026-08-23
+**Area:** registries / JSON Schema / guards
+**Severity:** medium — the edit reads as a tightening in review and in the diff, and it is a loosening
+
+## What happened
+
+`harness/model-map.json` declares `chains`, an ordered per-tier fallback. Every
+tier's value was held to one shape by `additionalProperties`:
+
+```jsonc
+"chains": {
+  "type": "object",
+  "minProperties": 1,
+  "additionalProperties": {
+    "type": "array", "minItems": 1,
+    "items": { "type": "string", "pattern": "^[^:[:space:]]+:[^:[:space:]]+$" }
+  }
+}
+```
+
+ADR-032 §4 says the top tier never degrades, so `chains.top` must not be allowed
+to declare a fallback. The obvious edit — cap it at one entry:
+
+```jsonc
+"properties": {
+  "top": { "maxItems": 1, "description": "the top tier declares no fallback" }
+},
+"additionalProperties": { …unchanged… }
+```
+
+That edit adds a constraint and removes four. In JSON Schema,
+`additionalProperties` applies **only to properties not matched by `properties`
+or `patternProperties`**. Naming `top` moves it out of that set, so it keeps
+`maxItems: 1` and loses `type: array`, `minItems: 1` and the `pool:model`
+pattern that every other tier is still held to.
+
+Measured by deleting the fix and re-running the cases:
+
+| `chains.top` | With the `$ref` | Without it |
+|---|---|---|
+| `["claude:opus", "nan:deepseek-v4-flash"]` | rejected (`maxItems`) | rejected |
+| `["claude-opus"]` — not `pool:model` | rejected (`pattern`) | **accepted** |
+| `"claude:opus"` — a bare string | rejected (`array`) | **accepted** |
+| `[]` — nothing to route to | rejected (`minItems`) | **accepted** |
+
+`maxItems` does not apply to a string, so the one constraint that survived was
+also inert on two of the three newly-legal values. The key the rule was written
+to protect became the only key in the file with no shape at all.
+
+## Why it survives inspection
+
+**The diff is a pure addition.** Nothing was deleted, so a reviewer scanning for
+removals sees none. What was removed is an *application* of a rule that is still
+sitting there in the file, four lines below, looking as though it covers
+everything.
+
+**The real map still validates.** `chains.top` is `["claude:opus"]`, which
+passes either way, so the existing suite stayed green and the shipped registry
+was never in danger. The hole is only reachable by a value nobody has written
+yet — which is exactly what a schema is for.
+
+**Both keywords are present and correct.** There is no typo, no invalid schema,
+no warning from the validator. `properties` and `additionalProperties` are doing
+precisely what the specification says.
+
+## The fix
+
+Extract the shape once and reference it from both places, so the named key is
+constrained *in addition to* its cap rather than *instead of* it:
+
+```jsonc
+"$defs": { "chain": { "type": "array", "minItems": 1, "items": { … } } },
+
+"chains": {
+  "properties": { "top": { "$ref": "#/$defs/chain", "maxItems": 1 } },
+  "additionalProperties": { "$ref": "#/$defs/chain" }
+}
+```
+
+In draft 2020-12 `$ref` composes with sibling keywords, so this needs no
+`allOf`. (Under draft-07 it would: `$ref` there replaces the schema it sits in,
+and `maxItems` beside it is ignored — the same class of silent loss.)
+
+## The rule
+
+**When you add a key to `properties` in a schema that relies on
+`additionalProperties`, the new key inherits nothing. Reference the shared shape
+explicitly, and write the test that proves the *unchanged* constraints still
+apply to it** — not only the new one you came to add.
+
+`TestChainsTopIsCappedWithoutLosingTheChainShape` is that test: five cases, of
+which four assert constraints this edit was never meant to touch. Three of them
+go red when the `$ref` is removed, which is how the hole was found.
+
+## Relation to Lessons 204 and 220
+
+[204](lesson-204-a-check-that-cannot-fail-the-way-you-cite-it.md) — a check that
+cannot fail the way you cite it. This is that shape in a schema: the constraint
+is cited as "top is capped and validated like any chain" and can only fail on the
+first half.
+
+[220](lesson-220-four-defects-one-shape-a-thing-verified-by-a-proxy.md) — its
+diagnostic question, *what would this still pass on if the thing it checks were
+broken?*, is what surfaced it. Answering it required deleting the fix and running
+the cases, not re-reading the schema; re-reading is how the bug got written.
+
+## Evidence
+
+- Mutation run, 2026-08-23: `$ref` removed from `chains.top` → 3 of 5 cases in
+  `TestChainsTopIsCappedWithoutLosingTheChainShape` fail, with
+  `chains.top: "claude:opus"` and `chains.top: []` both accepted
+- `harness/model-map.schema.json` — `$defs.chain` and the two references to it
+- JSON Schema draft 2020-12, §10.3.2.3: `additionalProperties` applies to
+  instance names not matched by `properties` or `patternProperties`
+- `specs/CLI-042-dotf-agent-run/` — the PR B change that needed the cap

--- a/harness/model-map.schema.json
+++ b/harness/model-map.schema.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mlorentedev/dotfiles/harness/model-map.schema.json",
+  "$defs": {
+    "chain": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "pattern": "^[^:[:space:]]+:[^:[:space:]]+$",
+        "description": "`pool:model`, both halves non-empty and free of whitespace. A pattern rather than minLength, because \"nan:\" is four characters and still routes nowhere. The trailing `+` rather than `.*` is deliberate: `.*` accepted \"nan:deepseek   \" and \"nan:deep:seek\"."
+      }
+    }
+  },
   "title": "model-map",
   "description": "The dispatch-time routing registry (ADR-032 §3, shaped by ADR-035). Validated by cli/internal/harness/model_map.go, which reads THIS FILE rather than restating its rules — so the contract lives here and only its interpreter lives in Go. Standard draft-2020-12 keywords are interpreted by santhosh-tekuri/jsonschema, so adding one here needs no Go change. The `x-` namespace is this repo's own: those keywords name cross-block rules implemented in Go, they are a closed set, and one this validator does not implement is a loud error rather than the annotation draft 2020-12 would otherwise make it.",
   "type": "object",
@@ -150,14 +161,15 @@
       "description": "Ordered fallback per tier, as `pool:model`. Resolved at RUN time and read only by a level-2 dispatcher: a Claude Task cannot fail over to NaN, so cross-pool fallback exists only outside the session. Kept separate from reviewer-pool.json deliberately — that one ranks independence above availability, this one ranks availability. ADR-035 states the merge trigger: a third consumer needing an ordered chain.",
       "type": "object",
       "minProperties": 1,
-      "additionalProperties": {
-        "type": "array",
-        "minItems": 1,
-        "items": {
-          "type": "string",
-          "pattern": "^[^:[:space:]]+:[^:[:space:]]+$",
-          "description": "`pool:model`, both halves non-empty and free of whitespace. A pattern rather than minLength, because \"nan:\" is four characters and still routes nowhere. The trailing `+` rather than `.*` is deliberate: `.*` accepted \"nan:deepseek   \" and \"nan:deep:seek\"."
+      "properties": {
+        "top": {
+          "$ref": "#/$defs/chain",
+          "maxItems": 1,
+          "description": "The top tier declares no fallback, and the schema is where that is a SHAPE rule (ADR-032 §4). The dispatcher enforces the matching BEHAVIOUR rule — it never advances past the first entry — and the two are not a duplication: this one stops a second entry being written, that one stops a second entry being used if one ever is. A top tier that quietly degrades converts a gate into a green checkmark. The $ref is load-bearing: naming `top` under `properties` exempts it from `additionalProperties`, so without it this key would lose the array type, the minimum and the `pool:model` pattern that every other tier is held to."
         }
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/chain"
       }
     },
     "services": {

--- a/specs/CLI-042-dotf-agent-run/features.json
+++ b/specs/CLI-042-dotf-agent-run/features.json
@@ -2,7 +2,7 @@
   {
     "id": "CLI-042-dotf-agent-run-f1",
     "behavior": "AC1 — `dotf agent run` writes one JSON object to stdout carrying status, tier, pool, model, exit, duration_ms and output, with every log line on stderr",
-    "verification": "cd cli && go test ./internal/cmd/ -run '^TestAgentRun_WritesOneJSONObjectToStdout$' -v 2>&1 | grep -q '^--- PASS: TestAgentRun_WritesOneJSONObjectToStdout'",
+    "verification": "cd cli && out=$(go test ./internal/cmd/ -run '^TestAgentRun_WritesOneJSONObjectToStdout$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestAgentRun_WritesOneJSONObjectToStdout'",
     "state": "pending",
     "evidence": ""
   },
@@ -16,84 +16,84 @@
   {
     "id": "CLI-042-dotf-agent-run-f3",
     "behavior": "AC1 — a refusal before dispatch (no role/task, no tier, no timeout, no backend, unknown backend, undeclared tier) leaves stdout empty and exits 1, never 3",
-    "verification": "cd cli && go test ./internal/cmd/ -run '^TestAgentRun_RefusalsLeaveStdoutEmpty$' -v 2>&1 | grep -q '^--- PASS: TestAgentRun_RefusalsLeaveStdoutEmpty'",
+    "verification": "cd cli && out=$(go test ./internal/cmd/ -run '^TestAgentRun_RefusalsLeaveStdoutEmpty$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestAgentRun_RefusalsLeaveStdoutEmpty'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f4",
     "behavior": "AC1 — `agent run` is registered in the stdout-contract registry alongside the other machine-read subcommands",
-    "verification": "cd cli && go test ./internal/cmd/ -run '^TestStdoutContracts$' -v 2>&1 | grep -q 'PASS: TestStdoutContracts/agent_run'",
+    "verification": "cd cli && out=$(go test ./internal/cmd/ -run '^TestStdoutContracts$' -v 2>&1) && printf '%s' \"$out\" | grep -q 'PASS: TestStdoutContracts/agent_run'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f5",
     "behavior": "AC2 — a backend reporting pool-unavailable advances to the next chains entry; one reporting task-failed does not; an exhausted chain is its own status; an unrecognised status is a task failure, never an advance",
-    "verification": "cd cli && go test ./internal/agent/ -run '^TestDispatch_ChainWalk$' -v 2>&1 | grep -q '^--- PASS: TestDispatch_ChainWalk'",
+    "verification": "cd cli && out=$(go test ./internal/agent/ -run '^TestDispatch_ChainWalk$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestDispatch_ChainWalk'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f6",
     "behavior": "AC2 — the record names the pool and model that answered, and every attempt the walk made, so a skipped entry leaves a trace",
-    "verification": "cd cli && go test ./internal/agent/ -run '^TestDispatch_RecordsDurationAndAttempts$' -v 2>&1 | grep -q '^--- PASS: TestDispatch_RecordsDurationAndAttempts'",
+    "verification": "cd cli && out=$(go test ./internal/agent/ -run '^TestDispatch_RecordsDurationAndAttempts$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestDispatch_RecordsDurationAndAttempts'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f7",
     "behavior": "AC2 — the two classes survive the process boundary: chain-exhausted exits 3 and a task failure exits 1, so a composer can act on the difference",
-    "verification": "cd cli && go test ./internal/cmd/ -run '^TestExitCode$' -v 2>&1 | grep -q '^--- PASS: TestExitCode'",
+    "verification": "cd cli && out=$(go test ./internal/cmd/ -run '^TestExitCode$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestExitCode'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f8",
     "behavior": "AC3 — a dispatch exceeding its timeout kills the worker and releases its semaphore slot without waiting for it, reporting a non-zero exit with a timeout status",
-    "verification": "cd cli && go test ./internal/agent/ -run '^TestTimeoutReleasesSlotBeforeReap$' -v 2>&1 | grep -q '^--- PASS: TestTimeoutReleasesSlotBeforeReap'",
+    "verification": "cd cli && out=$(go test ./internal/agent/ -run '^TestTimeoutReleasesSlotBeforeReap$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestTimeoutReleasesSlotBeforeReap'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f9",
     "behavior": "AC3 — the per-dispatch deadline actually reaches the backend rather than being a parsed-but-inert flag (the half of AC3 that PR B can hold; the kill is PR C's)",
-    "verification": "cd cli && go test ./internal/agent/ -run '^TestDispatch_BackendReceivesADeadline$' -v 2>&1 | grep -q '^--- PASS: TestDispatch_BackendReceivesADeadline'",
+    "verification": "cd cli && out=$(go test ./internal/agent/ -run '^TestDispatch_BackendReceivesADeadline$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestDispatch_BackendReceivesADeadline'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f10",
     "behavior": "AC4 — an unreadable concurrency counter exits non-zero rather than reading as zero in use, and an unidentifiable machine denies every non-local pool",
-    "verification": "cd cli && go test ./internal/agent/ -run '^TestFailsClosed$' -v 2>&1 | grep -q '^--- PASS: TestFailsClosed'",
+    "verification": "cd cli && out=$(go test ./internal/agent/ -run '^TestFailsClosed$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestFailsClosed'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f11",
     "behavior": "AC4 — help text and error messages state the narrow guarantee ('dotf alone will never be the cause of exhaustion'), never that exhaustion cannot happen",
-    "verification": "cd cli && go test ./internal/agent/ -run '^TestGuaranteeWordingIsNarrow$' -v 2>&1 | grep -q '^--- PASS: TestGuaranteeWordingIsNarrow'",
+    "verification": "cd cli && out=$(go test ./internal/agent/ -run '^TestGuaranteeWordingIsNarrow$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestGuaranteeWordingIsNarrow'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f12",
     "behavior": "AC5 — a --tier top dispatch whose first entry is unavailable escalates and exits non-zero; it never reaches a second entry and never carries a lower-tier answer",
-    "verification": "cd cli && go test ./internal/agent/ -run '^TestDispatch_TopTierNeverDegrades$' -v 2>&1 | grep -q '^--- PASS: TestDispatch_TopTierNeverDegrades'",
+    "verification": "cd cli && out=$(go test ./internal/agent/ -run '^TestDispatch_TopTierNeverDegrades$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestDispatch_TopTierNeverDegrades'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f13",
     "behavior": "AC5 — the map cannot declare a top-tier fallback either: chains.top is capped at one entry AND still held to the array type, the minimum and the pool:model pattern",
-    "verification": "cd cli && go test ./internal/harness/ -run '^TestChainsTopIsCappedWithoutLosingTheChainShape$' -v 2>&1 | grep -q '^--- PASS: TestChainsTopIsCappedWithoutLosingTheChainShape'",
+    "verification": "cd cli && out=$(go test ./internal/harness/ -run '^TestChainsTopIsCappedWithoutLosingTheChainShape$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestChainsTopIsCappedWithoutLosingTheChainShape'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f14",
     "behavior": "AC6 — the hive backend answers and the record reports the pool and model the chain resolved (the pool name is the dispatcher's claim from `chains`; hive names no provider)",
-    "verification": "dotf agent run --backend hive --tier mid --role scout --task 'reply with OK' --timeout 120s | jq -e '.pool == \"nan\" and .status == \"ok\"'",
+    "verification": "dotf agent run --backend hive --tier mid --role scout --task 'reply with OK' --timeout 120s | jq -e --arg m \"$(dotf harness resolve-tier mid --harness pi)\" '.pool == \"nan\" and .status == \"ok\" and .model == $m'",
     "state": "pending",
     "evidence": ""
   },
@@ -114,7 +114,7 @@
   {
     "id": "CLI-042-dotf-agent-run-f17",
     "behavior": "AC9 — `dotf doctor` fails when a backend probes present but can serve no model, so 'zero reachable models' is caught at diagnostic time",
-    "verification": "cd cli && go test ./internal/doctor/ -run '^TestBackendReachability$' -v 2>&1 | grep -q '^--- PASS: TestBackendReachability'",
+    "verification": "cd cli && out=$(go test ./internal/doctor/ -run '^TestBackendReachability$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestBackendReachability'",
     "state": "pending",
     "evidence": ""
   }

--- a/specs/CLI-042-dotf-agent-run/features.json
+++ b/specs/CLI-042-dotf-agent-run/features.json
@@ -1,71 +1,120 @@
 [
   {
     "id": "CLI-042-dotf-agent-run-f1",
-    "behavior": "AC1 — `dotf agent run` writes one JSON object to stdout carrying status, pool, model, exit, duration_ms and output, with every log line on stderr",
-    "verification": "cd cli && go test ./internal/agent/ -run TestRunEmitsJSONContract",
+    "behavior": "AC1 — `dotf agent run` writes one JSON object to stdout carrying status, tier, pool, model, exit, duration_ms and output, with every log line on stderr",
+    "verification": "cd cli && go test ./internal/cmd/ -run '^TestAgentRun_WritesOneJSONObjectToStdout$' -v 2>&1 | grep -q '^--- PASS: TestAgentRun_WritesOneJSONObjectToStdout'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f2",
-    "behavior": "AC2 — a backend reporting pool-unavailable advances to the next chains entry; one reporting task-failed does not, and the record names the pool and model that answered",
-    "verification": "cd cli && go test ./internal/agent/ -run TestChainAdvancesOnlyOnPoolUnavailable",
+    "behavior": "AC1 — the contract holds through a real pipe, not only in-process: the compiled binary's stdout parses as JSON on its own, and `| jq -r .status` answers",
+    "verification": "~/.local/bin/bats tests/dotf-agent-run.bats",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f3",
-    "behavior": "AC3 — a dispatch exceeding its timeout kills the worker and releases its semaphore slot without waiting for it, reporting a non-zero exit with a timeout status",
-    "verification": "cd cli && go test ./internal/agent/ -run TestTimeoutReleasesSlotBeforeReap",
+    "behavior": "AC1 — a refusal before dispatch (no role/task, no tier, no timeout, no backend, unknown backend, undeclared tier) leaves stdout empty and exits 1, never 3",
+    "verification": "cd cli && go test ./internal/cmd/ -run '^TestAgentRun_RefusalsLeaveStdoutEmpty$' -v 2>&1 | grep -q '^--- PASS: TestAgentRun_RefusalsLeaveStdoutEmpty'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f4",
-    "behavior": "AC4 — an unreadable concurrency counter exits non-zero rather than reading as zero in use, and an unidentifiable machine denies every non-local pool",
-    "verification": "cd cli && go test ./internal/agent/ -run TestFailsClosed",
+    "behavior": "AC1 — `agent run` is registered in the stdout-contract registry alongside the other machine-read subcommands",
+    "verification": "cd cli && go test ./internal/cmd/ -run '^TestStdoutContracts$' -v 2>&1 | grep -q 'PASS: TestStdoutContracts/agent_run'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f5",
-    "behavior": "AC4 — help text and error messages state the narrow guarantee ('dotf alone will never be the cause of exhaustion'), never that exhaustion cannot happen",
-    "verification": "cd cli && go test ./internal/agent/ -run TestGuaranteeWordingIsNarrow",
+    "behavior": "AC2 — a backend reporting pool-unavailable advances to the next chains entry; one reporting task-failed does not; an exhausted chain is its own status; an unrecognised status is a task failure, never an advance",
+    "verification": "cd cli && go test ./internal/agent/ -run '^TestDispatch_ChainWalk$' -v 2>&1 | grep -q '^--- PASS: TestDispatch_ChainWalk'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f6",
-    "behavior": "AC5 — a --tier top dispatch with claude:opus unavailable escalates and exits non-zero; it never falls through to a mid-tier model",
-    "verification": "cd cli && go test ./internal/agent/ -run TestTopTierNeverDegrades",
+    "behavior": "AC2 — the record names the pool and model that answered, and every attempt the walk made, so a skipped entry leaves a trace",
+    "verification": "cd cli && go test ./internal/agent/ -run '^TestDispatch_RecordsDurationAndAttempts$' -v 2>&1 | grep -q '^--- PASS: TestDispatch_RecordsDurationAndAttempts'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f7",
-    "behavior": "AC6 — the hive backend answers through NaN and reports the pool and model the chain resolved",
-    "verification": "dotf agent run --backend hive --tier mid --role scout --task 'reply with OK' | jq -e '.pool == \"nan\" and .status == \"ok\"'",
+    "behavior": "AC2 — the two classes survive the process boundary: chain-exhausted exits 3 and a task failure exits 1, so a composer can act on the difference",
+    "verification": "cd cli && go test ./internal/cmd/ -run '^TestExitCode$' -v 2>&1 | grep -q '^--- PASS: TestExitCode'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f8",
+    "behavior": "AC3 — a dispatch exceeding its timeout kills the worker and releases its semaphore slot without waiting for it, reporting a non-zero exit with a timeout status",
+    "verification": "cd cli && go test ./internal/agent/ -run '^TestTimeoutReleasesSlotBeforeReap$' -v 2>&1 | grep -q '^--- PASS: TestTimeoutReleasesSlotBeforeReap'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f9",
+    "behavior": "AC3 — the per-dispatch deadline actually reaches the backend rather than being a parsed-but-inert flag (the half of AC3 that PR B can hold; the kill is PR C's)",
+    "verification": "cd cli && go test ./internal/agent/ -run '^TestDispatch_BackendReceivesADeadline$' -v 2>&1 | grep -q '^--- PASS: TestDispatch_BackendReceivesADeadline'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f10",
+    "behavior": "AC4 — an unreadable concurrency counter exits non-zero rather than reading as zero in use, and an unidentifiable machine denies every non-local pool",
+    "verification": "cd cli && go test ./internal/agent/ -run '^TestFailsClosed$' -v 2>&1 | grep -q '^--- PASS: TestFailsClosed'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f11",
+    "behavior": "AC4 — help text and error messages state the narrow guarantee ('dotf alone will never be the cause of exhaustion'), never that exhaustion cannot happen",
+    "verification": "cd cli && go test ./internal/agent/ -run '^TestGuaranteeWordingIsNarrow$' -v 2>&1 | grep -q '^--- PASS: TestGuaranteeWordingIsNarrow'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f12",
+    "behavior": "AC5 — a --tier top dispatch whose first entry is unavailable escalates and exits non-zero; it never reaches a second entry and never carries a lower-tier answer",
+    "verification": "cd cli && go test ./internal/agent/ -run '^TestDispatch_TopTierNeverDegrades$' -v 2>&1 | grep -q '^--- PASS: TestDispatch_TopTierNeverDegrades'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f13",
+    "behavior": "AC5 — the map cannot declare a top-tier fallback either: chains.top is capped at one entry AND still held to the array type, the minimum and the pool:model pattern",
+    "verification": "cd cli && go test ./internal/harness/ -run '^TestChainsTopIsCappedWithoutLosingTheChainShape$' -v 2>&1 | grep -q '^--- PASS: TestChainsTopIsCappedWithoutLosingTheChainShape'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f14",
+    "behavior": "AC6 — the hive backend answers and the record reports the pool and model the chain resolved (the pool name is the dispatcher's claim from `chains`; hive names no provider)",
+    "verification": "dotf agent run --backend hive --tier mid --role scout --task 'reply with OK' --timeout 120s | jq -e '.pool == \"nan\" and .status == \"ok\"'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f15",
     "behavior": "AC7 — the hive service unit invokes `dotf secrets run -- hive serve`, and the deployed environment.d fragment carries no credential",
     "verification": "~/.local/bin/bats tests/hive-service-secret-delivery.bats",
     "state": "pending",
     "evidence": ""
   },
   {
-    "id": "CLI-042-dotf-agent-run-f9",
-    "behavior": "AC8 — no configuration this repo deploys still names Ollama or OpenRouter for hive's worker",
+    "id": "CLI-042-dotf-agent-run-f16",
+    "behavior": "AC8 — no configuration this repo deploys still names Ollama or OpenRouter for hive's WORKER (opencode's own provider catalogue is out of scope and must survive)",
     "verification": "~/.local/bin/bats tests/hive-provider-drop.bats",
     "state": "pending",
     "evidence": ""
   },
   {
-    "id": "CLI-042-dotf-agent-run-f10",
+    "id": "CLI-042-dotf-agent-run-f17",
     "behavior": "AC9 — `dotf doctor` fails when a backend probes present but can serve no model, so 'zero reachable models' is caught at diagnostic time",
-    "verification": "cd cli && go test ./internal/doctor/ -run TestBackendReachability",
+    "verification": "cd cli && go test ./internal/doctor/ -run '^TestBackendReachability$' -v 2>&1 | grep -q '^--- PASS: TestBackendReachability'",
     "state": "pending",
     "evidence": ""
   }

--- a/specs/CLI-042-dotf-agent-run/proposal.md
+++ b/specs/CLI-042-dotf-agent-run/proposal.md
@@ -185,7 +185,8 @@ Failure modes, dependencies, and unknowns to clarify before implementation. If a
 
 Observable outcomes. Each must be testable.
 
-- [ ] **AC1 — the machine contract holds.** `dotf agent run --role <r> --task <t> --tier mid` writes a
+- [ ] **AC1 — the machine contract holds.** `dotf agent run --role <r> --task <t> --tier mid --backend
+      <b> --timeout <d>` writes a
       single JSON object to **stdout** carrying at least `status`, `pool`, `model`, `exit`,
       `duration_ms` and `output`, with every log line on **stderr**. Verified by a table-driven Go test
       and a bats smoke that pipes stdout through a JSON parser with stderr attached.

--- a/specs/CLI-042-dotf-agent-run/proposal.md
+++ b/specs/CLI-042-dotf-agent-run/proposal.md
@@ -1,7 +1,7 @@
 ---
 id: "CLI-042-dotf-agent-run"
 type: spec
-status: draft # draft | implementing | verifying | archived
+status: implementing # draft | implementing | verifying | archived
 created: "2026-08-23"
 issue: "mlorentedev/dotfiles#1190"   # repo#NNN — GitHub issue / Project item that tracks this spec
 tags: [spec, proposal]
@@ -45,6 +45,14 @@ Three contract decisions taken deliberately, recorded here so they are not re-de
 | Dispatch mode | **Synchronous**: blocks, returns R | ADR-032 §2's seam is literally *"run role A on task T, isolated in W, return R"*. Local evidence: `dotf spec review` launches **detached**, which is exactly why GUARD-005 exists — a detached launcher cannot observe its own verdict, so it needed a sidecar plus a downstream assertion. Starting synchronous avoids reopening that hole; `--detach` can be added later, never the reverse. |
 | Backend selection | **Probe, with `--backend` as an override** | ADR-032 §7: machine facts are probed, never stored — an inventory file rots, a probe cannot lie. Consistent with how the map already declares `probe: bin:claude` / `env:NAN_API_KEY`. The flag exists to force a backend and to make tests deterministic. |
 | stdout | **JSON always**; logs to stderr | The consumer of `agent run` is a dispatcher, not a person — the verb exists to be composed. Precedent: `dotf env path` and the agent-mode contract of #700. |
+
+Three more fixed while implementing PR B, recorded here so they are not re-derived either:
+
+| Decision | Choice | Why |
+|---|---|---|
+| Exit codes | **0 answered, 1 task failed, 3 no pool could serve.** Anything unrecognised is read as *task failed*. | The same three `hive delegate` uses, deliberately: one vocabulary spans the seam, so a composer that already speaks to hive speaks to `dotf agent run` without a translation table — and a translation table is where the two would drift. The fail-closed direction is pinned by the same reasoning as in `tasks.md`: reading an unknown code as *unavailable* would advance the chain and spend a second pool on a task that may already have been answered. The record's `status` carries the fine-grained truth (`escalated` and `chain_exhausted` share exit 3 and are different facts); the exit code carries the coarse class. |
+| A `dry-run` backend | **A first-class backend, shipped in PR B** — resolves the route, sends nothing, reports `status: dry_run` and exit 0. | Two reasons, and the second is the one that made it a decision rather than a convenience. It has standing value after PR D: inspecting which pool and model a tier resolves to on this machine, without spending a slot of a shared quota. And it is what makes AC1's bats half *runnable* — without it PR B would ship a criterion whose verification command selects nothing, which is precisely the defect measured on this spec's sibling in the 2026-08-22 session (four of eight `features.json` commands ran zero tests). The scripted fake the Go tests use stays test-only and is reachable only through the seam: a `--backend` value that exists to make tests pass is a surface users reach by accident. |
+| No backend default | **`--backend` is required until probing lands (PR D).** | Defaulting to `dry-run` would be the worst option available: a dispatch that silently ran nothing and exited 0. A loud refusal naming what exists is the fail-closed direction, and it disappears on its own when the probe can answer. |
 
 **Backends: two, and the second one has to be repaired first.** Decided 2026-08-22 after the
 measurement in Risks below: a seam validated against a single implementation is a speculative
@@ -208,15 +216,28 @@ Observable outcomes. Each must be testable.
 - [ ] **AC5 — the top tier never degrades silently.** With `claude:opus` unavailable, a `--tier top`
       dispatch escalates and exits non-zero; it never falls through to a mid-tier model. Tested.
 - [ ] **AC6 — the hive backend passes a real smoke check.** `dotf agent run --backend hive --tier mid`
-      returns an answer served by NaN and reports `pool=nan` with the model the chain resolved. This is
-      the criterion hive's repair exists to unblock, and it is the one that cannot pass today.
+      returns an answer and reports `pool=nan` with the model the chain resolved. This is the criterion
+      hive's repair exists to unblock, and it is the one that cannot pass on this machine today.
+      **Reworded 2026-08-23, after PR A shipped.** The original said "returns an answer *served by NaN*",
+      which is not observable from this side of the seam: `hive delegate --help` describes "the
+      configured worker" and names no provider on any shipped surface (`mlorentedev/hive#392`, `#394`),
+      by design. The pool name in the record is the DISPATCHER's claim, read from `chains` — so the
+      falsifiable form is *the model the chain named is the model that answered*, and the smoke asserts
+      that rather than grepping hive's output for a provider string it will never print.
 - [ ] **AC7 — the NaN credential never lands in a file.** The hive service unit invokes
       `dotf secrets run -- hive serve`, and the deployed `environment.d` fragment contains no
       credential. Asserted by a test reading the rendered unit and grepping the deployed fragment,
       verified by consequence (the daemon answers) rather than by printing the value.
-- [ ] **AC8 — the drop of Ollama and OpenRouter is complete, not partial.** No configuration this repo
-      deploys still names them for hive's worker, and `ai/agy/mcp_servers.json`'s `HIVE_OLLAMA_ENDPOINT`
-      is removed in the same change that removes the provider.
+- [ ] **AC8 — the drop of Ollama and OpenRouter from hive's worker is complete, not partial.** No
+      configuration this repo deploys still names either **for hive's worker**, and
+      `ai/agy/mcp_servers.json`'s `HIVE_OLLAMA_ENDPOINT` is removed in the same change.
+      **Scoped and re-measured 2026-08-23; NOT retired.** Two corrections. First, the criterion is
+      about hive's worker and nothing wider: `ai/opencode/opencode.jsonc` declares `ollama` and
+      `openrouter` as providers of the **opencode TUI**, which this drop does not touch — removing
+      those would be an unrelated regression wearing this criterion's clothes. Second, hive removing
+      the provider upstream did not satisfy this: `HIVE_OLLAMA_ENDPOINT` is still deployed at
+      `ai/agy/mcp_servers.json:10` on this tree. Hive dropping a provider and this repo ceasing to
+      deploy its endpoint are two changes, and only the first has happened.
 - [ ] **AC9 — "zero reachable models" is caught at diagnostic time, not under dispatch load.**
       `dotf doctor` reports a backend that probes present but can serve nothing, and fails rather than
       passing quietly. This is the incident-to-guard emission for the defect that shaped this spec:

--- a/specs/CLI-042-dotf-agent-run/tasks.md
+++ b/specs/CLI-042-dotf-agent-run/tasks.md
@@ -39,31 +39,58 @@ The dispatcher must therefore treat an unrecognised exit code as *task failed*, 
 
 ## Setup
 
-- [ ] Branch created from main: `feat/dotf-agent-run`
-- [ ] `proposal.md` is complete and acceptance criteria are testable
-- [ ] No open questions left in `proposal.md` "Risks / open questions" — **two are still open**: the
-      backend tie-break for a `nan` chain entry, and the secret-delivery shape for the hive daemon
-- [ ] Issue opened on `mlorentedev/hive` for PR A, linked as blocking #1190
+- [x] Branch created from main: `feat/dotf-agent-run`
+- [x] `proposal.md` is complete and acceptance criteria are testable — the nine were blessed in PR B
+      (2026-08-23), with AC6 and AC8 reworded against what PR A actually shipped
+- [x] No open questions left in `proposal.md` "Risks / open questions" **that gate the PR being
+      worked**. The two that remain — the backend tie-break for a `nan` chain entry, and the
+      secret-delivery shape for the hive daemon — are scoped to PRs D and E respectively, and neither
+      is reachable from B or C: there is no second backend to tie-break between until D, and no daemon
+      to deliver a secret to until E. They must be closed before their own PR opens, not before this
+      one does.
+- [x] Issue opened on `mlorentedev/hive` for PR A, linked as blocking #1190 — `mlorentedev/hive#384`,
+      shipped and released as `hive-vault` 4.1.0; `hive delegate` is installed and dispatches
 
 ## Implementation
 
 ### PR B — the command and its contract
 
-- [ ] [P] [AC1] Failing test: `dotf agent run` writes one JSON object to stdout with `status`,
+- [x] [P] [AC1] Failing test: `dotf agent run` writes one JSON object to stdout with `status`,
       `pool`, `model`, `exit`, `duration_ms`, `output`, and nothing but JSON on stdout
-- [ ] [AC1] Implement the command, its flags (`--role`, `--task`, `--tier`, `--cwd`, `--timeout`,
+- [x] [AC1] Implement the command, its flags (`--role`, `--task`, `--tier`, `--cwd`, `--timeout`,
       `--backend`) and the JSON encoder; every log line goes to stderr
-- [ ] [P] [AC2] Failing test: a fake backend scripted to return *pool unavailable* advances to the
+- [x] [P] [AC2] Failing test: a fake backend scripted to return *pool unavailable* advances to the
       next `chains` entry; one scripted to return *task failed* does not
-- [ ] [AC2] Implement the chain walk over `harness.ResolveChain`, and the error classification that
+- [x] [AC2] Implement the chain walk over `harness.ResolveChain`, and the error classification that
       keeps the two cases distinct
-- [ ] [AC2] Failing test + implement: chain exhausted — every entry unavailable — is its own outcome,
+- [x] [AC2] Failing test + implement: chain exhausted — every entry unavailable — is its own outcome,
       distinguishable from a task failure
-- [ ] [P] [AC5] Failing test: `--tier top` with `claude:opus` unavailable escalates and exits
+- [x] [P] [AC5] Failing test: `--tier top` with `claude:opus` unavailable escalates and exits
       non-zero, and never resolves a mid-tier model
-- [ ] [AC5] Implement the top-tier no-degrade rule
-- [ ] Refactor: the backend interface is the seam — one method, the five semantics, no backend-specific
+- [x] [AC5] Implement the top-tier no-degrade rule
+- [x] Refactor: the backend interface is the seam — one method, the five semantics, no backend-specific
       types leaking into the dispatcher
+
+Added while implementing B, each because the work surfaced it rather than because it was planned:
+
+- [x] [AC1] Exit-code plumbing: `main()` could only ever exit 1, so `chain_exhausted` was
+      indistinguishable from a task failure at the process boundary — the exact collapse AC2 forbids
+      one layer down. A tagged error, unwrapped in `main`, rather than the `os.Exit`-inside-`RunE`
+      precedent in `secrets.go`, which costs a re-exec harness in its test file.
+- [x] [AC1] A `dry-run` backend, so the criterion's bats half runs against something. See the decision
+      table in `proposal.md`.
+- [x] [AC1] The record's output cap (`agent.OutputCap`) with an in-band `truncated` marker — ADR-032
+      §2's "output bounded by a cap" is part of the record contract, so it belongs to B, and a capped
+      output that does not say so reads as a complete short answer.
+- [x] [AC5] `chains.top` capped at one entry in `model-map.schema.json`. The behaviour rule alone
+      would leave a map free to *declare* a fallback the dispatcher silently ignores. **The first
+      attempt at this was wrong in an instructive way:** naming `top` under `properties` exempts it
+      from `additionalProperties`, so a bare `maxItems` removed the array type, the minimum and the
+      `pool:model` pattern — an edit that reads as a tightening and is a loosening. The sibling
+      `$ref` is what holds the shape, and `TestChainsTopIsCappedWithoutLosingTheChainShape` fails
+      without it.
+- [x] [AC1] `agent run` registered in `TestStdoutContracts`, the existing registry of subcommands
+      whose output is machine-read.
 
 ### PR C — the brakes
 

--- a/specs/CLI-042-dotf-agent-run/tasks.md
+++ b/specs/CLI-042-dotf-agent-run/tasks.md
@@ -73,7 +73,7 @@ The dispatcher must therefore treat an unrecognised exit code as *task failed*, 
 
 Added while implementing B, each because the work surfaced it rather than because it was planned:
 
-- [x] [AC1] Exit-code plumbing: `main()` could only ever exit 1, so `chain_exhausted` was
+- [x] [AC2] Exit-code plumbing: `main()` could only ever exit 1, so `chain_exhausted` was
       indistinguishable from a task failure at the process boundary — the exact collapse AC2 forbids
       one layer down. A tagged error, unwrapped in `main`, rather than the `os.Exit`-inside-`RunE`
       precedent in `secrets.go`, which costs a re-exec harness in its test file.

--- a/specs/CLI-042-dotf-agent-run/verification.md
+++ b/specs/CLI-042-dotf-agent-run/verification.md
@@ -46,8 +46,11 @@ Produced 2026-08-23 on branch `feat/dotf-agent-run`, off `origin/main` @ `a27dcc
 - Lint: `golangci-lint run` (v2.12.2, matching the `versions.conf` pin) -> **0 issues**
 - Shell: `~/.local/bin/bats tests/*.bats` -> **1462 tests, exit 0, 0 failures**; `shellcheck` clean on
   the new `tests/dotf-agent-run.bats`
-- `features.json` commands executed individually: the nine belonging to PR B exit 0; the eight
-  belonging to PRs C/D/E exit non-zero, which is what `pending` has to mean. **This was not free** —
+- `features.json` commands executed individually: **10 exit 0, 7 exit non-zero**. The ten are f1–f7,
+  f9, f12 and f13; note f9 belongs to AC3, which is PR C's — it is the half of that criterion B can
+  hold (the deadline reaches the backend), and counting it under B would misreport AC3 as met. The
+  seven that fail are the criteria PRs C, D and E own, which is what `pending` has to mean.
+  **This was not free** —
   the file's original commands named tests that do not exist, and `go test -run <nonexistent>` exits
   **0** with `[no tests to run]`, so every one of them would have certified an unwritten test. All
   seventeen were rewritten to the form `go test -run '^X$' -v | grep -q '^--- PASS: X'`, which fails

--- a/specs/CLI-042-dotf-agent-run/verification.md
+++ b/specs/CLI-042-dotf-agent-run/verification.md
@@ -9,28 +9,87 @@ created: "2026-08-23"
 
 Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
 
-- [ ] AC1 (JSON contract on stdout, logs on stderr) -> commit `<hash>` / test `<name>`
-- [ ] AC2 (pool-unavailable advances the chain, task-failed does not) -> commit `<hash>` / test `<name>`
-- [ ] AC3 (timeout kills the worker and frees the slot before reaping) -> commit `<hash>` / test `<name>`
-- [ ] AC4 (fails closed on an unreadable counter and an unidentifiable machine) -> commit `<hash>` / test `<name>`
-- [ ] AC5 (the top tier escalates, never degrades) -> commit `<hash>` / test `<name>`
-- [ ] AC6 (the hive backend answers through NaN and reports pool + model) -> commit `<hash>` / test `<name>`
-- [ ] AC7 (`dotf secrets run -- hive serve`; no credential in a deployed file) -> commit `<hash>` / test `<name>`
-- [ ] AC8 (Ollama and OpenRouter fully removed from deployed config) -> commit `<hash>` / test `<name>`
-- [ ] AC9 (`dotf doctor` fails a backend that can serve nothing) -> commit `<hash>` / test `<name>`
+**PR B only.** This spec ships as the five-PR sequence `tasks.md` declares. B covers AC1, AC2 and AC5;
+the rest are named here as open with the PR that owns them, so a partly-filled section is never read
+as a partly-met criterion.
+
+- [x] AC1 (JSON contract on stdout, logs on stderr) -> `TestAgentRun_WritesOneJSONObjectToStdout`,
+      `TestAgentRun_RefusalsLeaveStdoutEmpty`, `TestAgentRun_ReportsTheRouteTheMapDeclares`,
+      `TestStdoutContracts/agent_run`, and `tests/dotf-agent-run.bats` (7 cases) through the compiled
+      binary and a real pipe
+- [x] AC2 (pool-unavailable advances the chain, task-failed does not) -> `TestDispatch_ChainWalk`
+      (6 cases, including the exhausted chain, an unrecognised status and a malformed entry),
+      `TestDispatch_RecordsDurationAndAttempts`, `TestExitCode`
+- [ ] AC3 (timeout kills the worker and frees the slot before reaping) -> **PR C.** The half B can
+      hold is proven: `TestDispatch_BackendReceivesADeadline` shows the per-dispatch deadline reaches
+      the backend rather than being a parsed-but-inert flag. The kill and the slot release need
+      something real to kill.
+- [ ] AC4 (fails closed on an unreadable counter and an unidentifiable machine) -> **PR C**
+- [x] AC5 (the top tier escalates, never degrades) -> `TestDispatch_TopTierNeverDegrades` (behaviour)
+      and `TestChainsTopIsCappedWithoutLosingTheChainShape` (shape, in the schema)
+- [ ] AC6 (the hive backend answers and reports pool + model) -> **PR D.** Still unrunnable on this
+      machine: no worker endpoint is configured here. `hive delegate` itself is now installed
+      (`hive-vault` 4.1.0), so the blocker is this machine's configuration, not the missing verb.
+- [ ] AC7 (`dotf secrets run -- hive serve`; no credential in a deployed file) -> **PR E**
+- [ ] AC8 (Ollama and OpenRouter removed from what this repo deploys for hive's worker) -> **PR E.**
+      Re-measured 2026-08-23 and NOT already satisfied: `HIVE_OLLAMA_ENDPOINT` is still present at
+      `ai/agy/mcp_servers.json:10`.
+- [ ] AC9 (`dotf doctor` fails a backend that can serve nothing) -> **PR E**
 
 ## Test status
 
-- Test suite: `<command> -> <output / coverage %>`
-- Manual smoke test: what was exercised, what was observed
-- No regressions in existing test suite: yes / no (if no, document)
+Produced 2026-08-23 on branch `feat/dotf-agent-run`, off `origin/main` @ `a27dcc8`.
+
+- Go: `cd cli && go build ./... && go vet ./... && go test ./...` -> all packages ok, 0 failures
+- Windows leg: `GOOS=windows go vet ./...` -> clean (the CI leg that compiles the same tree)
+- Format: `gofmt -l .` -> no output
+- Lint: `golangci-lint run` (v2.12.2, matching the `versions.conf` pin) -> **0 issues**
+- Shell: `~/.local/bin/bats tests/*.bats` -> **1462 tests, exit 0, 0 failures**; `shellcheck` clean on
+  the new `tests/dotf-agent-run.bats`
+- `features.json` commands executed individually: the nine belonging to PR B exit 0; the eight
+  belonging to PRs C/D/E exit non-zero, which is what `pending` has to mean. **This was not free** —
+  the file's original commands named tests that do not exist, and `go test -run <nonexistent>` exits
+  **0** with `[no tests to run]`, so every one of them would have certified an unwritten test. All
+  seventeen were rewritten to the form `go test -run '^X$' -v | grep -q '^--- PASS: X'`, which fails
+  when the test is absent.
+
+### Mutation checks
+
+A passing test is not evidence that a test *would* fail, so the two rules this PR adds were checked by
+breaking them:
+
+- Removing the top-tier no-degrade branch from `Dispatch` -> `TestDispatch_TopTierNeverDegrades` fails
+  on all four assertions (status, exit code, entries attempted, and the leaked lower-tier answer).
+- Removing the sibling `$ref` from `chains.top` in the schema -> three of the five cases in
+  `TestChainsTopIsCappedWithoutLosingTheChainShape` fail: `chains.top: "claude:opus"` (a string) and
+  `chains.top: []` are both **accepted**.
 
 ## Decisions made during implementation
 
 Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
 
--
--
+- **Exit codes mirror `hive delegate` (0/1/3) rather than being chosen freshly.** One vocabulary spans
+  the seam, so a composer that already speaks to hive needs no translation table — and a translation
+  table is where the two sides would drift. `escalated` and `chain_exhausted` share exit 3 and stay
+  distinct in the record's `status`: the exit code is the coarse class, the record carries the fine one.
+- **`main()` had to change.** It could only ever exit 1, which collapsed *no pool could serve this*
+  into *the task failed* at the process boundary — the exact collapse AC2 forbids one layer down. A
+  tagged error unwrapped in `main`, in preference to the `os.Exit`-inside-`RunE` precedent in
+  `secrets.go`, which costs that file a child-process re-exec harness to test at all.
+- **A `dry-run` backend ships in B**, so AC1's bats half runs against something rather than being a
+  verification command that selects nothing. Rationale and the rejected alternative (exposing the
+  scripted test fake as a `--backend` value) are in `proposal.md`'s decision table.
+- **The chain arrives at `agent.Dispatch` already resolved.** `harness.ResolveChain` stays the map's
+  one reader; a second parse inside the dispatcher would be a second place the routing rules are true.
+- **Course correction: the first `chains.top` schema edit was a loosening that read as a tightening.**
+  Naming `top` under `properties` exempts it from `additionalProperties`, so adding a bare `maxItems`
+  silently dropped the array type, the minimum and the `pool:model` pattern. Caught by writing the
+  mutation check before believing the green run.
+- **A test that could not be written, and why that is the right answer.** The command-layer case for a
+  malformed chain entry is unreachable: the schema rejects such a map before `Dispatch` is called. The
+  dispatcher's own fail-closed branch is kept as defence for a chain that did not come from a
+  validated map, covered in the `agent` package; the command-layer test was rewritten to assert the
+  consequence that IS reachable — no record, empty stdout, exit 1 and never 3.
 
 ## Promotion candidates
 

--- a/specs/CLI-042-dotf-agent-run/verification.md
+++ b/specs/CLI-042-dotf-agent-run/verification.md
@@ -52,9 +52,15 @@ Produced 2026-08-23 on branch `feat/dotf-agent-run`, off `origin/main` @ `a27dcc
   seven that fail are the criteria PRs C, D and E own, which is what `pending` has to mean.
   **This was not free** —
   the file's original commands named tests that do not exist, and `go test -run <nonexistent>` exits
-  **0** with `[no tests to run]`, so every one of them would have certified an unwritten test. All
-  seventeen were rewritten to the form `go test -run '^X$' -v | grep -q '^--- PASS: X'`, which fails
-  when the test is absent.
+  **0** with `[no tests to run]`, so every one of them would have certified an unwritten test. The
+  **13 Go commands** were rewritten to capture the status before matching —
+  `out=$(go test -run '^X$' -v 2>&1) && printf '%s' "$out" | grep -q '^--- PASS: X'` — which fails
+  both when the test is absent and when `go test` exits non-zero after printing the PASS line. The
+  pipeline form does neither: `grep` reports the pipeline's status, so a package where one subtest
+  passes and another fails still certifies. The remaining four (f2, f15, f16 are bats over a whole
+  file; f14 is `dotf … | jq -e`) do not take that form and did not need it — bats fails on a missing
+  file, and f14's predicate now compares `.model` against the resolved chain entry rather than
+  accepting any non-empty record.
 
 ### Mutation checks
 

--- a/tests/dotf-agent-run.bats
+++ b/tests/dotf-agent-run.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# `dotf agent run` — the machine contract, smoked through the real binary
+# (CLI-042 AC1).
+#
+# The Go tests already assert the record's shape in-process. What they cannot
+# assert is the thing the criterion is actually about: that a SHELL pipeline
+# sees the record on stdout with nothing else mixed in. captureRealStreams swaps
+# os.Stdout for a pipe inside one process; this runs the compiled binary and
+# pipes it, which is how every consumer will reach it.
+#
+# Skips (never fails) when the Go toolchain is absent, so a shell-only checkout
+# still runs the rest of the suite. CI installs Go for the `test` job precisely
+# so this does not silently skip there.
+
+setup() {
+    REPO_ROOT="$BATS_TEST_DIRNAME/.."
+}
+
+# Build once per file run into a cached location, so the cases do not pay a
+# compilation each.
+_build_dotf() {
+    command -v go >/dev/null 2>&1 || skip "go toolchain not installed"
+    DOTF_BIN="${BATS_FILE_TMPDIR:-/tmp}/dotf-agent-run"
+    export DOTF_BIN
+    if [ ! -x "$DOTF_BIN" ]; then
+        ( cd "$REPO_ROOT/cli" && go build -o "$DOTF_BIN" ./cmd/dotf ) \
+            || skip "go build failed"
+    fi
+}
+
+_run_dry() {
+    _build_dotf
+    "$DOTF_BIN" agent run \
+        --role reviewer --task 'smoke the contract' --tier "${1:-mid}" \
+        --backend dry-run --timeout 30s --repo-root "$REPO_ROOT"
+}
+
+@test "agent run: stdout alone is a parseable JSON object" {
+    _build_dotf
+    # stderr deliberately NOT merged: the claim is that a consumer capturing
+    # only stdout gets the whole record. Merging 2>&1 would let a record written
+    # to the wrong stream pass.
+    run bash -c "'$DOTF_BIN' agent run --role reviewer --task smoke --tier mid \
+        --backend dry-run --timeout 30s --repo-root '$REPO_ROOT' 2>/dev/null"
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | python3 -c 'import json,sys; json.load(sys.stdin)'
+}
+
+@test "agent run: the record names status, route and duration" {
+    run _run_dry mid
+    [ "$status" -eq 0 ]
+    local parsed
+    parsed="$(printf '%s' "$output" | python3 -c '
+import json, sys
+r = json.load(sys.stdin)
+missing = [k for k in ("status", "tier", "pool", "model", "exit", "duration_ms", "output") if k not in r]
+print("MISSING:" + ",".join(missing) if missing else r["status"] + " " + r["pool"] + ":" + r["model"])
+')"
+    [ "${parsed#MISSING:}" = "$parsed" ]
+    [ "${parsed%% *}" = "dry_run" ]
+}
+
+@test "agent run: a dispatcher can read the status through a pipe" {
+    _build_dotf
+    command -v jq >/dev/null 2>&1 || skip "jq not installed"
+    # The documented consumer, verbatim from the command's own Long text.
+    run bash -c "'$DOTF_BIN' agent run --role reviewer --task smoke --tier mid \
+        --backend dry-run --timeout 30s --repo-root '$REPO_ROOT' | jq -r .status"
+    [ "$status" -eq 0 ]
+    [ "$output" = "dry_run" ]
+}
+
+@test "agent run: the top tier resolves to its single declared entry" {
+    _build_dotf
+    # Through a file rather than re-interpolating $output into another shell:
+    # the record contains quotes, and a case that breaks on its own payload
+    # fails for the wrong reason.
+    local rec="$BATS_TEST_TMPDIR/top.json"
+    run bash -c "'$DOTF_BIN' agent run --role architect --task decide --tier top \
+        --backend dry-run --timeout 30s --repo-root '$REPO_ROOT' >'$rec' 2>/dev/null"
+    [ "$status" -eq 0 ]
+    run python3 -c '
+import json, sys
+r = json.load(open(sys.argv[1]))
+assert len(r["attempts"]) == 1, r["attempts"]
+print(r["pool"])
+' "$rec"
+    [ "$status" -eq 0 ]
+    [ "$output" = "claude" ]
+}
+
+@test "agent run: a missing --timeout is refused and writes nothing to stdout" {
+    _build_dotf
+    run bash -c "'$DOTF_BIN' agent run --role r --task t --tier mid \
+        --backend dry-run --repo-root '$REPO_ROOT' 2>/dev/null"
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "agent run: --timeout is named in the refusal, on stderr" {
+    _build_dotf
+    run bash -c "'$DOTF_BIN' agent run --role r --task t --tier mid \
+        --backend dry-run --repo-root '$REPO_ROOT' 2>&1 >/dev/null"
+    [ "$status" -eq 1 ]
+    printf '%s' "$output" | grep -q -- '--timeout is required'
+}
+
+@test "agent run: no backend is a loud refusal, not a silent dry run" {
+    _build_dotf
+    run bash -c "'$DOTF_BIN' agent run --role r --task t --tier mid \
+        --timeout 30s --repo-root '$REPO_ROOT' 2>&1 >/dev/null"
+    [ "$status" -eq 1 ]
+    printf '%s' "$output" | grep -q -- '--backend is required'
+}

--- a/tests/dotf-agent-run.bats
+++ b/tests/dotf-agent-run.bats
@@ -28,6 +28,13 @@ _build_dotf() {
     fi
 }
 
+# python3 parses the record in three cases. It is probed like `go` and `jq` are,
+# so a checkout without it SKIPS rather than fails — the file header promises
+# that, and an unprobed dependency turns a missing interpreter into a red suite.
+_need_python() {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not installed"
+}
+
 _run_dry() {
     _build_dotf
     "$DOTF_BIN" agent run \
@@ -37,6 +44,7 @@ _run_dry() {
 
 @test "agent run: stdout alone is a parseable JSON object" {
     _build_dotf
+    _need_python
     # stderr deliberately NOT merged: the claim is that a consumer capturing
     # only stdout gets the whole record. Merging 2>&1 would let a record written
     # to the wrong stream pass.
@@ -47,6 +55,7 @@ _run_dry() {
 }
 
 @test "agent run: the record names status, route and duration" {
+    _need_python
     run _run_dry mid
     [ "$status" -eq 0 ]
     local parsed
@@ -72,6 +81,7 @@ print("MISSING:" + ",".join(missing) if missing else r["status"] + " " + r["pool
 
 @test "agent run: the top tier resolves to its single declared entry" {
     _build_dotf
+    _need_python
     # Through a file rather than re-interpolating $output into another shell:
     # the record contains quotes, and a case that breaks on its own payload
     # fails for the wrong reason.


### PR DESCRIPTION
PR **B** of the five-PR sequence declared in `specs/CLI-042-dotf-agent-run/tasks.md`. Covers **AC1, AC2 and AC5**. Refs #1190.

`harness/model-map.json` declares `chains`, resolved at run time, and nothing read it — `dotf agent` was an unknown command, so the orchestration stack had a policy layer and no execution layer. This adds the layer.

## What lands

- **`dotf agent run`** — flags `--role --task --tier --cwd --timeout --backend --repo-root`; one JSON record on stdout, every log line on stderr.
- **`cli/internal/agent`** — the `Backend` seam (one method, the five semantics of ADR-032 §2) and the chain walk over `harness.ResolveChain`.
- **A `dry-run` backend** — resolves the route, sends nothing, exits 0.
- **`chains.top` capped at one entry** in `model-map.schema.json`.
- **Exit-code plumbing in `main()`**.

## Contract decisions

Recorded in `proposal.md`'s decision table, so they are not re-derived in review:

| | |
|---|---|
| **Exit codes** | `0` answered, `1` task failed, `3` no pool could serve — the same three `hive delegate` uses, so one vocabulary spans the seam and no translation table exists to drift. An unrecognised backend status is read as *task failed*, never *unavailable*: the fail-closed direction is the one that does not spend a second pool on a task that may already have been answered. `escalated` and `chain_exhausted` share exit 3 and stay distinct in the record's `status` — the code is the coarse class, the record carries the fine one. |
| **`--backend` required** | Until probing lands in PR D. Defaulting to `dry-run` would be the worst option available: a dispatch that silently ran nothing and exited 0. |
| **`dry-run` is a real backend** | Not a test double. It makes AC1's bats half runnable today, and after PR D it is still the way to inspect which pool and model a tier resolves to without spending a slot of a shared quota. The scripted fake the Go tests use stays test-only, injected through the seam. |

## The top tier is guarded twice, and they are not duplicates

ADR-032 §4: the top tier never degrades. The **dispatcher** never advances past the first entry whatever the map says; the **schema** caps `chains.top` at one entry so a fallback cannot be declared at all. One stops a second entry being *used*, the other stops it being *written*.

The behaviour test uses a two-entry top chain the map does not declare — against today's single-entry `chains.top`, a dispatcher with no rule at all would pass.

## Three things the work surfaced

- **`main()` could only ever exit 1**, collapsing *no pool could serve this* into *the task failed* at the process boundary — the exact collapse AC2 forbids one layer down. Fixed with a tagged error unwrapped in `main`, rather than the `os.Exit`-inside-`RunE` precedent in `secrets.go`, which costs that file a child-process re-exec harness to test at all.
- **`features.json`'s verification commands named tests that do not exist.** `go test -run <nonexistent>` exits **0** with `[no tests to run]`, so all ten would have certified unwritten tests. Rewritten to `go test -run '^X$' -v | grep -q '^--- PASS: X'`. Lesson 217 already described this exactly, and the file violated it anyway — a written lesson is not a guard.
- **The first `chains.top` schema edit was a loosening that reads as a tightening.** Naming `top` under `properties` exempts it from `additionalProperties`, so a bare `maxItems` dropped the array type, the minimum and the `pool:model` pattern. Caught by mutation, fixed with a sibling `$ref`, written up as **lesson 226**.

## Acceptance criteria blessed

The nine ACs were blessed in this PR (the spec was `status: draft`). Two were reworded against what PR A actually shipped, and both corrections came from measurement rather than from the plan:

- **AC6** — dropped "*served by NaN*". `hive delegate` describes "the configured worker" and names no provider on any shipped surface, by design. The pool name in the record is the dispatcher's claim read from `chains`, so the falsifiable form is *the model the chain named is the model that answered*.
- **AC8** — scoped to hive's **worker** (opencode's own `ollama`/`openrouter` provider catalogue is out of scope and must survive), and **not retired**: `HIVE_OLLAMA_ENDPOINT` is still deployed at `ai/agy/mcp_servers.json:10`. Hive dropping a provider upstream and this repo ceasing to deploy its endpoint are two changes; only the first has happened.

## Verification

Full evidence in `specs/CLI-042-dotf-agent-run/verification.md`.

- `go build ./... && go vet ./... && go test ./...` → **exit 0**, 18 packages ok
- `GOOS=windows go vet ./...` → clean; `gofmt -l .` → no output
- `golangci-lint run` (v2.12.2, matching the `versions.conf` pin) → **0 issues**
- `~/.local/bin/bats tests/*.bats` → **1462 tests, exit 0, 0 failures**; shellcheck clean on the new file
- Every `features.json` command run individually: **10 exit 0, 7 exit non-zero**. The ten are f1–f7, f9, f12, f13 — note f9 belongs to AC3, which PR C owns; it is the half of that criterion B can hold (the deadline reaches the backend), and counting it under B would misreport AC3 as met. The seven failures are the criteria C/D/E own, which is what `pending` has to mean

**Mutation checks**, because a passing test is not evidence that a test *would* fail:
- Top-tier rule removed from `Dispatch` → all four assertions in `TestDispatch_TopTierNeverDegrades` fail.
- `$ref` removed from `chains.top` → 3 of 5 schema cases fail; `chains.top: "claude:opus"` and `chains.top: []` are both **accepted**.

## LOC breakdown (Discipline Gate)

Total added lines exceed the cap, so the breakdown is declared here. Production Go is **483 lines**, of which **~170 are executable**: 127 comment lines, 49 blank, 115 declarative (type/const/struct fields, flag registrations), 22 cobra help prose. The remainder of the diff is tests (~640 lines), the bats smoke (114), spec artefacts (258) and the schema (26) — all excluded by the executable-lines rule.

## Not in this PR

The semaphore, timeout kill and cancellation (**C**); the real subprocess and hive backends and the end-to-end smoke (**D**); the IaC and the `dotf doctor` reachability check (**E**). The two open questions in `proposal.md` — the `nan` backend tie-break and the hive secret-delivery shape — are scoped to D and E and are unreachable from here: there is no second backend to tie-break between yet, and no daemon to deliver a secret to.

