### PR TITLE
feat(cli): deny dispatch on a machine that has not declared who it is

### DIFF
--- a/cli/internal/agent/agent.go
+++ b/cli/internal/agent/agent.go
@@ -41,6 +41,10 @@ const (
 	StatusEscalated Status = "escalated"
 	// StatusDryRun — the routing was resolved and deliberately not executed.
 	StatusDryRun Status = "dry_run"
+	// StatusDenied — this machine forbids the pool (ADR-032 §7). A policy fact,
+	// not an availability one, but it advances the chain for the same reason:
+	// another entry may name a pool this machine does allow.
+	StatusDenied Status = "denied"
 	// StatusTimeout — the dispatch outlived its deadline and was abandoned.
 	// A dispatcher-level status: no backend returns it.
 	//
@@ -124,7 +128,10 @@ func ExitCode(s Status) int {
 	switch s {
 	case StatusOK, StatusDryRun:
 		return 0
-	case StatusChainExhausted, StatusEscalated:
+	case StatusChainExhausted, StatusEscalated, StatusDenied:
+		// Denied joins the 3 family: like an exhausted chain it means nothing
+		// ran, and unlike a task failure another machine may well be permitted
+		// to run it. The record's status carries the reason.
 		return 3
 	default:
 		return 1

--- a/cli/internal/agent/deny_test.go
+++ b/cli/internal/agent/deny_test.go
@@ -1,0 +1,126 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func denyOnly(pools ...string) func(string) bool {
+	set := map[string]bool{}
+	for _, p := range pools {
+		set[p] = true
+	}
+	return func(pool string) bool { return set[pool] }
+}
+
+// A denied pool is skipped and the chain continues: denial is a fact about
+// THIS machine, and another entry may name a pool it does allow. The point of
+// per-pool denial would be lost if one denied entry failed the whole dispatch.
+func TestDispatch_ADeniedPoolIsSkippedAndTheChainAdvances(t *testing.T) {
+	be := &scriptedBackend{byEntry: map[string]Response{
+		"claude:sonnet":         {Status: StatusOK, Output: "must never be reached"},
+		"nan:deepseek-v4-flash": {Status: StatusOK, Output: "answered"},
+	}}
+
+	rec := Dispatch(context.Background(), Options{
+		Tier:    "mid",
+		Chain:   []string{"claude:sonnet", "nan:deepseek-v4-flash"},
+		Timeout: time.Minute,
+		Denied:  denyOnly("claude"),
+		Now:     fixedClock(time.Millisecond),
+	}, be)
+
+	if rec.Status != StatusOK || rec.Pool != "nan" {
+		t.Errorf("record = %s on %s, want ok on nan", rec.Status, rec.Pool)
+	}
+	// The denied pool must never have been dispatched to. Asserting only the
+	// final record would pass on a dispatcher that asked claude first and threw
+	// the answer away — which would already have sent the task's content to a
+	// forbidden pool, the exact thing denial exists to prevent.
+	if len(be.seen) != 1 || be.seen[0] != "nan:deepseek-v4-flash" {
+		t.Errorf("backend saw %v; a denied pool must not be reached at all", be.seen)
+	}
+	if len(rec.Attempts) != 2 || rec.Attempts[0].Status != StatusDenied {
+		t.Errorf("attempts = %+v; the denial must leave a trace", rec.Attempts)
+	}
+}
+
+// Every entry denied is its own outcome, not "no pool could serve this". The
+// two send an operator to different places: one to quota and outages, the other
+// to machine.json.
+func TestDispatch_EveryEntryDeniedIsItsOwnStatus(t *testing.T) {
+	be := &scriptedBackend{byEntry: map[string]Response{}}
+
+	rec := Dispatch(context.Background(), Options{
+		Tier:    "mid",
+		Chain:   []string{"claude:sonnet", "nan:deepseek-v4-flash"},
+		Timeout: time.Minute,
+		Denied:  denyOnly("claude", "nan"),
+		Now:     fixedClock(time.Millisecond),
+	}, be)
+
+	if rec.Status != StatusDenied {
+		t.Errorf("status = %q, want %q", rec.Status, StatusDenied)
+	}
+	if rec.Exit == 0 {
+		t.Error("exit = 0; a dispatch that ran nowhere must not read as success")
+	}
+	if len(be.seen) != 0 {
+		t.Errorf("backend saw %v; nothing should have been dispatched", be.seen)
+	}
+}
+
+// An unidentified machine denies everything, so the top tier's single entry is
+// refused. The record must say DENIED rather than escalated: escalation means
+// "the pool could not serve this", and here the pool was never asked.
+func TestDispatch_AnUnidentifiedMachineDeniesEvenTheTopTier(t *testing.T) {
+	be := &scriptedBackend{byEntry: map[string]Response{
+		"claude:opus": {Status: StatusOK, Output: "must never be reached"},
+	}}
+
+	rec := Dispatch(context.Background(), Options{
+		Tier:    TierTop,
+		Chain:   []string{"claude:opus"},
+		Timeout: time.Minute,
+		Denied:  func(string) bool { return true }, // the unidentified-machine policy
+		Now:     fixedClock(time.Millisecond),
+	}, be)
+
+	if rec.Status != StatusDenied {
+		t.Errorf("status = %q, want %q", rec.Status, StatusDenied)
+	}
+	if len(be.seen) != 0 {
+		t.Errorf("backend saw %v on a machine that denies everything", be.seen)
+	}
+}
+
+// Denial is evaluated before the semaphore, so a forbidden pool consumes
+// nothing at all — not even a slot that some other dispatch could have used.
+func TestDispatch_ADeniedPoolTakesNoSemaphoreSlot(t *testing.T) {
+	dir := t.TempDir()
+	sem := NewSemaphore(dir)
+	be := &scriptedBackend{byEntry: map[string]Response{
+		"nan:deepseek-v4-flash": {Status: StatusOK, Output: "answered"},
+	}}
+
+	rec := Dispatch(context.Background(), Options{
+		Tier:      "mid",
+		Chain:     []string{"claude:sonnet", "nan:deepseek-v4-flash"},
+		Timeout:   time.Minute,
+		Denied:    denyOnly("claude"),
+		Semaphore: sem,
+		Capacity:  func(string) (int, bool) { return 1, true },
+		Now:       fixedClock(time.Millisecond),
+	}, be)
+
+	if rec.Status != StatusOK {
+		t.Fatalf("status = %q, want ok", rec.Status)
+	}
+	// claude's only slot must be free: it was denied, not dispatched to.
+	s, err := sem.Acquire("claude", 1)
+	if err != nil {
+		t.Fatalf("the denied pool's slot was consumed: %v", err)
+	}
+	s.Release()
+}

--- a/cli/internal/agent/dispatch.go
+++ b/cli/internal/agent/dispatch.go
@@ -19,6 +19,16 @@ type Options struct {
 	Cwd     string
 	Chain   []string
 	Timeout time.Duration
+	// Denied reports whether this machine forbids a pool. Evaluated per entry
+	// AT DISPATCH TIME rather than resolved once at config time (ADR-032 §7):
+	// otherwise a level-2 dispatch from a personal session could route work
+	// content through a personal pool on behalf of a denied machine.
+	//
+	// Nil means no policy was supplied. The command never leaves it nil — it
+	// refuses before the walk when the machine is unidentified — so nil here is
+	// a caller that is deliberately not enforcing denial, such as a unit test
+	// of the walk itself.
+	Denied func(pool string) bool
 	// Semaphore bounds concurrent dispatches per pool. Nil means no bound —
 	// only correct where the caller genuinely is not the launcher.
 	Semaphore *Semaphore
@@ -93,6 +103,14 @@ func Dispatch(ctx context.Context, opts Options, be Backend) Record {
 			return rec
 		}
 
+		if opts.Denied != nil && opts.Denied(pool) {
+			// Denial is checked before the slot is taken and before the backend
+			// is reached: a forbidden pool must consume nothing at all, not even
+			// a semaphore slot.
+			rec.Attempts = append(rec.Attempts, Attempt{Pool: pool, Model: model, Status: StatusDenied})
+			continue
+		}
+
 		// The slot is taken BEFORE the backend is reached and released as soon
 		// as the attempt is over, whether it answered or was abandoned.
 		slot, unbounded, err := acquire(opts, pool)
@@ -149,9 +167,16 @@ func Dispatch(ctx context.Context, opts Options, be Backend) Record {
 	// Nothing ran anywhere. The two ways to arrive here are different facts and
 	// get different names: the top tier DECLINED a fallback, a lower tier ran
 	// OUT of them.
-	if noFallback {
+	switch {
+	case allDenied(rec.Attempts):
+		// Naming this separately matters to whoever reads the record: "no pool
+		// could serve this" sends an operator looking at quota and outages,
+		// while "this machine forbids every pool the tier routes to" sends them
+		// to machine.json, which is where the answer actually is.
+		rec.Status = StatusDenied
+	case noFallback:
 		rec.Status = StatusEscalated
-	} else {
+	default:
 		rec.Status = StatusChainExhausted
 	}
 	rec.Exit = ExitCode(rec.Status)
@@ -225,3 +250,18 @@ func splitEntry(entry string) (pool, model string, err error) {
 }
 
 func elapsed(from, to time.Time) int64 { return to.Sub(from).Milliseconds() }
+
+// allDenied reports whether every entry the walk considered was refused by
+// machine policy. False for an empty slice: a chain with no entries never got
+// as far as being denied.
+func allDenied(attempts []Attempt) bool {
+	if len(attempts) == 0 {
+		return false
+	}
+	for _, a := range attempts {
+		if a.Status != StatusDenied {
+			return false
+		}
+	}
+	return true
+}

--- a/cli/internal/cmd/agent.go
+++ b/cli/internal/cmd/agent.go
@@ -58,7 +58,25 @@ A pool reporting itself unavailable advances to the next entry in the chain; a
 task that ran and failed does NOT — retrying a real failure on another model
 turns a bad answer into a silent second opinion. The top tier never degrades: if
 its pool cannot serve, this escalates and exits non-zero rather than quietly
-answering from a weaker model.`,
+answering from a weaker model.
+
+CONCURRENCY. Dispatches are bounded per pool at the map's declared concurrency
+minus its reserve_interactive, and the bound covers dispatches made through this
+command and nothing else. The pools are shared with consumers it cannot see — a
+hand-run qq, a pi TUI turn, hive embeddings, CI — each of which takes capacity
+no semaphore here counts. So the guarantee is exactly this and no wider:
+
+    dotf alone will never be the cause of exhaustion.
+
+The reserve makes starvation of your interactive session unlikely; it cannot
+make it impossible, and a dispatch that hits a rate limit is reported as the
+pool being unavailable so the chain moves on rather than retrying into the wall.
+
+DENIAL. Which pools a machine may use is declared in its machine.json, and is
+evaluated here at dispatch time rather than baked in at config time. A machine
+that has not declared an identity is refused outright: an undeclared machine
+denies every non-local pool, because defaulting the unknown case to "allowed"
+fails silently and in the direction nobody notices.`,
 		Example: `  dotf agent run --role reviewer --task "review this diff" --tier mid --backend dry-run --timeout 2m
   dotf agent run --role architect --task "decide" --tier top --backend dry-run --timeout 5m`,
 		Args:         cobra.NoArgs,
@@ -94,6 +112,17 @@ answering from a weaker model.`,
 				return err
 			}
 
+			policy, err := env.LoadMachinePolicy(env.MachinePath(env.Home()))
+			if err != nil {
+				return err
+			}
+			if !policy.Identified {
+				return fmt.Errorf(unidentifiedMachine, env.MachinePath(env.Home()))
+			}
+			if err := policy.ValidateDeny(declaredPools(m)); err != nil {
+				return err
+			}
+
 			semDir := semaphoreDir
 			if semDir == "" {
 				// Not derived from --repo-root: the budget is a property of the
@@ -107,6 +136,7 @@ answering from a weaker model.`,
 			rec := agent.Dispatch(cmd.Context(), agent.Options{
 				Tier: tier, Role: role, Task: task, Cwd: cwd,
 				Chain: chain, Timeout: timeout,
+				Denied:    policy.Denies,
 				Semaphore: agent.NewSemaphore(semDir),
 				Capacity:  declaredCapacity(m),
 			}, backend)
@@ -199,4 +229,43 @@ func summarise(rec agent.Record) error {
 	default:
 		return fmt.Errorf("task failed on %s:%s (exit %d)", rec.Pool, rec.Model, rec.Exit)
 	}
+}
+
+// unidentifiedMachine is the refusal a machine gets when it has not said who it
+// is. ADR-032 §8 makes this the required direction rather than a convenience:
+// a rebuilt corporate machine that has not restored machine.json probes
+// successfully for personal pools, so defaulting to "allowed" would fail
+// silently and in the wrong direction.
+//
+// It names the file, the key and a working value, because a fail-closed
+// refusal whose remedy the operator has to go and look up is a fail-closed
+// refusal people route around.
+const unidentifiedMachine = `this machine has not declared an identity, so every non-local pool is denied (ADR-032 §8)
+
+Declare one in %s:
+
+    {
+      "machine": { "id": "<a-name-for-this-machine>" },
+      "pools":   { "deny": [] }
+    }
+
+Keep any existing "paths" block; this adds to the same file. The deny list is
+where a machine forbids pools it must not use — an empty list denies nothing.
+The default is denial rather than permission on purpose: a rebuilt machine that
+has not restored this file probes successfully for every pool, and allowing them
+would be a silent failure in the direction that cannot be noticed`
+
+// declaredPools is the set of pool names the routing map declares — the
+// allow-list `pools.deny` entries are checked against, so a typo is refused
+// rather than silently leaving the pool it meant to forbid allowed.
+func declaredPools(m map[string]any) map[string]bool {
+	out := map[string]bool{}
+	pools, ok := m["pools"].(map[string]any)
+	if !ok {
+		return out
+	}
+	for name := range pools {
+		out[name] = true
+	}
+	return out
 }

--- a/cli/internal/cmd/agent_deny_test.go
+++ b/cli/internal/cmd/agent_deny_test.go
@@ -1,0 +1,193 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedMachine writes an arbitrary machine.json into a fixture config dir, for
+// the cases that need a shape declareIdentity does not produce.
+func seedMachine(t *testing.T, body string) {
+	t.Helper()
+	cfg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	dir := filepath.Join(cfg, "dotfiles")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "machine.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+// AC4's second half. ADR-032 §8: a machine whose identity cannot be established
+// denies every non-local pool, so the unknown case degrades to "no cross-pool
+// dispatch" rather than to "all pools allowed".
+func TestAgentRun_AnUnidentifiedMachineIsRefused(t *testing.T) {
+	root := repoRootForTest(t)
+
+	tests := []struct {
+		name string
+		// seed is the machine.json body; empty means no file at all.
+		seed string
+	}{
+		{name: "no machine.json at all"},
+		{name: "only paths declared", seed: `{"paths": {"VAULT_PATH": "/v"}}`},
+		{name: "a machine block with no id", seed: `{"machine": {}}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.seed == "" {
+				t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // exists, holds no machine.json
+			} else {
+				seedMachine(t, tc.seed)
+			}
+
+			stdout, _, err := captureRealStreams(t,
+				"agent", "run", "--role", "r", "--task", "t", "--tier", "mid",
+				"--backend", "dry-run", "--timeout", "1m", "--repo-root", root,
+			)
+			if err == nil {
+				t.Fatal("an unidentified machine dispatched; the default must be denial, not permission")
+			}
+			if strings.TrimSpace(stdout) != "" {
+				t.Errorf("stdout is not empty on a refusal: %q", stdout)
+			}
+			if got := ExitCode(err); got != 1 {
+				t.Errorf("exit = %d, want 1", got)
+			}
+
+			// The remedy has to be IN the message. A fail-closed refusal whose
+			// fix the operator must go and look up is one people route around.
+			msg := err.Error()
+			for _, want := range []string{"machine.json", `"machine"`, `"id"`, "deny"} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("refusal does not name %q, so it is not actionable:\n%s", want, msg)
+				}
+			}
+			if !strings.Contains(msg, "ADR-032") {
+				t.Errorf("refusal cites no decision record, so it reads as an arbitrary rule:\n%s", msg)
+			}
+		})
+	}
+}
+
+// A deny entry naming no declared pool is refused rather than ignored: `claud`
+// in the list leaves `claude` allowed on a machine whose intent was to forbid
+// it, and nothing would ever say so.
+func TestAgentRun_ADenyTypoIsRefused(t *testing.T) {
+	root := repoRootForTest(t)
+	seedMachine(t, `{"machine": {"id": "corp"}, "pools": {"deny": ["claud"]}}`)
+
+	stdout, _, err := captureRealStreams(t,
+		"agent", "run", "--role", "r", "--task", "t", "--tier", "mid",
+		"--backend", "dry-run", "--timeout", "1m", "--repo-root", root,
+	)
+	if err == nil {
+		t.Fatal("a deny entry naming no declared pool was accepted")
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Errorf("stdout is not empty on a refusal: %q", stdout)
+	}
+	if !strings.Contains(err.Error(), "claud") {
+		t.Errorf("refusal does not name the offending entry:\n%s", err.Error())
+	}
+}
+
+// An identified machine that denies the chain's first pool routes around it.
+func TestAgentRun_DenialSkipsThePoolAndRecordsIt(t *testing.T) {
+	root := repoRootForTest(t)
+	declareIdentity(t, "claude")
+
+	stdout, _, err := captureRealStreams(t,
+		"agent", "run", "--role", "reviewer", "--task", "t", "--tier", "mid",
+		"--backend", "dry-run", "--timeout", "1m", "--repo-root", root,
+	)
+	if err != nil {
+		t.Fatalf("agent run: %v", err)
+	}
+
+	var rec struct {
+		Status   string `json:"status"`
+		Pool     string `json:"pool"`
+		Attempts []struct {
+			Pool   string `json:"pool"`
+			Status string `json:"status"`
+		} `json:"attempts"`
+	}
+	if jsonErr := json.Unmarshal([]byte(stdout), &rec); jsonErr != nil {
+		t.Fatalf("stdout is not a record: %v (%q)", jsonErr, stdout)
+	}
+	if rec.Pool == "claude" {
+		t.Error("the dispatch went to a denied pool")
+	}
+	if len(rec.Attempts) == 0 || rec.Attempts[0].Pool != "claude" || rec.Attempts[0].Status != "denied" {
+		t.Errorf("attempts = %+v; the denial must leave a trace naming the pool", rec.Attempts)
+	}
+}
+
+// Every pool denied is its own record, distinguishable from "no pool could
+// serve this" — the two send an operator to different places.
+func TestAgentRun_EveryPoolDeniedIsItsOwnOutcome(t *testing.T) {
+	root := repoRootForTest(t)
+	declareIdentity(t, "claude", "nan")
+
+	stdout, _, err := captureRealStreams(t,
+		"agent", "run", "--role", "r", "--task", "t", "--tier", "mid",
+		"--backend", "dry-run", "--timeout", "1m", "--repo-root", root,
+	)
+	if err == nil {
+		t.Fatal("a dispatch with every pool denied succeeded")
+	}
+
+	var rec struct {
+		Status string `json:"status"`
+	}
+	if jsonErr := json.Unmarshal([]byte(stdout), &rec); jsonErr != nil {
+		t.Fatalf("no record for a walk that happened: %v (%q)", jsonErr, stdout)
+	}
+	if rec.Status != "denied" {
+		t.Errorf("status = %q, want denied — not chain_exhausted, which would send an operator "+
+			"looking at quota rather than at machine.json", rec.Status)
+	}
+	if got := ExitCode(err); got != 3 {
+		t.Errorf("exit = %d, want 3: nothing ran, and another machine may be permitted to run it", got)
+	}
+}
+
+// AC4's wording clause, asserted rather than trusted to review. The guarantee
+// this tool can keep is narrow, and overstating it is the failure: a reader who
+// believes exhaustion cannot happen will not build for the case where it does.
+func TestAgentRun_StatesTheNarrowGuaranteeAndNotAWiderOne(t *testing.T) {
+	stdout, _, err := captureRealStreams(t, "agent", "run", "--help")
+	if err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	help := stdout
+
+	if !strings.Contains(help, "dotf alone will never be the cause of exhaustion") {
+		t.Error("help text does not state the narrow guarantee verbatim")
+	}
+	// The concurrency the map declares is shared with consumers dotf cannot
+	// see, and the help has to say so or the narrow claim reads as a wide one.
+	for _, want := range []string{"shared", "reserve"} {
+		if !strings.Contains(strings.ToLower(help), want) {
+			t.Errorf("help text does not mention %q, so the bound reads as absolute", want)
+		}
+	}
+	// Claims the tool cannot keep.
+	for _, forbidden := range []string{
+		"exhaustion cannot happen",
+		"guarantees that the pool",
+		"will never be exhausted",
+		"prevents exhaustion",
+	} {
+		if strings.Contains(strings.ToLower(help), strings.ToLower(forbidden)) {
+			t.Errorf("help text overstates the guarantee with %q", forbidden)
+		}
+	}
+}

--- a/cli/internal/cmd/agent_test.go
+++ b/cli/internal/cmd/agent_test.go
@@ -11,12 +11,41 @@ import (
 	"github.com/mlorentedev/dotfiles/cli/internal/harness"
 )
 
+// declareIdentity points machine.json at a fixture that declares one, so a case
+// exercising the dispatch path is not stopped by the identity gate.
+//
+// It is a fixture rather than the machine's real file for the reason the gate
+// exists: a test that passed only on a machine whose owner had configured it
+// would be green here and red in CI, and the version that "fixed" that would be
+// one that skipped the gate.
+func declareIdentity(t *testing.T, deny ...string) {
+	t.Helper()
+	cfg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	dir := filepath.Join(cfg, "dotfiles")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	list, err := json.Marshal(deny)
+	if err != nil {
+		t.Fatalf("marshal deny: %v", err)
+	}
+	if deny == nil {
+		list = []byte("[]")
+	}
+	body := `{"machine": {"id": "test-machine"}, "pools": {"deny": ` + string(list) + `}}`
+	if err := os.WriteFile(filepath.Join(dir, "machine.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("seed machine.json: %v", err)
+	}
+}
+
 // AC1. This is a stdout contract, so it is tested through captureRealStreams
 // rather than execute(): the consumer is a dispatcher reading a pipe, and a
 // record written to stderr is an empty string at that call site while looking
 // perfectly fine in a merged capture (BUG-070 #915).
 func TestAgentRun_WritesOneJSONObjectToStdout(t *testing.T) {
 	root := repoRootForTest(t)
+	declareIdentity(t)
 
 	stdout, stderr, err := captureRealStreams(t,
 		"agent", "run",
@@ -80,6 +109,7 @@ func TestAgentRun_WritesOneJSONObjectToStdout(t *testing.T) {
 // failed dispatch would otherwise read a truncated object.
 func TestAgentRun_RefusalsLeaveStdoutEmpty(t *testing.T) {
 	root := repoRootForTest(t)
+	declareIdentity(t)
 	base := []string{"agent", "run", "--repo-root", root}
 
 	tests := []struct {
@@ -150,6 +180,7 @@ func TestAgentRun_RefusalsLeaveStdoutEmpty(t *testing.T) {
 // stdout, exit 1 — never exit 3, which a composer would read as "busy, try the
 // next pool" and retry against a registry that is broken for every pool.
 func TestAgentRun_AMapTheSchemaRefusesStopsBeforeDispatch(t *testing.T) {
+	declareIdentity(t)
 	root := t.TempDir()
 	writeMapFixture(t, root, mapFixtureWithMidChain(`["nan-deepseek-v4-flash"]`))
 	copySchemaFixture(t, root)
@@ -174,6 +205,7 @@ func TestAgentRun_AMapTheSchemaRefusesStopsBeforeDispatch(t *testing.T) {
 // command works against reality; this one proves it reports the route it was
 // given rather than one it invented.
 func TestAgentRun_ReportsTheRouteTheMapDeclares(t *testing.T) {
+	declareIdentity(t)
 	root := t.TempDir()
 	writeMapFixture(t, root, mapFixtureWithMidChain(`["nan:mimo-v2.5"]`))
 	copySchemaFixture(t, root)

--- a/cli/internal/cmd/stdout_contract_test.go
+++ b/cli/internal/cmd/stdout_contract_test.go
@@ -68,6 +68,8 @@ func captureRealStreams(t *testing.T, args ...string) (stdout, stderr string, er
 // an empty string at the call site rather than a visible failure.
 func TestStdoutContracts(t *testing.T) {
 	t.Setenv("VAULT_PATH", "/tmp/stdout-contract-probe")
+	// `agent run` refuses on a machine with no declared identity (ADR-032 §8).
+	declareIdentity(t)
 
 	tests := []struct {
 		name     string

--- a/cli/internal/env/machinepolicy.go
+++ b/cli/internal/env/machinepolicy.go
@@ -1,0 +1,123 @@
+package env
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// MachinePolicy is what machine.json says about WHO this machine is and which
+// pools it forbids. It is the one exception to ADR-032 §7's "machine facts are
+// probed, never stored": a probe can answer whether a pool is reachable, and
+// cannot answer whether it is permitted.
+//
+// The zero value denies everything, deliberately. ADR-032 §8 requires that a
+// machine whose identity cannot be established denies every non-local pool, so
+// the unknown case degrades to "no cross-pool dispatch" rather than to "all
+// pools allowed" — and a caller that forgets to populate this gets the safe
+// answer rather than the permissive one.
+type MachinePolicy struct {
+	// Identified is false when machine.json declares no id. It is not an error
+	// condition: an unconfigured machine is a normal state, it is simply one
+	// that may not dispatch anywhere until it says who it is.
+	Identified bool
+	ID         string
+	Deny       []string
+
+	denied map[string]bool
+}
+
+// Denies reports whether this machine forbids dispatching to pool.
+//
+// An unidentified machine denies everything. That is the security-relevant
+// default and the reason this type exists: a rebuilt corporate machine that has
+// not restored machine.json probes successfully for personal pools, and the
+// failure of allowing them would be silent and in the wrong direction.
+func (p MachinePolicy) Denies(pool string) bool {
+	if !p.Identified {
+		return true
+	}
+	return p.denied[pool]
+}
+
+// ValidateDeny rejects a deny entry that names no declared pool.
+//
+// The typo fails dangerously: `claud` in the list leaves `claude` allowed on a
+// machine whose whole intent was to forbid it, and nothing would ever say so.
+// declared is the set of pool names the routing map declares.
+func (p MachinePolicy) ValidateDeny(declared map[string]bool) error {
+	var unknown []string
+	for _, name := range p.Deny {
+		if !declared[name] {
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	known := make([]string, 0, len(declared))
+	for name := range declared {
+		known = append(known, name)
+	}
+	sort.Strings(known)
+	return fmt.Errorf(
+		"machine.json pools.deny names %s, which the routing map does not declare (it declares %s)\n"+
+			"this is refused rather than ignored: a misspelled entry silently leaves the pool it meant "+
+			"to forbid allowed, which is the direction that cannot be noticed",
+		strings.Join(quoteAll(unknown), ", "), strings.Join(quoteAll(known), ", "))
+}
+
+func quoteAll(in []string) []string {
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = fmt.Sprintf("%q", s)
+	}
+	return out
+}
+
+// machinePolicyFile is the subset of machine.json this reads. It is a separate
+// struct from `machine` because the two have different absence semantics: an
+// absent `paths` is an empty override set, while an absent `machine` block is a
+// machine that may not dispatch.
+type machinePolicyFile struct {
+	Machine struct {
+		ID string `json:"id"`
+	} `json:"machine"`
+	Pools struct {
+		Deny []string `json:"deny"`
+	} `json:"pools"`
+}
+
+// LoadMachinePolicy reads the identity and denial policy from machine.json.
+//
+// An ABSENT file yields an unidentified policy and no error: not declaring an
+// identity is a state, not a fault, and the denial that follows is the point. A
+// MALFORMED file is an error: the file is there and cannot be trusted, and
+// silently denying would send an operator hunting for a policy that is really a
+// syntax error.
+func LoadMachinePolicy(path string) (MachinePolicy, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return MachinePolicy{}, nil
+		}
+		return MachinePolicy{}, fmt.Errorf("read machine.json (%s): %w", path, err)
+	}
+	var f machinePolicyFile
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return MachinePolicy{}, fmt.Errorf("parse machine.json (%s): %w", path, err)
+	}
+
+	id := strings.TrimSpace(f.Machine.ID)
+	p := MachinePolicy{Identified: id != "", ID: id, denied: map[string]bool{}}
+	for _, name := range f.Pools.Deny {
+		if n := strings.TrimSpace(name); n != "" {
+			p.Deny = append(p.Deny, n)
+			p.denied[n] = true
+		}
+	}
+	return p, nil
+}

--- a/cli/internal/env/machinepolicy_test.go
+++ b/cli/internal/env/machinepolicy_test.go
@@ -1,0 +1,153 @@
+package env
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func seedMachineFile(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "machine.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("seed machine.json: %v", err)
+	}
+	return path
+}
+
+// The default is the security-relevant one. ADR-032 §8: a machine whose
+// identity cannot be established denies every non-local pool, so the unknown
+// case degrades to "no cross-pool dispatch" rather than to "all pools allowed".
+//
+// The failure this prevents is specific and silent: a rebuilt corporate machine
+// that has not restored machine.json probes successfully for personal pools and
+// would otherwise default to allowing them.
+func TestLoadMachinePolicy_UnidentifiedMachineIsNotAPermissiveOne(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		// path empty means "the file does not exist at all"
+		missing bool
+	}{
+		{name: "no file at all", missing: true},
+		{name: "a file with only paths", body: `{"paths": {"VAULT_PATH": "/v"}}`},
+		{name: "a machine block with no id", body: `{"machine": {}}`},
+		{name: "an id that is only whitespace", body: `{"machine": {"id": "   "}}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "machine.json")
+			if !tc.missing {
+				path = seedMachineFile(t, tc.body)
+			}
+			p, err := LoadMachinePolicy(path)
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			if p.Identified {
+				t.Fatal("identity reported as established; an undeclared machine must not be a trusted one")
+			}
+			// Every pool is denied, including ones no deny list mentions.
+			for _, pool := range []string{"nan", "claude", "anything"} {
+				if !p.Denies(pool) {
+					t.Errorf("pool %q allowed on an unidentified machine", pool)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadMachinePolicy_DeclaredIdentity(t *testing.T) {
+	path := seedMachineFile(t, `{
+      "paths": {"VAULT_PATH": "/v"},
+      "machine": {"id": "msi"},
+      "pools": {"deny": ["claude"]}
+    }`)
+
+	p, err := LoadMachinePolicy(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !p.Identified {
+		t.Fatal("a declared id did not establish identity")
+	}
+	if p.ID != "msi" {
+		t.Errorf("id = %q, want msi", p.ID)
+	}
+	if !p.Denies("claude") {
+		t.Error("claude is on the deny list and was allowed")
+	}
+	if p.Denies("nan") {
+		t.Error("nan is not on the deny list and was denied")
+	}
+	if len(p.Deny) != 1 || p.Deny[0] != "claude" {
+		t.Errorf("Deny = %v, want [claude]", p.Deny)
+	}
+}
+
+// An identified machine with no deny list denies nothing. The fail-closed
+// default is about UNKNOWN identity, not about silence on denial: conflating
+// them would make declaring an identity useless.
+func TestLoadMachinePolicy_IdentifiedWithNoDenyListAllowsEverything(t *testing.T) {
+	p, err := LoadMachinePolicy(seedMachineFile(t, `{"machine": {"id": "msi"}}`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !p.Identified {
+		t.Fatal("identity not established")
+	}
+	for _, pool := range []string{"nan", "claude", "copilot"} {
+		if p.Denies(pool) {
+			t.Errorf("pool %q denied with no deny list present", pool)
+		}
+	}
+}
+
+// A malformed machine.json must not read as an absent one. Absent means "not
+// declared" and denies; malformed means the file is there and cannot be
+// trusted, which has to be loud — silently denying would send an operator
+// hunting for a policy that is actually a syntax error.
+func TestLoadMachinePolicy_MalformedIsAnErrorNotAnAbsence(t *testing.T) {
+	_, err := LoadMachinePolicy(seedMachineFile(t, `{"machine": {"id": "msi"`))
+	if err == nil {
+		t.Fatal("a truncated machine.json parsed successfully")
+	}
+	if !strings.Contains(err.Error(), "machine.json") {
+		t.Errorf("error does not name the file: %v", err)
+	}
+}
+
+// A deny entry naming a pool that does not exist is almost always a typo, and
+// the typo fails in the dangerous direction: `claud` in the list leaves
+// `claude` allowed on a machine that meant to forbid it.
+func TestMachinePolicy_ValidateDenyNames(t *testing.T) {
+	declared := map[string]bool{"nan": true, "claude": true, "copilot": true}
+
+	t.Run("every name resolves", func(t *testing.T) {
+		p := MachinePolicy{Identified: true, Deny: []string{"claude", "nan"}}
+		if err := p.ValidateDeny(declared); err != nil {
+			t.Errorf("valid deny list rejected: %v", err)
+		}
+	})
+
+	t.Run("a typo is rejected and named", func(t *testing.T) {
+		p := MachinePolicy{Identified: true, Deny: []string{"claud"}}
+		err := p.ValidateDeny(declared)
+		if err == nil {
+			t.Fatal("a deny entry naming no declared pool was accepted; the pool it meant stays allowed")
+		}
+		if !strings.Contains(err.Error(), "claud") {
+			t.Errorf("error does not name the offending entry: %v", err)
+		}
+	})
+
+	t.Run("an empty deny list is not an error", func(t *testing.T) {
+		p := MachinePolicy{Identified: true}
+		if err := p.ValidateDeny(declared); err != nil {
+			t.Errorf("empty deny list rejected: %v", err)
+		}
+	})
+}

--- a/machine.json.example
+++ b/machine.json.example
@@ -1,8 +1,15 @@
 {
-  "_comment": "EXAMPLE per-machine path overrides (ADR-025). Copy to ~/.config/dotfiles/machine.json (Windows: %USERPROFILE%\\.config\\dotfiles\\machine.json) and edit. List ONLY the keys this machine relocates vs env-contract.json defaults; omit the rest. After editing, run `dotf env generate`. The real machine.json lives OUTSIDE any repo and is never committed — this example is the only path file that belongs in git.",
+  "_comment": "EXAMPLE per-machine path overrides (ADR-025). Copy to ~/.config/dotfiles/machine.json (Windows: %USERPROFILE%\\.config\\dotfiles\\machine.json) and edit. List ONLY the keys this machine relocates vs env-contract.json defaults; omit the rest. The `machine` and `pools` blocks below are separate from `paths` and are read by `dotf agent run`. After editing, run `dotf env generate`. The real machine.json lives OUTSIDE any repo and is never committed — this example is the only path file that belongs in git.",
   "paths": {
     "DOTFILES_REPO_DIR": "/home/you/Projects/dotfiles",
     "VAULT_PATH": "/home/you/Projects/knowledge",
     "HIVE_VAULT_PATH": "/home/you/Projects/knowledge"
+  },
+  "machine": {
+    "id": "give-this-machine-a-name"
+  },
+  "pools": {
+    "_comment": "Pools this machine must NOT dispatch to (ADR-032 §7), evaluated at dispatch time. An empty list denies nothing. A corporate machine forbidding personal pools would read [\"claude\", \"nan\"]. Every name must be one the routing map declares — a typo is refused rather than ignored, because it would silently leave the pool it meant to forbid allowed.",
+    "deny": []
   }
 }

--- a/specs/CLI-042-dotf-agent-run/features.json
+++ b/specs/CLI-042-dotf-agent-run/features.json
@@ -99,15 +99,36 @@
   },
   {
     "id": "CLI-042-dotf-agent-run-f10",
-    "behavior": "AC4 — an unreadable concurrency counter exits non-zero rather than reading as zero in use, and an unidentifiable machine denies every non-local pool",
-    "verification": "cd cli && out=$(go test ./internal/agent/ -run '^TestFailsClosed$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestFailsClosed'",
+    "behavior": "AC4 — a machine whose identity cannot be established denies every non-local pool, and the refusal names the file, the key and a working value",
+    "verification": "cd cli && out=$(go test ./internal/env/ -run '^TestLoadMachinePolicy_UnidentifiedMachineIsNotAPermissiveOne$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestLoadMachinePolicy_UnidentifiedMachineIsNotAPermissiveOne'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f11",
     "behavior": "AC4 — help text and error messages state the narrow guarantee ('dotf alone will never be the cause of exhaustion'), never that exhaustion cannot happen",
-    "verification": "cd cli && out=$(go test ./internal/agent/ -run '^TestGuaranteeWordingIsNarrow$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestGuaranteeWordingIsNarrow'",
+    "verification": "cd cli && out=$(go test ./internal/cmd/ -run '^TestAgentRun_StatesTheNarrowGuaranteeAndNotAWiderOne$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestAgentRun_StatesTheNarrowGuaranteeAndNotAWiderOne'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f23",
+    "behavior": "AC4 — the command refuses an unidentified machine before dispatching, leaves stdout empty, and exits 1",
+    "verification": "cd cli && out=$(go test ./internal/cmd/ -run '^TestAgentRun_AnUnidentifiedMachineIsRefused$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestAgentRun_AnUnidentifiedMachineIsRefused'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f24",
+    "behavior": "AC4 — pools.deny is evaluated per entry at dispatch time: a denied pool is skipped without being reached, and every pool denied is its own status rather than chain_exhausted",
+    "verification": "cd cli && out=$(go test ./internal/agent/ -run '^TestDispatch_(ADeniedPoolIsSkippedAndTheChainAdvances|EveryEntryDeniedIsItsOwnStatus|ADeniedPoolTakesNoSemaphoreSlot)$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestDispatch_ADeniedPoolIsSkippedAndTheChainAdvances'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f25",
+    "behavior": "AC4 — a pools.deny entry naming no declared pool is refused, because the typo silently leaves the pool it meant to forbid allowed",
+    "verification": "cd cli && out=$(go test ./internal/cmd/ -run '^TestAgentRun_ADenyTypoIsRefused$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestAgentRun_ADenyTypoIsRefused'",
     "state": "pending",
     "evidence": ""
   },

--- a/specs/CLI-042-dotf-agent-run/tasks.md
+++ b/specs/CLI-042-dotf-agent-run/tasks.md
@@ -120,16 +120,31 @@ Added while implementing C1:
 
 ### PR C2 — machine identity and denial
 
-- [ ] [AC4] Failing test: a machine whose identity cannot be established denies every non-local pool
-- [ ] [AC4] Implement machine identity and `pools.deny`, read from `machine.json` **at dispatch time**
+- [x] [AC4] Failing test: a machine whose identity cannot be established denies every non-local pool
+- [x] [AC4] Implement machine identity and `pools.deny`, read from `machine.json` **at dispatch time**
       (ADR-032 §7) and never cached
-- [ ] [AC4] Validate `pools.deny` names against the map's pools — a typo (`claud`) would leave
+- [x] [AC4] Validate `pools.deny` names against the map's pools — a typo (`claud`) would leave
       `claude` allowed, a silent failure in the direction §8 exists to prevent
-- [ ] [AC4] Assert the wording: help text and error messages state *`dotf` alone will never be the
+- [x] [AC4] Assert the wording: help text and error messages state *`dotf` alone will never be the
       cause of exhaustion*, never that exhaustion cannot happen
-- [ ] [AC4] Point the bats smoke at a fixture HOME. Once identity is required, the smoke's own
+- [x] [AC4] Point the bats smoke at a fixture HOME. Once identity is required, the smoke's own
       dispatches refuse on any machine that has not declared one — including CI. The case that
       asserts the refusal is AC4's bats evidence.
+
+Added while implementing C2:
+
+- [x] [AC4] `MachinePolicy`'s **zero value denies everything**, so a caller that forgets to populate
+      it gets the safe answer rather than the permissive one. The fail-closed direction is the
+      default by construction, not by remembering to ask.
+- [x] [AC4] An **absent** `machine.json` is an unidentified machine (denies, no error); a
+      **malformed** one is a hard error. Conflating them would send an operator hunting for a policy
+      that is really a syntax error.
+- [x] [AC4] Denial is evaluated **before the semaphore**, so a forbidden pool consumes nothing —
+      not even a slot another dispatch could have used.
+- [x] [AC4] Every entry denied is its own status (`denied`, exit 3), distinguishable from
+      `chain_exhausted`: one sends an operator to quota and outages, the other to `machine.json`.
+- [x] [AC4] `machine.json.example` carries the `machine` and `pools` blocks — it is the surface
+      people copy, so a gate whose remedy is undocumented there is a gate people route around.
 
 ### PR D — the real backends
 

--- a/specs/CLI-042-dotf-agent-run/verification.md
+++ b/specs/CLI-042-dotf-agent-run/verification.md
@@ -9,9 +9,9 @@ created: "2026-08-23"
 
 Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
 
-**PRs B and C1.** This spec ships as the sequence `tasks.md` declares (C was split into C1/C2 during
+**PRs B, C1 and C2.** This spec ships as the sequence `tasks.md` declares (C was split into C1/C2 during
 C1, because one PR carrying both AC3 and AC4 does not fit the atomic cap). B covered AC1, AC2 and
-AC5; **C1 covers AC3**. The rest are named here as open with the PR that owns them, so a
+AC5; **C1 covers AC3, C2 covers AC4**. With that, **AC1-AC5 are complete**; the rest are named here as open with the PR that owns them, so a
 partly-filled section is never read as a partly-met criterion.
 
 - [x] AC1 (JSON contract on stdout, logs on stderr) -> `TestAgentRun_WritesOneJSONObjectToStdout`,
@@ -31,10 +31,17 @@ partly-filled section is never read as a partly-met criterion.
       work only. A hand-run `qq`, a pi TUI turn or a hive embedding call takes a slot the semaphore
       never sees. The claim is *`dotf` alone will never be the cause of exhaustion*, not that
       exhaustion cannot happen.
-- [ ] AC4 (fails closed on an unreadable counter and an unidentifiable machine) -> **PR C2**, except
-      the counter half, which landed in C1 (`TestSemaphore_UnreadableStateIsAnErrorNotZeroInUse`) —
-      in this design the semaphore state IS the counter, so the test has nowhere else to live. The
-      machine-identity half and the wording assertion are C2's.
+- [x] AC4 (fails closed on an unreadable counter and an unidentifiable machine) -> **the counter half
+      in C1** (`TestSemaphore_UnreadableStateIsAnErrorNotZeroInUse` — in this design the semaphore
+      state IS the counter); **the machine half and the wording in C2**:
+      `TestLoadMachinePolicy_*` (4 tests: unidentified denies everything across four shapes, declared
+      identity, identified-with-no-deny-list allows, malformed is an error not an absence),
+      `TestMachinePolicy_ValidateDenyNames`, `TestAgentRun_AnUnidentifiedMachineIsRefused` (asserts
+      the remedy is IN the message), `TestAgentRun_ADenyTypoIsRefused`,
+      `TestAgentRun_EveryPoolDeniedIsItsOwnOutcome`, `TestDispatch_ADenied*` (3), and three bats cases
+      through the compiled binary.
+      `TestAgentRun_StatesTheNarrowGuaranteeAndNotAWiderOne` asserts the wording in both directions:
+      the narrow guarantee verbatim, and four overstatements that must NOT appear.
 - [x] AC5 (the top tier escalates, never degrades) -> `TestDispatch_TopTierNeverDegrades` (behaviour)
       and `TestChainsTopIsCappedWithoutLosingTheChainShape` (shape, in the schema)
 - [ ] AC6 (the hive backend answers and reports pool + model) -> **PR D.** Still unrunnable on this

--- a/tests/dotf-agent-run.bats
+++ b/tests/dotf-agent-run.bats
@@ -19,6 +19,14 @@ setup() {
     # subscription), so a smoke that used the default would take real slots from
     # whatever else is dispatching on this box.
     SEM_DIR="$BATS_TEST_TMPDIR/slots"
+    # `dotf agent run` refuses on a machine that has not declared an identity
+    # (ADR-032 §8), so the smoke points machine.json at a fixture rather than
+    # the real one. Pointing at the real file would make these cases pass only
+    # on a machine whose owner had configured it — green here, red in CI.
+    export XDG_CONFIG_HOME="$BATS_TEST_TMPDIR/config"
+    mkdir -p "$XDG_CONFIG_HOME/dotfiles"
+    printf '%s\n' '{"machine": {"id": "bats-fixture"}, "pools": {"deny": []}}' \
+        > "$XDG_CONFIG_HOME/dotfiles/machine.json"
 }
 
 # Build once per file run into a cached location, so the cases do not pay a
@@ -172,4 +180,52 @@ print("advanced")
 ' "$rec"
     [ "$status" -eq 0 ]
     [ "$output" = "advanced" ]
+}
+
+@test "agent run: a machine with no declared identity is refused, and told how to fix it" {
+    _build_dotf
+    # A config dir that exists and holds no machine.json — the rebuilt-machine
+    # case ADR-032 §8 is about, not a broken environment.
+    local empty="$BATS_TEST_TMPDIR/no-identity"
+    mkdir -p "$empty"
+    run env XDG_CONFIG_HOME="$empty" "$DOTF_BIN" agent run \
+        --role r --task t --tier mid --backend dry-run --timeout 30s \
+        --repo-root "$REPO_ROOT" --semaphore-dir "$SEM_DIR"
+    [ "$status" -eq 1 ]
+    printf '%s' "$output" | grep -q 'has not declared an identity'
+    printf '%s' "$output" | grep -q 'machine.json'
+}
+
+@test "agent run: the refusal writes nothing to stdout" {
+    _build_dotf
+    local empty="$BATS_TEST_TMPDIR/no-identity-2"
+    mkdir -p "$empty"
+    run bash -c "XDG_CONFIG_HOME='$empty' '$DOTF_BIN' agent run --role r --task t \
+        --tier mid --backend dry-run --timeout 30s --repo-root '$REPO_ROOT' \
+        --semaphore-dir '$SEM_DIR' 2>/dev/null"
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "agent run: a denied pool is skipped and the chain advances" {
+    _build_dotf
+    _need_python
+    local cfg="$BATS_TEST_TMPDIR/deny-claude" rec="$BATS_TEST_TMPDIR/denied.json"
+    mkdir -p "$cfg/dotfiles"
+    printf '%s\n' '{"machine": {"id": "corp"}, "pools": {"deny": ["claude"]}}' \
+        > "$cfg/dotfiles/machine.json"
+    run bash -c "XDG_CONFIG_HOME='$cfg' '$DOTF_BIN' agent run --role r --task t \
+        --tier mid --backend dry-run --timeout 30s --repo-root '$REPO_ROOT' \
+        --semaphore-dir '$SEM_DIR' >'$rec' 2>/dev/null"
+    [ "$status" -eq 0 ]
+    run python3 -c '
+import json, sys
+r = json.load(open(sys.argv[1]))
+assert r["pool"] != "claude", r["pool"]
+assert r["attempts"][0]["pool"] == "claude", r["attempts"]
+assert r["attempts"][0]["status"] == "denied", r["attempts"]
+print(r["pool"])
+' "$rec"
+    [ "$status" -eq 0 ]
+    [ "$output" = "nan" ]
 }


### PR DESCRIPTION
**PR C2** of the sequence in `specs/CLI-042-dotf-agent-run/tasks.md`, covering **AC4** and closing **AC1–AC5**. Follows #1212 (C1). Part of the CLI-042 sequence tracked by issue 1190 — deliberately written without a linking reference, because release-please aggregates any mention of a parent issue into the release changelog as a closing keyword, and the release PR then closes it. That is lesson 115, and it recurred today on #1210. PR E is the one that should close it.

`machine.json` gains two blocks beside `paths` — `machine.id` and `pools.deny` — read **at dispatch time and never cached** (ADR-032 §7). Caching them would let a level-2 dispatch from a personal session route work content through a personal pool on behalf of a denied machine.

## ⚠️ This gate refuses on your machine until you declare an identity

That is the specified behaviour, not a regression, and it is the point of the PR. ADR-032 §8: *a machine whose identity cannot be established denies every non-local pool*, so the unknown case degrades to **no cross-pool dispatch** rather than to **all pools allowed**. The failure it prevents is concrete — a rebuilt corporate machine that has not restored `machine.json` probes successfully for personal pools, and allowing them would be silent and in the direction nobody notices.

After merging, add to `~/.config/dotfiles/machine.json` (keeping any existing `paths` block):

```json
{
  "machine": { "id": "msi" },
  "pools":   { "deny": [] }
}
```

The refusal prints exactly that, with the resolved path filled in. Two things make the gate survivable rather than merely correct: **the remedy is in the message** (a fail-closed refusal whose fix must be looked up is one people route around), and **`machine.json.example` carries both blocks**, since that is the surface people copy.

`MachinePolicy`'s **zero value denies everything** — a caller that forgets to populate it gets the safe answer, not the permissive one. Fail-closed by construction rather than by remembering.

## Four distinctions the tests pin

Each fails in the wrong direction if collapsed:

| | |
|---|---|
| **Absent vs malformed** `machine.json` | Absent = unidentified, denies, no error. Malformed = hard error. Silently denying on a syntax error sends an operator hunting for a policy that does not exist |
| **A deny typo** | **Refused**, not ignored. `claud` in the list leaves `claude` allowed on a machine whose whole intent was to forbid it, and nothing would ever say so |
| **Denial vs the semaphore** | Denial is evaluated **first**, so a forbidden pool consumes nothing — not even a slot another dispatch could have used |
| **All-denied vs chain-exhausted** | Its own status, exit 3. One sends an operator to quota and outages, the other to `machine.json` |

The denial tests assert **the backend was never reached**, not merely that the record names another pool. A dispatcher that asked the denied pool and discarded its answer has already sent the task's content there — which is the entire thing denial exists to prevent, and a record-only assertion would pass on it.

## The wording clause is asserted, not left to review

`TestAgentRun_StatesTheNarrowGuaranteeAndNotAWiderOne` checks both directions: the help states ***`dotf` alone will never be the cause of exhaustion*** verbatim and names the shared consumers and the reserve, and four overstatements (`exhaustion cannot happen`, `prevents exhaustion`, …) are asserted **absent**. Overstating is the failure mode here — a reader who believes exhaustion cannot happen will not build for the case where it does.

## The bats smoke points at a fixture, deliberately

Once identity is required, the smoke's own dispatches refuse on any machine that has not declared one. The fixture `XDG_CONFIG_HOME` is the fix; pointing at the real file would make these cases pass **only on a machine whose owner had configured it** — green locally, red in CI — and the version that "fixed" *that* would be one that skipped the gate. Three new bats cases cover the refusal, its empty stdout, and a denied pool being skipped, all through the compiled binary.

## Verification

- `go build ./... && go vet ./... && go test ./...` → **exit 0**, 18 packages
- `GOOS=windows go build ./... && GOOS=windows go vet ./...` → clean
- `gofmt -l .` empty; `golangci-lint run` (v2.12.2, matching the pin) → **0 issues** (it caught an `ST1005` on the refusal text; fixed to the convention the `harness` messages already follow)
- `~/.local/bin/bats tests/*.bats` → **exit 0, 1466 tests, 0 failures**; shellcheck clean
- `features.json` run individually: **21 pass / 4 fail** (10/7 after B, 16/6 after C1). The four remaining are **AC6 → PR D** and **AC7–AC9 → PR E**. Every criterion this sequence has claimed so far is executable and green.

**Mutation:** replacing the narrow guarantee with *"This prevents exhaustion."* fails the wording test on both halves — the missing verbatim claim and the forbidden overstatement.

## LOC breakdown (Discipline Gate)

Production Go is **~110 executable lines** (`machinepolicy.go` 55, the dispatcher's denial branch and `allDenied` 20, the command's gate and `declaredPools` 35); the rest of the Go diff is comments, declarations and the refusal text. Tests ~390 lines, bats ~55, spec artefacts ~90, `machine.json.example` 8 — all excluded by the executable-lines rule.

## What is left in the spec

**PR D** — the real subprocess and hive backends, the probe and the tie-break, and the end-to-end smoke (AC6). **PR E** — the hive service unit via `dotf secrets run`, the Ollama/OpenRouter removal, and the `dotf doctor` reachability check (AC7–AC9). Both open questions in `proposal.md` belong to those two and are now the next thing to close, since they gate the PRs that follow rather than this one.

