### PR TITLE
fix(ssh): the hub alias still named the instance that was destroyed

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -35,8 +35,11 @@ Host jet1
   User manu
   IdentityFile ~/.ssh/id_ed25519
 
-Host aws1
-  Hostname aws1.kubelab.internal
+# The Argo CD hub. NAME, never a mesh IP: a MIG recreate rotates it
+# (.21 -> .24 -> .12 -> .13 across August 2026), so a pinned address is stale
+# from the next recreate onward. MagicDNS tracks it.
+Host gcp1
+  Hostname gcp1.kubelab.internal
   User deployer
   IdentityFile ~/.ssh/id_ed25519
 
@@ -86,7 +89,8 @@ Host jet1-lan
   IdentityFile ~/.ssh/id_ed25519
   ProxyJump rpi4-lan
 
-# aws1-pub removed — use `terraform output public_ip` for bootstrap access
+# No hub-pub alias: the GCP hub has no static public address to pin, and its
+# bootstrap access is `gcloud compute ssh` against the MIG's current instance.
 
 Host vps-pub
   Hostname 162.55.57.175
@@ -132,8 +136,10 @@ Host jet1-ext
   IdentityFile ~/.ssh/id_ed25519
   ProxyJump vps-pub
 
-Host aws1-ext
-  Hostname 100.64.0.7
+# Resolved on the bastion, which is itself on the mesh — so the name works here
+# too, and survives the recreates that would strand a pinned address.
+Host gcp1-ext
+  Hostname gcp1.kubelab.internal
   User deployer
   IdentityFile ~/.ssh/id_ed25519
   ProxyJump vps-pub


### PR DESCRIPTION
## What

The `KUBELAB-SSH` block carried `Host aws1` and `Host aws1-ext` and never gained a `gcp1` entry when the Argo CD hub migrated to GCP.

## Why it mattered today

Without an alias, `ssh gcp1` falls through to OpenSSH defaults:

| Expected | Actual |
|---|---|
| user `deployer` | user **`manu`** |
| hostname `gcp1.kubelab.internal` | hostname taken literally as `gcp1` |
| known host key | `StrictHostKeyChecking=ask` |

The `ask` has nobody to ask when it runs inside a Makefile, so `make fetch-kubeconfig ENV=hub` died on `ssh_askpass: exec(): No such file or directory` — an error that names the symptom and not the cause. That blocked `make deploy-argocd` mid-run, after the OIDC client secrets had already been rotated in SOPS and applied to Authelia but not yet to Argo CD.

## By name, not by address

Both entries address the host by name. A MIG recreate rotates the hub's mesh address — `.21 → .24 → .12 → .13` across August 2026 — so the pinned `100.64.0.7` in `aws1-ext` was the same failure waiting to happen again. MagicDNS tracks it. The `-ext` hostname resolves on the bastion, which is itself on the mesh.

## Verified

`ssh gcp1` and `ssh gcp1-ext` both connect as `deployer`, and `make fetch-kubeconfig ENV=hub` completes.

## Known structural debt, already tracked

This block is maintained by hand, which is why it kept a destroyed host and missed a new one. Generating it from `networking.*` is **kubelab#1289**; host certificates that would remove the key-approval step entirely are **kubelab#1261**. Neither is in scope here.