### PR TITLE
fix(tests): make it impossible for a test to launch a GUI application

### DIFF
--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -240,3 +240,4 @@ tags: [lessons, index, dotfiles]
 | [224 - A negated assertion is exempt from `set -e`, so it cannot fail a test](lesson-224-a-negated-assertion-is-exempt-from-set-e-so-it-cann.md) | 2026-08-23 |  |
 | [225 - A stacked PR costs a reviewer, and re-conflicts on every squash](lesson-225-a-stacked-pr-costs-a-reviewer-and-re-conflicts-on-e.md) | 2026-08-23 |  |
 | [226 - Naming a key under `properties` exempts it from `additionalProperties`, so adding a constraint there can loosen the schema](lesson-226-naming-a-key-under-properties-exempts-it-from-additio.md) | 2026-08-23 |  |
+| [227 - A test suite inherits the developer's installed applications, and PATH is the door](lesson-227-a-test-suite-inherits-the-developers-installed-apps.md) | 2026-08-23 |  |

--- a/docs/lessons/lesson-227-a-test-suite-inherits-the-developers-installed-apps.md
+++ b/docs/lessons/lesson-227-a-test-suite-inherits-the-developers-installed-apps.md
@@ -1,0 +1,115 @@
+# Lesson 227 — A test suite inherits the developer's installed applications, and PATH is the door
+
+**Date:** 2026-08-23
+**Area:** tests / isolation / guards
+**Severity:** medium — noisy and destructive-adjacent rather than silently wrong, but it drove a real desktop and touched live data
+
+## What happened
+
+A routine `bats tests/*.bats` left **18 Obsidian processes** running. Their argv
+says what they were:
+
+```
+obsidian --no-sandbox dead-ends  --vault knowledge
+obsidian --no-sandbox unresolved --vault knowledge
+  --user-data-dir=/tmp/bats-run-gtlnlo/test/7/config/obsidian
+```
+
+`dead-ends` and `unresolved` are sections of `scripts/vault-health.sh`, which
+reaches Obsidian as a bare command name. `--vault knowledge` is the developer's
+**real** vault. The `bats-run` tmpdir in `--user-data-dir` is what proves a test
+started them: Electron derives that path from the environment, and only a test
+has a bats tmpdir there.
+
+So a test ran a production script, the script resolved `obsidian` through PATH,
+PATH found the developer's AppImage, and the GUI opened against real data —
+eighteen times, silently, with the suite reporting green throughout.
+
+## Why it survived
+
+**The suite already knew about this hazard and had solved it once.**
+`tests/golden/vault-health/lib.sh` replaces PATH with a sandbox and then asserts
+no leak, with a comment naming the exact risk: *"any case could in principle
+launch the actual GUI against the actual vault"*. That protection was correct,
+thorough — and local to one file. Every other test inherited the developer's
+PATH unchanged.
+
+**Nothing failed.** The processes are a side effect, not an assertion, so no
+test noticed. The only symptom was the human watching windows appear.
+
+**The obvious fix is an instruction.** "Stub GUI tools in your tests" is exactly
+the kind of rule that holds until someone writes a test without having read it —
+the same shape as lesson 115, violated three times the same day it was reread.
+
+## The fix
+
+`tests/setup_suite.bash`, which bats loads once for the whole suite, so a new
+test file inherits the protection without its author knowing it exists. Two
+halves, because one cannot cover the other's gap:
+
+**Interceptors on PATH** for every GUI binary installed on a developer machine
+(`obsidian`, `orca`, `code`, `xdg-open` — the class, not just the one that bit).
+They **refuse** rather than exit quietly: a silent success would convert "opens
+a window" into "passes for the wrong reason", trading a visible failure for an
+invisible one. Each refusal prints the remedy inline and logs the attempt with
+`BATS_TEST_NAME`, so the next occurrence names its own culprit instead of
+requiring process-table archaeology.
+
+They exit **99, not 127**. 127 means *command not found*; this command was found
+and declined. bats says so out loud (BW01), and the wrong code would teach every
+reader of a failure the wrong cause.
+
+**A post-suite stray detector**, because PATH governs a bare command name and
+nothing else: an absolute path, an AppImage, walks straight past an interceptor.
+`teardown_suite` looks for GUI processes carrying a bats tmpdir in
+`--user-data-dir`, reports them, and terminates them.
+
+**A test's own stub still wins**, being earlier on PATH. The guard sets the safe
+default; it does not take the decision away — which is why the golden harness,
+which replaces PATH wholesale, keeps working untouched.
+
+## What the guard's own tests had to prove
+
+`tests/guard-no-gui.bats` checks the interceptors resolve, refuse, name the
+remedy, log the caller, and yield to a local stub. The detector is checked **in
+both directions**, and the second is the one that matters:
+
+| Fixture | Must be |
+|---|---|
+| `obsidian --user-data-dir=/tmp/bats-run-FAKE/…` | detected |
+| `obsidian --user-data-dir=$HOME/.config/obsidian` | **ignored** |
+
+A detector that swept up a human's open editor would be a worse bug than the one
+it fixes. That is why the signature is `--user-data-dir` inside a bats tmpdir
+and not the binary's name.
+
+## A measurement trap worth carrying
+
+The first reading of this incident reported three stray processes that did not
+exist. `ps | grep --user-data-dir=...bats-run` matches **the shell running the
+grep**, whose own argv contains the pattern. The same trap applies to `pgrep -f`.
+The detector therefore matches by process NAME and filters the flag afterwards.
+
+**A measurement that includes the measurer is not a measurement** — and it fails
+in the alarming direction, which is the one that wastes time.
+
+## The rule
+
+**A test may never launch an application, and the suite must make that true
+rather than ask for it.** Protection that lives in one test file protects one
+test file.
+
+## Relation to Lesson 224
+
+[224](lesson-224-a-negated-assertion-is-exempt-from-set-e-so-it-cann.md) ends on
+*falsify the check deliberately and confirm it goes red*. Applied here: the
+interceptor is proven by a script written to reach for `obsidian`, and the
+detector by a process built to look like a stray — plus one built to look like a
+human's, to prove it is left alone.
+
+## Evidence
+
+- 18 Obsidian processes after a suite run, argv and `--user-data-dir` above (2026-08-23)
+- `tests/golden/vault-health/lib.sh:45` — the same hazard, solved for one file
+- Full suite with the guard: **1475 tests, exit 0, 0 failures, 0 attempts logged, 0 strays**
+- `tests/guard-no-gui.bats` — 9 cases, including both directions of the detector

--- a/tests/guard-no-gui.bats
+++ b/tests/guard-no-gui.bats
@@ -1,0 +1,147 @@
+#!/usr/bin/env bats
+# The guard that keeps tests from launching GUI applications, tested.
+#
+# A guard nobody verifies is the failure it exists to catch, one level up
+# (lessons 212 and 224). So this asserts the interceptors are actually on PATH,
+# that they refuse rather than succeed, and that the detector works against a
+# case built to trip it.
+
+setup() {
+    REPO_ROOT="$BATS_TEST_DIRNAME/.."
+}
+
+# Whether setup_suite ran at all. bats loads it only for a directory or more
+# than one file, so a single-file run has no guard — reported, never hidden.
+_guard_is_active() {
+    [ -n "${GUI_GUARD_BIN_DIR:-}" ] && [ -d "${GUI_GUARD_BIN_DIR:-/nonexistent}" ]
+}
+
+@test "guard: setup_suite.bash declares the GUI binaries it intercepts" {
+    grep -q '^GUI_BINARIES=(' "$REPO_ROOT/tests/setup_suite.bash"
+    # obsidian is the one that bit: 18 live processes against the real vault.
+    grep -qE '^GUI_BINARIES=\(.*obsidian' "$REPO_ROOT/tests/setup_suite.bash"
+}
+
+@test "guard: every declared binary is intercepted on PATH" {
+    _guard_is_active || skip "setup_suite did not run (single-file invocation); the guard is inactive here"
+
+    # shellcheck source=setup_suite.bash disable=SC1091
+    . "$REPO_ROOT/tests/setup_suite.bash"
+    local bin
+    for bin in "${GUI_BINARIES[@]}"; do
+        local resolved
+        resolved="$(command -v "$bin" || true)"
+        [ "$resolved" = "$GUI_GUARD_BIN_DIR/$bin" ] || {
+            printf 'guard leak: %s resolves to %s, not the interceptor\n' "$bin" "$resolved" >&2
+            return 1
+        }
+    done
+}
+
+@test "guard: an intercepted binary refuses instead of succeeding quietly" {
+    _guard_is_active || skip "setup_suite did not run (single-file invocation); the guard is inactive here"
+
+    run obsidian --no-sandbox dead-ends --vault knowledge
+    # 99 rather than 127: the interceptor was FOUND and refused. 127 would say
+    # "not installed", which is a different fact and the wrong remedy.
+    # Exit 0 would be the worst outcome of all: the window never opens AND the
+    # test that tried passes, so the reach goes unnoticed until someone reads ps.
+    [ "$status" -eq 99 ]
+    printf '%s' "$output" | grep -q 'refused to launch'
+}
+
+@test "guard: the refusal names the remedy, not just the rule" {
+    _guard_is_active || skip "setup_suite did not run (single-file invocation); the guard is inactive here"
+
+    run obsidian vault
+    # A guard whose fix must be looked up elsewhere is one people remove.
+    printf '%s' "$output" | grep -q 'BATS_TEST_TMPDIR'
+    printf '%s' "$output" | grep -q 'tests/setup_suite.bash'
+}
+
+@test "guard: an attempt is logged with the test that made it" {
+    _guard_is_active || skip "setup_suite did not run (single-file invocation); the guard is inactive here"
+
+    run obsidian unresolved --vault knowledge
+    [ -f "$GUI_GUARD_LOG" ]
+    grep -q 'unresolved --vault knowledge' "$GUI_GUARD_LOG"
+    # Blocking alone would stop the windows without ever saying which test
+    # opened them — which is exactly the position the 18-process incident left
+    # us in, reading a process table after the fact.
+    grep -q "$(basename "$BATS_TEST_FILENAME")" "$GUI_GUARD_LOG"
+}
+
+# The detector tested against a case built to trip it: a script that reaches for
+# obsidian the way a production script does. If the interceptor ever stopped
+# matching, this goes red rather than the suite going quietly permissive.
+@test "guard: a script that shells out to obsidian is stopped" {
+    _guard_is_active || skip "setup_suite did not run (single-file invocation); the guard is inactive here"
+
+    local probe="$BATS_TEST_TMPDIR/reaches-for-obsidian.sh"
+    printf '#!/usr/bin/env bash\nobsidian --no-sandbox vault\n' > "$probe"
+    chmod +x "$probe"
+
+    run "$probe"
+    [ "$status" -eq 99 ]
+    printf '%s' "$output" | grep -q 'refused to launch'
+}
+
+# A test that stubs the tool itself must still win — the guard bounds the
+# default, it does not take the decision away.
+@test "guard: a test's own stub takes precedence over the interceptor" {
+    _guard_is_active || skip "setup_suite did not run (single-file invocation); the guard is inactive here"
+
+    printf '#!/bin/sh\nprintf "stubbed"\n' > "$BATS_TEST_TMPDIR/obsidian"
+    chmod +x "$BATS_TEST_TMPDIR/obsidian"
+
+    run env PATH="$BATS_TEST_TMPDIR:$PATH" obsidian vault
+    [ "$status" -eq 0 ]
+    [ "$output" = "stubbed" ]
+}
+
+@test "guard: setup_suite.bash passes shellcheck" {
+    command -v "$HOME/.local/bin/shellcheck" >/dev/null 2>&1 || skip "shellcheck not installed"
+    run "$HOME/.local/bin/shellcheck" -s bash "$REPO_ROOT/tests/setup_suite.bash"
+    [ "$status" -eq 0 ]
+}
+
+# The post-suite detector, tested against a process built to look exactly like
+# the strays the incident left behind. A detector never seen firing is a claim,
+# not a check — and this one's job is to catch what the PATH interceptors
+# structurally cannot: an invocation by absolute path.
+@test "guard: the stray detector matches a test-shaped GUI process and not a human's" {
+    _guard_is_active || skip "setup_suite did not run (single-file invocation); the guard is inactive here"
+    command -v pgrep >/dev/null 2>&1 || skip "pgrep not installed"
+
+    # shellcheck source=setup_suite.bash disable=SC1091
+    . "$REPO_ROOT/tests/setup_suite.bash"
+
+    # A fake `obsidian` that sleeps, carrying the signature of a test-launched
+    # GUI: a bats tmpdir in --user-data-dir.
+    local fake="$BATS_TEST_TMPDIR/obsidian"
+    printf '#!/bin/sh\nsleep 30\n' > "$fake"
+    chmod +x "$fake"
+    "$fake" --user-data-dir=/tmp/bats-run-FAKE/test/1/config/obsidian &
+    local stray=$!
+    # And one that looks like a human's: the real config dir, no bats tmpdir.
+    "$fake" --user-data-dir="$HOME/.config/obsidian" &
+    local human=$!
+    sleep 0.3
+
+    local found
+    found="$(_gui_guard_test_shaped_processes)"
+
+    kill -9 "$stray" "$human" 2>/dev/null || true
+
+    printf '%s' "$found" | grep -q "$stray" || {
+        printf 'detector missed a test-shaped process (pid %s):\n%s\n' "$stray" "$found" >&2
+        return 1
+    }
+    # The half that matters more: it must never sweep up something a human
+    # opened. Killing the developer's editor would be a worse bug than the one
+    # this guard exists to fix.
+    if printf '%s' "$found" | grep -q "$human"; then
+        printf 'detector matched a human-shaped process (pid %s) — it would kill a real editor\n' "$human" >&2
+        return 1
+    fi
+}

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Suite-wide guard: a test can never launch a real GUI application.
+#
+# Measured 2026-08-23: a suite run left **18 Obsidian processes** alive, talking
+# to the developer's real vault (`obsidian --no-sandbox dead-ends --vault
+# knowledge`). Production scripts resolve these tools through PATH, so any test
+# that runs one without isolating PATH finds the developer's actual install and
+# opens windows against actual data.
+#
+# The fix is not "remember to stub it". `tests/golden/vault-health/lib.sh`
+# already does this correctly for itself — it replaces PATH and then asserts no
+# leak — and the rest of the suite had no such protection, which is precisely
+# the shape that recurs. This makes the protection the default for every test,
+# so a new test file inherits it without its author knowing it exists.
+#
+# The interceptors REFUSE rather than succeed quietly. A silent exit 0 would
+# turn "opens a window" into "passes for the wrong reason", trading a visible
+# failure for an invisible one. A test that legitimately needs one of these
+# tools stubs it itself, and wins because its stub is earlier on PATH.
+#
+# KNOWN GAP, stated rather than papered over: bats runs `setup_suite` only when
+# invoked over a directory or more than one file. `bats tests/one-file.bats`
+# does not load this. CI and `bats tests/*.bats` both do.
+# `tests/guard-no-gui.bats` reports the gap rather than skipping silently.
+
+# GUI_BINARIES is the class, not just the one that bit. Every entry is a tool
+# that opens a window or attaches to a running desktop session, and every one of
+# them is installed on a developer machine here.
+GUI_BINARIES=(obsidian orca code xdg-open)
+
+# GUI_GUARD_LOG records any attempt, so the NEXT occurrence names its own
+# culprit instead of needing a process-table archaeology session. Blocking alone
+# would have stopped the windows; it would not have said which test opened them.
+export GUI_GUARD_LOG="${BATS_SUITE_TMPDIR:-/tmp}/gui-guard-attempts.log"
+
+setup_suite() {
+    local bin_dir="${BATS_SUITE_TMPDIR:?bats did not provide a suite tmpdir}/gui-guard"
+    mkdir -p "$bin_dir"
+
+    local bin
+    for bin in "${GUI_BINARIES[@]}"; do
+        _gui_guard_write_interceptor "$bin_dir" "$bin"
+    done
+
+    export PATH="$bin_dir:$PATH"
+    export GUI_GUARD_BIN_DIR="$bin_dir"
+}
+
+# _gui_guard_write_interceptor emits one refusing stand-in. The message names
+# the remedy inline: a refusal whose fix has to be looked up is a refusal people
+# route around by deleting the guard.
+_gui_guard_write_interceptor() {
+    local dir="$1" name="$2"
+    cat > "$dir/$name" <<INTERCEPTOR
+#!/usr/bin/env bash
+{
+    printf '%s\n' "\$(date -u +%Y-%m-%dT%H:%M:%SZ) $name \$*"
+    printf '  file=%s\n' "\${BATS_TEST_FILENAME:-<unknown>}"
+    printf '  test=%s\n' "\${BATS_TEST_NAME:-<unknown>}"
+} >> "\${GUI_GUARD_LOG:-/dev/null}" 2>/dev/null
+
+cat >&2 <<'MSG'
+tests: refused to launch \`$name\` — a test reached a real GUI application.
+
+Tests must never open a window or touch live desktop state. On this machine
+\`$name\` is installed, so PATH resolution finds it and the test drives the real
+application against real data.
+
+Stub it in your own test, which wins because it is earlier on PATH:
+
+    printf '#!/bin/sh\nexit 0\n' > "\$BATS_TEST_TMPDIR/$name"
+    chmod +x "\$BATS_TEST_TMPDIR/$name"
+    PATH="\$BATS_TEST_TMPDIR:\$PATH"
+
+Or replace PATH outright, as tests/golden/vault-health/lib.sh does, when the
+test must also cover the case where the tool is absent.
+
+Guard: tests/setup_suite.bash
+MSG
+# 99, not 127. 127 means "command not found", and this command was found — it
+# declined. bats says so out loud (BW01), and a wrong code here would teach
+# every reader of a failure the wrong cause.
+exit 99
+INTERCEPTOR
+    chmod +x "$dir/$name"
+}
+
+# teardown_suite closes the gap the interceptors cannot: PATH only governs a
+# bare command name, so anything invoking an absolute path — `~/.local/bin/
+# obsidian`, an AppImage — walks straight past them.
+#
+# The detection is exact rather than heuristic. Electron derives --user-data-dir
+# from the environment, so a GUI launched from inside a test carries a bats
+# tmpdir in that flag, and nothing a human opens ever does. That is the
+# signature the 2026-08-23 incident left behind, and it is what distinguishes a
+# test's stray process from the developer's own editor sitting open beside it.
+teardown_suite() {
+    local strays
+    strays="$(_gui_guard_test_shaped_processes)"
+    [ -n "$strays" ] || return 0
+
+    {
+        printf '\n'
+        printf 'GUI GUARD: a test launched a real GUI application and left it running.\n'
+        printf '\n'
+        printf 'These carry a bats tmpdir in --user-data-dir, so they came from this suite\n'
+        printf 'rather than from anything you opened:\n\n'
+        printf '%s\n' "$strays"
+        printf '\n'
+        printf 'The PATH interceptors did not catch it, which means the call used an\n'
+        printf 'absolute path rather than a bare command name. Find the caller and give it\n'
+        printf 'a stub, or have it resolve the tool through PATH so the guard can see it.\n'
+        printf '\n'
+        printf 'Guard: tests/setup_suite.bash\n'
+    } >&2
+
+    # Leave nothing behind for the developer to hunt down and kill by hand.
+    printf '%s\n' "$strays" | awk '{print $1}' | while read -r pid; do
+        [ -n "$pid" ] && kill -TERM "$pid" 2>/dev/null
+    done
+
+    return 1
+}
+
+# _gui_guard_test_shaped_processes lists pid+command for GUI processes whose
+# user-data-dir points inside a bats tmpdir. Matching on that flag rather than
+# on the binary name is what keeps a developer's own open editor out of the
+# result — the check must never kill something a human started.
+_gui_guard_test_shaped_processes() {
+    command -v pgrep >/dev/null 2>&1 || return 0
+
+    local bin line
+    for bin in "${GUI_BINARIES[@]}"; do
+        # pgrep by NAME, then filter on the flag. Matching the flag with
+        # `pgrep -f` would also match this very shell, whose own argv contains
+        # the pattern — the false positive that made the first reading of this
+        # incident report three strays that were the measurement itself.
+        while IFS= read -r line; do
+            case "$line" in
+                *--user-data-dir=*bats-run*) printf '%s\n' "$line" ;;
+            esac
+        done < <(pgrep -a "$bin" 2>/dev/null || true)
+    done
+}

--- a/tests/stub-real-pairing.bats
+++ b/tests/stub-real-pairing.bats
@@ -38,6 +38,13 @@ setup() {
 #                             does; the API's verdict on that call only arrives from a real run.
 #   board-pickup              stubs `gh` — same; a real run self-assigns real issues
 #   guard-memory-sink         stubs `git` — the real path is covered end-to-end by the dispatcher's own commit-time behaviour
+#   guard-no-gui              stubs `obsidian` — and here a real run is not merely inconvenient, it is
+#                             the defect. That suite's whole subject is that a test must never launch a
+#                             GUI application; a real-dependency sibling would be a test that opens
+#                             Obsidian against the developer's live vault, which is the thing measured
+#                             on 2026-08-23 (18 stray processes) and the reason the guard exists. The
+#                             stub there is not standing in for a real run — it proves the guard yields
+#                             to a test's own stub.
 #   hermes-setup              stubs remote installers — a real run provisions an agent host
 #   install-dotf              stubs the release download — a real run fetches from GitHub releases
 #   shell-profile             stubs `zsh`/`bash` timing probes — a real run measures this machine, not a fixture
@@ -47,8 +54,9 @@ setup() {
 #                             .bats file itself — see #892) — same rationale as vault-health: a
 #                             real run needs the AppImage and a live vault
 #   vault-maintenance-weekly  stubs `cron`/`hive` — a real run installs a crontab entry
-EXEMPT_SUITES="bitacora-reconcile bitacora-rollout board-pickup guard-memory-sink hermes-setup
-install-dotf shell-profile skills-pipeline vault-health vault-health-golden vault-maintenance-weekly"
+EXEMPT_SUITES="bitacora-reconcile bitacora-rollout board-pickup guard-memory-sink guard-no-gui
+hermes-setup install-dotf shell-profile skills-pipeline vault-health vault-health-golden
+vault-maintenance-weekly"
 
 exempt() {
     local base


### PR DESCRIPTION
A routine `bats tests/*.bats` left **18 Obsidian processes** running, driving the developer's real vault. Their argv says exactly what they were:

```
obsidian --no-sandbox dead-ends  --vault knowledge
obsidian --no-sandbox unresolved --vault knowledge
  --user-data-dir=/tmp/bats-run-gtlnlo/test/7/config/obsidian
```

`dead-ends` and `unresolved` are sections of `scripts/vault-health.sh`, which reaches Obsidian as a **bare command name**. A test ran the script, PATH found the developer's AppImage, and the GUI opened against live data.

**Nothing failed.** The processes are a side effect, not an assertion, so the suite stayed green and the only symptom was a human watching windows appear and asking what was going on.

## Why an instruction would not have been enough

The hazard was already known and already solved — **for one file**. `tests/golden/vault-health/lib.sh` replaces PATH with a sandbox and then asserts no leak, and its comment names this exact risk:

> There is a REAL obsidian binary on a developer machine […] any case could in principle launch the actual GUI against the actual vault.

That protection is correct and thorough, and every other test inherited the developer's PATH unchanged. "Stub GUI tools in your tests" would be the third instruction of this kind violated by someone who had not read it — lesson 115 was violated three times the day it was reread. So: a guard.

## The guard

`tests/setup_suite.bash`, which bats loads once per suite, so a new test file inherits the protection **without its author knowing it exists**. Two halves, because neither covers the other's gap:

**1. Interceptors on PATH** for every GUI binary installed on a developer machine — `obsidian`, `orca`, `code`, `xdg-open`: the class, not just the one that bit. They **refuse** rather than exit quietly, because a silent success would turn *"opens a window"* into *"passes for the wrong reason"* — trading a visible failure for an invisible one. Each prints the remedy inline and logs the attempt with `BATS_TEST_NAME`, so a recurrence names its own culprit instead of needing the process-table archaeology this one took.

They exit **99, not 127**. 127 means *command not found*; this command was found and declined. bats says so out loud (BW01), and the wrong code would teach every reader of a failure the wrong cause.

**2. A post-suite stray detector**, because PATH governs a bare command name and nothing else — an absolute path or an AppImage walks straight past an interceptor. `teardown_suite` finds GUI processes carrying a bats tmpdir in `--user-data-dir`, reports them, and terminates them.

**A test's own stub still wins**, being earlier on PATH. The guard sets the safe default without taking the decision away — which is why the golden harness, which replaces PATH wholesale, keeps working untouched.

## What the guard's own tests prove

Nine cases. The interceptors resolve, refuse, name the remedy, log the caller, and yield to a local stub. The detector is checked **in both directions**, and the second matters more:

| Fixture | Must be |
|---|---|
| `obsidian --user-data-dir=/tmp/bats-run-FAKE/…` | detected |
| `obsidian --user-data-dir=$HOME/.config/obsidian` | **ignored** |

A detector that swept up a human's open editor would be a worse bug than the one it fixes. That is why the signature is a bats tmpdir in `--user-data-dir` — Electron derives it from the environment, so only a test-launched process carries one — and not the binary's name.

## A measurement trap, recorded because it cost time

The first reading of this incident reported three strays that did not exist. `ps | grep -- '--user-data-dir=...bats-run'` matches **the shell running the grep**, whose own argv contains the pattern; `pgrep -f` has the same flaw. The detector matches by process **name** and filters the flag afterwards.

A measurement that includes the measurer is not a measurement, and this one fails in the alarming direction.

## Known gap, stated rather than papered over

bats loads `setup_suite` only for a directory or **more than one file**. `bats tests/one-file.bats` has no guard. CI and `bats tests/*.bats` both do. `tests/guard-no-gui.bats` reports the gap with a skip that says so, rather than passing silently.

## Housekeeping

`guard-no-gui` is added to the stub/real pairing exemption table — in all three places that file deliberately keeps the fact — with the reason: a real-dependency sibling here would be *a test that opens Obsidian against the live vault*, which is precisely what this guard exists to prevent.

## Verification

- `~/.local/bin/bats tests/*.bats` → **exit 0, 1475 tests, 0 failures**, 0 attempts logged, 0 strays detected
- `shellcheck` clean on `tests/setup_suite.bash` and `tests/guard-no-gui.bats`
- No Go changes

Lesson 227.
