### PR TITLE
feat(cli): probe real backends and route each chain entry to one that serves it

### DIFF
--- a/cli/internal/agent/backends.go
+++ b/cli/internal/agent/backends.go
@@ -1,0 +1,125 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+)
+
+// harnessFor maps a pool to the harness binary that reaches it, and how that
+// binary is asked for one non-interactive answer.
+//
+// This table is Go rather than another block in model-map.json, deliberately.
+// The map declares WHAT exists — pools, tiers, chains, budgets — and adding
+// argv to it would make it declare how to invoke things too, which is the
+// "map, never a director" drift ADR-035 §4 exists to stop. Two entries also do
+// not justify a schema change; a third harness is the trigger to revisit.
+var harnessFor = map[string]struct {
+	bin  string
+	args func(model string) []string
+}{
+	"claude": {bin: "claude", args: func(m string) []string { return []string{"-p", "--model", m} }},
+	"nan":    {bin: "pi", args: func(m string) []string { return []string{"--print", "--model", m} }},
+}
+
+// Subprocess dispatches by running a harness binary in non-interactive mode.
+// It is the floor bootstrap guarantees: no daemon, no protocol, no state.
+type Subprocess struct{}
+
+// Serves answers whether this machine has the binary that reaches the pool.
+func (Subprocess) Serves(pool string) bool {
+	h, ok := harnessFor[pool]
+	return ok && binaryPresent(h.bin)
+}
+
+func (Subprocess) Dispatch(ctx context.Context, req Request) Response {
+	h, ok := harnessFor[req.Pool]
+	if !ok {
+		return Response{Status: StatusPoolUnavailable,
+			Output: fmt.Sprintf("no harness binary is mapped to pool %q", req.Pool)}
+	}
+	stdout, stderr, code, err := runProcess(ctx, h.bin, h.args(req.Model), req.Task)
+	return classifyProcess(stdout, stderr, code, err)
+}
+
+// Hive dispatches through `hive delegate`, launched as a subprocess.
+//
+// Argv is its transport, not a second mechanism: the seam's hard semantics —
+// kill on timeout, release the slot without waiting — are what the subprocess
+// backend already implements, and the hive verb rides that code path verbatim.
+// An MCP client in Go would add a dependency, a handshake that can drift, and a
+// surface bats cannot smoke.
+type Hive struct{}
+
+// hivePool is the only pool hive's worker serves. Its worker became NaN-only
+// upstream (mlorentedev/hive#384), which is what aligns it with this map.
+const hivePool = "nan"
+
+func (Hive) Serves(pool string) bool { return pool == hivePool && binaryPresent("hive") }
+
+// Exit codes are the cross-repo contract, pinned on both sides. `hive delegate`
+// documents them in its own help: 3 means the pool would not serve the request
+// (try the next entry), 1 means the worker answered with a failure (do not).
+const (
+	hiveExitTaskFailed  = 1
+	hiveExitUnavailable = 3
+)
+
+func (Hive) Dispatch(ctx context.Context, req Request) Response {
+	args := []string{
+		"delegate",
+		"--model", req.Model,
+		"--timeout", hiveTimeoutSeconds(req.Timeout),
+		// --prompt is required on argv by the shipped verb: unlike claude and
+		// pi it does not read stdin. Recorded as a limitation of that contract
+		// rather than worked around here.
+		"--prompt", req.Task,
+	}
+	stdout, stderr, code, err := runProcess(ctx, "hive", args, "")
+	if err != nil {
+		return Response{Status: StatusTaskFailed, Exit: 1,
+			Output: fmt.Sprintf("could not run hive delegate: %v", err)}
+	}
+	switch code {
+	case 0:
+		return classifyProcess(stdout, stderr, 0, nil)
+	case hiveExitUnavailable:
+		return Response{Status: StatusPoolUnavailable, Exit: code, Output: combine(stdout, stderr)}
+	case hiveExitTaskFailed:
+		return Response{Status: StatusTaskFailed, Exit: code, Output: combine(stdout, stderr)}
+	default:
+		// An unrecognised code is a task failure, never an unavailability. The
+		// fail-closed direction is the one that does not advance the chain and
+		// spend a second pool on work that may already have been billed.
+		return Response{Status: StatusTaskFailed, Exit: code, Output: combine(stdout, stderr)}
+	}
+}
+
+// hiveTimeoutSeconds renders the deadline the way the verb accepts it: whole
+// seconds. Rounded UP with a floor of one, because truncation would send `0`
+// for any sub-second deadline and a zero timeout is not the deadline anyone
+// asked for.
+func hiveTimeoutSeconds(d time.Duration) string {
+	secs := int(math.Ceil(d.Seconds()))
+	if secs < 1 {
+		secs = 1
+	}
+	return fmt.Sprintf("%d", secs)
+}
+
+// DefaultBackends is the probe order, and the order IS the tie-break.
+//
+// Settled here and in tasks.md rather than left to code review, per the open
+// question in proposal.md: a `nan` entry is servable by both, and subprocess
+// wins where `pi` is present because that is the transport that exists without
+// a daemon. Where it is absent — headless, CI — hive takes it. `--backend`
+// overrides both.
+func DefaultBackends() []NamedBackend {
+	sub, hive := Subprocess{}, Hive{}
+	return []NamedBackend{
+		{Name: "subprocess", Backend: sub, Serves: sub.Serves},
+		{Name: "hive", Backend: hive, Serves: hive.Serves},
+		{Name: "dry-run", Backend: DryRun{}, Serves: func(string) bool { return true }, ExplicitOnly: true},
+	}
+}

--- a/cli/internal/agent/backends_test.go
+++ b/cli/internal/agent/backends_test.go
@@ -1,0 +1,230 @@
+//go:build !windows
+
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubBin writes an executable shell script named `name` into a dir prepended
+// to PATH, and returns a path the script appends its argv and stdin to.
+//
+// Stubs rather than mocks: this exercises the real fork/exec, the real kill on
+// deadline, real exit codes and real stdout capture, through the same code path
+// production takes — and spends no quota. Mocking runProcess would leave every
+// one of those untested, which is the half most likely to be wrong.
+func stubBin(t *testing.T, name, script string) string {
+	t.Helper()
+	dir := t.TempDir()
+	log := filepath.Join(dir, name+".log")
+	body := "#!/bin/sh\n" +
+		"printf '%s\\n' \"argv: $*\" >> " + log + "\n" +
+		"cat >> " + log + " 2>/dev/null\n" +
+		script + "\n"
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return log
+}
+
+func readLog(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func TestSubprocess_RunsTheHarnessForThePoolAndPassesTheTaskOnStdin(t *testing.T) {
+	log := stubBin(t, "pi", `printf 'the answer'`)
+
+	got := Subprocess{}.Dispatch(context.Background(), Request{
+		Pool: "nan", Model: "deepseek-v4-flash", Task: "what is 2+2", Timeout: time.Minute,
+	})
+
+	if got.Status != StatusOK {
+		t.Errorf("status = %q, want ok (output %q)", got.Status, got.Output)
+	}
+	if got.Output != "the answer" {
+		t.Errorf("output = %q", got.Output)
+	}
+	logged := readLog(t, log)
+	if !strings.Contains(logged, "--print") || !strings.Contains(logged, "--model deepseek-v4-flash") {
+		t.Errorf("argv wrong: %q", logged)
+	}
+	// The task must NOT be on argv: it is world-readable through `ps` and
+	// bounded by ARG_MAX, and it is arbitrary user text.
+	if strings.Contains(strings.SplitN(logged, "\n", 2)[0], "what is 2+2") {
+		t.Errorf("the task text was passed on argv: %q", logged)
+	}
+	if !strings.Contains(logged, "what is 2+2") {
+		t.Errorf("the task text never reached the process at all: %q", logged)
+	}
+}
+
+func TestSubprocess_ServesOnlyPoolsWhoseBinaryIsPresent(t *testing.T) {
+	// A PATH with pi but no claude.
+	stubBin(t, "pi", `printf x`)
+	t.Setenv("PATH", filepath.Dir(mustLook(t, "pi")))
+
+	s := Subprocess{}
+	if !s.Serves("nan") {
+		t.Error("nan not served with pi present")
+	}
+	if s.Serves("claude") {
+		t.Error("claude served with no claude binary on PATH")
+	}
+	if s.Serves("copilot") {
+		t.Error("copilot served; no harness is mapped to it")
+	}
+}
+
+// The measured case, and the reason this rule exists: on a machine without the
+// NaN credential, `pi --print` exits 0, warns that no model matches, and
+// answers nothing. Reporting that as `ok` hands the caller a successful record
+// containing no answer.
+func TestSubprocess_ExitZeroWithNoOutputIsATaskFailure(t *testing.T) {
+	stubBin(t, "pi", `printf 'No models match pattern "nan/deepseek-v4-flash"' >&2; exit 0`)
+
+	got := Subprocess{}.Dispatch(context.Background(), Request{
+		Pool: "nan", Model: "deepseek-v4-flash", Task: "t", Timeout: time.Minute,
+	})
+
+	if got.Status != StatusTaskFailed {
+		t.Errorf("status = %q, want task_failed: a dispatch that answers nothing has not done the task", got.Status)
+	}
+	if !strings.Contains(got.Output, "No models match") {
+		t.Errorf("output drops the stderr that explains the failure: %q", got.Output)
+	}
+}
+
+// A harness that ran and failed is a TASK failure, never an unavailable pool:
+// advancing the chain would retry a real failure on a different model.
+func TestSubprocess_ANonZeroExitIsATaskFailureNotAnUnavailablePool(t *testing.T) {
+	stubBin(t, "pi", `printf 'boom' >&2; exit 7`)
+
+	got := Subprocess{}.Dispatch(context.Background(), Request{
+		Pool: "nan", Model: "m", Task: "t", Timeout: time.Minute,
+	})
+
+	if got.Status != StatusTaskFailed {
+		t.Errorf("status = %q, want task_failed", got.Status)
+	}
+	if got.Exit != 7 {
+		t.Errorf("exit = %d, want the child's 7", got.Exit)
+	}
+}
+
+// The deadline kills a real process. Without WaitDelay a child whose output
+// pipe is held open would block Wait past the kill, which is what would quietly
+// undo AC3's release-before-reap in the real case rather than the fake one.
+func TestSubprocess_IsKilledOnTheDeadline(t *testing.T) {
+	stubBin(t, "pi", `sleep 30; printf 'too late'`)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	got := Subprocess{}.Dispatch(ctx, Request{Pool: "nan", Model: "m", Task: "t", Timeout: time.Minute})
+	elapsed := time.Since(start)
+
+	if elapsed > 10*time.Second {
+		t.Errorf("took %s: the child was not killed on the deadline", elapsed)
+	}
+	if strings.Contains(got.Output, "too late") {
+		t.Error("the killed child's answer was kept")
+	}
+}
+
+func TestHive_MapsTheDocumentedExitCodes(t *testing.T) {
+	tests := []struct {
+		name   string
+		script string
+		want   Status
+	}{
+		{name: "0 is an answer", script: `printf 'answered'; exit 0`, want: StatusOK},
+		{name: "3 is the pool declining", script: `printf 'busy'; exit 3`, want: StatusPoolUnavailable},
+		{name: "1 is the worker failing", script: `printf 'bad'; exit 1`, want: StatusTaskFailed},
+		{
+			name:   "an unrecognised code fails closed, never as unavailable",
+			script: `printf 'who knows'; exit 42`, want: StatusTaskFailed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stubBin(t, "hive", tc.script)
+			got := Hive{}.Dispatch(context.Background(), Request{
+				Pool: "nan", Model: "m", Task: "t", Timeout: time.Minute,
+			})
+			if got.Status != tc.want {
+				t.Errorf("status = %q, want %q (output %q)", got.Status, tc.want, got.Output)
+			}
+		})
+	}
+}
+
+func TestHive_PassesTheContractArguments(t *testing.T) {
+	log := stubBin(t, "hive", `printf 'ok'`)
+
+	Hive{}.Dispatch(context.Background(), Request{
+		Pool: "nan", Model: "deepseek-v4-flash", Task: "the task", Timeout: 90 * time.Second,
+	})
+
+	logged := readLog(t, log)
+	for _, want := range []string{"delegate", "--model deepseek-v4-flash", "--timeout 90", "--prompt the task"} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("argv missing %q: %q", want, logged)
+		}
+	}
+}
+
+// The verb takes whole seconds, so a sub-second deadline must not truncate to
+// zero — a zero timeout is not the deadline anyone asked for.
+func TestHive_TimeoutIsWholeSecondsRoundedUp(t *testing.T) {
+	tests := []struct {
+		in   time.Duration
+		want string
+	}{
+		{90 * time.Second, "90"},
+		{500 * time.Millisecond, "1"},
+		{1500 * time.Millisecond, "2"},
+		{0, "1"},
+	}
+	for _, tc := range tests {
+		if got := hiveTimeoutSeconds(tc.in); got != tc.want {
+			t.Errorf("hiveTimeoutSeconds(%s) = %s, want %s", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestHive_ServesOnlyNan(t *testing.T) {
+	stubBin(t, "hive", `exit 0`)
+	h := Hive{}
+	if !h.Serves("nan") {
+		t.Error("nan not served with hive present")
+	}
+	if h.Serves("claude") {
+		t.Error("hive claims to serve claude; its worker is NaN-only")
+	}
+}
+
+func mustLook(t *testing.T, bin string) string {
+	t.Helper()
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		p := filepath.Join(dir, bin)
+		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+			return p
+		}
+	}
+	t.Fatalf("%s not on PATH", bin)
+	return ""
+}

--- a/cli/internal/agent/process.go
+++ b/cli/internal/agent/process.go
@@ -1,0 +1,111 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// waitDelay bounds how long we wait for a killed child's descriptors to close.
+//
+// Without it, exec's Wait blocks until every process holding the pipe exits —
+// including grandchildren that inherited stdout. A harness that spawns a helper
+// would therefore keep the dispatcher waiting long after the deadline killed
+// the child, which would quietly undo the release-before-reap guarantee AC3
+// makes. Small, because by this point we have already abandoned the work.
+const waitDelay = 2 * time.Second
+
+// runProcess is the one place this package forks anything. Both real backends
+// ride it — argv is hive's transport, not a second mechanism — so kill-on-
+// deadline, output capture and exit-code handling exist once rather than twice.
+//
+// stdin carries the task text where the tool accepts it: argv is world-readable
+// through `ps` and is bounded by ARG_MAX, and a task is arbitrary user text.
+func runProcess(ctx context.Context, bin string, args []string, stdin string) (stdout, stderr string, code int, err error) {
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.WaitDelay = waitDelay
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	var out, errBuf bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &out, &errBuf
+
+	runErr := cmd.Run()
+	stdout, stderr = out.String(), errBuf.String()
+
+	// stderr is returned whatever the exit status, and classification decides
+	// what to make of it. Discarding it on a zero exit is what hid the measured
+	// case: `pi --print` with no credential exits 0, answers nothing, and puts
+	// the only explanation — `No models match pattern …` — on stderr.
+	if runErr == nil {
+		return stdout, stderr, 0, nil
+	}
+	var ee *exec.ExitError
+	if errors.As(runErr, &ee) {
+		return stdout, stderr, ee.ExitCode(), nil
+	}
+	// Could not run it at all — binary vanished between probe and dispatch,
+	// permission denied, context cancelled before start.
+	return stdout, stderr, -1, runErr
+}
+
+func combine(stdout, stderr string) string {
+	stderr = strings.TrimSpace(stderr)
+	if stderr == "" {
+		return stdout
+	}
+	if strings.TrimSpace(stdout) == "" {
+		return stderr
+	}
+	return stdout + "\n" + stderr
+}
+
+// binaryPresent answers the `bin:NAME` probe: is this harness on PATH.
+//
+// It is the dispatch-time question, and it is deliberately NOT the map's
+// declared pool probe. `pools.nan.probe` is `env:NAN_API_KEY`, and that
+// variable is empty in any ordinary environment here because the key is a
+// registered secret resolved just-in-time (ADR-028) and pi decrypts it itself.
+// Reading the map's probe would therefore report nan unreachable on a machine
+// where it is perfectly reachable. The map declares what a pool IS; this
+// answers whether a transport can serve it right now.
+func binaryPresent(bin string) bool {
+	_, err := exec.LookPath(bin)
+	return err == nil
+}
+
+// classifyProcess turns a completed process into the seam's vocabulary.
+//
+// Fail-closed, and the direction is the contract's: a process that RAN and
+// exited non-zero is a task failure, never an unavailable pool. Neither
+// `claude -p` nor `pi --print` has an exit code meaning "rate limited", and
+// grepping stderr for one would be the fragile proxy this repo keeps catching.
+// Unavailability is answered before dispatch, by the probe, so it never has to
+// be inferred from output afterwards.
+//
+// The empty-output rule is measured, not defensive. `printf … | pi --print` on
+// a machine without the NaN credential exits **0**, prints `No models match
+// pattern "nan/…"` on stderr and answers nothing. A dispatcher that reported
+// that as `ok` would hand its caller a successful record with no answer in it,
+// which is worse than a failure because nothing downstream would look twice.
+func classifyProcess(stdout, stderr string, code int, runErr error) Response {
+	if runErr != nil {
+		return Response{Status: StatusTaskFailed, Exit: 1,
+			Output: fmt.Sprintf("could not run the backend: %v", runErr)}
+	}
+	if code != 0 {
+		// The child's stderr is the useful half of the report; a bare exit code
+		// sends the reader back to a terminal to reproduce it.
+		return Response{Status: StatusTaskFailed, Exit: code, Output: combine(stdout, stderr)}
+	}
+	if strings.TrimSpace(stdout) == "" {
+		return Response{Status: StatusTaskFailed, Exit: 0, Output: combine(stderr,
+			"the backend exited 0 and produced no output; a dispatch that answers nothing "+
+				"has not done the task, whatever its exit code says")}
+	}
+	return Response{Status: StatusOK, Exit: 0, Output: stdout}
+}

--- a/cli/internal/agent/router.go
+++ b/cli/internal/agent/router.go
@@ -1,0 +1,108 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// NamedBackend is one implementation behind the seam, plus the question only it
+// can answer: which pools it can actually serve on this machine.
+//
+// Serves is separate from Dispatch because the answer decides ROUTING, and
+// routing must be decided without spending anything. Asking a backend to try
+// and reporting the failure would already have sent the task's content
+// somewhere it does not belong.
+type NamedBackend struct {
+	Name    string
+	Backend Backend
+	Serves  func(pool string) bool
+	// ExplicitOnly keeps a member out of the probe: it is reachable only when
+	// --backend names it.
+	//
+	// dry-run is the reason this field exists. It serves every pool by
+	// construction, so leaving it in probe order would make it the answer to
+	// every dispatch that named no backend — a dispatch that silently ran
+	// nothing and exited 0, which is the worst option available and the one
+	// PR B's decision table already rejected. It was reintroduced here by
+	// accident and caught by the test below.
+	ExplicitOnly bool
+}
+
+// Router is a Backend that picks a member per REQUEST rather than per dispatch.
+//
+// Per-request is forced by the data: `chains.mid` mixes `claude:sonnet` with
+// `nan:deepseek-v4-flash`, and hive serves only nan. A router chosen once for a
+// whole dispatch could not walk that chain. Being a Backend itself is what
+// keeps `Dispatch` untouched — the seam absorbs the fan-out instead of the
+// dispatcher learning about backends.
+type Router struct {
+	members []NamedBackend
+	// forced is the --backend override. Empty means probe order decides.
+	forced string
+}
+
+// NewRouter builds a router over members, in tie-break order: the FIRST member
+// that serves a pool wins it.
+//
+// For a `nan` entry both subprocess and hive can serve, and the order encodes
+// the answer `proposal.md` proposed and `tasks.md` settles: prefer subprocess
+// where the harness binary is present, fall back to hive where it is not.
+func NewRouter(members []NamedBackend, forced string) *Router {
+	return &Router{members: members, forced: forced}
+}
+
+// ResolveRouter builds a router and validates the --backend override against
+// the members that exist, so a typo is a refusal rather than a dispatch that
+// silently uses something else.
+func ResolveRouter(members []NamedBackend, forced string) (*Router, error) {
+	if forced != "" {
+		known := make([]string, 0, len(members))
+		found := false
+		for _, m := range members {
+			known = append(known, m.Name)
+			if m.Name == forced {
+				found = true
+			}
+		}
+		if !found {
+			sort.Strings(known)
+			return nil, fmt.Errorf("unknown backend %q: this machine has %s",
+				forced, strings.Join(known, ", "))
+		}
+	}
+	return NewRouter(members, forced), nil
+}
+
+// Dispatch routes one request to the first member that serves its pool.
+//
+// A pool nothing can serve is POOL UNAVAILABLE, not a task failure. Nothing
+// ran, so the next chain entry deserves its turn — and that is also what makes
+// `--backend hive --tier mid` work as AC6's smoke expects: the claude entry is
+// skipped rather than failing the dispatch, and nan answers.
+func (r *Router) Dispatch(ctx context.Context, req Request) Response {
+	for _, m := range r.members {
+		if r.forced == "" && m.ExplicitOnly {
+			continue
+		}
+		if r.forced != "" && m.Name != r.forced {
+			continue
+		}
+		if m.Serves == nil || !m.Serves(req.Pool) {
+			continue
+		}
+		return m.Backend.Dispatch(ctx, req)
+	}
+	return Response{
+		Status: StatusPoolUnavailable,
+		Output: fmt.Sprintf("no backend on this machine serves pool %q%s", req.Pool, r.forcedNote()),
+	}
+}
+
+func (r *Router) forcedNote() string {
+	if r.forced == "" {
+		return ""
+	}
+	return fmt.Sprintf(" through the forced backend %q", r.forced)
+}

--- a/cli/internal/agent/router_test.go
+++ b/cli/internal/agent/router_test.go
@@ -1,0 +1,146 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// stubBackend records what it was asked and answers a fixed response.
+type stubBackend struct {
+	name  string
+	serve map[string]bool // pools it can serve
+	seen  []string
+	resp  Response
+}
+
+func (b *stubBackend) Serves(pool string) bool { return b.serve[pool] }
+func (b *stubBackend) Dispatch(_ context.Context, req Request) Response {
+	b.seen = append(b.seen, b.name+"->"+req.Pool)
+	return b.resp
+}
+
+func TestRouter_PicksTheBackendThatServesThePool(t *testing.T) {
+	sub := &stubBackend{name: "subprocess", serve: map[string]bool{"claude": true, "nan": true},
+		resp: Response{Status: StatusOK, Output: "sub"}}
+	hive := &stubBackend{name: "hive", serve: map[string]bool{"nan": true},
+		resp: Response{Status: StatusOK, Output: "hive"}}
+
+	r := NewRouter([]NamedBackend{
+		{Name: "subprocess", Backend: sub, Serves: sub.Serves},
+		{Name: "hive", Backend: hive, Serves: hive.Serves},
+	}, "")
+
+	// claude is served only by subprocess.
+	if got := r.Dispatch(context.Background(), Request{Pool: "claude", Model: "opus"}); got.Output != "sub" {
+		t.Errorf("claude routed to %q, want subprocess", got.Output)
+	}
+	// nan is served by both; declaration order is the tie-break, and subprocess
+	// is declared first when pi is present.
+	if got := r.Dispatch(context.Background(), Request{Pool: "nan", Model: "x"}); got.Output != "sub" {
+		t.Errorf("nan routed to %q, want subprocess (first that serves it)", got.Output)
+	}
+}
+
+// A pool no backend can serve is UNAVAILABLE, not a task failure: nothing ran,
+// and the next chain entry may name a pool that something can serve.
+func TestRouter_APoolNoBackendServesIsUnavailable(t *testing.T) {
+	hive := &stubBackend{name: "hive", serve: map[string]bool{"nan": true}, resp: Response{Status: StatusOK}}
+	r := NewRouter([]NamedBackend{{Name: "hive", Backend: hive, Serves: hive.Serves}}, "")
+
+	got := r.Dispatch(context.Background(), Request{Pool: "claude", Model: "opus"})
+	if got.Status != StatusPoolUnavailable {
+		t.Errorf("status = %q, want %q", got.Status, StatusPoolUnavailable)
+	}
+	if len(hive.seen) != 0 {
+		t.Errorf("hive was asked to serve a pool it does not: %v", hive.seen)
+	}
+}
+
+// --backend restricts the router to one member. The semantics that matter for
+// AC6's smoke: a forced backend that cannot serve an entry reports the entry
+// unavailable so the CHAIN advances, rather than failing the whole dispatch.
+// `--backend hive --tier mid` must skip claude:sonnet and answer on nan.
+func TestRouter_AForcedBackendSkipsEntriesItCannotServe(t *testing.T) {
+	sub := &stubBackend{name: "subprocess", serve: map[string]bool{"claude": true, "nan": true},
+		resp: Response{Status: StatusOK, Output: "sub"}}
+	hive := &stubBackend{name: "hive", serve: map[string]bool{"nan": true},
+		resp: Response{Status: StatusOK, Output: "hive"}}
+
+	r := NewRouter([]NamedBackend{
+		{Name: "subprocess", Backend: sub, Serves: sub.Serves},
+		{Name: "hive", Backend: hive, Serves: hive.Serves},
+	}, "hive")
+
+	rec := Dispatch(context.Background(), Options{
+		Tier:    "mid",
+		Chain:   []string{"claude:sonnet", "nan:deepseek-v4-flash"},
+		Timeout: time.Minute,
+		Now:     fixedClock(time.Millisecond),
+	}, r)
+
+	if rec.Status != StatusOK || rec.Pool != "nan" {
+		t.Errorf("record = %s on %s, want ok on nan", rec.Status, rec.Pool)
+	}
+	if rec.Output != "hive" {
+		t.Errorf("output = %q; the forced backend was not the one that answered", rec.Output)
+	}
+	if len(sub.seen) != 0 {
+		t.Errorf("subprocess was used despite --backend hive: %v", sub.seen)
+	}
+	if len(rec.Attempts) != 2 || rec.Attempts[0].Status != StatusPoolUnavailable {
+		t.Errorf("attempts = %+v; the unservable entry must be skipped, not fatal", rec.Attempts)
+	}
+}
+
+func TestRouter_AnUnknownForcedBackendIsRefused(t *testing.T) {
+	sub := &stubBackend{name: "subprocess", serve: map[string]bool{"claude": true}}
+	_, err := ResolveRouter([]NamedBackend{{Name: "subprocess", Backend: sub, Serves: sub.Serves}}, "orca")
+	if err == nil {
+		t.Fatal("an unknown --backend was accepted")
+	}
+	if got := err.Error(); got == "" {
+		t.Error("refusal carries no message")
+	}
+}
+
+// With no backend able to serve anything, the router must still be usable and
+// report every entry unavailable — the chain-exhausted path, not a crash.
+func TestRouter_NoBackendsAtAll(t *testing.T) {
+	r := NewRouter(nil, "")
+	rec := Dispatch(context.Background(), Options{
+		Tier:    "mid",
+		Chain:   []string{"claude:sonnet", "nan:x"},
+		Timeout: time.Minute,
+		Now:     fixedClock(time.Millisecond),
+	}, r)
+
+	if rec.Status != StatusChainExhausted {
+		t.Errorf("status = %q, want %q", rec.Status, StatusChainExhausted)
+	}
+}
+
+// dry-run serves every pool, so leaving it in probe order would make it the
+// answer to every dispatch that named no backend: a dispatch that ran nothing
+// and exited 0. That is the failure PR B's decision table rejected, and it was
+// reintroduced here by accident when dry-run joined DefaultBackends.
+func TestRouter_DryRunIsNeverChosenByTheProbe(t *testing.T) {
+	dry := &stubBackend{name: "dry-run", serve: map[string]bool{}, resp: Response{Status: StatusDryRun}}
+	r := NewRouter([]NamedBackend{
+		{Name: "dry-run", Backend: dry, Serves: func(string) bool { return true }, ExplicitOnly: true},
+	}, "")
+
+	got := r.Dispatch(context.Background(), Request{Pool: "nan", Model: "m"})
+	if got.Status != StatusPoolUnavailable {
+		t.Errorf("status = %q, want %q: an unforced dispatch must not silently resolve to dry-run",
+			got.Status, StatusPoolUnavailable)
+	}
+
+	// Named explicitly, it is reachable.
+	forced := NewRouter([]NamedBackend{
+		{Name: "dry-run", Backend: dry, Serves: func(string) bool { return true }, ExplicitOnly: true},
+	}, "dry-run")
+	if got := forced.Dispatch(context.Background(), Request{Pool: "nan", Model: "m"}); got.Status != StatusDryRun {
+		t.Errorf("status = %q, want dry_run when named explicitly", got.Status)
+	}
+}

--- a/cli/internal/cmd/agent.go
+++ b/cli/internal/cmd/agent.go
@@ -94,7 +94,7 @@ fails silently and in the direction nobody notices.`,
 				return fmt.Errorf("--timeout is required and must be positive: ADR-032 §2 makes a bounded dispatch " +
 					"part of the contract, and a backend that cannot be bounded is not eligible")
 			}
-			backend, err := resolveBackend(backendName)
+			backend, err := agent.ResolveRouter(agent.DefaultBackends(), backendName)
 			if err != nil {
 				return err
 			}
@@ -161,7 +161,8 @@ fails silently and in the direction nobody notices.`,
 	c.Flags().StringVar(&tier, "tier", "", "neutral tier whose chain is walked: top|mid|low (required)")
 	c.Flags().StringVar(&cwd, "cwd", "", "working copy the task runs against (default: the current directory)")
 	c.Flags().DurationVar(&timeout, "timeout", 0, "per-dispatch deadline, e.g. 90s or 5m (required)")
-	c.Flags().StringVar(&backendName, "backend", "", "backend to dispatch through (required until probing lands)")
+	c.Flags().StringVar(&backendName, "backend", "",
+		"force one backend: subprocess|hive|dry-run (default: probe, preferring subprocess where the harness binary is present)")
 	c.Flags().StringVar(&semaphoreDir, "semaphore-dir", "",
 		"directory holding per-pool slot state (default: the machine's runtime dir; the budget is a machine property, not a checkout's)")
 	c.Flags().StringVar(&repoRoot, "repo-root", "",
@@ -197,24 +198,10 @@ func declaredCapacity(m map[string]any) func(string) (int, bool) {
 	}
 }
 
-// resolveBackend picks the implementation behind the seam.
-//
-// Probing (ADR-032 §7) selects it automatically once a real backend exists;
-// until then the flag is required, and its absence is a loud refusal rather
-// than a default. Defaulting to dry-run would be the worst of the options: a
-// dispatch that silently ran nothing and exited 0.
-func resolveBackend(name string) (agent.Backend, error) {
-	switch name {
-	case "dry-run":
-		return agent.DryRun{}, nil
-	case "":
-		return nil, fmt.Errorf("--backend is required: the only backend implemented today is `dry-run`, " +
-			"which resolves the route without dispatching. The subprocess and hive backends, and the probe " +
-			"that would pick one for you, are not built yet")
-	default:
-		return nil, fmt.Errorf("unknown backend %q: the only backend implemented today is `dry-run`", name)
-	}
-}
+// The backend is no longer chosen by a switch: `agent.DefaultBackends()` is the
+// probe order and `agent.ResolveRouter` validates the --backend override
+// against it. Routing is per chain ENTRY, because `chains.mid` mixes pools and
+// hive serves only one of them.
 
 // summarise is the human line on stderr. The JSON already carries the truth; a
 // person reading a failing &&-chain should not have to pipe it through a parser

--- a/cli/internal/cmd/agent_test.go
+++ b/cli/internal/cmd/agent_test.go
@@ -20,6 +20,7 @@ import (
 // one that skipped the gate.
 func declareIdentity(t *testing.T, deny ...string) {
 	t.Helper()
+	isolatePATH(t)
 	cfg := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", cfg)
 	dir := filepath.Join(cfg, "dotfiles")
@@ -37,6 +38,18 @@ func declareIdentity(t *testing.T, deny ...string) {
 	if err := os.WriteFile(filepath.Join(dir, "machine.json"), []byte(body), 0o600); err != nil {
 		t.Fatalf("seed machine.json: %v", err)
 	}
+}
+
+// isolatePATH empties PATH for the duration of a test, so no backend probe can
+// find a real harness binary.
+//
+// Without it these cases dispatch for real the moment --backend stops being
+// required: one run reached `claude -p`, took 35 seconds and spent a live
+// request. A test that spends quota is not hermetic, and one whose result
+// depends on which binaries the machine happens to have is not a test.
+func isolatePATH(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir())
 }
 
 // AC1. This is a stdout contract, so it is tested through captureRealStreams
@@ -116,6 +129,10 @@ func TestAgentRun_RefusalsLeaveStdoutEmpty(t *testing.T) {
 		name    string
 		args    []string
 		errSubs []string
+		// wantExit defaults to 1: a refusal before dispatch must never read as
+		// `pool unavailable`. The chain-exhausted case is the one exception and
+		// says so.
+		wantExit int
 	}{
 		{
 			name:    "no task",
@@ -131,11 +148,6 @@ func TestAgentRun_RefusalsLeaveStdoutEmpty(t *testing.T) {
 			name:    "no timeout",
 			args:    []string{"--role", "r", "--task", "t", "--tier", "mid", "--backend", "dry-run"},
 			errSubs: []string{"--timeout is required", "not eligible"},
-		},
-		{
-			name:    "no backend",
-			args:    []string{"--role", "r", "--task", "t", "--tier", "mid", "--timeout", "1m"},
-			errSubs: []string{"--backend is required", "dry-run"},
 		},
 		{
 			name:    "unknown backend",
@@ -163,9 +175,12 @@ func TestAgentRun_RefusalsLeaveStdoutEmpty(t *testing.T) {
 					t.Errorf("error %q does not name %q", err.Error(), sub)
 				}
 			}
-			if ExitCode(err) != 1 {
-				t.Errorf("exit = %d, want 1: a refusal before dispatch must not read as `pool unavailable`",
-					ExitCode(err))
+			want := tc.wantExit
+			if want == 0 {
+				want = 1
+			}
+			if got := ExitCode(err); got != want {
+				t.Errorf("exit = %d, want %d", got, want)
 			}
 		})
 	}
@@ -293,5 +308,47 @@ func writeMapFixture(t *testing.T, root, body string) {
 	}
 	if err := os.WriteFile(filepath.Join(path, "model-map.json"), []byte(body), 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
+	}
+}
+
+// --backend became optional in PR D: the probe chooses. That moves the
+// no-backend case out of the refusal table, because it is no longer a refusal
+// before dispatch — the walk runs, finds no transport for any entry, and
+// reports it. The record still reaches stdout, and the exit code is 3 rather
+// than 1: nothing ran, so another machine may well be able to run it.
+func TestAgentRun_NoHarnessOnPathExhaustsTheChainRatherThanRefusing(t *testing.T) {
+	declareIdentity(t) // also isolates PATH
+	root := repoRootForTest(t)
+
+	stdout, _, err := captureRealStreams(t,
+		"agent", "run", "--role", "r", "--task", "t", "--tier", "mid",
+		"--timeout", "1m", "--repo-root", root,
+	)
+	if err == nil {
+		t.Fatal("a dispatch with no transport for any pool succeeded")
+	}
+	if got := ExitCode(err); got != 3 {
+		t.Errorf("exit = %d, want 3", got)
+	}
+
+	var rec struct {
+		Status   string `json:"status"`
+		Attempts []struct {
+			Status string `json:"status"`
+		} `json:"attempts"`
+	}
+	if jsonErr := json.Unmarshal([]byte(stdout), &rec); jsonErr != nil {
+		t.Fatalf("no record for a walk that happened: %v (%q)", jsonErr, stdout)
+	}
+	if rec.Status != "chain_exhausted" {
+		t.Errorf("status = %q, want chain_exhausted", rec.Status)
+	}
+	if len(rec.Attempts) != 3 {
+		t.Errorf("attempts = %d, want 3 (the whole mid chain was tried)", len(rec.Attempts))
+	}
+	// Critically NOT dry_run: an unforced dispatch must never silently resolve
+	// to the backend that does nothing.
+	if rec.Status == "dry_run" {
+		t.Error("the probe selected dry-run")
 	}
 }

--- a/specs/CLI-042-dotf-agent-run/features.json
+++ b/specs/CLI-042-dotf-agent-run/features.json
@@ -148,8 +148,36 @@
   },
   {
     "id": "CLI-042-dotf-agent-run-f14",
-    "behavior": "AC6 — the hive backend answers and the record reports the pool and model the chain resolved (the pool name is the dispatcher's claim from `chains`; hive names no provider)",
+    "behavior": "AC6 — the hive backend answers and the record reports the pool and model the chain resolved. BLOCKED on this machine: no hive worker endpoint, and pi reaches no nan model without the credential. Environment, not code.",
     "verification": "dotf agent run --backend hive --tier mid --role scout --task 'reply with OK' --timeout 120s | jq -e --arg m \"$(dotf harness resolve-tier mid --harness pi)\" '.pool == \"nan\" and .status == \"ok\" and .model == $m'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f26",
+    "behavior": "AC6 — the router selects a backend per chain entry by which pools it can serve; a forced backend skips entries it cannot serve so the chain advances; dry-run is never chosen by the probe",
+    "verification": "cd cli && out=$(go test ./internal/agent/ -run '^TestRouter_' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestRouter_DryRunIsNeverChosenByTheProbe'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f27",
+    "behavior": "AC6 — the subprocess backend runs the mapped harness, passes the task on stdin not argv, is killed on the deadline, and classifies a non-zero exit and an empty answer as task_failed",
+    "verification": "cd cli && out=$(go test ./internal/agent/ -run '^TestSubprocess_' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestSubprocess_ExitZeroWithNoOutputIsATaskFailure'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f28",
+    "behavior": "AC6 — the hive backend maps the documented exit codes (0 ok, 3 unavailable, 1 task failed, unknown fails closed), passes the contract argv, and renders the timeout as whole seconds rounded up",
+    "verification": "cd cli && out=$(go test ./internal/agent/ -run '^TestHive_' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestHive_MapsTheDocumentedExitCodes'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f29",
+    "behavior": "AC6 — the probe holds through the compiled binary: a stub harness on PATH is selected and answers; an empty PATH exhausts the chain rather than silently resolving to dry-run",
+    "verification": "~/.local/bin/bats tests/dotf-agent-run.bats",
     "state": "pending",
     "evidence": ""
   },

--- a/specs/CLI-042-dotf-agent-run/proposal.md
+++ b/specs/CLI-042-dotf-agent-run/proposal.md
@@ -63,6 +63,16 @@ Four more fixed while implementing PR C1:
 | `timeout` in the vocabulary | **A dispatcher-level status, exit 1, and it does NOT advance the chain.** | It joins `escalated` as a status no backend returns. Exit 1 rather than 3 because 3 means *no pool could serve this, try elsewhere*, and a timed-out dispatch may have been served perfectly well and merely too slowly — reporting 3 would invite a composer to retry it against another pool. Not advancing is the same anti-double-spend reasoning as `task_failed`: the task may have been submitted and be running still, and a second pool would be billed for work already in flight. |
 | The deadline is enforced, not merely handed over | **The backend runs on its own goroutine and its result is selected against the deadline.** | Passing a context and trusting it is the shape that fails silently. A subprocess blocked on a read, or a remote that never answers, would hold the dispatcher open indefinitely while `--timeout` claimed otherwise. ADR-032 §2 rules a backend that cannot enforce a timeout ineligible; this makes the dispatcher's own guarantee independent of the backend's cooperation. |
 
+Four more fixed while implementing PR D:
+
+| Decision | Choice | Why |
+|---|---|---|
+| Backend selection shape | **A `Router` that is itself a `Backend`, choosing per REQUEST.** | Forced by the data rather than by taste: `chains.mid` mixes `claude:sonnet` with `nan:deepseek-v4-flash`, and hive serves only nan, so a backend chosen once per dispatch could not walk that chain. Making the router a `Backend` is what leaves `Dispatch` untouched — the seam absorbs the fan-out instead of the dispatcher learning what a backend is. |
+| A forced backend that cannot serve an entry | **Reports that entry `pool_unavailable`, so the chain advances** — it does not fail the dispatch. | This is what makes AC6's own smoke work as written: `--backend hive --tier mid` must skip `claude:sonnet` and answer on nan. Failing instead would make the flag mean "use only this backend AND only pools it serves", which no criterion asks for. |
+| Subprocess error classification | **A process that ran and exited non-zero is `task_failed`, always.** Unavailability is decided BEFORE dispatch, by the probe. | Neither `claude -p` nor `pi --print` has an exit code meaning "rate limited", and grepping stderr for one is the fragile proxy this repo keeps catching. The honest consequence, stated rather than hidden: **a 429 through the subprocess backend reads as `task_failed` in v1.** That is the fail-closed direction — it stops rather than spending a second pool on work that may already have been billed. |
+| `dry-run` is reachable only by name | **`ExplicitOnly`: it is skipped by the probe and selected only by `--backend dry-run`.** | It serves every pool by construction, so leaving it in probe order made it the answer to every dispatch that named no backend — a dispatch that silently ran nothing and exited 0. That is precisely the option PR B's table rejected, reintroduced by accident when dry-run joined the backend list, and caught by a test rather than by review. |
+
+
 
 **Backends: two, and the second one has to be repaired first.** Decided 2026-08-22 after the
 measurement in Risks below: a seam validated against a single implementation is a speculative
@@ -146,13 +156,27 @@ Failure modes, dependencies, and unknowns to clarify before implementation. If a
   **Resolution: hive is NaN-only and single-shot; the dispatcher owns the chain** (see What). The
   Gemini arm is a map-level question, not a backend-level one.
 
-- **[OPEN — must be answered in `tasks.md`, not in code review] Which backend serves a `nan` chain
+- **[RESOLVED 2026-08-23 in PR D, as `tasks.md` required] Which backend serves a `nan` chain
   entry when two can.** After the repair, both `subprocess` (via `pi --model <id>`) and `hive` can
   serve `nan:deepseek-v4-flash`. The probe order and the tie-break are a contract decision, not an
   implementation detail: they determine which process consumes the pool's slot and what
-  `pool`/`model` reporting means when two transports reach the same model. Proposed default, to be
-  confirmed with the task breakdown: **prefer `subprocess` on an interactive machine and `hive` where
-  no harness binary is present**, with `--backend` overriding both.
+  `pool`/`model` reporting means when two transports reach the same model. **Resolution: the proposed
+  default, operationalised as a probe rather than as a notion of "interactive".** `bin:pi` present →
+  subprocess; absent → hive; `--backend` overrides both. The probe order in `agent.DefaultBackends()`
+  IS the tie-break, so the answer lives in one ordered list rather than in a conditional.
+
+  Two measurements taken while resolving it, both of which change what the surrounding code may
+  assume:
+
+  1. **`NAN_API_KEY` is empty in any ordinary environment here.** It is a registered secret resolved
+     just-in-time (ADR-028) and pi decrypts it itself. So the map's declared `pools.nan.probe` —
+     `env:NAN_API_KEY` — would report nan unreachable on a machine where it is perfectly reachable.
+     Dispatch-time servability is therefore probed as `bin:pi`. The map declares what a pool IS;
+     the transport answers whether it can serve it right now, and the two are not the same question.
+  2. **`printf … | pi --print` exits 0, answers nothing, and warns `No models match pattern "nan/…"`
+     on stderr** when the credential is absent. A backend reporting that as `ok` would hand its
+     caller a successful record containing no answer, which is worse than a failure because nothing
+     downstream would look twice. Hence: exit 0 with empty stdout is classified `task_failed`.
 
 - **[OPEN — SRE, and the sharpest detail of the repair] How `NAN_API_KEY` reaches the hive daemon.**
   With Ollama and OpenRouter gone, the worker needs a NaN credential, and a plaintext key in

--- a/specs/CLI-042-dotf-agent-run/tasks.md
+++ b/specs/CLI-042-dotf-agent-run/tasks.md
@@ -148,14 +148,34 @@ Added while implementing C2:
 
 ### PR D — the real backends
 
-- [ ] [AC6] Failing test: backend probe selects `subprocess` when a harness binary is present and
+- [x] [AC6] Failing test: backend probe selects `subprocess` when a harness binary is present and
       `hive` when it is not; `--backend` overrides both
-- [ ] [AC6] Implement the subprocess backend (`claude -p`, `pi -p`) on the shared process machinery
-- [ ] [AC6] Implement the hive backend as `hive delegate` over the **same** process machinery — argv
+- [x] [AC6] Implement the subprocess backend (`claude -p`, `pi --print`) on the shared process machinery
+- [x] [AC6] Implement the hive backend as `hive delegate` over the **same** process machinery — argv
       is its transport, not a second mechanism
-- [ ] [AC6] Resolve and encode the tie-break for a `nan` chain entry servable by both backends
+- [x] [AC6] Resolve and encode the tie-break for a `nan` chain entry servable by both backends —
+      **answered here, per this file's own instruction that it not be left to code review**:
+      `bin:pi` present → subprocess, absent → hive, `--backend` overrides. The probe order in
+      `agent.DefaultBackends()` IS the tie-break.
 - [ ] [AC6] End-to-end smoke: `dotf agent run --backend hive --tier mid` answers, and reports
-      `pool=nan` with the model the chain resolved
+      `pool=nan` with the model the chain resolved — **still blocked, and now on two counts.** hive
+      has no worker endpoint configured on this machine (known), and `pi --print` reaches no nan
+      model from an environment without the credential (measured today). Both are environment, not
+      code. The machinery is covered by stub binaries on PATH: real fork/exec, real kill-on-deadline,
+      real exit-code mapping, zero quota.
+
+Added while implementing D:
+
+- [x] [AC6] A `Router` that is itself a `Backend`, selecting per chain ENTRY rather than per dispatch
+- [x] [AC6] `dry-run` marked `ExplicitOnly` — it serves every pool, so being in probe order made it
+      the silent answer to any dispatch naming no backend
+- [x] [AC6] Exit 0 with empty output classified `task_failed`, from the measured `pi --print` case
+- [x] [AC6] `cmd.WaitDelay` on the child, so a grandchild holding the output pipe cannot block the
+      reap past the deadline and undo AC3's guarantee in the real case
+- [x] [AC6] Task text on **stdin** for claude and pi (argv is world-readable via `ps` and bounded by
+      ARG_MAX); `hive delegate` requires `--prompt` on argv, recorded as a limitation of its contract
+- [x] [AC6] Command tests isolate `PATH`. Once `--backend` became optional they dispatched for real —
+      one run reached `claude -p`, took 35s and spent a live request.
 
 ### PR E — the deployment, as IaC
 

--- a/tests/dotf-agent-run.bats
+++ b/tests/dotf-agent-run.bats
@@ -129,13 +129,11 @@ print(r["pool"])
     printf '%s' "$output" | grep -q -- '--timeout is required'
 }
 
-@test "agent run: no backend is a loud refusal, not a silent dry run" {
-    _build_dotf
-    run bash -c "'$DOTF_BIN' agent run --role r --task t --tier mid \
-        --timeout 30s --repo-root '$REPO_ROOT' --semaphore-dir '$SEM_DIR' 2>&1 >/dev/null"
-    [ "$status" -eq 1 ]
-    printf '%s' "$output" | grep -q -- '--backend is required'
-}
+
+# The former "no backend is a loud refusal" case lived here. PR D made --backend
+# optional — the probe chooses — so a missing backend is no longer a refusal at
+# all. Its replacement is the last case in this file: with nothing on PATH the
+# chain exhausts, and critically does NOT silently resolve to dry-run.
 
 @test "agent run: a saturated pool is skipped and the chain advances to the next entry" {
     _build_dotf
@@ -228,4 +226,48 @@ print(r["pool"])
 ' "$rec"
     [ "$status" -eq 0 ]
     [ "$output" = "nan" ]
+}
+
+@test "agent run: the probe selects a backend by which harness binary is present" {
+    _build_dotf
+    _need_python
+    # Stub harness binaries on PATH, so this exercises the real probe and the
+    # real fork/exec through the compiled binary without spending any quota.
+    local stubs="$BATS_TEST_TMPDIR/stubs" rec="$BATS_TEST_TMPDIR/probe.json"
+    mkdir -p "$stubs"
+    printf '#!/bin/sh\nprintf "answered by the claude stub"\n' > "$stubs/claude"
+    chmod +x "$stubs/claude"
+
+    run bash -c "PATH='$stubs:/usr/bin:/bin' '$DOTF_BIN' agent run --role r --task t \
+        --tier mid --timeout 30s --repo-root '$REPO_ROOT' --semaphore-dir '$SEM_DIR' \
+        >'$rec' 2>/dev/null"
+    [ "$status" -eq 0 ]
+    run python3 -c '
+import json, sys
+r = json.load(open(sys.argv[1]))
+assert r["status"] == "ok", r["status"]
+assert r["pool"] == "claude", r["pool"]           # the only harness on PATH
+assert "claude stub" in r["output"], r["output"]
+print(r["pool"])
+' "$rec"
+    [ "$status" -eq 0 ]
+    [ "$output" = "claude" ]
+}
+
+@test "agent run: with no harness on PATH the chain exhausts, never a silent dry run" {
+    _build_dotf
+    _need_python
+    local empty="$BATS_TEST_TMPDIR/nobins" rec="$BATS_TEST_TMPDIR/none.json"
+    mkdir -p "$empty"
+    run bash -c "PATH='$empty' '$DOTF_BIN' agent run --role r --task t \
+        --tier mid --timeout 30s --repo-root '$REPO_ROOT' --semaphore-dir '$SEM_DIR' \
+        >'$rec' 2>/dev/null"
+    [ "$status" -eq 3 ]
+    run python3 -c '
+import json, sys
+r = json.load(open(sys.argv[1]))
+assert r["status"] == "chain_exhausted", r["status"]
+print(r["status"])
+' "$rec"
+    [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
PR D of the CLI-042 sequence, tracked by issue 1190 — which this PR does **not**
close. PR E is the one that ends it. No commit in this branch names the issue in
its footer either, because
release-please aggregates any such mention into the release changelog as a
closing keyword (lesson 115).

Covers the machinery half of **AC6**. The end-to-end smoke stays blocked on
environment, and `features.json` says so rather than claiming a pass.

## The shape

A `Router` that is **itself a `Backend`**, selecting per chain **entry** rather
than per dispatch. Forced by the data, not by taste: `chains.mid` mixes
`claude:sonnet` with `nan:deepseek-v4-flash`, and hive serves only nan, so a
backend chosen once per dispatch could not walk that chain. Making the router a
`Backend` is what leaves `Dispatch` untouched — the seam absorbs the fan-out
instead of the dispatcher learning what a backend is.

A forced `--backend` that cannot serve an entry reports it `pool_unavailable` so
the chain advances. That is what makes AC6's own smoke work as written
(`--backend hive --tier mid` must skip `claude:sonnet` and answer on nan);
failing instead would silently redefine the flag as "only this backend AND only
pools it serves", which no criterion asks for.

Both real backends ride one process helper — deadline kill, output capture and
exit-code handling exist once. Task text goes on **stdin** for claude and pi
(argv is world-readable through `ps` and bounded by `ARG_MAX`); `hive delegate`
requires `--prompt` on argv, which is its shipped contract.

## Two measurements that changed the design

**`NAN_API_KEY` is empty in any ordinary environment here.** It is a JIT secret
(ADR-028) and pi decrypts it itself — so the map's declared `env:NAN_API_KEY`
probe would report nan *unreachable on a machine where it is reachable*.
Dispatch-time servability is probed as `bin:pi` instead. The map declares what a
pool **is**; the transport answers whether it can serve it **right now**, and
those are not the same question. The divergence is recorded in the spec rather
than left implied.

**`printf … | pi --print` exits 0, answers nothing, and warns on stderr** when
the credential is absent. So **exit 0 with empty stdout is `task_failed`**: a
successful record containing no answer is worse than a failure, because nothing
downstream looks twice. That also required `runProcess` to stop discarding
stderr on a zero exit — which is where the only explanation lived.

## Two defects caught by tests, not by review

- **`dry-run` was answering everything.** It serves every pool by construction,
  so leaving it in probe order made it the silent answer to any dispatch naming
  no backend — a dispatch that ran nothing and exited 0. That is exactly the
  option PR B's table rejected, reintroduced by accident. It is now
  `ExplicitOnly`: skipped by the probe, reachable only as `--backend dry-run`.
- **Command tests were dispatching for real.** Once `--backend` became optional,
  one run reached `claude -p`, took 35s and spent a live request. Tests now
  isolate `PATH`.

## Stated, not hidden

Neither `claude -p` nor `pi --print` has an exit code meaning "rate limited",
and grepping stderr for one is the fragile proxy this repo keeps catching. So
**a 429 through the subprocess backend reads as `task_failed` in v1.** That is
the fail-closed direction — it stops rather than spending a second pool on work
that may already have been billed.

## Verification

Re-run after rebasing onto current main, which had moved six commits (#1215's
suite-wide no-GUI guard, #1217, #1223, both dependabot bumps, #1226). #1215
matters here specifically: this is the PR that spawns subprocesses, and that
guard landed after these tests were written. The interaction is clean.

```
$ go build ./... && go vet ./...
OK / OK

$ GOOS=windows go vet ./...
OK

$ go test -count=1 ./...          # -count=1: cached results are not evidence after a rebase
exit 0, 0 FAIL lines

$ golangci-lint run                # pinned 2.12.2, matches versions.conf (BUG-071)
0 issues.

$ bats tests/*.bats
1501 ok, 0 not ok  (BATS_EXIT=0)
```

## Still open in CLI-042 after this

**PR E** — AC7-AC9: the hive service unit via `dotf secrets run`, the
Ollama/OpenRouter removal, and the `dotf doctor` reachability check. That is the
PR that ends issue 1190.

> Written as "issue 1190", never `closes #1190`. The first draft of this body
> used the keyword form and **spec-gate rejected the PR** — correctly: GitHub
> honours a closing keyword in a PR body, so merging it would have closed the
> epic with PR E unwritten and the CLI-042 spec still active. The same trap as
> #1210, caught this time by a check rather than by someone remembering.