### PR TITLE
fix(ci): stop running the jobs a Dependabot PR cannot possibly pass

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -39,7 +39,32 @@ jobs:
     # Fork PRs run without repository secrets — BITACORA_PAT would be empty and the
     # job would fail (Codex review on kubelab#237). Skip them; fork PRs reach the
     # board via the reconciler or a manual item-add.
-    if: github.event_name == 'issues' || github.event.pull_request.head.repo.fork == false
+    #
+    # Dependabot is the SAME failure with a different cause, and the fork test does
+    # not catch it: a Dependabot PR is a branch in this repo, not a fork, so
+    # `head.repo.fork` is false and the job ran with an empty token. GitHub serves
+    # Dependabot-triggered runs from a SEPARATE secrets store, and this repo's is
+    # empty — measured 2026-08-24 on #1219/#1220 (HARNESS-080, #1221):
+    #
+    #   gh api repos/OWNER/REPO/actions/secrets    -> BITACORA_PAT, NAN_API_KEY, ...
+    #   gh api repos/OWNER/REPO/dependabot/secrets -> total_count: 0
+    #
+    # so `secrets.BITACORA_PAT` expands to the empty string with no error, the
+    # GraphQL call fails auth, and the script correctly classifies it as "not a
+    # rate limit" and goes red — on every weekly PR, forever.
+    #
+    # Keyed on `github.actor`, deliberately: it is the SAME field GitHub uses to
+    # decide which secrets store to serve, so the skip applies exactly when the
+    # credential is absent and never when it is present. If a human pushes to a
+    # Dependabot branch the actor is that human, the secrets are there, and the
+    # job runs. A branch-name or author-string rule would have neither property.
+    #
+    # Not a silent drop: bitacora-reconcile.yml adds every open issue and PR to
+    # the board daily, which is the healing path this workflow's header already
+    # names for the rate-limited case.
+    if: >
+      (github.event_name == 'issues' || github.event.pull_request.head.repo.fork == false)
+      && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -100,8 +100,39 @@ jobs:
     # `head.ref` is read by the expression engine here, never interpolated into a
     # `run:` — the injection concern that normally attaches to it does not apply
     # to an `if`.
+    # The Dependabot exclusion is the same shape as the release-please one above
+    # and lands for a harder reason: on a Dependabot-triggered run this reviewer
+    # CANNOT work. GitHub serves those runs from a separate secrets store, and
+    # this repo's is empty (`dependabot/secrets` -> total_count: 0), so
+    # `secrets.NAN_API_KEY` expands to "" — LiteLLM cannot authenticate, PR-Agent
+    # swallows the failure and exits green, and the guard below then goes red on
+    # every weekly PR. Measured 2026-08-24 on #1219/#1220 (HARNESS-080, #1221).
+    #
+    # Keyed on `github.actor` rather than on the branch, and unlike the
+    # release-please line above that choice is load-bearing rather than
+    # stylistic: `github.actor` is the SAME field GitHub reads to pick the
+    # secrets store, so the skip fires exactly when the credential is missing.
+    # A human pushing to a Dependabot branch is a different actor with the
+    # secrets present, and gets a real review. `dependabot[bot]` is also
+    # unforgeable — GitHub does not permit `[` in a user login — which the
+    # attacker-chosen branch name discussed above is not.
+    #
+    # This removes a review, it can never grant one: `review-attestation` still
+    # reads `pending` and the PR still cannot merge until a human reviews it.
+    # That is `dependabot.yml`'s stated policy ("every PR is reviewed and merged
+    # by a human"), and the classifier already counts a human review
+    # (`check-review-attestation.sh`) with `pull_request_review` re-firing the
+    # gate. Mirroring NAN_API_KEY into the Dependabot store was the alternative
+    # and was rejected: it spends scarce NaN concurrency — 5 requests shared with
+    # pi, qq and hive embeddings, see #1107 — on dependency bumps whose verdict a
+    # human makes anyway.
+    #
+    # Only the `pull_request` half is gated, for the same reason as release PRs:
+    # a human typing `/review` on a Dependabot PR is asking on purpose, that run
+    # is triggered by the human, and its secrets are present.
     if: >
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        && github.actor != 'dependabot[bot]'
         && !startsWith(github.event.pull_request.head.ref, 'release-please--')) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request
         && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)

--- a/.github/workflows/review-attestation.yml
+++ b/.github/workflows/review-attestation.yml
@@ -8,15 +8,26 @@ name: review-attestation
 # available asserted the opposite of the truth. This job adds an honest one
 # beside it — it cannot change the vendor's own check status.
 #
-# NOT `required` in branch protection yet. Promoting it is a real step with a
-# real order, and getting the order wrong blocks the repository — so the order
-# lives here, next to the thing it constrains, rather than in a ticket nobody
-# reads at the moment of enabling it.
+# REQUIRED in branch protection. Promoting it was a real step with a real order,
+# and getting the order wrong blocks the repository — so the order lives here,
+# next to the thing it constrains, rather than in a ticket nobody reads at the
+# moment of enabling it.
 #
 #   1. #1047  the classifier counts comment-shaped review output.        DONE
 #   2. #1041  a `pending` verdict stops freezing the check-run red.      DONE
 #   3. #1052  a `workflow_run` re-evaluates when the reviewer finishes.  DONE
-#   4. promote — and promote the STATUS, never the check-run.
+#   4. promote — and promote the STATUS, never the check-run.            DONE
+#
+# Verified 2026-08-24 (HARNESS-080, #1221):
+#
+#   gh api repos/OWNER/REPO/branches/main/protection \
+#     --jq .required_status_checks.contexts
+#   -> ["lint","lint-powershell","test","test-windows","review-attestation"]
+#
+# Step 4 had been executed and this header still said "not required yet", while
+# the failure message at the bottom of this file told every reader the check
+# "does not veto". A gate that misreports its own authority is the same class of
+# defect as one that misreports a review.
 #
 # Require the commit status `review-attestation`, never the `attestation`
 # check-run. A check-run belongs to the run that created it and can never be
@@ -300,7 +311,8 @@ jobs:
             echo "  (b) Declare the unreviewed merge: add the 'merged-unreviewed' label AND a"
             echo "      non-empty '## Unreviewed merge rationale' section to the PR body."
             echo
-            echo "This check is NOT required in branch protection: it reports, it does not veto."
-            echo "Proceeding on an unreviewed PR is allowed. Proceeding silently is not."
+            echo "This check IS required in branch protection, so (a) or (b) is not advice."
+            echo "Proceeding on an unreviewed PR is allowed — that is what (b) is for."
+            echo "Proceeding silently is not."
           fi
           exit "$CODE"

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -242,3 +242,4 @@ tags: [lessons, index, dotfiles]
 | [226 - Naming a key under `properties` exempts it from `additionalProperties`, so adding a constraint there can loosen the schema](lesson-226-naming-a-key-under-properties-exempts-it-from-additio.md) | 2026-08-23 |  |
 | [227 - A test suite inherits the developer's installed applications, and PATH is the door](lesson-227-a-test-suite-inherits-the-developers-installed-apps.md) | 2026-08-23 |  |
 | [228 - A calendar date is not a timestamp, and UTC is the wrong zone for one](lesson-228-a-calendar-date-is-not-a-timestamp-utc-is-wrong-for.md) | 2026-08-23 |  |
+| [229 - An empty secret is not an error, so a job with no credential fails as if the work failed](lesson-229-an-empty-secret-is-not-an-error-so-a-job-with-no-cr.md) | 2026-08-24 |  |

--- a/docs/lessons/lesson-229-an-empty-secret-is-not-an-error-so-a-job-with-no-cr.md
+++ b/docs/lessons/lesson-229-an-empty-secret-is-not-an-error-so-a-job-with-no-cr.md
@@ -1,0 +1,22 @@
+---
+id: lesson-229-an-empty-secret-is-not-an-error-so-a-job-with-no-cr
+type: lesson
+status: active
+created: "2026-08-24"
+owner: manu
+tags: [lesson, dotfiles]
+---
+
+# Lesson 229: An empty secret is not an error, so a job with no credential fails as if the work failed
+
+**Context**: Every Dependabot PR opened since 2026-08-07 carried red checks — `add-to-project`, `review`, and `review-attestation` downstream of them. Measured on #1219 and #1220 (HARNESS-080, #1221). GitHub serves Dependabot-triggered `pull_request` runs from a **separate** secrets store; this repository's was empty (`gh api repos/OWNER/REPO/dependabot/secrets` → `total_count: 0`), while the Actions store held all three secrets.
+
+**Problem**: `secrets.BITACORA_PAT` and `secrets.NAN_API_KEY` do not raise when the store lacks them — they expand to the **empty string**. So each job proceeded to do its work with no credential, and each failed at the point where the credential was used rather than at the point where it was missing. The resulting red says *"could not add this item to the board"* and *"PR-Agent published no review"* — both true, both describing a symptom three layers from the cause, and both indistinguishable from the genuine failures those messages were written for. Neither job was ever going to succeed, so the red was permanent, and a check that is always red is one everybody learns to scroll past. It went unread for seventeen days.
+
+Two adjacent traps sharpened it. `add-to-project.yml` already skipped **fork** PRs for precisely this reason (`head.repo.fork == false`), and that guard could never fire here: a Dependabot PR is a branch in the repo, not a fork. And re-running the job does not help — secrets access follows the actor of the *original* event, so a human pressing "re-run" gets the same empty store (verified: run 32698096060, `actor=dependabot[bot]`, `triggering_actor=mlorentedev`, failed identically).
+
+**Solution**: Skip the jobs that cannot work, keyed on `github.actor != 'dependabot[bot]'` — the **same field GitHub reads to choose the secrets store**, so the skip fires exactly when the credential is absent and never when it is present. A human pushing to a Dependabot branch is a different actor with the secrets available, and gets the full treatment. The guard is a class assertion, not two patches: any workflow that triggers on `pull_request` and reads a secret other than `GITHUB_TOKEN` must carry the exclusion (`tests/dependabot-ci.bats`), so the next workflow to reach for a credential cannot rediscover this the same way.
+
+What was deliberately **not** done: mirroring the key into the Dependabot store, and exempting the PR from `review-attestation`. The first spends scarce inference on a change whose verdict a human makes anyway; the second turns "nobody reviewed this" green, which is the failure GUARD-002 exists to prevent. The attestation stays `pending` until a human reviews — which the classifier already supports and which `dependabot.yml` already declares as policy.
+
+**Rule**: When a job's credential can be absent **by construction** rather than by accident, gate the job on the same signal the platform uses to decide, and let it skip rather than fail. A red that can never go green is not a finding; it is a broken instrument, and it costs the credibility of every check beside it. Corollary, paid for twice here: an existing guard against "no credentials in this context" (the fork test) is evidence the context has *more than one* entrance — check whether it covers all of them before assuming it covers yours.

--- a/docs/lessons/lesson-229-an-empty-secret-is-not-an-error-so-a-job-with-no-cr.md
+++ b/docs/lessons/lesson-229-an-empty-secret-is-not-an-error-so-a-job-with-no-cr.md
@@ -9,7 +9,16 @@ tags: [lesson, dotfiles]
 
 # Lesson 229: An empty secret is not an error, so a job with no credential fails as if the work failed
 
-**Context**: Every Dependabot PR opened since 2026-08-07 carried red checks — `add-to-project`, `review`, and `review-attestation` downstream of them. Measured on #1219 and #1220 (HARNESS-080, #1221). GitHub serves Dependabot-triggered `pull_request` runs from a **separate** secrets store; this repository's was empty (`gh api repos/OWNER/REPO/dependabot/secrets` → `total_count: 0`), while the Actions store held all three secrets.
+**Context**: Every Dependabot PR opened since 2026-08-07 carried red checks — `add-to-project`, `review`, and `review-attestation` downstream of them. Measured on #1219 and #1220 (HARNESS-080, #1221). GitHub serves Dependabot-triggered `pull_request` runs from a **separate** secrets store; this repository's was empty, while the Actions store held all three secrets:
+
+```sh
+# Projected with --jq, never dumped. The endpoint returns names and timestamps
+# rather than values, but "decrypt everything, then filter what a human reads"
+# is the shape the transcript rule forbids — and a command copied out of a
+# lesson is a command someone will run against a store that does hold more.
+gh api repos/OWNER/REPO/dependabot/secrets --jq '.total_count'   # -> 0
+gh api repos/OWNER/REPO/actions/secrets    --jq '.total_count'   # -> 3
+```
 
 **Problem**: `secrets.BITACORA_PAT` and `secrets.NAN_API_KEY` do not raise when the store lacks them — they expand to the **empty string**. So each job proceeded to do its work with no credential, and each failed at the point where the credential was used rather than at the point where it was missing. The resulting red says *"could not add this item to the board"* and *"PR-Agent published no review"* — both true, both describing a symptom three layers from the cause, and both indistinguishable from the genuine failures those messages were written for. Neither job was ever going to succeed, so the red was permanent, and a check that is always red is one everybody learns to scroll past. It went unread for seventeen days.
 

--- a/tests/dependabot-ci.bats
+++ b/tests/dependabot-ci.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# HARNESS-080 (#1221): a Dependabot-triggered workflow run cannot read this
+# repository's secrets.
+#
+# GitHub serves those runs from a SEPARATE store — `dependabot/secrets`, empty
+# here — so `secrets.ANYTHING` expands to the empty string with no error and no
+# warning. Measured 2026-08-24 on #1219 and #1220: two red checks on every
+# weekly dependency PR since 2026-08-07, and nobody looked, because a red check
+# on a bot's PR is exactly what a reader learns to scroll past.
+#
+# The generic assertion below is the point of this file. Fixing the two current
+# offenders one at a time would leave the NEXT workflow that reaches for a
+# secret to rediscover this the same way — a class of defect the repository
+# already decided is answered with a guard, not with a memo.
+
+load 'lib/refute'
+
+setup() {
+    REPO="$BATS_TEST_DIRNAME/.."
+    WF_DIR="$REPO/.github/workflows"
+    ACTOR_GUARD="github.actor != 'dependabot\[bot\]'"
+}
+
+# --- the class guard ---------------------------------------------------------
+
+@test "dependabot: every pull_request workflow needing a repo secret excludes dependabot" {
+    # A workflow qualifies when BOTH hold: it triggers on `pull_request`, and it
+    # reads a secret other than GITHUB_TOKEN (which is always present, merely
+    # read-only for Dependabot). Such a job cannot do its work on a Dependabot
+    # run, so it must not pretend to try.
+    #
+    # Read line by line rather than word-split: zsh does not split unquoted
+    # parameters, so `set -- $list` would yield one field holding everything.
+    offenders=""
+    while IFS= read -r wf; do
+        [ -n "$wf" ] || continue
+        grep -qE '^[[:space:]]{2}pull_request:' "$wf" || continue
+        grep -oE 'secrets\.[A-Z_]+' "$wf" | grep -qv 'secrets\.GITHUB_TOKEN' || continue
+        grep -q "$ACTOR_GUARD" "$wf" || offenders="$offenders $(basename "$wf")"
+    done <<< "$(find "$WF_DIR" -maxdepth 1 -name '*.yml' | sort)"
+
+    if [ -n "$offenders" ]; then
+        echo "These workflows run on pull_request, read a repository secret, and do not"
+        echo "exclude dependabot[bot] — on a Dependabot PR that secret is the empty string:"
+        echo "  $offenders"
+        echo
+        echo "Add \"github.actor != 'dependabot[bot]'\" to the job's \`if:\`, or move the"
+        echo "credential into the Dependabot secrets store deliberately."
+        return 1
+    fi
+}
+
+@test "dependabot: the class guard actually inspects the workflow directory" {
+    # Without this, the loop above passes vacuously the day the glob, the path
+    # or the trigger pattern stops matching anything — a guard that inspects
+    # nothing reports the same green as a guard that found nothing wrong. The
+    # repository has paid for that distinction (#1203, #1206).
+    matched=0
+    while IFS= read -r wf; do
+        [ -n "$wf" ] || continue
+        grep -qE '^[[:space:]]{2}pull_request:' "$wf" || continue
+        grep -oE 'secrets\.[A-Z_]+' "$wf" | grep -qv 'secrets\.GITHUB_TOKEN' || continue
+        matched=$((matched + 1))
+    done <<< "$(find "$WF_DIR" -maxdepth 1 -name '*.yml' | sort)"
+
+    # add-to-project.yml (BITACORA_PAT) and pr-agent.yml (NAN_API_KEY).
+    [ "$matched" -ge 2 ]
+}
+
+# --- add-to-project ----------------------------------------------------------
+
+@test "add-to-project: skips dependabot without dropping the fork guard" {
+    wf="$WF_DIR/add-to-project.yml"
+    grep -q "$ACTOR_GUARD" "$wf"
+    # The fork test is a SEPARATE failure mode with the same symptom, and the
+    # Dependabot fix must not be mistaken for a replacement: a Dependabot PR is
+    # a branch in this repo, so `head.repo.fork` is false and never caught it.
+    grep -q 'github.event.pull_request.head.repo.fork == false' "$wf"
+}
+
+@test "add-to-project: still runs for issues, which carry no fork or bot concern" {
+    grep -q "github.event_name == 'issues'" "$WF_DIR/add-to-project.yml"
+}
+
+# --- pr-agent ----------------------------------------------------------------
+
+@test "pr-agent: gates exactly one half of the trigger on the dependabot actor" {
+    wf="$WF_DIR/pr-agent.yml"
+    # Exactly one occurrence: the `pull_request` half. A human typing `/review`
+    # on a Dependabot PR is asking on purpose, and that run is triggered by the
+    # human — so its secrets are present and the reviewer works. Gating the
+    # issue_comment half too would silently refuse them.
+    [ "$(grep -c "$ACTOR_GUARD" "$wf")" -eq 1 ]
+    grep -q "github.event_name == 'issue_comment'" "$wf"
+}
+
+@test "pr-agent: keeps the release-please exclusion it already had" {
+    # Two independent conditions that each only ever REMOVE a review. Losing one
+    # while adding the other would be a silent regression.
+    grep -q "startsWith(github.event.pull_request.head.ref, 'release-please--')" \
+        "$WF_DIR/pr-agent.yml"
+}
+
+# --- review-attestation ------------------------------------------------------
+
+@test "review-attestation: does not tell readers it is unrequired when it is required" {
+    # Verified 2026-08-24: required_status_checks.contexts includes
+    # "review-attestation". The workflow's failure message said the opposite,
+    # and that message is what a reader sees at the moment the check is red.
+    wf="$WF_DIR/review-attestation.yml"
+    refute_grep 'This check is NOT required in branch protection' "$wf"
+    refute_grep 'NOT `required` in branch protection yet' "$wf"
+}
+
+@test "review-attestation: still offers both ways out of a red verdict" {
+    # Narrowing what the message CLAIMS must not narrow what it OFFERS.
+    wf="$WF_DIR/review-attestation.yml"
+    grep -q 'Get the PR reviewed' "$wf"
+    grep -q 'merged-unreviewed' "$wf"
+}

--- a/tests/dependabot-ci.bats
+++ b/tests/dependabot-ci.bats
@@ -23,48 +23,85 @@ setup() {
 
 # --- the class guard ---------------------------------------------------------
 
-@test "dependabot: every pull_request workflow needing a repo secret excludes dependabot" {
-    # A workflow qualifies when BOTH hold: it triggers on `pull_request`, and it
-    # reads a secret other than GITHUB_TOKEN (which is always present, merely
-    # read-only for Dependabot). Such a job cannot do its work on a Dependabot
-    # run, so it must not pretend to try.
+@test "dependabot: every pull_request job needing a repo secret excludes dependabot" {
+    # Scoped PER JOB, not per file, and that distinction is the whole assertion.
+    # A file-wide `grep` accepts a guard that sits on some OTHER job — or in a
+    # comment — while the job actually holding the credential runs unguarded.
+    # It would report green on a workflow whose `lint` job carries the guard and
+    # whose `publish` job reads a deploy token without it, which is precisely
+    # the arrangement this file exists to make impossible. Raised by CodeRabbit
+    # on the first revision of this test, correctly: a guard that looks like it
+    # covers the class is the failure mode of the very lesson this PR writes.
     #
-    # Read line by line rather than word-split: zsh does not split unquoted
-    # parameters, so `set -- $list` would yield one field holding everything.
-    offenders=""
-    while IFS= read -r wf; do
-        [ -n "$wf" ] || continue
-        grep -qE '^[[:space:]]{2}pull_request:' "$wf" || continue
-        grep -oE 'secrets\.[A-Z_]+' "$wf" | grep -qv 'secrets\.GITHUB_TOKEN' || continue
-        grep -q "$ACTOR_GUARD" "$wf" || offenders="$offenders $(basename "$wf")"
-    done <<< "$(find "$WF_DIR" -maxdepth 1 -name '*.yml' | sort)"
+    # Secret names are matched EXACTLY. `secrets.GITHUB_TOKEN2` is not
+    # GITHUB_TOKEN, and a substring test silently exempted the job that read it.
+    #
+    # Parsed with PyYAML rather than grepped, following tests/pr-agent-config.bats.
+    # Note `d[True]`: YAML 1.1 resolves a bare `on:` key to the boolean true, so
+    # `d['on']` is a KeyError on every workflow file in this repository.
+    run python3 -c "
+import pathlib, re, sys, yaml
 
-    if [ -n "$offenders" ]; then
-        echo "These workflows run on pull_request, read a repository secret, and do not"
-        echo "exclude dependabot[bot] — on a Dependabot PR that secret is the empty string:"
-        echo "  $offenders"
-        echo
-        echo "Add \"github.actor != 'dependabot[bot]'\" to the job's \`if:\`, or move the"
-        echo "credential into the Dependabot secrets store deliberately."
-        return 1
-    fi
+GUARD = \"github.actor != 'dependabot[bot]'\"
+offenders = []
+for wf in sorted(pathlib.Path('$WF_DIR').glob('*.yml')):
+    doc = yaml.safe_load(open(wf))
+    if not isinstance(doc, dict):
+        continue
+    triggers = doc.get(True, doc.get('on'))
+    if not isinstance(triggers, dict) or 'pull_request' not in triggers:
+        continue
+    for name, job in (doc.get('jobs') or {}).items():
+        body = yaml.safe_dump(job)
+        secrets = set(re.findall(r'secrets\.([A-Za-z_][A-Za-z0-9_]*)', body))
+        secrets.discard('GITHUB_TOKEN')
+        if not secrets:
+            continue
+        if GUARD not in str(job.get('if', '')):
+            offenders.append('%s job %s reads %s' % (wf.name, name, ', '.join(sorted(secrets))))
+
+if offenders:
+    print('These jobs run on pull_request and read a repository secret, but their')
+    print('own \`if:\` does not exclude dependabot[bot]. On a Dependabot run that')
+    print('secret is the empty string, so the job cannot succeed and never will:')
+    for o in offenders:
+        print('  ' + o)
+    print('')
+    print('Add \"github.actor != %s\" to THAT JOB (a guard on a' % repr('dependabot[bot]'))
+    print('sibling job does not protect this one), or put the credential into the')
+    print('Dependabot secrets store as a deliberate decision.')
+    sys.exit(1)
+"
+    [ "$status" -eq 0 ] || { printf '%s\n' "$output" >&2; false; }
 }
 
-@test "dependabot: the class guard actually inspects the workflow directory" {
-    # Without this, the loop above passes vacuously the day the glob, the path
-    # or the trigger pattern stops matching anything — a guard that inspects
+@test "dependabot: the class guard actually inspects some secret-using jobs" {
+    # Without this, the check above passes vacuously the day the glob, the `on:`
+    # key or the secret pattern stops matching anything — a guard that inspected
     # nothing reports the same green as a guard that found nothing wrong. The
     # repository has paid for that distinction (#1203, #1206).
-    matched=0
-    while IFS= read -r wf; do
-        [ -n "$wf" ] || continue
-        grep -qE '^[[:space:]]{2}pull_request:' "$wf" || continue
-        grep -oE 'secrets\.[A-Z_]+' "$wf" | grep -qv 'secrets\.GITHUB_TOKEN' || continue
-        matched=$((matched + 1))
-    done <<< "$(find "$WF_DIR" -maxdepth 1 -name '*.yml' | sort)"
+    run python3 -c "
+import pathlib, re, sys, yaml
 
-    # add-to-project.yml (BITACORA_PAT) and pr-agent.yml (NAN_API_KEY).
-    [ "$matched" -ge 2 ]
+inspected = []
+for wf in sorted(pathlib.Path('$WF_DIR').glob('*.yml')):
+    doc = yaml.safe_load(open(wf))
+    if not isinstance(doc, dict):
+        continue
+    triggers = doc.get(True, doc.get('on'))
+    if not isinstance(triggers, dict) or 'pull_request' not in triggers:
+        continue
+    for name, job in (doc.get('jobs') or {}).items():
+        secrets = set(re.findall(r'secrets\.([A-Za-z_][A-Za-z0-9_]*)', yaml.safe_dump(job)))
+        secrets.discard('GITHUB_TOKEN')
+        if secrets:
+            inspected.append('%s:%s' % (wf.name, name))
+
+# add-to-project.yml (BITACORA_PAT) and pr-agent.yml (NAN_API_KEY).
+print('inspected: ' + ', '.join(inspected))
+sys.exit(0 if len(inspected) >= 2 else 1)
+"
+    [ "$status" -eq 0 ] || { printf '%s\n' "$output" >&2; false; }
 }
 
 # --- add-to-project ----------------------------------------------------------


### PR DESCRIPTION
Every Dependabot PR has opened with red checks since 2026-08-07. All of them
trace to one mechanism, and neither job could ever have gone green.

## Measurement

GitHub serves Dependabot-triggered `pull_request` runs from a **separate**
secrets store. This repository's is empty:

```
gh api repos/mlorentedev/dotfiles/actions/secrets    --jq '.total_count'  -> 3
gh api repos/mlorentedev/dotfiles/dependabot/secrets --jq '.total_count'  -> 0
gh api repos/mlorentedev/dotfiles/actions/runs/32698096060 -> actor=dependabot[bot]
```

`secrets.BITACORA_PAT` and `secrets.NAN_API_KEY` therefore expand to the empty
string — no error, no warning. Everything observed on #1219 and #1220 follows:

| Check | Failing step | Cause |
|---|---|---|
| `add-to-project` | "Add to bitácora board" | `GH_TOKEN=""` -> GraphQL auth fails. The script classifies correctly: not a rate limit, so red. |
| `review` | "Fail if no review was published" — **not** the PR-Agent step, which exits `success` | `OPENAI__KEY=""` -> LiteLLM cannot authenticate, PR-Agent swallows it and exits clean. The #1109 guard exposes it. |
| `review-attestation` | — | Downstream. The only one of the three that is a required status check. |

Two details that shaped the fix:

- **The existing fork guard could never catch this.** `add-to-project.yml` skips
  fork PRs for exactly this reason, but a Dependabot PR is a branch in this repo,
  so `head.repo.fork` is false.
- **Re-running does not help.** Secrets access follows the actor of the original
  event. Run 32698096060 was re-run by a human (`triggering_actor=mlorentedev`,
  `actor=dependabot[bot]`) and failed identically.

## Why it surfaced now

GitHub's behaviour dates from 2021. The gates do not:

```
2026-08-05  last merged Dependabot PR (#742, #743)
2026-08-07  #813   add-to-project starts failing hard instead of dropping items silently
2026-08-15  #1019  review-attestation   +   #1032  pr-agent
2026-08-19  #1109  fail the review job when it published no review
```

#1219/#1220 are the first Dependabot PRs to cross all three.

## The change

Both skips are keyed on `github.actor`, which is **the same field GitHub reads to
choose the secrets store**. So a skip fires exactly when the credential is absent,
and never when it is present: a human pushing to a Dependabot branch is a
different actor with the secrets available, and gets the full treatment. A
branch-name rule would have neither property, and `dependabot[bot]` is
unforgeable — GitHub does not permit `[` in a user login.

Only the `pull_request` half of `pr-agent` is gated. A human typing `/review` on
a Dependabot PR is asking on purpose, and that run carries their secrets.

**The guard asserts the class, not the two instances.** `tests/dependabot-ci.bats`
fails any workflow that triggers on `pull_request`, reads a secret other than
`GITHUB_TOKEN`, and does not exclude `dependabot[bot]` — so the next workflow to
reach for a credential cannot rediscover this the same way. Verified to fail
without the fix, naming the offending file:

```
$ # actor guard removed from add-to-project.yml
not ok 1 dependabot: every pull_request workflow needing a repo secret excludes dependabot
# These workflows run on pull_request, read a repository secret, and do not
#    add-to-project.yml
not ok 3 add-to-project: skips dependabot without dropping the fork guard
```

A second test asserts the loop inspected at least two workflows, so it cannot
pass vacuously the day the glob or the trigger pattern stops matching (#1203,
#1206).

## Deliberately not done

- **Mirroring `NAN_API_KEY` into the Dependabot store.** It would spend scarce NaN
  concurrency — 5 requests shared with pi, qq and hive embeddings (#1107) — on
  dependency bumps whose verdict a human makes anyway.
- **Exempting these PRs in `harness/review-attestation.json`.** That registry
  matches by diff signature, *never* by author, and turning "nobody reviewed
  this" green is the failure GUARD-002 exists to prevent.

A Dependabot PR now reads `pending` until a human reviews it. That is the policy
`dependabot.yml` already declares ("every PR is reviewed and merged by a human"),
and the machinery already supports it end to end:
`check-review-attestation.sh` counts any human review, and
`review-attestation.yml` re-fires on `pull_request_review`.

## Debt fixed in scope

`review-attestation.yml` told every reader — in the failure message shown at the
moment the check is red — that it "is NOT required in branch protection: it
reports, it does not veto". It is required:

```
gh api repos/mlorentedev/dotfiles/branches/main/protection --jq .required_status_checks.contexts
-> ["lint","lint-powershell","test","test-windows","review-attestation"]
```

Step 4 of that file's own promotion ladder had been executed and neither the
header nor the message was updated. A gate that misreports its own authority is
the same class of defect as one that misreports a review.

## Split out

**#1222** — the `dependencies` label does not exist in this repository, so the
spec-gate skip for bot authors (`check-spec-gate.sh:604`) has never fired.
Latent, not causing a red today, and its fix is a label reconciler plus a guard.
Filed with the full root cause rather than mentioned in passing.

## Verification

```
$ bats tests/*.bats
1483 ok, 0 not ok   (BATS_EXIT=0)

$ bats tests/dependabot-ci.bats
1..8   all ok, and verified failing without the fix (above)

$ python3 -c "yaml.safe_load(...)"   # all three edited workflows
add-to-project.yml: OK    pr-agent.yml: OK    review-attestation.yml: OK

$ actionlint .github/workflows/{add-to-project,pr-agent,review-attestation}.yml
one SC2016 info in add-to-project.yml — reproduced identically on origin/main,
not introduced here (single-quoted GraphQL query strings, intentional)
```

## SDD skip rationale

The Discipline Gate counts **84 added lines** across the three workflows. The
executable diff is **7 lines** — three `if:` conditions and one corrected
message. The breakdown, as AGENTS.md requires when total added lines exceed the
cap:

| File | Added | Executable | Rest |
|---|---:|---:|---:|
| `add-to-project.yml` | 27 | 2 | 25 comment |
| `pr-agent.yml` | 31 | 2 | 29 comment |
| `review-attestation.yml` | 26 | 3 | 23 comment |
| `tests/dependabot-ci.bats` | 120 | — | test |
| `docs/lessons/` | 23 | — | docs |

```
$ git diff origin/main -- .github/workflows | grep '^+' | grep -v '^+++' \
    | grep -vE '^\+\s*#' | grep -vE '^\+\s*$' | wc -l
7
```

The comment-to-code ratio matches the house style of these three files, where an
`if:` routinely carries an eighty-line rationale — the reason each one is
maintainable at all. Trimming them to pass a raw line counter would remove the
part worth keeping. This is a bug fix with an obvious cause well under the
"<20 lines" skip criterion in AGENTS.md; no public contract changes, no
dependency added, not the first step of a sequence.

Closes #1221