### PR TITLE
fix(mem): file session records under the local calendar date and complete their frontmatter

### DIFF
--- a/cli/internal/cmd/mem.go
+++ b/cli/internal/cmd/mem.go
@@ -82,7 +82,14 @@ func newMemSessionEndCmd() *cobra.Command {
 			payload, _ := io.ReadAll(cmd.InOrStdin())
 			// Best-effort by contract: a SessionEnd hook must never crash a
 			// session, so the write result is intentionally discarded — exit 0.
-			_, _ = mem.SessionEnd(payload, vault.ResolveVault(), time.Now().UTC())
+			//
+			// Local time, not UTC: `now` is formatted down to a calendar date
+			// that becomes the record's filename and its human-facing heading,
+			// so it must be the date the operator actually worked (CLI-043).
+			// UTC filed every post-18:00 session in America/Denver under the
+			// next day and collided with the following morning's record.
+			// session-start below is already local; this keeps the pair consistent.
+			_, _ = mem.SessionEnd(payload, vault.ResolveVault(), time.Now())
 			return nil
 		},
 	}

--- a/cli/internal/mem/session_end.go
+++ b/cli/internal/mem/session_end.go
@@ -112,11 +112,18 @@ func isHandoffHeading(line string) bool {
 // buildRecord renders the durable session record (frontmatter + heading + block).
 // This is the single converged form of the two drifting shell twins: the .sh used
 // an em-dash in the heading, the .ps1 a hyphen — the em-dash wins.
+//
+// The frontmatter satisfies the vault Frontmatter Law (id, type, status, created,
+// owner) with id/type/status as the first three keys, per handoff/SKILL.md §1b —
+// vault_health and vault-validate.py §1 both report a missing field as an error.
 func buildRecord(date, project, sid, block string) string {
 	var b strings.Builder
 	b.WriteString("---\n")
 	fmt.Fprintf(&b, "id: \"session-%s-%s-claude\"\n", date, project)
 	b.WriteString("type: session\n")
+	b.WriteString("status: active\n")
+	fmt.Fprintf(&b, "created: \"%s\"\n", date)
+	b.WriteString("owner: manu\n")
 	fmt.Fprintf(&b, "session_id: %s\n", sid)
 	b.WriteString("agent: claude\n")
 	fmt.Fprintf(&b, "project: %s\n", project)

--- a/cli/internal/mem/session_end_test.go
+++ b/cli/internal/mem/session_end_test.go
@@ -76,6 +76,9 @@ func TestSessionEnd_HappyPath(t *testing.T) {
 	for _, frag := range []string{
 		`id: "session-2026-06-23-proj-claude"`,
 		"type: session",
+		"status: active",
+		`created: "2026-06-23"`,
+		"owner: manu",
 		"session_id: sid-123",
 		"agent: claude",
 		"project: proj",
@@ -92,6 +95,64 @@ func TestSessionEnd_HappyPath(t *testing.T) {
 	// The block stops at the next "## " heading — the index must not leak in.
 	if strings.Contains(got, "## Index") || strings.Contains(got, "- foo") {
 		t.Errorf("record leaked content past the handoff block:\n%s", got)
+	}
+}
+
+// TestSessionEnd_UsesLocalCalendarDate pins the CLI-043 contract: the record's
+// date is the calendar date of the `now` it is handed, in that value's own
+// location — never normalised to UTC. An 18:30 session in a -0600 zone is
+// 00:30 the next day in UTC; filing it under tomorrow both misdates the record
+// and collides with the following morning's session on one filename.
+func TestSessionEnd_UsesLocalCalendarDate(t *testing.T) {
+	vault := t.TempDir()
+	writeMemory(t, vault, "## Session Handoff\n\nevening work\n")
+
+	denver := time.FixedZone("MDT", -6*60*60)
+	evening := time.Date(2026, 8, 23, 18, 30, 0, 0, denver)
+	if evening.UTC().Format("2006-01-02") == evening.Format("2006-01-02") {
+		t.Fatal("fixture is not timezone-sensitive; it cannot catch the regression")
+	}
+
+	written, err := SessionEnd([]byte(`{"cwd":"/x/proj","session_id":"sid"}`), vault, evening)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(vault, "10_projects", "proj", "sessions", "2026-08-23-proj-claude.md")
+	if written != want {
+		t.Fatalf("written path = %q, want %q", written, want)
+	}
+	b, _ := os.ReadFile(written)
+	for _, frag := range []string{`date: "2026-08-23"`, `created: "2026-08-23"`, "# Session 2026-08-23 —"} {
+		if !strings.Contains(string(b), frag) {
+			t.Errorf("record missing %q\n--- got ---\n%s", frag, b)
+		}
+	}
+}
+
+// TestSessionEnd_FrontmatterKeyOrder pins handoff/SKILL.md §1b: id, type and
+// status are the first three keys, which is what vault_health validates against.
+func TestSessionEnd_FrontmatterKeyOrder(t *testing.T) {
+	vault := t.TempDir()
+	writeMemory(t, vault, "## Session Handoff\n\nwork\n")
+	written, err := SessionEnd([]byte(`{"cwd":"/x/proj","session_id":"sid"}`), vault, fixedNow)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b, _ := os.ReadFile(written)
+	lines := strings.Split(string(b), "\n")
+	if len(lines) < 4 {
+		t.Fatalf("record too short:\n%s", b)
+	}
+	for i, prefix := range []string{"---", "id: ", "type: ", "status: "} {
+		if !strings.HasPrefix(lines[i], prefix) {
+			t.Errorf("line %d = %q, want prefix %q\n--- got ---\n%s", i, lines[i], prefix, b)
+		}
+	}
+	// The Frontmatter Law requires these regardless of position.
+	for _, frag := range []string{"created: ", "owner: "} {
+		if !strings.Contains(string(b), frag) {
+			t.Errorf("record missing %q\n--- got ---\n%s", frag, b)
+		}
 	}
 }
 

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -241,3 +241,4 @@ tags: [lessons, index, dotfiles]
 | [225 - A stacked PR costs a reviewer, and re-conflicts on every squash](lesson-225-a-stacked-pr-costs-a-reviewer-and-re-conflicts-on-e.md) | 2026-08-23 |  |
 | [226 - Naming a key under `properties` exempts it from `additionalProperties`, so adding a constraint there can loosen the schema](lesson-226-naming-a-key-under-properties-exempts-it-from-additio.md) | 2026-08-23 |  |
 | [227 - A test suite inherits the developer's installed applications, and PATH is the door](lesson-227-a-test-suite-inherits-the-developers-installed-apps.md) | 2026-08-23 |  |
+| [228 - A calendar date is not a timestamp, and UTC is the wrong zone for one](lesson-228-a-calendar-date-is-not-a-timestamp-utc-is-wrong-for.md) | 2026-08-23 |  |

--- a/docs/lessons/lesson-228-a-calendar-date-is-not-a-timestamp-utc-is-wrong-for.md
+++ b/docs/lessons/lesson-228-a-calendar-date-is-not-a-timestamp-utc-is-wrong-for.md
@@ -1,0 +1,101 @@
+# Lesson 228 — A calendar date is not a timestamp, and UTC is the wrong zone for one
+
+**Date:** 2026-08-23
+**Area:** cli / mem / time handling
+**Severity:** medium — silently misfiles durable records, and can overwrite one
+
+## What happened
+
+`dotf mem session-end` writes the durable session record whose filename *is* a
+date:
+
+```
+<vault>/10_projects/<project>/sessions/<date>-<project>-claude.md
+```
+
+The caller handed it UTC:
+
+```go
+_, _ = mem.SessionEnd(payload, vault.ResolveVault(), time.Now().UTC())
+```
+
+On `America/Denver` (UTC-6) that means every session ending after 18:00 local is
+filed under **tomorrow**. On 2026-08-23 five records written between 18:21 and
+18:47 MDT all landed as `2026-08-24-*`:
+
+```
+10_projects/{kubelab,resume,ts-bridge,web,dotfiles}/sessions/2026-08-24-*-claude.md
+```
+
+The `ts-bridge` record made the split visible from inside the file: its body
+read `Updated: 2026-08-13` under a filename claiming `2026-08-24`.
+
+## Why it is worse than a cosmetic wrong label
+
+The record path is append-only with a same-day collision rule (`-2`, `-3`, …
+per `handoff/SKILL.md` §1b). That rule is enforced by the *agent* writing a
+handoff, not by the Go writer, which does a plain `os.WriteFile`.
+
+So an evening session filed under tomorrow sits exactly where **tomorrow
+morning's** session will be written — and the morning run overwrites it with no
+error and no diff, because the file is not in git until the next vault commit.
+A wrong date is recoverable. A silently clobbered session journal is not.
+
+## The general shape
+
+`time.Now().UTC()` is close to a reflex, and for an *instant* it is usually
+right — logs, sync cursors, `RFC3339` fields all want a fixed zone.
+
+The tell that this was not an instant is one line down:
+
+```go
+date := now.Format("2006-01-02")
+```
+
+**The moment you format away the clock, you are no longer storing a point in
+time — you are naming a day in someone's life.** A day belongs to the observer's
+timezone. Once the hours are discarded, UTC is not "the precise choice"; it is a
+different day for a predictable slice of every 24 hours.
+
+Rule of thumb: **instants are UTC, calendar dates are local.** If the value ever
+reaches a filename, a heading, a `created:` field, or anything a human reads as
+"when I did this", it is a calendar date.
+
+## Why it survived four months
+
+It was not a considered policy. Blame puts the `.UTC()` in `dd95039`
+(CLI-025, #569), the commit that assembled the session-start adapter — and the
+same file already calls plain `time.Now()` for session-start (`mem.go:129`,
+`:161`). One noun in the pair was normalised and the other was not, which is
+the signature of an incidental keystroke rather than a decision.
+
+It stayed invisible because the failure is **timezone- and time-of-day-gated**:
+CI runs in UTC, where the bug cannot reproduce, and a developer only sees it
+after 18:00 local. Neither the tests nor the pipeline was ever in a position to
+observe it.
+
+## Guards added
+
+Two tests, both verified to fail against the unfixed code before being kept:
+
+- `TestSessionEnd_UsesLocalCalendarDate` — hands `SessionEnd` an 18:30 time in a
+  `-0600` zone and asserts the record is filed under that local date. It opens
+  by asserting the fixture is actually timezone-sensitive, so it cannot decay
+  into a test that would pass in any zone.
+- `TestSessionEnd_FrontmatterKeyOrder` — pins `id`/`type`/`status` as the first
+  three keys and the presence of `created`/`owner`.
+
+The second exists because the same writer was also emitting frontmatter missing
+`status`, `created` and `owner` — an error-level finding in both `vault_health`
+and `vault-validate.py` §1 that had produced four of the vault's five open
+frontmatter failures. Nothing in the CLI validated its own output against the
+Frontmatter Law it was writing for.
+
+## Takeaways
+
+1. `Format("2006-01-02")` on a UTC time is a code smell. Ask whose day it is.
+2. A writer that emits into a schema should have a test asserting the schema,
+   not rely on a downstream validator in another repo to notice.
+3. When a bug can only reproduce outside CI's environment, the regression test
+   has to *construct* that environment — here, an explicit `time.FixedZone`
+   rather than whatever the runner's local zone happens to be.


### PR DESCRIPTION
Closes #1216 (CLI-043).

## The bug

`dotf mem session-end` derives the session record's **filename**, heading and `date:` field from the `time.Time` its caller hands it. The caller handed it UTC:

```go
_, _ = mem.SessionEnd(payload, vault.ResolveVault(), time.Now().UTC())
```

One line later that value is formatted down to a calendar date:

```go
date := now.Format("2006-01-02")
```

Once the clock is discarded the value stops being an instant and becomes *a day in the operator's life*, which belongs to the operator's zone. On `America/Denver` (UTC-6) every session ending after 18:00 local was filed under **tomorrow**.

Observed 2026-08-23 — five records written between 18:21 and 18:47 MDT, all stamped `2026-08-24`:

```
10_projects/{kubelab,resume,ts-bridge,web,dotfiles}/sessions/2026-08-24-*-claude.md
```

The `ts-bridge` record showed the split from inside: body `Updated: 2026-08-13`, filename `2026-08-24`.

### Why it is more than a wrong label

That path is where **tomorrow morning's** record will be written. The same-day `-2`/`-3` suffix rule is applied by the agent authoring a handoff, not by this writer, which does a plain `os.WriteFile` — so the morning run overwrites the evening journal with no error and no diff.

## Second defect, same function

`buildRecord` emitted `id, type, session_id, agent, project, date, tags` — omitting `status`, `created` and `owner`. The vault Frontmatter Law requires all three, and `handoff/SKILL.md` §1b specifies the key order explicitly. Every generated record was an **error-level** finding; four of the vault's five open frontmatter failures came from this writer.

## The fix

- `mem.go` — `time.Now().UTC()` → `time.Now()`. Note `session-start` in the same file already used local time (`:129`, `:161`); the UTC call was the odd one out, introduced incidentally in `dd95039` (CLI-025, #569), not as a policy.
- `buildRecord` — emit `status: active`, `created`, `owner: manu`, with `id`/`type`/`status` first per the skill spec. `owner: manu` matches the idiom already used by `cli/internal/vault/templates/`.

## Verification

```
go build ./...               ok
go vet ./...                 ok
go test ./internal/mem/...   ok  (6/6)
```

Both new tests were **confirmed to fail against the unfixed code** before being kept:

| Guard | Unfixed result |
|---|---|
| `TestSessionEnd_UsesLocalCalendarDate` | `FAIL` — wrote `2026-08-24-proj-claude.md`, wanted `2026-08-23-` |
| `TestSessionEnd_FrontmatterKeyOrder` | `FAIL` — `status`/`created`/`owner` absent |

The timezone test opens by asserting its own fixture is zone-sensitive, so it cannot silently decay into a test that would pass in any zone. This matters because **CI runs in UTC, where the bug cannot reproduce** — the test has to construct the zone rather than inherit it.

## Rollout note

The five misdated records were repaired separately in the vault (`vault-validate.py`: 5 issues → 0). The deployed `dotf` binary only picks this up after merge and a setup re-run, so sessions ending this evening will still produce one misdated record until then.

Lesson: `docs/lessons/lesson-228-a-calendar-date-is-not-a-timestamp-utc-is-wrong-for.md`
