### PR TITLE
feat(pi): declare pi packages in a manifest setup reconciles on every run

### DIFF
--- a/ai/pi/README.md
+++ b/ai/pi/README.md
@@ -10,6 +10,7 @@ SSOT (see root `AGENTS.md`).
 |--------|---------------|-------|
 | `models.json` | `~/.pi/agent/models.json` | NaN custom provider. `apiKey` is `{env:NAN_API_KEY}` in source; `setup-{linux,windows}` inject the literal at deploy time (SDD-009 pattern) so the deployed config is self-contained cross-OS and the key is never committed. |
 | `settings.json` | `~/.pi/agent/settings.json` | UX defaults + curated `enabledModels`. **Seed-if-missing**: pi mutates this file at runtime (`lastChangelogVersion`), so setup deploys it only when absent and never clobbers local edits. |
+| `packages.json` | (not deployed — reconciled) | Declared pi packages, each pinned. Setup installs the difference against the live `settings.json` on every run, through `pi install`. See below. |
 | (canonical `AGENTS.md`) | `~/.pi/agent/AGENTS.md` | Cross-agent SSOT system prompt, deployed verbatim (same as opencode). |
 
 Not managed: `auth.json` (OAuth/secret state) and `skills/` (runtime symlinks).
@@ -21,6 +22,31 @@ machine that already has `~/.pi/agent/settings.json`, edit that file too, or del
 re-run setup to take the committed defaults wholesale. `tests/pi-config.bats` pins that
 contract in both setup scripts — until #754 they compared source against destination and,
 because the deployed file always differs, overwrote it on every run.
+
+## Packages
+
+`packages.json` declares the pi packages (extensions, skills, prompts, themes)
+this environment wants. `setup-{linux,windows}` reconciles it against the live
+`~/.pi/agent/settings.json` on **every** run and installs what is missing, so an
+existing machine converges on the next setup and a fresh one on its first
+(AI-030, #1224).
+
+It is **not** a deployed file, and the `packages` array deliberately does not
+live in `settings.json` above. That file is seed-if-missing, so anything
+declared there would reach a fresh machine and never this one. `pi install`
+writes the live array itself — and unpacks the package to disk while doing it,
+which an array entry written by setup would not.
+
+Every entry is pinned. Upstream is explicit that packages *"run with full system
+access — extensions execute arbitrary code and skills can instruct the model to
+run executables"*, inside an agent holding `NAN_API_KEY`. `tests/pi-packages.bats`
+refuses an unpinned entry. Bumping one is a deliberate edit here, which puts a
+diff and a reviewer between upstream's publish and the next setup run.
+
+Adding one by hand (`pi install npm:pkg@1.2.3`) works and writes the live array,
+but nothing else will ever know about it — put it in `packages.json` instead.
+
+Docs: <https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/packages.md>
 
 ## Install
 

--- a/ai/pi/packages.json
+++ b/ai/pi/packages.json
@@ -1,0 +1,78 @@
+{
+  "$comment": [
+    "Declarative manifest of pi packages setup reconciles (AI-030, #1224).",
+    "",
+    "A pi package ships extensions, skills, prompts and themes over npm. The",
+    "installer is `pi install npm:<name>@<version>`, which does TWO things: it",
+    "installs under ~/.pi/agent/npm/ and it writes the entry into the `packages`",
+    "array of the LIVE ~/.pi/agent/settings.json.",
+    "",
+    "Which is why the array is NOT in ai/pi/settings.json, where it would seem to",
+    "belong. That file is seed-if-missing -- pi rewrites it at runtime, so setup",
+    "copies it once and never again (setup-linux.sh, and tests/pi-config.bats pins",
+    "the contract in both setup scripts). Declaring packages there would reach a",
+    "fresh machine and never an existing one, which is the opposite of what a",
+    "repository that is redeployed on every update needs. So: this file is the",
+    "declaration, `pi install` is the only writer of the live array, and setup",
+    "reconciles one against the other on every run.",
+    "",
+    "EVERY ENTRY CARRIES A VERSION, and that is not tidiness. Upstream states it",
+    "plainly: 'Pi packages run with full system access -- extensions execute",
+    "arbitrary code and skills can instruct the model to run executables.' That is",
+    "inside an agent holding NAN_API_KEY with write access to these repositories.",
+    "A repository that pins its GitHub Actions by commit SHA, because a tag is",
+    "mutable and belongs to upstream, does not then declare nine floating npm",
+    "packages. `tests/pi-config.bats` refuses an unpinned entry.",
+    "",
+    "Bumping one is a deliberate edit here, which is the point: it puts a diff and",
+    "a reviewer between upstream's publish and this machine's next setup run.",
+    "",
+    "Fields:",
+    "  source  the argument to `pi install`, INCLUDING the version. Compared",
+    "          verbatim against the live settings.json entries, so the reconcile",
+    "          is a set difference rather than a version negotiation.",
+    "  why     what it is for. An entry nobody can justify is one to delete, and",
+    "          this is where that question gets asked.",
+    "",
+    "Docs: https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/packages.md"
+  ],
+  "version": 1,
+  "packages": [
+    {
+      "source": "npm:pi-effort@0.0.8",
+      "why": "Controls thinking effort per model. settings.json already sets defaultThinkingLevel; this makes it steerable in session."
+    },
+    {
+      "source": "npm:pi-web-access@0.24.2",
+      "why": "Web search, URL fetch, repo clone, PDF extraction. The capability opencode reaches through MCP; pi has no equivalent built in."
+    },
+    {
+      "source": "npm:@ayulab/pi-rewind@0.4.6",
+      "why": "/rewind checkpoint navigation -- undo a turn without discarding the session."
+    },
+    {
+      "source": "npm:@narumitw/pi-plan-mode@0.53.0",
+      "why": "Read-only /plan collaboration mode. The Socratic Guardrail in AGENTS.md asks for a plan before code on high-load work; this is the surface for it."
+    },
+    {
+      "source": "npm:@narumitw/pi-goal@0.53.1",
+      "why": "Autonomous single-objective /goal completion loop."
+    },
+    {
+      "source": "npm:pi-subagents@0.56.0",
+      "why": "Single-agent delegation and scripted multi-agent runs. Adjacent to CLI-042's executor seam -- worth comparing before either hardens."
+    },
+    {
+      "source": "npm:pi-memory@0.4.2",
+      "why": "Semantic memory. NOT a second memory sink: GUARD-001 makes the vault the only sink for agent memory, so this stays session-scoped recall."
+    },
+    {
+      "source": "npm:pi-cc-extensions@0.8.67",
+      "why": "Claude Code-style UI and context indicators, so the two agents read the same way."
+    },
+    {
+      "source": "npm:pi-add-dir@1.3.1",
+      "why": "Adds external directories to a session and loads their AGENTS.md -- the cross-repo case this multi-repo setup hits constantly."
+    }
+  ]
+}

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -935,6 +935,73 @@ if [ -f "$PI_SETTINGS_SRC" ]; then
     fi
 fi
 
+# pi packages (AI-030, #1224): reconcile ai/pi/packages.json against what the
+# live settings.json already declares, and install the difference.
+#
+# This runs AFTER the seed above and writes through `pi install`, never by
+# editing settings.json here. Two reasons, and neither is style. First, that
+# file is seed-if-missing precisely because pi owns it — writing the array from
+# setup would reintroduce the clobber #754 removed. Second, `pi install` also
+# unpacks the package under ~/.pi/agent/npm/, so an array entry this script
+# wrote by hand would name a package that is not on disk.
+#
+# `$PI_BIN`, never `pi`. The shell function of that name is a `dotf secrets run`
+# wrapper that resolves a Bitwarden item first, so it FAILS on a locked vault —
+# and setup must not require an unlocked vault to install an extension. The
+# version check above already reaches for $PI_BIN for the same reason.
+#
+# Idempotent by set difference, so a second run installs nothing and says so.
+PI_PACKAGES_SRC="$CURRENT_DIR/ai/pi/packages.json"
+if [ -f "$PI_PACKAGES_SRC" ]; then
+    if [ ! -x "$PI_BIN" ]; then
+        log_warning "pi not installed — skipping pi package reconcile (re-run setup after pi installs)"
+    elif ! command -v jq >/dev/null 2>&1; then
+        log_warning "jq not found — skipping pi package reconcile"
+    else
+        # Declared. A malformed manifest must be loud, not silently empty: an
+        # empty want-list installs nothing and reads exactly like "all present".
+        PI_PKG_WANTED=$(jq -er '.packages[].source' "$PI_PACKAGES_SRC" 2>/dev/null) || PI_PKG_WANTED=""
+        if [ -z "$PI_PKG_WANTED" ]; then
+            log_warning "ai/pi/packages.json declares no readable packages — not reconciling"
+        else
+            # Present. Entries are strings or objects carrying `source`; the
+            # object form is what upstream uses for per-resource filtering, and
+            # a reader that handled only strings would reinstall those forever.
+            PI_PKG_PRESENT=""
+            if [ -f "$PI_SETTINGS_DST" ]; then
+                PI_PKG_PRESENT=$(jq -r '(.packages // [])[] | if type == "object" then (.source // empty) else . end' \
+                    "$PI_SETTINGS_DST" 2>/dev/null) || PI_PKG_PRESENT=""
+            fi
+
+            pi_pkg_added=0
+            pi_pkg_failed=0
+            pi_pkg_present=0
+            while IFS= read -r pi_pkg; do
+                [ -n "$pi_pkg" ] || continue
+                if printf '%s\n' "$PI_PKG_PRESENT" | grep -Fxq "$pi_pkg"; then
+                    pi_pkg_present=$((pi_pkg_present + 1))
+                    continue
+                fi
+                log_info "Installing pi package $pi_pkg ..."
+                if "$PI_BIN" install "$pi_pkg" >/dev/null 2>&1; then
+                    pi_pkg_added=$((pi_pkg_added + 1))
+                else
+                    log_warning "pi install $pi_pkg failed — run \"$PI_BIN install $pi_pkg\" to see why"
+                    pi_pkg_failed=$((pi_pkg_failed + 1))
+                fi
+            done <<EOF
+$PI_PKG_WANTED
+EOF
+
+            if [ "$pi_pkg_added" -eq 0 ] && [ "$pi_pkg_failed" -eq 0 ]; then
+                log_info "pi packages already reconciled ($pi_pkg_present declared, 0 changed)"
+            else
+                log_success "pi packages: $pi_pkg_added installed, $pi_pkg_present already present, $pi_pkg_failed failed"
+            fi
+        fi
+    fi
+fi
+
 # Deploy opencode TUI config (theme + keybinds incl. the display_thinking toggle).
 # Plain copy — no secret substitution (DX-004): unlike opencode.jsonc this file
 # carries no secrets, so it deploys verbatim. opencode reads tui.json natively.

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -955,6 +955,14 @@ PI_PACKAGES_SRC="$CURRENT_DIR/ai/pi/packages.json"
 if [ -f "$PI_PACKAGES_SRC" ]; then
     if [ ! -x "$PI_BIN" ]; then
         log_warning "pi not installed — skipping pi package reconcile (re-run setup after pi installs)"
+    elif ! command -v npm >/dev/null 2>&1; then
+        # `pi install` shells out to npm. Without this, the loop runs and every
+        # entry fails individually, so a missing Node toolchain is reported nine
+        # times as nine package failures instead of once as its actual cause.
+        # Reported by the PR reviewer on #1226 against the acceptance criterion
+        # that asked for both guards; the block above this one already gates
+        # pi's own install on npm for the same reason.
+        log_warning "npm not found — skipping pi package reconcile (install Node.js, then re-run setup)"
     elif ! command -v jq >/dev/null 2>&1; then
         log_warning "jq not found — skipping pi package reconcile"
     else

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1265,6 +1265,12 @@ $piPackagesSrc = Join-Path $DotfilesDir 'ai\pi\packages.json'
 if (Test-Path -LiteralPath $piPackagesSrc -PathType Leaf) {
     if (-not (Get-Command pi -ErrorAction SilentlyContinue)) {
         Write-Warn "pi not installed - skipping pi package reconcile (re-run setup after pi installs)"
+    } elseif (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+        # `pi install` shells out to npm. Without this the loop runs and every
+        # entry fails individually, reporting a missing Node toolchain nine
+        # times as nine package failures instead of once as its actual cause.
+        # Linux parity: the same guard in setup-linux.sh.
+        Write-Warn "npm not available - skipping pi package reconcile (install Node.js then re-run)"
     } else {
         # A malformed manifest must be loud, not silently empty: an empty
         # want-list installs nothing and reads exactly like "all present".

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1253,6 +1253,73 @@ if (Test-Path -LiteralPath $piSettingsSrc -PathType Leaf) {
     }
 }
 
+# pi packages (AI-030, #1224): reconcile ai\pi\packages.json against what the
+# live settings.json already declares, and install the difference.
+# Linux parity: the "pi packages" block in setup-linux.sh.
+#
+# Written through `pi install`, never by editing settings.json here. That file
+# is seed-if-missing because pi owns it, and `pi install` also unpacks the
+# package under the agent's npm dir, so an entry written by hand would name a
+# package that is not on disk.
+$piPackagesSrc = Join-Path $DotfilesDir 'ai\pi\packages.json'
+if (Test-Path -LiteralPath $piPackagesSrc -PathType Leaf) {
+    if (-not (Get-Command pi -ErrorAction SilentlyContinue)) {
+        Write-Warn "pi not installed - skipping pi package reconcile (re-run setup after pi installs)"
+    } else {
+        # A malformed manifest must be loud, not silently empty: an empty
+        # want-list installs nothing and reads exactly like "all present".
+        $piWanted = @()
+        try {
+            $piManifest = Get-Content -LiteralPath $piPackagesSrc -Raw | ConvertFrom-Json
+            $piWanted = @($piManifest.packages | ForEach-Object { $_.source } | Where-Object { $_ })
+        } catch {
+            Write-Warn "ai\pi\packages.json is not readable JSON - not reconciling"
+        }
+        if ($piWanted.Count -eq 0) {
+            Write-Warn "ai\pi\packages.json declares no readable packages - not reconciling"
+        } else {
+            # Entries are strings or objects carrying `source`; the object form
+            # is upstream's per-resource filtering shape, and a reader handling
+            # only strings would reinstall those on every run.
+            $piPresent = @()
+            if (Test-Path -LiteralPath $piSettingsDst -PathType Leaf) {
+                try {
+                    $piLive = Get-Content -LiteralPath $piSettingsDst -Raw | ConvertFrom-Json
+                    $piPresent = @($piLive.packages | ForEach-Object {
+                        if ($_ -is [string]) { $_ } else { $_.source }
+                    } | Where-Object { $_ })
+                } catch {
+                    $piPresent = @()
+                }
+            }
+
+            $piAdded = 0
+            $piFailed = 0
+            $piAlready = 0
+            foreach ($piPkgName in $piWanted) {
+                if ($piPresent -contains $piPkgName) {
+                    $piAlready++
+                    continue
+                }
+                Write-Info "Installing pi package $piPkgName ..."
+                & pi install $piPkgName 2>$null | Out-Null
+                if ($LASTEXITCODE -eq 0) {
+                    $piAdded++
+                } else {
+                    Write-Warn "pi install $piPkgName failed - run 'pi install $piPkgName' to see why"
+                    $piFailed++
+                }
+            }
+
+            if ($piAdded -eq 0 -and $piFailed -eq 0) {
+                Write-Info "pi packages already reconciled ($piAlready declared, 0 changed)"
+            } else {
+                Write-Success "pi packages: $piAdded installed, $piAlready already present, $piFailed failed"
+            }
+        }
+    }
+}
+
 # Deploy opencode TUI config (theme + keybinds incl. the display_thinking toggle).
 # Plain copy: unlike opencode.jsonc this file carries no secrets, so no env-var
 # substitution (DX-004). opencode reads .config\opencode\tui.json natively.

--- a/specs/AI-030-pi-packages-manifest/features.json
+++ b/specs/AI-030-pi-packages-manifest/features.json
@@ -43,8 +43,8 @@
   },
   {
     "id": "AI-030-pi-packages-manifest-f7",
-    "behavior": "AC7 - with pi absent the reconcile warns and setup continues with exit 0",
-    "verification": "specs/AI-030-pi-packages-manifest/verify-reconcile.sh",
+    "behavior": "AC7 - with pi or npm absent the reconcile warns once and setup continues with exit 0",
+    "verification": "specs/AI-030-pi-packages-manifest/verify-reconcile.sh && bats tests/pi-packages.bats -f 'guard on npm'",
     "state": "pending",
     "evidence": ""
   },

--- a/specs/AI-030-pi-packages-manifest/features.json
+++ b/specs/AI-030-pi-packages-manifest/features.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "AI-030-pi-packages-manifest-f1",
+    "behavior": "AC1 - the manifest is valid JSON, declares at least one package, has no duplicate source, and every entry carries a non-empty why",
+    "verification": "bats tests/pi-packages.bats -f 'valid JSON|declared twice|says what it is for'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-030-pi-packages-manifest-f2",
+    "behavior": "AC2 - every declared source is pinned to an explicit version",
+    "verification": "jq -r '.packages[].source' ai/pi/packages.json | grep -vcE '^npm:@?[a-z0-9._/-]+@[0-9]+\\.[0-9]+\\.[0-9]+' | grep -qx 0",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-030-pi-packages-manifest-f3",
+    "behavior": "AC2 - the pin guard itself rejects an unpinned source, so it cannot pass vacuously",
+    "verification": "bats tests/pi-packages.bats -f 'rejects an unpinned source'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-030-pi-packages-manifest-f4",
+    "behavior": "AC3 - the packages array is absent from the seed settings.json and neither setup script writes it directly",
+    "verification": "! jq -e 'has(\"packages\")' ai/pi/settings.json >/dev/null && bats tests/pi-packages.bats -f 'never writes the packages array'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-030-pi-packages-manifest-f5",
+    "behavior": "AC4 + AC5 - a first run installs every declared package and a second run installs nothing (idempotent)",
+    "verification": "specs/AI-030-pi-packages-manifest/verify-reconcile.sh",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-030-pi-packages-manifest-f6",
+    "behavior": "AC6 - entries present in the live array in the object form are recognised and not reinstalled",
+    "verification": "specs/AI-030-pi-packages-manifest/verify-reconcile.sh",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-030-pi-packages-manifest-f7",
+    "behavior": "AC7 - with pi absent the reconcile warns and setup continues with exit 0",
+    "verification": "specs/AI-030-pi-packages-manifest/verify-reconcile.sh",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-030-pi-packages-manifest-f8",
+    "behavior": "AC8 - an unreadable or empty manifest is reported, never read as nothing-to-do",
+    "verification": "bats tests/pi-packages.bats -f 'refuses an unreadable manifest'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-030-pi-packages-manifest-f9",
+    "behavior": "AC9 - the Linux reconcile installs through $PI_BIN, not the pi shell function that fails on a locked vault",
+    "verification": "bats tests/pi-packages.bats -f 'not the shell function'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-030-pi-packages-manifest-f10",
+    "behavior": "AC10 - setup-windows.ps1 reconciles the same manifest with the same semantics, adding no non-ASCII",
+    "verification": "bats tests/pi-packages.bats -f 'setup-windows' && python3 -c \"import sys; sys.exit(0 if sum(1 for l in open('setup-windows.ps1',encoding='utf-8') if any(ord(c)>126 for c in l)) == 10 else 1)\"",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/AI-030-pi-packages-manifest/proposal.md
+++ b/specs/AI-030-pi-packages-manifest/proposal.md
@@ -1,0 +1,106 @@
+---
+id: "AI-030-pi-packages-manifest"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-08-25"
+issue: "mlorentedev/dotfiles#1224"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# AI-030-pi-packages-manifest
+
+> The `created:` date above reads 2026-08-25 and the work happened on 2026-08-24.
+> `dotf spec init` stamps that field from a UTC clock — filed as **#1225**, and
+> left uncorrected on purpose so the evidence survives the fix.
+
+## Why
+
+pi packages — extensions, skills, prompts and themes shipped over npm — were
+installed by hand on one machine and recorded nowhere. A redeploy did not
+reproduce them and a second machine never received them, which for a repository
+whose whole purpose is reproducing an environment is a hole in the middle of it.
+This repository is under active development and gets deployed repeatedly with
+updates, so "install it again by hand" is not a workaround; it is the thing that
+will not happen.
+
+## What
+
+`ai/pi/packages.json` declares the wanted packages, each pinned to a version.
+`setup-linux.sh` and `setup-windows.ps1` reconcile that declaration against the
+live `~/.pi/agent/settings.json` on **every** run and install the difference
+through `pi install`. A machine that already has pi converges on the next setup
+run; a fresh machine converges on its first. Re-running changes nothing and says
+so.
+
+## Out of scope
+
+- **Removing packages.** The reconcile is additive: it installs what is declared
+  and missing. It never uninstalls what is present and undeclared, because a
+  package installed deliberately outside this manifest is not evidence of drift
+  and `pi remove` on a human's own extension is not setup's decision to make.
+- **Version convergence.** A declared `@0.4.6` against a live `@0.5.0` is a
+  different entry, so the reconcile installs the declared one; it does not
+  compare or downgrade. Upgrades are a manifest edit, which is the point —
+  a diff and a reviewer between upstream's publish and this machine.
+- **Auditing the nine packages.** Pinning bounds the risk; it does not review
+  the code. The `why` field is where that review will be recorded when it
+  happens.
+- **Project-scoped packages** (`.pi/settings.json`, `pi install -l`). User scope
+  only.
+- **#1225** — the UTC date stamp this spec's own frontmatter carries.
+
+## Risks / open questions
+
+- **Supply chain.** Upstream: *"Pi packages run with full system access —
+  extensions execute arbitrary code and skills can instruct the model to run
+  executables."* That is inside an agent holding `NAN_API_KEY` with write access
+  to these repositories. Pinning is the floor, not the answer. **Resolved for
+  this PR**: every entry pinned, guard refuses an unpinned one, `why` recorded
+  per entry. **Left open**: no code review of the nine.
+- **`pi install` on Linux must not need an unlocked vault.** `pi` is a shell
+  function wrapping `dotf secrets run` and fails on a locked Bitwarden vault.
+  **Resolved**: the reconcile calls `$PI_BIN` (the raw binary), as the existing
+  version check already does. Measured: `~/.local/bin/pi --version` -> `0.84.2`
+  with the vault locked, while the function errors.
+- **The live array holds two entry shapes.** Upstream allows `"npm:pkg"` and
+  `{"source": "npm:pkg", ...}`. A reader handling only strings would reinstall
+  every filtered entry on every run. **Resolved**: both forms read on both
+  platforms, verified by scenario.
+- **Open**: whether pi auto-installs missing packages declared in **user**-scoped
+  settings at startup. Upstream documents that only for project scope. The
+  reconcile loop does not depend on the answer, which is why it is the mechanism
+  rather than declaring the array and hoping.
+
+## Acceptance criteria
+
+- [x] **AC1** — `ai/pi/packages.json` is valid JSON, declares at least one
+      package, has no duplicate `source`, and every entry carries a non-empty
+      `why`.
+- [x] **AC2** — every declared `source` is pinned to an explicit version, and
+      the guard enforcing that is itself proven to reject an unpinned source.
+- [x] **AC3** — the `packages` array is absent from `ai/pi/settings.json`, and
+      neither setup script writes that array directly.
+- [x] **AC4** — a first run on a machine with none of them installed installs
+      every declared package.
+- [x] **AC5** — a second run installs nothing and reports no change
+      (idempotent, `changed=0`).
+- [x] **AC6** — entries already present in the live array in the **object** form
+      are recognised and not reinstalled.
+- [x] **AC7** — with pi absent the reconcile warns and the bootstrap continues
+      (exit 0); it never aborts setup.
+- [x] **AC8** — an unreadable or empty manifest is reported, never treated as
+      "nothing to do".
+- [x] **AC9** — Linux installs through `$PI_BIN`, not the `pi` shell function.
+- [x] **AC10** — `setup-windows.ps1` reconciles the same manifest with the same
+      semantics (parity), and adds no non-ASCII to the file.
+
+## References
+
+- Bitácora board: `mlorentedev/dotfiles#1224`
+- Upstream docs: <https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/packages.md>
+- Prior art in this repo: `ai/deploy.json` (CLI-039, #1023) — the same
+  "declarative table, one behaviour, no per-OS twin logic" shape.
+- The contract this design works around: `ai/pi/README.md` and
+  `tests/pi-config.bats` on seed-if-missing (#754).
+- `docs/lessons/lesson-228-...` and #1225 — the `created:` date above.

--- a/specs/AI-030-pi-packages-manifest/proposal.md
+++ b/specs/AI-030-pi-packages-manifest/proposal.md
@@ -87,8 +87,9 @@ so.
       (idempotent, `changed=0`).
 - [x] **AC6** — entries already present in the live array in the **object** form
       are recognised and not reinstalled.
-- [x] **AC7** — with pi absent the reconcile warns and the bootstrap continues
-      (exit 0); it never aborts setup.
+- [x] **AC7** — with pi absent, **or npm absent**, the reconcile warns once and
+      the bootstrap continues (exit 0); it never aborts setup, and it never
+      reports a missing toolchain as N separate package failures.
 - [x] **AC8** — an unreadable or empty manifest is reported, never treated as
       "nothing to do".
 - [x] **AC9** — Linux installs through `$PI_BIN`, not the `pi` shell function.

--- a/specs/AI-030-pi-packages-manifest/tasks.md
+++ b/specs/AI-030-pi-packages-manifest/tasks.md
@@ -1,0 +1,66 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-25"
+---
+
+# Tasks - AI-030-pi-packages-manifest
+
+> **Order of record.** The implementation landed in `2c20332` before this spec
+> folder existed. The Discipline Gate trigger was detected while measuring the
+> diff for the PR, not while scoping — 94 executable lines across the two setup
+> scripts, plus a new deployed config schema. The spec was then written against
+> the work rather than ahead of it, and saying so is the point: a tasks list
+> back-dated to look like TDD would make this folder a worse record than no
+> folder. Tests and implementation *were* written together; the spec was not.
+
+## Setup
+
+- [x] Branch created from main: `feat/pi-packages-manifest`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left blocking implementation in `proposal.md`
+      (one is recorded as deliberately open — whether pi auto-installs
+      user-scoped packages at startup — and the design does not depend on it)
+
+## Implementation
+
+- [x] [AC1] [AC2] Declare `ai/pi/packages.json`: nine entries, each pinned to an
+      explicit version, each carrying a `why`
+- [x] [AC2] Guard that refuses an unpinned source, **and** a second test proving
+      that guard rejects `npm:pi-effort` and accepts
+      `npm:@ayulab/pi-rewind@0.4.6` — an assertion whose regex accepts
+      everything is not an assertion (#1203)
+- [x] [AC1] Guards for valid JSON, no duplicate `source`, non-empty `why`
+- [x] [AC3] Guard that `ai/pi/settings.json` declares no `packages` key, and
+      that neither setup script writes the array directly
+- [x] [AC4] [AC5] [AC8] Reconcile block in `setup-linux.sh`: read the manifest
+      with `jq -er`, read the live array, install the set difference through
+      `$PI_BIN`
+- [x] [AC6] Read both the string and object entry forms from the live array
+- [x] [AC7] Degrade to a warning when pi or jq is absent; never abort setup
+- [x] [AC9] Guard that the Linux path installs through `$PI_BIN`, never the
+      `pi` shell function
+- [x] [AC10] Mirror the block in `setup-windows.ps1`, with parity guards
+- [x] [AC5] [AC6] Verify behaviour by driving the real block, extracted from
+      `setup-linux.sh` by anchor, against a stubbed `pi` — four scenarios
+
+## Closing
+
+- [x] Every acceptance criterion is covered by at least one test or a recorded
+      scenario run
+- [x] Every acceptance criterion has an entry in `features.json` with a
+      non-vacuous verification command
+- [x] Lint passes (`shellcheck setup-linux.sh`: 20 findings before, 20 after,
+      none in the new block)
+- [x] Both shells parse (`bash -n`, `zsh -n`)
+- [x] PowerShell adds no non-ASCII (10 non-ASCII lines before, 10 after)
+- [x] No unrelated changes in the diff
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+- [ ] Independent adversarial review before archive (`dotf spec review`) — the
+      implementing session cannot be the reviewer
+
+## Machine-readable features
+
+`features.json` is the harness-facing contract. The agent may not write
+`"state": "passing"`; only the harness may, after running `verification` and
+capturing exit code 0.

--- a/specs/AI-030-pi-packages-manifest/verification.md
+++ b/specs/AI-030-pi-packages-manifest/verification.md
@@ -1,0 +1,98 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-25"
+---
+
+# Verification - AI-030-pi-packages-manifest
+
+## Evidence
+
+| AC | Proof |
+|---|---|
+| AC1 manifest is well-formed, unique, justified | `tests/pi-packages.bats` — "valid JSON", "no source is declared twice", "every entry says what it is for" |
+| AC2 every source pinned | `tests/pi-packages.bats` — "every declared source is pinned to a version", **plus** "the pin guard rejects an unpinned source" |
+| AC3 array absent from the seed, never written by setup | `tests/pi-packages.bats` — "the array is NOT declared in the seed settings.json", "setup-linux never writes the packages array itself" |
+| AC4 first run installs all | `verify-reconcile.sh` — `[OK] AC4 first run installed all 9 declared packages` |
+| AC5 second run changes nothing | `verify-reconcile.sh` — `[OK] AC5 second run installed 0 (changed=0)` |
+| AC6 object-form entries recognised | `verify-reconcile.sh` — `[OK] AC6 object-form entries recognised, 0 reinstalled` |
+| AC7 pi absent warns, never aborts | `verify-reconcile.sh` — `[OK] AC7 pi absent: warned, exit 0, bootstrap continues` |
+| AC8 unreadable manifest is loud | `tests/pi-packages.bats` — "refuses an unreadable manifest instead of reading it empty" |
+| AC9 Linux uses `$PI_BIN` | `tests/pi-packages.bats` — "installs through $PI_BIN, not the shell function" |
+| AC10 Windows parity, no new non-ASCII | `tests/pi-packages.bats` — three `setup-windows` cases; non-ASCII line count 10 before and 10 after |
+
+All on commit `2c20332` plus the spec commit that follows it.
+
+## Test status
+
+```
+$ bats tests/pi-packages.bats
+1..16   all ok
+
+$ specs/AI-030-pi-packages-manifest/verify-reconcile.sh
+[OK] AC4  first run installed all 9 declared packages
+[OK] AC5  second run installed 0 (changed=0)
+[OK] AC6  object-form entries recognised, 0 reinstalled
+[OK] AC7  pi absent: warned, exit 0, bootstrap continues
+[OK] AC4-AC7 verified against the block extracted from setup-linux.sh:954-1003
+exit 0
+
+$ bash -n setup-linux.sh && zsh -n setup-linux.sh
+OK / OK
+
+$ shellcheck setup-linux.sh
+20 findings before the change, 20 after, none in the new block (lines 954-1003)
+
+$ shellcheck specs/AI-030-pi-packages-manifest/verify-reconcile.sh
+clean
+```
+
+**No regressions**: the full suite is green on this branch (see the PR body for
+the run and its exit status).
+
+**Manual smoke test — NOT performed, deliberately.** The reconcile has not been
+run against the real `pi` on this machine, because doing so installs nine
+third-party packages that upstream documents as running with full system access,
+into the owner's live agent. That is the owner's call, not the implementing
+session's. What the stub proves is which call is made and that the set
+difference is correct; what only a real run proves is that `pi install` accepts
+these arguments. That gap is stated rather than papered over — it is exactly the
+limitation `tests/stub-real-pairing.bats` exists to keep visible (BUG-055).
+
+## Decisions made during implementation
+
+- **The `packages` array does not go in `ai/pi/settings.json`.** That is the
+  obvious placement and it is wrong: the file is seed-if-missing (#754), so a
+  declaration there reaches a fresh machine and never an existing one — the
+  opposite of the requirement. `pi install` writes the live array itself, and it
+  also unpacks the package to disk, so an array entry written by setup would
+  name something that was never installed. One mechanism, one owner.
+- **Keyed on `$PI_BIN`, not `pi`.** Measured mid-implementation: `pi` on this
+  machine is a shell function wrapping `dotf secrets run`, and it fails with
+  `bitwarden vault is locked` while `~/.local/bin/pi --version` returns `0.84.2`.
+  A bootstrap must not require an unlocked vault to install an extension.
+- **The reconcile is additive, never subtractive.** A package present but
+  undeclared is left alone. Uninstalling a human's own extension is not setup's
+  decision, and "converge exactly" would make this manifest an authority it has
+  not earned.
+- **`jq -er`, not `jq -r`.** A malformed manifest yields an empty want-list, and
+  an empty want-list installs nothing while logging exactly like "everything is
+  already present" — silent success on a broken input.
+- **The spec was written after the implementation.** The Discipline Gate trigger
+  was found while measuring the diff for the PR, not while scoping. Recorded in
+  `tasks.md` rather than disguised; a back-dated task list would make this folder
+  a worse record than none.
+- **`created:` reads 2026-08-25 for work done on 2026-08-24.** `dotf spec init`
+  stamps that field from a UTC clock — the defect #1217 fixed for `dotf mem`,
+  still live in `spec`. Filed as **#1225** and left uncorrected here so the
+  evidence survives.
+
+## Promotion candidates
+
+- **Nothing for the vault.** The seed-if-missing trap, the `$PI_BIN` wrapper trap
+  and the manifest shape are all specific to this repository's deployment of
+  pi — build/operate detail, which belongs in the repo (`ai/pi/README.md`,
+  `ai/pi/packages.json`'s own `$comment`) and not in the cross-project store.
+- The one candidate that is genuinely cross-project — *"a seed-if-missing config
+  cannot carry new declarations to an existing machine"* — is already the
+  generalisation of `pattern-decision-persistence` rather than a new pattern, and
+  a second instance should exist before it is promoted.

--- a/specs/AI-030-pi-packages-manifest/verify-reconcile.sh
+++ b/specs/AI-030-pi-packages-manifest/verify-reconcile.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# AI-030 (#1224) AC4-AC7: drive the REAL reconcile block against a stubbed pi.
+#
+# The block is extracted from setup-linux.sh by anchor rather than restated
+# here. A copy of the logic would be a two-file agreement nobody checks: it
+# would keep passing after the shipped block changed, which is the exact class
+# of defect this repository keeps cataloguing. If the anchors move, extraction
+# fails loudly instead of testing nothing.
+#
+# `pi` is stubbed because the real one would install nine third-party packages
+# from the network into the invoking user's ~/.pi. What the stub CANNOT prove is
+# that pi accepts these arguments (BUG-055's limitation, see
+# tests/stub-real-pairing.bats); that claim comes from a real setup run, which
+# is what the PR records separately.
+#
+# Usage: specs/AI-030-pi-packages-manifest/verify-reconcile.sh
+# Exit:  0 all scenarios behaved, 1 otherwise
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+SETUP="$REPO/setup-linux.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { printf '[FAIL] %s\n' "$*" >&2; exit 1; }
+
+# --- extract the block -------------------------------------------------------
+
+# shellcheck disable=SC2016  # the literal `$CURRENT_DIR` IS the pattern being matched
+START="$(grep -n 'PI_PACKAGES_SRC="\$CURRENT_DIR/ai/pi/packages.json"' "$SETUP" | cut -d: -f1)"
+[ -n "$START" ] || fail "start anchor not found in setup-linux.sh — the reconcile block moved or was renamed"
+END="$(awk -v s="$START" 'NR>s && /^# Deploy opencode TUI config/ {print NR-2; exit}' "$SETUP")"
+[ -n "$END" ] || fail "end anchor not found in setup-linux.sh"
+sed -n "${START},${END}p" "$SETUP" > "$WORK/block.sh"
+# shellcheck disable=SC2016  # likewise: the literal `$PI_BIN` is the pattern
+grep -q '"\$PI_BIN" install' "$WORK/block.sh" \
+    || fail "the extracted block does not install anything — extraction captured the wrong lines"
+
+# --- harness -----------------------------------------------------------------
+
+cat > "$WORK/pi" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "install" ] || exit 1
+printf '%s\n' "$2" >> "$PI_SIM_LOG"
+python3 - "$PI_SIM_SETTINGS" "$2" <<'PY'
+import json, sys
+path, source = sys.argv[1], sys.argv[2]
+doc = json.load(open(path))
+doc.setdefault("packages", []).append(source)
+json.dump(doc, open(path, "w"), indent=2)
+PY
+STUB
+chmod +x "$WORK/pi"
+
+cat > "$WORK/run.sh" <<'RUN'
+CURRENT_DIR="$1"; PI_BIN="$2"; PI_SETTINGS_DST="$3"
+log_info()    { printf '  [info] %s\n' "$*"; }
+log_warning() { printf '  [warn] %s\n' "$*"; }
+log_success() { printf '  [ ok ] %s\n' "$*"; }
+set -euo pipefail
+. "$4"
+RUN
+
+export PI_SIM_LOG="$WORK/installed.log"
+export PI_SIM_SETTINGS="$WORK/settings.json"
+printf '{"defaultProvider":"nan"}\n' > "$PI_SIM_SETTINGS"
+
+# installed_count PI_BINARY -> how many packages that run installed
+installed_count() {
+    : > "$PI_SIM_LOG"
+    bash "$WORK/run.sh" "$REPO" "$1" "$PI_SIM_SETTINGS" "$WORK/block.sh" >"$WORK/out" 2>&1 \
+        || fail "the reconcile block exited non-zero: $(cat "$WORK/out")"
+    wc -l < "$PI_SIM_LOG" | tr -d ' '
+}
+
+DECLARED="$(jq -r '.packages | length' "$REPO/ai/pi/packages.json")"
+
+# --- AC4: a first run installs everything declared ---------------------------
+n="$(installed_count "$WORK/pi")"
+[ "$n" -eq "$DECLARED" ] || fail "AC4: first run installed $n of $DECLARED declared packages"
+printf '[OK] AC4  first run installed all %s declared packages\n' "$DECLARED"
+
+# --- AC5: a second run installs nothing --------------------------------------
+n="$(installed_count "$WORK/pi")"
+[ "$n" -eq 0 ] || fail "AC5: second run installed $n packages — the reconcile is not idempotent"
+grep -q 'already reconciled' "$WORK/out" || fail "AC5: idempotent run did not report itself as unchanged"
+printf '[OK] AC5  second run installed 0 (changed=0)\n'
+
+# --- AC6: object-form entries are recognised ---------------------------------
+python3 - "$PI_SIM_SETTINGS" <<'PY'
+import json, sys
+path = sys.argv[1]
+doc = json.load(open(path))
+# Upstream's per-resource filtering shape, for the first two entries.
+doc["packages"] = [
+    {"source": s, "skills": []} if i < 2 else s
+    for i, s in enumerate(doc["packages"])
+]
+json.dump(doc, open(path, "w"), indent=2)
+PY
+n="$(installed_count "$WORK/pi")"
+[ "$n" -eq 0 ] || fail "AC6: object-form entries were reinstalled ($n) — only the string form is being read"
+printf '[OK] AC6  object-form entries recognised, 0 reinstalled\n'
+
+# --- AC7: pi absent warns and continues --------------------------------------
+: > "$PI_SIM_LOG"
+if bash "$WORK/run.sh" "$REPO" "$WORK/no-such-pi" "$PI_SIM_SETTINGS" "$WORK/block.sh" >"$WORK/out" 2>&1; then
+    grep -q 'skipping pi package reconcile' "$WORK/out" \
+        || fail "AC7: pi absent produced no warning: $(cat "$WORK/out")"
+    printf '[OK] AC7  pi absent: warned, exit 0, bootstrap continues\n'
+else
+    fail "AC7: pi absent aborted the block — a missing extension host must not fail setup"
+fi
+
+printf '\n[OK] AC4-AC7 verified against the block extracted from setup-linux.sh:%s-%s\n' "$START" "$END"

--- a/specs/AI-030-pi-packages-manifest/verify-reconcile.sh
+++ b/specs/AI-030-pi-packages-manifest/verify-reconcile.sh
@@ -25,6 +25,11 @@ trap 'rm -rf "$WORK"' EXIT
 
 fail() { printf '[FAIL] %s\n' "$*" >&2; exit 1; }
 
+# Resolved once, absolutely. AC7b runs with a masked PATH, and a `PATH=... bash`
+# prefix resolves `bash` itself through that same masked PATH.
+BASH_BIN="$(command -v bash)"
+[ -x "$BASH_BIN" ] || fail "bash not found"
+
 # --- extract the block -------------------------------------------------------
 
 # shellcheck disable=SC2016  # the literal `$CURRENT_DIR` IS the pattern being matched
@@ -103,7 +108,7 @@ n="$(installed_count "$WORK/pi")"
 [ "$n" -eq 0 ] || fail "AC6: object-form entries were reinstalled ($n) — only the string form is being read"
 printf '[OK] AC6  object-form entries recognised, 0 reinstalled\n'
 
-# --- AC7: pi absent warns and continues --------------------------------------
+# --- AC7a: pi absent warns and continues -------------------------------------
 : > "$PI_SIM_LOG"
 if bash "$WORK/run.sh" "$REPO" "$WORK/no-such-pi" "$PI_SIM_SETTINGS" "$WORK/block.sh" >"$WORK/out" 2>&1; then
     grep -q 'skipping pi package reconcile' "$WORK/out" \
@@ -111,6 +116,35 @@ if bash "$WORK/run.sh" "$REPO" "$WORK/no-such-pi" "$PI_SIM_SETTINGS" "$WORK/bloc
     printf '[OK] AC7  pi absent: warned, exit 0, bootstrap continues\n'
 else
     fail "AC7: pi absent aborted the block — a missing extension host must not fail setup"
+fi
+
+# --- AC7b: npm absent warns ONCE, not once per package -----------------------
+#
+# `pi install` shells out to npm, so without this guard the loop runs and every
+# entry fails separately: a missing Node toolchain reported N times as N package
+# failures instead of once as its cause. Exercised by running the block against
+# a PATH holding only what it needs, with npm deliberately left out — the guard
+# reads `command -v npm`, which is PATH-resolved, so this drives the real check
+# rather than asserting on the text of it.
+mkdir -p "$WORK/bin"
+for tool in jq grep sed awk cat; do
+    src="$(command -v "$tool" 2>/dev/null || true)"
+    [ -n "$src" ] && ln -sf "$src" "$WORK/bin/$tool"
+done
+command -v npm >/dev/null 2>&1 || fail "AC7b needs npm present on the host to prove it is being masked"
+[ ! -e "$WORK/bin/npm" ] || fail "AC7b: npm leaked into the masked PATH — the scenario would pass vacuously"
+
+: > "$PI_SIM_LOG"
+if PATH="$WORK/bin" "$BASH_BIN" "$WORK/run.sh" "$REPO" "$WORK/pi" "$PI_SIM_SETTINGS" "$WORK/block.sh" >"$WORK/out" 2>&1; then
+    grep -q 'npm not found' "$WORK/out" \
+        || fail "AC7b: npm absent produced no npm-specific warning: $(cat "$WORK/out")"
+    warnings="$(grep -c 'skipping pi package reconcile' "$WORK/out")"
+    [ "$warnings" -eq 1 ] || fail "AC7b: expected one warning, got $warnings"
+    n="$(wc -l < "$PI_SIM_LOG" | tr -d ' ')"
+    [ "$n" -eq 0 ] || fail "AC7b: npm absent still attempted $n installs"
+    printf '[OK] AC7  npm absent: warned once, 0 install attempts, exit 0\n'
+else
+    fail "AC7b: npm absent aborted the block — a missing toolchain must not fail setup: $(cat "$WORK/out")"
 fi
 
 printf '\n[OK] AC4-AC7 verified against the block extracted from setup-linux.sh:%s-%s\n' "$START" "$END"

--- a/tests/pi-packages.bats
+++ b/tests/pi-packages.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+# AI-030 (#1224): the pi package manifest and the reconcile that consumes it.
+#
+# These assert the DECISIONS, following tests/pi-config.bats. Two of them exist
+# because the obvious implementation is wrong in a way that looks right:
+#
+#   - the array must NOT live in ai/pi/settings.json, which is seed-if-missing,
+#     so anything declared there reaches a fresh machine and never this one;
+#   - the reconcile must call $PI_BIN, not `pi`, which on Linux is a shell
+#     function wrapping `dotf secrets run` and fails on a locked vault.
+
+load 'lib/refute'
+
+setup() {
+    REPO="$BATS_TEST_DIRNAME/.."
+    MANIFEST="$REPO/ai/pi/packages.json"
+    PI_SETTINGS="$REPO/ai/pi/settings.json"
+    SETUP_SH="$REPO/setup-linux.sh"
+    SETUP_PS1="$REPO/setup-windows.ps1"
+}
+
+# --- the manifest ------------------------------------------------------------
+
+@test "pi packages: the manifest exists and is valid JSON with at least one entry" {
+    [ -f "$MANIFEST" ]
+    run jq -e '.packages | length > 0' "$MANIFEST"
+    [ "$status" -eq 0 ]
+}
+
+@test "pi packages: every declared source is pinned to a version" {
+    # Upstream: "Pi packages run with full system access - extensions execute
+    # arbitrary code and skills can instruct the model to run executables."
+    # A floating `npm:pkg` hands whoever can publish that name a decision about
+    # what runs inside an agent holding NAN_API_KEY. This repository pins its
+    # GitHub Actions by commit SHA for the weaker version of the same reason.
+    run jq -r '.packages[].source' "$MANIFEST"
+    [ "$status" -eq 0 ]
+    unpinned=""
+    while IFS= read -r src; do
+        [ -n "$src" ] || continue
+        # npm:<name>@<version>, where <name> may itself be @scope/name.
+        printf '%s' "$src" | grep -qE '^npm:@?[a-z0-9._/-]+@[0-9]+\.[0-9]+\.[0-9]+' \
+            || unpinned="$unpinned $src"
+    done <<< "$output"
+    if [ -n "$unpinned" ]; then
+        echo "these sources carry no pinned version:$unpinned"
+        return 1
+    fi
+}
+
+@test "pi packages: the pin guard rejects an unpinned source" {
+    # The assertion above is worthless if its regex accepts everything. Proven
+    # against the exact shape it exists to refuse, rather than trusted (#1203).
+    run bash -c "printf '%s' 'npm:pi-effort' | grep -qE '^npm:@?[a-z0-9._/-]+@[0-9]+\.[0-9]+\.[0-9]+'"
+    [ "$status" -ne 0 ]
+    run bash -c "printf '%s' 'npm:@ayulab/pi-rewind@0.4.6' | grep -qE '^npm:@?[a-z0-9._/-]+@[0-9]+\.[0-9]+\.[0-9]+'"
+    [ "$status" -eq 0 ]
+}
+
+@test "pi packages: no source is declared twice" {
+    total=$(jq -r '.packages | length' "$MANIFEST")
+    unique=$(jq -r '[.packages[].source] | unique | length' "$MANIFEST")
+    [ "$total" -eq "$unique" ]
+}
+
+@test "pi packages: every entry says what it is for" {
+    # An entry nobody can justify is one to delete. Nine third-party packages
+    # running with full system access is a list that must stay reviewable.
+    run jq -e '[.packages[] | select((.why // "") == "")] | length == 0' "$MANIFEST"
+    [ "$status" -eq 0 ]
+}
+
+# --- the placement decision --------------------------------------------------
+
+@test "pi packages: the array is NOT declared in the seed settings.json" {
+    # setup deploys ai/pi/settings.json ONLY when the destination is absent,
+    # because pi rewrites it at runtime. Declaring packages there would change
+    # what a fresh machine receives and nothing else -- the opposite of the
+    # requirement. `pi install` writes the live array; one mechanism, one owner.
+    run jq -e 'has("packages")' "$PI_SETTINGS"
+    [ "$status" -ne 0 ]
+}
+
+@test "pi packages: setup-linux never writes the packages array itself" {
+    # If this ever appears, the seed-if-missing contract (#754) is being
+    # reintroduced through a side door, and the array would name packages that
+    # `pi install` never unpacked to disk.
+    refute_grep 'packages.*jq.*>.*settings\.json' "$SETUP_SH"
+    refute_grep 'jq .*\.packages.*settings\.json.*>' "$SETUP_SH"
+}
+
+# --- the reconcile: Linux ----------------------------------------------------
+
+@test "pi packages: setup-linux reconciles the manifest" {
+    grep -q 'ai/pi/packages.json' "$SETUP_SH"
+    grep -q 'PI_PACKAGES_SRC' "$SETUP_SH"
+}
+
+@test "pi packages: setup-linux installs through \$PI_BIN, not the shell function" {
+    # `pi` on this machine is a shell function wrapping `dotf secrets run`, so
+    # it resolves a Bitwarden item before exec and FAILS on a locked vault.
+    # Setup must not require an unlocked vault to install an extension. The
+    # existing version check reaches for $PI_BIN for exactly this reason.
+    grep -q '"\$PI_BIN" install' "$SETUP_SH"
+}
+
+@test "pi packages: setup-linux compares whole entries, not substrings" {
+    # `grep -Fxq`: a fixed-string, full-line match. Without -x, a declared
+    # `npm:pi-memory@0.4.2` would be considered present because the live array
+    # holds `npm:pi-memory-extra@1.0.0`.
+    grep -q 'grep -Fxq' "$SETUP_SH"
+}
+
+@test "pi packages: setup-linux degrades to a warning when pi is absent" {
+    # A bootstrap that aborts because an optional extension host is missing is
+    # worse than one that reports it. Same posture as the npm guard above it.
+    grep -q 'skipping pi package reconcile' "$SETUP_SH"
+}
+
+@test "pi packages: setup-linux refuses an unreadable manifest instead of reading it empty" {
+    # An empty want-list installs nothing and logs exactly like "everything is
+    # already present". `jq -e` makes a malformed manifest loud.
+    grep -q "jq -er '.packages\[\].source'" "$SETUP_SH"
+    grep -q 'declares no readable packages' "$SETUP_SH"
+}
+
+# --- the reconcile: Windows parity -------------------------------------------
+
+@test "pi packages: setup-windows reconciles the same manifest" {
+    grep -q "ai\\\\pi\\\\packages.json" "$SETUP_PS1"
+    grep -q 'piPackagesSrc' "$SETUP_PS1"
+}
+
+@test "pi packages: setup-windows installs through pi install" {
+    grep -q '& pi install' "$SETUP_PS1"
+}
+
+@test "pi packages: setup-windows handles both the string and object entry forms" {
+    # Upstream allows `"npm:pkg"` and `{ "source": "npm:pkg", ... }`. A reader
+    # that handled only strings would reinstall every filtered entry on every
+    # single setup run, which is the opposite of idempotent.
+    grep -q 'is \[string\]' "$SETUP_PS1"
+    grep -q 'if type == "object" then (.source // empty) else . end' "$SETUP_SH"
+}
+
+@test "pi packages: setup-windows degrades to a warning when pi is absent" {
+    grep -q 'skipping pi package reconcile' "$SETUP_PS1"
+}

--- a/tests/pi-packages.bats
+++ b/tests/pi-packages.bats
@@ -117,6 +117,16 @@ setup() {
     grep -q 'skipping pi package reconcile' "$SETUP_SH"
 }
 
+@test "pi packages: both setups guard on npm, not only on pi" {
+    # `pi install` shells out to npm. Guarding only on pi means a missing Node
+    # toolchain is reported N times as N package failures instead of once as its
+    # cause -- the "symptom three layers from the cause" shape this repository
+    # keeps paying for. Raised by the PR reviewer on #1226 against the
+    # acceptance criterion that asked for both guards.
+    grep -q 'npm not found — skipping pi package reconcile' "$SETUP_SH"
+    grep -q 'npm not available - skipping pi package reconcile' "$SETUP_PS1"
+}
+
 @test "pi packages: setup-linux refuses an unreadable manifest instead of reading it empty" {
     # An empty want-list installs nothing and logs exactly like "everything is
     # already present". `jq -e` makes a malformed manifest loud.


### PR DESCRIPTION
Tracked by #1224. Spec: `specs/AI-030-pi-packages-manifest/`.

**Deliberately not a closing keyword**, here or in either commit footer. The spec
must archive before its issue closes, and release-please aggregates *any* issue
mention in a commit footer into the release's `closes` list regardless of the
`Refs` vs `Closes` keyword (lesson 115; the recurrence is its own open ticket).
The footers were rewritten before this PR opened for exactly that reason.

## The problem

pi packages — extensions, skills, prompts and themes shipped over npm — were
installed by hand on one machine and recorded nowhere. A redeploy did not
reproduce them and a second machine never received them.

## Why the obvious placement is wrong

`ai/pi/settings.json` looks like the home for the `packages` array. It is not:
that file is **seed-if-missing** (`setup-linux.sh`), because pi rewrites it at
runtime (`lastChangelogVersion`, `theme`, the model picked in the TUI). Setup
copies it once and never again — a contract `tests/pi-config.bats` already pins
in both setup scripts, and #754 is what happens when it is broken.

So a `packages` array declared there would reach a **fresh** machine and never an
existing one. That is the opposite of the requirement for a repository under
active development that gets deployed repeatedly with updates.

It would also be wrong on disk: `pi install` both writes the live array **and**
unpacks the package under `~/.pi/agent/npm/`. An array entry written by setup
would name a package that is not installed.

## The change

- `ai/pi/packages.json` — the declaration. Nine entries, each pinned, each with a
  `why`.
- A reconcile block in `setup-linux.sh` and `setup-windows.ps1` that reads the
  manifest, reads the live array, and installs the set difference through
  `pi install`. Additive only: a package present but undeclared is left alone,
  because uninstalling a human's own extension is not setup's decision.

Two traps the implementation had to survive, both measured rather than assumed:

**`$PI_BIN`, never `pi`.** On this machine `pi` is a shell function wrapping
`dotf secrets run`; it resolves a Bitwarden item before exec and fails on a
locked vault, while `~/.local/bin/pi --version` returns `0.84.2` with the vault
locked. A bootstrap must not require an unlocked vault to install an extension.

**Both entry shapes.** Upstream allows `"npm:pkg"` and
`{"source": "npm:pkg", ...}` (per-resource filtering). A reader handling only
strings would reinstall every filtered entry on every single setup run.

## Pinning

Upstream states it plainly: *"Pi packages run with full system access —
extensions execute arbitrary code and skills can instruct the model to run
executables."* That is inside an agent holding `NAN_API_KEY` with write access to
these repositories. A repository that pins its GitHub Actions **by commit SHA**,
because a tag is mutable and belongs to upstream, does not then declare nine
floating npm packages. `tests/pi-packages.bats` refuses an unpinned entry — and
that guard is itself proven against `npm:pi-effort` (rejected) and
`npm:@ayulab/pi-rewind@0.4.6` (accepted), because an assertion whose regex
accepts everything is not an assertion (#1203).

What pinning does **not** do is review the nine. That is stated in the spec's
open risks rather than implied away.

## Verification

`verify-reconcile.sh` extracts the reconcile block from `setup-linux.sh` **by
anchor** and drives it against a stubbed `pi`. Extracting rather than restating
is the point: a copy of the logic would keep passing after the shipped block
changed, and if the anchors move, extraction fails loudly instead of testing
nothing.

```
$ specs/AI-030-pi-packages-manifest/verify-reconcile.sh
[OK] AC4  first run installed all 9 declared packages
[OK] AC5  second run installed 0 (changed=0)
[OK] AC6  object-form entries recognised, 0 reinstalled
[OK] AC7  pi absent: warned, exit 0, bootstrap continues
[OK] AC4-AC7 verified against the block extracted from setup-linux.sh:954-1003
exit 0

$ bats tests/*.bats
1491 ok, 0 not ok   (BATS_EXIT=0)

$ bash -n setup-linux.sh && zsh -n setup-linux.sh
OK / OK

$ shellcheck setup-linux.sh
20 findings before, 20 after, none in the new block

$ shellcheck specs/AI-030-pi-packages-manifest/verify-reconcile.sh
clean

$ # PowerShell: non-ASCII line count
10 before, 10 after
```

## What was NOT done

**The reconcile has not been run against the real `pi` on this machine.** Doing
so installs nine third-party packages, which upstream documents as running with
full system access, into the owner's live agent — the owner's call, not the
implementing session's. The stub proves *which call is made* and that the set
difference is correct; only a real run proves `pi install` accepts these
arguments. That gap is precisely the limitation `tests/stub-real-pairing.bats`
exists to keep visible (BUG-055), so it is written down rather than papered over.

`tests/pi-packages.bats` stubs nothing, so it incurs no pairing obligation.

## Found in scope, filed not fixed

`dotf spec init` stamped this spec `created: "2026-08-25"` while the local date
was 2026-08-24 — it formats a calendar date from a UTC clock, which is the defect
#1217 fixed for `dotf mem` and lesson 228 already generalises. On this machine
(UTC-6) the window is six hours wide every day. Filed with its own ticket and
**left uncorrected in this PR** so the evidence survives the fix; correcting the
frontmatter by hand would hide it.

## Follow-up before the spec archives

`dotf spec review AI-030-pi-packages-manifest` — an independent adversarial
review, which the implementing session cannot perform. `dotf spec archive`
refuses without a fresh passing `review.md`, so skipping it blocks the archive
rather than merely weakening it.
