### PR TITLE
feat(agent): give hive's daemon its worker contract without a credential on disk

### DIFF
--- a/ai/agy/mcp_servers.json
+++ b/ai/agy/mcp_servers.json
@@ -6,9 +6,7 @@
         "hive-vault"
       ],
       "env": {
-        "VAULT_PATH": "${VAULT_PATH}",
-        "HIVE_OLLAMA_ENDPOINT": "http://ollama.kubelab.live:11434",
-        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
+        "VAULT_PATH": "${VAULT_PATH}"
       },
       "timeout": 30000,
       "trust": false

--- a/cli/internal/cmd/secrets.go
+++ b/cli/internal/cmd/secrets.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/mlorentedev/dotfiles/cli/internal/env"
 	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
@@ -501,6 +503,22 @@ func resolveOnly(reg *secrets.Registry, s string) (map[string]bool, error) {
 // runChild runs argv with environ and inherited stdio, returning the child's exit
 // code. A non-zero exit is the child's own status (not our error); only a failure
 // to launch (binary missing, etc.) is returned as an error.
+//
+// SIGINT and SIGTERM are forwarded to the child rather than killing us out from
+// under it. Without this, Go's default disposition terminates `dotf` on the first
+// signal and leaves the child ORPHANED: a Ctrl-C returns the prompt while the
+// command keeps running, and `kill <dotf-pid>` never reaches what actually holds
+// the secret. The case that forced it is CLI-042 AC7 — the hive daemon runs as
+// `dotf secrets run -- hive serve`, so this process is a systemd unit's MainPID
+// and a supervisor for the first time. systemd's default KillMode=control-group
+// would SIGTERM the whole cgroup and paper over the gap there; every other caller
+// (a shell, `timeout`, a CI runner) signals the process, not a cgroup, and got
+// the orphan.
+//
+// Scoped to the two signals a supervisor actually sends. SIGKILL and SIGSTOP
+// cannot be caught, and forwarding the rest (SIGHUP, SIGWINCH, job control)
+// would mean re-implementing a shell's terminal handling for a wrapper that owns
+// no terminal.
 func runChild(argv, environ []string, stdin io.Reader, stdout, stderr io.Writer) (int, error) {
 	if len(argv) == 0 {
 		return 1, errors.New("no command given after --")
@@ -508,7 +526,32 @@ func runChild(argv, environ []string, stdin io.Reader, stdout, stderr io.Writer)
 	c := exec.Command(argv[0], argv[1:]...) //nolint:gosec // argv is the user's own command
 	c.Env = environ
 	c.Stdin, c.Stdout, c.Stderr = stdin, stdout, stderr
-	err := c.Run()
+	if err := c.Start(); err != nil {
+		return 1, fmt.Errorf("launch %s: %w", argv[0], err)
+	}
+
+	// Buffered so a signal arriving between Start and the goroutine's first
+	// receive is delivered rather than dropped.
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case s := <-sigs:
+				// Best-effort: the child may have already exited, in which case
+				// the signal has nowhere to go and the Wait below is what matters.
+				_ = c.Process.Signal(s)
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	err := c.Wait()
+	close(done)
+	signal.Stop(sigs)
+
 	if err == nil {
 		return 0, nil
 	}
@@ -516,7 +559,7 @@ func runChild(argv, environ []string, stdin io.Reader, stdout, stderr io.Writer)
 	if errors.As(err, &ee) {
 		return ee.ExitCode(), nil
 	}
-	return 1, fmt.Errorf("launch %s: %w", argv[0], err)
+	return 1, fmt.Errorf("wait %s: %w", argv[0], err)
 }
 
 // ageKeyPath resolves the age identity: $AGE_KEY_PATH, else ~/.config/age/key.txt

--- a/cli/internal/cmd/secrets_registry_test.go
+++ b/cli/internal/cmd/secrets_registry_test.go
@@ -288,6 +288,42 @@ func TestResolveOnly_IdSelectsAllVars_NameSelectsOne(t *testing.T) {
 	}
 }
 
+// The ambiguity the hive daemon's ExecStart depends on, pinned.
+//
+// The real NAN_API_KEY secret has an ID equal to one of the two vars it exposes,
+// so `--only NAN_API_KEY` is simultaneously an id token and a var token.
+// Selector resolves IDs FIRST, which is what delivers HIVE_WORKER_API_KEY to
+// hive's worker from a flag that names only NAN_API_KEY
+// (systemd/hive.service.d/10-dotf-secrets.conf).
+//
+// Swapping those two loops would still pass every other test here — and would
+// silently strip hive's credential, restoring the unconfigured-worker state
+// CLI-042 AC9 exists to catch. That failure would surface as a daemon that runs
+// and answers nothing, which is precisely the shape that went unnoticed once.
+func TestResolveOnly_IdWinsWhenIdAndVarNameCollide(t *testing.T) {
+	const collides = `version: 1
+secrets:
+  - id: NAN_API_KEY
+    plane: app
+    backend: bw
+    bw: { item: nan-api-key, field: api-key }
+    expose: { env: [NAN_API_KEY, HIVE_WORKER_API_KEY] }
+`
+	reg, err := secrets.ParseRegistry([]byte(collides))
+	if err != nil {
+		t.Fatal(err)
+	}
+	set, err := resolveOnly(reg, "NAN_API_KEY")
+	if err != nil {
+		t.Fatalf("resolveOnly: %v", err)
+	}
+	if len(set) != 2 || !set["NAN_API_KEY"] || !set["HIVE_WORKER_API_KEY"] {
+		t.Errorf("--only NAN_API_KEY = %v, want BOTH vars: the token matches the "+
+			"secret's id, and an id selects every var it exposes. Selecting only "+
+			"the same-named var would leave hive's worker without a credential.", set)
+	}
+}
+
 func TestSecretsVerify_ReportsStatuses_NoValues(t *testing.T) {
 	useTempRegistry(t, "version: 1\nsecrets:\n"+
 		"  - {id: age-ok, plane: app, backend: age, age: a.key, expose: {env: AGE_OK}}\n"+

--- a/cli/internal/cmd/secrets_signal_unix_test.go
+++ b/cli/internal/cmd/secrets_signal_unix_test.go
@@ -1,0 +1,122 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// CLI-042 AC7 makes `dotf secrets run` a daemon supervisor (`hive serve` under
+// systemd), so its signal contract stops being academic: a SIGTERM that kills
+// `dotf` without reaching the child leaves the daemon orphaned and the unit
+// lying about what it stopped.
+//
+// The test runs on a NESTED helper rather than signalling the test binary
+// itself. Signalling ourselves would work — but against a regressed runChild the
+// unhandled SIGTERM would kill the test RUNNER, taking the whole package down
+// instead of reporting one red test. A guard whose failure mode is "the harness
+// dies" trains people to disable it. Here the death is contained in a
+// subprocess, so a regression reports as an ordinary assertion failure.
+//
+// Layering: test -> forwarder helper (calls runChild, signals itself) -> trap
+// helper (catches SIGTERM, exits 42).
+
+const (
+	trapChildExitCode = 42
+	helperDeadline    = 10 * time.Second
+)
+
+// TestTrapHelperProcess is not a real test. Re-exec'd with GO_HELPER_MODE=trap,
+// it installs a SIGTERM handler, announces readiness by creating READY_FILE, and
+// exits 42 when signalled. The marker is what makes the parent's signal
+// deterministic rather than racing a sleep: a SIGTERM delivered before
+// signal.Notify runs would kill it outright and the test would read as a
+// forwarding failure it did not have.
+func TestTrapHelperProcess(t *testing.T) {
+	if os.Getenv("GO_HELPER_MODE") != "trap" {
+		return
+	}
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGTERM)
+
+	if f := os.Getenv("READY_FILE"); f != "" {
+		if err := os.WriteFile(f, []byte("ready"), 0o600); err != nil {
+			os.Exit(90) // distinct from every expected code, so a setup failure is not read as a verdict
+		}
+	}
+	select {
+	case <-sigs:
+		os.Exit(trapChildExitCode)
+	case <-time.After(helperDeadline):
+		os.Exit(91) // never signalled — the forwarding under test did not happen
+	}
+}
+
+// TestForwarderHelperProcess is not a real test. Re-exec'd with
+// GO_HELPER_MODE=forwarder it plays the role `dotf` plays under systemd: it
+// calls runChild on the trap helper and then sends itself a SIGTERM, exactly as
+// a supervisor would. It prints the child's exit code so the parent can assert
+// on it.
+//
+// A regressed runChild (no signal.Notify) dies here on the unhandled SIGTERM,
+// and the parent observes a signal-terminated helper with no output.
+func TestForwarderHelperProcess(t *testing.T) {
+	if os.Getenv("GO_HELPER_MODE") != "forwarder" {
+		return
+	}
+	ready := os.Getenv("READY_FILE")
+	go func() {
+		deadline := time.Now().Add(helperDeadline)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(ready); err == nil {
+				_ = syscall.Kill(os.Getpid(), syscall.SIGTERM)
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
+	environ := append(os.Environ(), "GO_HELPER_MODE=trap")
+	code, err := runChild(
+		[]string{os.Args[0], "-test.run=TestTrapHelperProcess"},
+		environ, nil, io.Discard, io.Discard,
+	)
+	if err != nil {
+		os.Exit(92)
+	}
+	_, _ = io.WriteString(os.Stdout, "CHILD_EXIT="+strconv.Itoa(code))
+	os.Exit(0)
+}
+
+func TestRunChild_ForwardsSIGTERMToChild(t *testing.T) {
+	ready := filepath.Join(t.TempDir(), "ready")
+
+	var out bytes.Buffer
+	environ := append(os.Environ(), "GO_HELPER_MODE=forwarder", "READY_FILE="+ready)
+	code, err := runChild(
+		[]string{os.Args[0], "-test.run=TestForwarderHelperProcess"},
+		environ, nil, &out, io.Discard,
+	)
+	if err != nil {
+		t.Fatalf("running the forwarder helper: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("forwarder helper exited %d (want 0); a signal-terminated or "+
+			"non-zero helper means runChild did not forward SIGTERM and was "+
+			"killed by it instead. stdout=%q", code, out.String())
+	}
+	want := "CHILD_EXIT=" + strconv.Itoa(trapChildExitCode)
+	if !strings.Contains(out.String(), want) {
+		t.Errorf("forwarder reported %q, want %q — the trap child did not "+
+			"receive the forwarded SIGTERM", out.String(), want)
+	}
+}

--- a/cli/internal/doctor/checks_agent_reach.go
+++ b/cli/internal/doctor/checks_agent_reach.go
@@ -1,0 +1,116 @@
+package doctor
+
+import "strings"
+
+// checkHiveBackendCanServe is CLI-042 AC9: "zero reachable models" must be
+// caught at diagnostic time, not under dispatch load.
+//
+// This is the incident-to-guard emission for the defect that shaped the whole
+// spec. hive was a declared backend of `dotf agent run` with no reachable
+// provider for an unknown length of time and NOTHING NOTICED — the daemon was
+// `active (running)`, its binary was on PATH, every probe said present, and it
+// could not have answered a single request. Measured 2026-08-24: hive.service
+// had been up for 2h40m with no NAN_API_KEY anywhere in its environment.
+//
+// The check is deliberately a PROXY rather than a live reachability probe.
+// hive DOES expose the stronger surface — its `worker_status` MCP tool probes
+// the provider rather than inferring it, built by mlorentedev/hive#384 for
+// exactly this failure — but reaching it from here would mean an MCP client
+// inside `dotf doctor`: a dependency, a handshake that can drift, and a surface
+// bats cannot smoke. PR D rejected that same trade for the hive BACKEND, and it
+// does not become a better trade for a diagnostic. So this asks the question
+// that is free, and sound in the one direction that matters:
+//
+//	hive's worker serves exactly one pool (nan, since hive#384), and reaching it
+//	needs BOTH halves of its contract — HIVE_WORKER_BASE_URL and
+//	HIVE_WORKER_API_KEY. A supervised daemon missing either can serve NOTHING,
+//	with certainty rather than by inference.
+//
+// It therefore cannot report every unreachable configuration and never claims
+// to: a present-but-wrong key still reads as configured here, and only
+// `worker_status` or a real dispatch would catch that. What it does guarantee is
+// that the exact state nobody noticed for an unknown length of time goes red the
+// moment it recurs, which is the bar the criterion sets.
+func checkHiveBackendCanServe(sys *System, rep *Report) {
+	rep.Section("hive backend reachability (dotf agent run)")
+
+	// Not a Linux systemd host. Windows supervises the daemon through a
+	// Scheduled Task (windows/hive-serve-supervisor.ps1), whose equivalent
+	// assertion is that script's own concern — claiming a verdict here from a
+	// host that cannot see the unit would be a guess wearing a check's clothes.
+	if sys.GOOS == "windows" {
+		rep.Info("skipped: the daemon is a Scheduled Task on Windows, not a systemd unit")
+		return
+	}
+	if _, err := sys.LookPath("systemctl"); err != nil {
+		rep.Info("skipped: no systemctl on this host, so no supervised hive daemon to inspect")
+		return
+	}
+
+	// hive is not installed here, so nothing declares it as a backend and there
+	// is no claim to falsify. Silent rather than Info: a machine that never had
+	// hive should not carry a line about it in every doctor run.
+	if _, err := sys.LookPath("hive"); err != nil {
+		return
+	}
+
+	// Both directives in one call, WITHOUT --value, so each comes back on its own
+	// `Key=value` line and the two cannot be confused for one another.
+	out, err := sys.CommandOutput("systemctl", "--user", "show", "hive.service",
+		"-p", "ExecStart", "-p", "Environment")
+	if err != nil {
+		rep.Warn("could not read hive.service, so backend reachability was not checked (" + err.Error() + ")")
+		return
+	}
+
+	var execStart, environment string
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case strings.HasPrefix(line, "ExecStart="):
+			execStart = strings.TrimPrefix(line, "ExecStart=")
+		case strings.HasPrefix(line, "Environment="):
+			environment = strings.TrimPrefix(line, "Environment=")
+		}
+	}
+
+	// `systemctl show` on an unknown unit SUCCEEDS with an empty value — it does
+	// not error. Telling that apart from a real reading matters: an empty string
+	// must not be read as "no credential injection" and reported as the failure.
+	// hive works without the daemon (the client falls back), so this is a state
+	// to name, not to fail.
+	if strings.TrimSpace(execStart) == "" {
+		rep.Info("hive is installed but hive.service is not, so no supervised daemon is declared")
+		return
+	}
+
+	// Both halves, because a daemon holding one serves exactly as little as one
+	// holding neither — which is what `worker_status` reported on this machine
+	// while systemd called the unit active.
+	//
+	// The credential arrives through `dotf secrets run` (AC7), and the token it
+	// is scoped to is the registry ID: that selects every var the secret
+	// exposes, which is how hive gets HIVE_WORKER_API_KEY from an item whose
+	// primary name is NAN_API_KEY. Matching the mechanism alone would pass a
+	// drop-in that injected some unrelated secret.
+	missing := []string{}
+	if !strings.Contains(execStart, "secrets run") || !strings.Contains(execStart, "NAN_API_KEY") {
+		missing = append(missing, "the API key (no `dotf secrets run --only NAN_API_KEY` in ExecStart)")
+	}
+	// Never echo the value: an Environment= line is operator-controlled and this
+	// message is written to a transcript.
+	if !strings.Contains(environment, "HIVE_WORKER_BASE_URL=") {
+		missing = append(missing, "the worker base URL (no HIVE_WORKER_BASE_URL in the unit)")
+	}
+	if len(missing) > 0 {
+		rep.Fail("hive.service is running without " + strings.Join(missing, " and ") +
+			", so the hive backend probes PRESENT and can serve nothing. " +
+			"`dotf agent run` will route to it and every dispatch will fail. " +
+			"Fix: re-run ./setup-linux.sh to deploy " +
+			"systemd/hive.service.d/10-dotf-secrets.conf, then `systemctl --user " +
+			"daemon-reload && systemctl --user restart hive.service`. Confirm with " +
+			"hive's own worker_status, which must report Configured: yes.")
+		return
+	}
+
+	rep.Pass("hive.service carries both halves of the worker contract — the backend can reach its pool")
+}

--- a/cli/internal/doctor/checks_agent_reach_test.go
+++ b/cli/internal/doctor/checks_agent_reach_test.go
@@ -1,0 +1,225 @@
+package doctor
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// found/notFound build the LookPath seam for a set of binaries that resolve.
+func lookPathFor(present ...string) func(string) (string, error) {
+	set := map[string]bool{}
+	for _, p := range present {
+		set[p] = true
+	}
+	return func(name string) (string, error) {
+		if set[name] {
+			return "/usr/bin/" + name, nil
+		}
+		return "", errors.New("not found")
+	}
+}
+
+// unitSeam fakes `systemctl show -p ExecStart -p Environment`, which returns one
+// Key=value line per requested directive.
+func unitSeam(execStart, environment string) func(string, ...string) (string, error) {
+	out := "ExecStart=" + execStart + "\nEnvironment=" + environment + "\n"
+	return func(_ string, _ ...string) (string, error) { return out, nil }
+}
+
+func failingSeam(err error) func(string, ...string) (string, error) {
+	return func(_ string, _ ...string) (string, error) { return "", err }
+}
+
+// The shape a correctly deployed drop-in produces, used wherever a test needs
+// "everything is fine except the one thing under test".
+const (
+	goodExecStart = "/home/u/.local/bin/dotf secrets run --only NAN_API_KEY -- /home/u/.local/bin/hive serve"
+	goodEnv       = "HIVE_WORKER_BASE_URL=https://api.nan.builders/v1"
+)
+
+// The criterion's case, and the one measured on this machine: the daemon is
+// supervised and running, every probe says hive is present, and its ExecStart
+// injects no credential — so it can serve nothing. This must FAIL, not warn:
+// AC9's wording is "fails rather than passing quietly", because the state went
+// unnoticed for an unknown length of time precisely by being quiet.
+func TestHiveBackendCanServe_NoCredentialInjectionFails(t *testing.T) {
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	sys := &System{
+		LookPath:      lookPathFor("systemctl", "hive"),
+		CommandOutput: unitSeam("/home/u/.local/bin/hive serve", goodEnv),
+	}
+
+	checkHiveBackendCanServe(sys, rep)
+
+	got := buf.String()
+	if !strings.Contains(got, "can serve nothing") {
+		t.Fatalf("expected the probes-present-serves-nothing failure, got: %s", got)
+	}
+	if !strings.Contains(got, "setup-linux.sh") {
+		t.Errorf("the failure must name the remediation, got: %s", got)
+	}
+}
+
+// A drop-in that ran `dotf secrets run` without scoping to NAN_API_KEY leaves
+// the worker exactly as unreachable as no injection at all, so the check must
+// not be satisfied by the mechanism alone.
+func TestHiveBackendCanServe_WrongVariableStillFails(t *testing.T) {
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	sys := &System{
+		LookPath: lookPathFor("systemctl", "hive"),
+		CommandOutput: unitSeam(
+			"/home/u/.local/bin/dotf secrets run --only OPENROUTER_API_KEY -- /home/u/.local/bin/hive serve", goodEnv),
+	}
+
+	checkHiveBackendCanServe(sys, rep)
+
+	if got := buf.String(); !strings.Contains(got, "can serve nothing") {
+		t.Fatalf("a run that injects the wrong variable must still fail, got: %s", got)
+	}
+}
+
+// The worker contract has two halves and a daemon holding one serves exactly as
+// little as one holding neither. This is not a hypothetical: on 2026-08-24 the
+// daemon's own worker_status reported `Configured: no — set
+// HIVE_WORKER_BASE_URL`, and the first draft of this check would have passed a
+// unit in that state because it only looked for the credential.
+func TestHiveBackendCanServe_MissingBaseURLFails(t *testing.T) {
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	sys := &System{
+		LookPath:      lookPathFor("systemctl", "hive"),
+		CommandOutput: unitSeam(goodExecStart, ""),
+	}
+
+	checkHiveBackendCanServe(sys, rep)
+
+	got := buf.String()
+	if !strings.Contains(got, "can serve nothing") {
+		t.Fatalf("a credential with no base URL must still fail, got: %s", got)
+	}
+	if !strings.Contains(got, "HIVE_WORKER_BASE_URL") {
+		t.Errorf("the failure must name the missing half, got: %s", got)
+	}
+}
+
+// Both halves missing must report both, not stop at the first: an operator who
+// fixes only what the message named would restart into the same red.
+func TestHiveBackendCanServe_BothHalvesMissingAreBothNamed(t *testing.T) {
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	sys := &System{
+		LookPath:      lookPathFor("systemctl", "hive"),
+		CommandOutput: unitSeam("/home/u/.local/bin/hive serve", ""),
+	}
+
+	checkHiveBackendCanServe(sys, rep)
+
+	got := buf.String()
+	if !strings.Contains(got, "API key") || !strings.Contains(got, "HIVE_WORKER_BASE_URL") {
+		t.Errorf("both missing halves must be named, got: %s", got)
+	}
+}
+
+func TestHiveBackendCanServe_CredentialInjectedPasses(t *testing.T) {
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	sys := &System{
+		LookPath: lookPathFor("systemctl", "hive"),
+		CommandOutput: unitSeam(goodExecStart, goodEnv),
+	}
+
+	checkHiveBackendCanServe(sys, rep)
+
+	got := buf.String()
+	if strings.Contains(got, "can serve nothing") {
+		t.Fatalf("a correctly injected daemon must not fail, got: %s", got)
+	}
+	if !strings.Contains(got, "can reach its pool") {
+		t.Errorf("expected the pass line, got: %s", got)
+	}
+}
+
+// `systemctl show` on an unknown unit SUCCEEDS with an empty value rather than
+// erroring. Reading that empty string as "no credential injection" would fail
+// every machine that runs hive without the daemon — a false red on a supported
+// configuration, which is how a check earns the reputation that gets it muted.
+func TestHiveBackendCanServe_UnitNotInstalledIsNotAFailure(t *testing.T) {
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	sys := &System{
+		LookPath:      lookPathFor("systemctl", "hive"),
+		CommandOutput: unitSeam("", ""),
+	}
+
+	checkHiveBackendCanServe(sys, rep)
+
+	got := buf.String()
+	if strings.Contains(got, "can serve nothing") {
+		t.Fatalf("an absent unit is not the probes-present failure, got: %s", got)
+	}
+	if !strings.Contains(got, "no supervised daemon is declared") {
+		t.Errorf("expected the unit-absent info line, got: %s", got)
+	}
+}
+
+// A machine that never had hive should not carry a line about it in every run.
+func TestHiveBackendCanServe_HiveAbsentIsSilent(t *testing.T) {
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	sys := &System{
+		LookPath:      lookPathFor("systemctl"),
+		CommandOutput: unitSeam("", ""),
+	}
+
+	checkHiveBackendCanServe(sys, rep)
+
+	if strings.Contains(buf.String(), "can serve nothing") {
+		t.Fatalf("no hive means no claim to falsify, got: %s", buf.String())
+	}
+}
+
+func TestHiveBackendCanServe_WindowsSkips(t *testing.T) {
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	sys := &System{
+		GOOS:          "windows",
+		LookPath:      lookPathFor("systemctl", "hive"),
+		CommandOutput: unitSeam("/home/u/.local/bin/hive serve", goodEnv),
+	}
+
+	checkHiveBackendCanServe(sys, rep)
+
+	got := buf.String()
+	if strings.Contains(got, "can serve nothing") {
+		t.Fatalf("Windows supervises via a Scheduled Task; this check must not verdict there, got: %s", got)
+	}
+	if !strings.Contains(got, "Scheduled Task") {
+		t.Errorf("expected the Windows skip line, got: %s", got)
+	}
+}
+
+// An unreadable systemctl is an unanswered question, not a clean bill of
+// health — the same fail-shape distinction dotf pr triage-queue draws between
+// "nothing pending" and "could not be determined".
+func TestHiveBackendCanServe_UnreadableUnitWarnsRatherThanPasses(t *testing.T) {
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	sys := &System{
+		LookPath:      lookPathFor("systemctl", "hive"),
+		CommandOutput: failingSeam(errors.New("dbus unavailable")),
+	}
+
+	checkHiveBackendCanServe(sys, rep)
+
+	got := buf.String()
+	if !strings.Contains(got, "dbus unavailable") {
+		t.Fatalf("expected the underlying error surfaced, got: %s", got)
+	}
+	if strings.Contains(got, "can reach its pool") {
+		t.Errorf("an unreadable unit must never report the pass line, got: %s", got)
+	}
+}

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -90,6 +90,7 @@ func Run(opts Options) (int, error) {
 		checkBWServeDaemon(sys, rep)
 		checkBWMapping(sys, cfg, rep)
 		checkAgentConfigSecrets(sys, rep)
+		checkHiveBackendCanServe(sys, rep)
 		checkDisasterRecovery(sys, cfg, rep)
 		checkPATExpiry(sys, cfg, rep)
 		checkGuardHooks(sys, cfg, rep, opts.Fix)

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -243,3 +243,4 @@ tags: [lessons, index, dotfiles]
 | [227 - A test suite inherits the developer's installed applications, and PATH is the door](lesson-227-a-test-suite-inherits-the-developers-installed-apps.md) | 2026-08-23 |  |
 | [228 - A calendar date is not a timestamp, and UTC is the wrong zone for one](lesson-228-a-calendar-date-is-not-a-timestamp-utc-is-wrong-for.md) | 2026-08-23 |  |
 | [229 - An empty secret is not an error, so a job with no credential fails as if the work failed](lesson-229-an-empty-secret-is-not-an-error-so-a-job-with-no-cr.md) | 2026-08-24 |  |
+| [230 - A config that parses is not a config the consumer reads](lesson-230-a-config-that-parses-is-not-a-config-the-consumer-re.md) | 2026-08-24 |  |

--- a/docs/lessons/lesson-230-a-config-that-parses-is-not-a-config-the-consumer-re.md
+++ b/docs/lessons/lesson-230-a-config-that-parses-is-not-a-config-the-consumer-re.md
@@ -1,0 +1,93 @@
+# Lesson 230 — A config that parses is not a config the consumer reads
+
+**Date:** 2026-08-24
+**Context:** CLI-042 PR E (#1190) — wiring the NaN credential into hive's daemon.
+
+## What happened
+
+I wrote a systemd drop-in to hand the hive daemon its credential, and nine bats
+assertions to prove it. All nine passed:
+
+- does the `ExecStart` invoke `dotf secrets run`?
+- is the injection scoped with `--only`?
+- is the `ExecStart` list reset before the override?
+- does it use `%h` rather than a literal home?
+- is `StartLimitIntervalSec` under `[Unit]` and `RestartSec` under `[Service]`?
+
+Every one of those was true. The drop-in was also useless: it injected
+`NAN_API_KEY`, and hive's worker reads `HIVE_WORKER_API_KEY` and
+`HIVE_WORKER_BASE_URL`. It ignores `NAN_API_KEY` entirely.
+
+Deployed as written, the daemon would have restarted, systemd would have
+reported `active (running)`, the test suite would have stayed green, and the
+worker would have gone on serving nothing — the exact state the criterion
+existed to end.
+
+## Why the tests could not catch it
+
+They asserted the **shape** of the configuration and never its **effect**. Every
+question above is about the artifact: its syntax, its directives, its internal
+consistency. None of them is about the consumer.
+
+That gap is invisible from inside the artifact, because a config file has no
+opinion about whether anyone reads it. `Environment=BANANA=1` is a perfectly
+valid systemd directive. A schema check, a linter, and a unit test on the
+rendered text will all pass on a variable no process on earth consumes.
+
+## What broke the tie
+
+Asking the consumer. hive ships a `worker_status` tool that **probes** the
+provider rather than inferring it from configuration, and it answered:
+
+```
+## Provider
+- Configured: no — set HIVE_WORKER_BASE_URL
+```
+
+One question to the thing being configured, and the whole test suite's verdict
+was overturned. Reading `/proc/<pid>/environ` for variable NAMES (never values)
+confirmed it independently: zero credential-shaped variables in a daemon that
+had been "healthy" for 2h40m.
+
+## The rule
+
+**When you configure a consumer you do not own, one assertion must come from the
+consumer.** Everything else — syntax, directives, deployment, idempotence — is
+worth testing and proves only that you wrote the file you meant to write.
+
+Concretely, before believing a config change works:
+
+1. Find the consumer's own status/probe surface and ask it. Most daemons worth
+   configuring have one.
+2. Failing that, read the process's actual environment for variable NAMES — never
+   values, which belong in no transcript.
+3. Failing both, name the gap in `verification.md` as owed rather than closing
+   the criterion.
+
+## The near-miss worth naming
+
+hive had already learned this lesson and I did not read it. `worker_status`'s
+own documentation says:
+
+> The old output ... reported two providers by *configuration*: it said "Ollama:
+> offline / OpenRouter: no API key" for an unknown length of time while every
+> caller treated the worker as a working capability. A status surface that cannot
+> distinguish "configured" from "answers" is how a dead backend stays invisible.
+
+Upstream rebuilt that tool precisely so configuration could not masquerade as
+capability — and I then wrote nine tests that asserted configuration and called
+it done. The tool that would have told me in one call was already installed.
+
+## Related
+
+- Lesson 229 — an empty secret is not an error. Same family: the failure is
+  silent and points away from its cause.
+- CLI-042 AC9 is the guard emitted for this: `dotf doctor` now fails when hive
+  probes present but is missing either half of its worker contract, so the
+  configured-but-dead state cannot go unnoticed for an unknown length of time
+  again.
+- The AC9 check is itself a **proxy** and says so in its own doc comment: it
+  reads the unit rather than probing the worker, because reaching `worker_status`
+  from `dotf doctor` would put an MCP client inside a diagnostic. A proxy whose
+  limit is written down is honest; one whose limit is implied is this lesson
+  repeating.

--- a/scripts/nan-bench.sh
+++ b/scripts/nan-bench.sh
@@ -8,15 +8,20 @@
 
 set -euo pipefail
 
-# NAN_API_KEY: injected by `dotf secrets run -- <this script>`, or self-fetched
-# on demand via `dotf secrets show` (ADR-028 — never the ambient shell env).
-if [ -z "${NAN_API_KEY:-}" ] && command -v dotf >/dev/null 2>&1; then
-    NAN_API_KEY="$(dotf secrets show NAN_API_KEY 2>/dev/null || true)"
-    export NAN_API_KEY
+# NAN_API_KEY: injected by `dotf secrets run`. The `dotf secrets show` self-fetch
+# that stood here is gone — CLI-042 gave nan-api-key a second exposed name
+# (HIVE_WORKER_API_KEY), and `show` refuses a multi-var secret because one value
+# on stdout is ambiguous for it. Re-exec'ing through `run` is also the stronger
+# form: the credential stays in the process environment instead of a shell
+# variable that `set -x` or a core dump can spill.
+if [ -z "${NAN_API_KEY:-}" ] && [ -z "${NAN_BENCH_REEXEC:-}" ] && command -v dotf >/dev/null 2>&1; then
+    # The sentinel bounds the re-exec to one hop, so a `run` that somehow
+    # returned without injecting cannot spin.
+    NAN_BENCH_REEXEC=1 exec dotf secrets run --only NAN_API_KEY -- "$0" "$@"
 fi
 
 if [ -z "${NAN_API_KEY:-}" ]; then
-    echo "ERROR: NAN_API_KEY not set. Run: dotf secrets run -- $0" >&2
+    echo "ERROR: NAN_API_KEY not set. Run: dotf secrets run --only NAN_API_KEY -- $0" >&2
     exit 1
 fi
 

--- a/scripts/nan-debug.sh
+++ b/scripts/nan-debug.sh
@@ -9,6 +9,25 @@
 
 set -euo pipefail
 
+# NAN_API_KEY: injected by `dotf secrets run`. Self-fetching it with
+# `dotf secrets show` is no longer possible and no longer desirable.
+#
+# Not possible: CLI-042 gave the nan-api-key item a second exposed name
+# (HIVE_WORKER_API_KEY, hive's own worker contract), and `show` refuses a
+# multi-var secret because one value on stdout is ambiguous for it.
+#
+# Not desirable: `show` put the credential in a shell variable, where `set -x`,
+# a core dump or an `env` in a subshell can spill it. Re-exec'ing through `run`
+# keeps it in the process environment and out of the script's own state.
+#
+# This must precede argument parsing: the re-exec replays "$@", and the parser
+# below consumes it with shift.
+if [ -z "${NAN_API_KEY:-}" ] && [ -z "${NAN_DEBUG_REEXEC:-}" ] && command -v dotf >/dev/null 2>&1; then
+    # The sentinel bounds the re-exec to one hop, so a `run` that somehow
+    # returned without injecting cannot spin.
+    NAN_DEBUG_REEXEC=1 exec dotf secrets run --only NAN_API_KEY -- "$0" "$@"
+fi
+
 MODEL="deepseek-v4-flash"
 PROMPT_FILE=""
 ARGS=()
@@ -34,13 +53,7 @@ else
     exit 1
 fi
 
-# NAN_API_KEY: injected by `dotf secrets run`, or self-fetched via `dotf secrets
-# show` on demand (ADR-028 — never the ambient shell env).
-if [ -z "${NAN_API_KEY:-}" ] && command -v dotf >/dev/null 2>&1; then
-    NAN_API_KEY="$(dotf secrets show NAN_API_KEY 2>/dev/null || true)"
-    export NAN_API_KEY
-fi
-[ -z "${NAN_API_KEY:-}" ] && { echo "ERROR: NAN_API_KEY not set. Run: dotf secrets run -- $0" >&2; exit 1; }
+[ -z "${NAN_API_KEY:-}" ] && { echo "ERROR: NAN_API_KEY not set. Run: dotf secrets run --only NAN_API_KEY -- $0" >&2; exit 1; }
 
 BASE_URL="${NAN_BASE_URL:-https://api.nan.builders/v1}"
 

--- a/scripts/nan-quality-bench.sh
+++ b/scripts/nan-quality-bench.sh
@@ -8,13 +8,18 @@
 
 set -euo pipefail
 
-# NAN_API_KEY: injected by `dotf secrets run`, or self-fetched via `dotf secrets
-# show` on demand (ADR-028 — never the ambient shell env).
-if [ -z "${NAN_API_KEY:-}" ] && command -v dotf >/dev/null 2>&1; then
-    NAN_API_KEY="$(dotf secrets show NAN_API_KEY 2>/dev/null || true)"
-    export NAN_API_KEY
+# NAN_API_KEY: injected by `dotf secrets run`. The `dotf secrets show` self-fetch
+# that stood here is gone — CLI-042 gave nan-api-key a second exposed name
+# (HIVE_WORKER_API_KEY), and `show` refuses a multi-var secret because one value
+# on stdout is ambiguous for it. Re-exec'ing through `run` is also the stronger
+# form: the credential stays in the process environment instead of a shell
+# variable that `set -x` or a core dump can spill.
+if [ -z "${NAN_API_KEY:-}" ] && [ -z "${NAN_BENCH_REEXEC:-}" ] && command -v dotf >/dev/null 2>&1; then
+    # The sentinel bounds the re-exec to one hop, so a `run` that somehow
+    # returned without injecting cannot spin.
+    NAN_BENCH_REEXEC=1 exec dotf secrets run --only NAN_API_KEY -- "$0" "$@"
 fi
-[ -z "${NAN_API_KEY:-}" ] && { echo "ERROR: NAN_API_KEY not set. Run: dotf secrets run -- $0" >&2; exit 1; }
+[ -z "${NAN_API_KEY:-}" ] && { echo "ERROR: NAN_API_KEY not set. Run: dotf secrets run --only NAN_API_KEY -- $0" >&2; exit 1; }
 
 OUT="${1:-/tmp/nan-bench-$(date +%Y%m%d-%H%M%S)}"
 mkdir -p "$OUT"

--- a/secrets/registry.yaml
+++ b/secrets/registry.yaml
@@ -93,11 +93,24 @@ secrets:
     plane: app
     backend: bw
     bw: { item: nan-api-key, field: api-key, folder: apps }
-    expose: { env: NAN_API_KEY }
+    # Two names, ONE credential and one rotation. hive's worker reads
+    # HIVE_WORKER_API_KEY (its own contract, mlorentedev/hive#384) while opencode
+    # and pi read NAN_API_KEY — the same NaN subscription under two consumer
+    # names, which is exactly what expose.env's list form is for. Declaring a
+    # second registry entry over the same bw item would instead give one
+    # credential two rotation cadences that can drift apart.
+    #
+    # Note for callers: a multi-var secret is not resolvable through
+    # `dotf secrets show` (one value to stdout is ambiguous for it) — use
+    # `dotf secrets run --only NAN_API_KEY`, which selects BOTH vars because the
+    # token matches the secret's id.
+    expose: { env: [NAN_API_KEY, HIVE_WORKER_API_KEY] }
     # ci:… added by TOOL-013 (#786): the pr-agent workflow reviews pull requests
     # through NaN. Declared per-consumer rather than ambient, so the reviewer
     # holds exactly one credential — see #1025 for the cost of the alternative.
-    consumers: ["agent:opencode", "agent:pi", "ci:mlorentedev/dotfiles"]
+    # daemon:hive-worker added by CLI-042 (#1190): the hive serve unit takes it
+    # from `dotf secrets run`, so it is a consumer that holds nothing at rest.
+    consumers: ["agent:opencode", "agent:pi", "ci:mlorentedev/dotfiles", "daemon:hive-worker"]
     rotate: 90d
 
   - id: POLLEX_API_KEY

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -414,19 +414,16 @@ fi
 if [ -f "$CURRENT_DIR/mcp-servers.json" ] && command -v jq >/dev/null 2>&1; then
     log_info "Consolidating Antigravity MCP servers..."
 
-    # Recover OpenRouter key: env → existing config → secrets vault.
     # NOTE: canonical agy schema uses `mcpServers` (not `servers`) per Antigravity docs.
-    OLD_KEY="${OPENROUTER_API_KEY:-}"
-    if [ -z "$OLD_KEY" ] || [ "$OLD_KEY" = "null" ]; then
-        # `|| true` keeps the assignment safe under set -e even when grep
-        # returns 1 (no matches) or jq fails on a missing config file
-        # (fresh-install path on CI containers without the master MCP yet).
-        OLD_KEY=$(jq -r '.mcpServers["hive-vault"].env.OPENROUTER_API_KEY // empty' "$GEMINI_HOME/config/mcp_config.json" 2>/dev/null | grep -v "null" || true)
-    fi
-    if [ -z "$OLD_KEY" ] || [ "$OLD_KEY" = "null" ] || [ "$OLD_KEY" = '${OPENROUTER_API_KEY}' ]; then
-        # Last resort: fetch straight from the dotf secrets facade (ADR-028).
-        OLD_KEY="$(dotf secrets show OPENROUTER_API_KEY 2>/dev/null || true)"
-    fi
+    #
+    # CLI-042 AC8: the OpenRouter key recovery cascade that stood here is gone
+    # with the provider. hive's worker is NaN-only since mlorentedev/hive#384, so
+    # an OPENROUTER_API_KEY handed to hive-vault buys nothing — and the cascade
+    # ended in `dotf secrets show`, baking a live credential into
+    # mcp_config.json in plaintext. Removing the provider removes that file as a
+    # place a secret lives, which is AC7's rule applied to the same daemon from
+    # the other side. opencode's own OpenRouter provider is untouched: that is a
+    # different consumer, and the spec scopes this criterion to hive's worker.
 
     # Substitute ${VAULT_PATH} placeholder with the canonical Linux vault dir.
     # Committed JSON uses a placeholder so the same source works cross-OS;
@@ -445,9 +442,8 @@ if [ -f "$CURRENT_DIR/mcp-servers.json" ] && command -v jq >/dev/null 2>&1; then
         log_warning "  the VAULT_PATH env var in your shell."
     fi
 
-    NEW_MCP_CONFIG=$(jq --arg key "$OLD_KEY" --arg vault "$VAULT_PATH_DEFAULT" '
-        .mcpServers["hive-vault"].env.OPENROUTER_API_KEY = (if $key != "" and $key != "null" then $key else .mcpServers["hive-vault"].env.OPENROUTER_API_KEY end)
-        | .mcpServers["hive-vault"].env.VAULT_PATH = $vault
+    NEW_MCP_CONFIG=$(jq --arg vault "$VAULT_PATH_DEFAULT" '
+        .mcpServers["hive-vault"].env.VAULT_PATH = $vault
     ' "$CURRENT_DIR/ai/agy/mcp_servers.json")
 
     # Merge stdio servers from root mcp-servers.json into mcpServers map
@@ -1208,6 +1204,37 @@ if command -v hive >/dev/null 2>&1 && [ -n "$hive_ver" ] \
         log_success "Installed hive daemon service (systemd --user, v$hive_ver)"
     else
         log_warning "hive service install failed (non-fatal; client works via fallback)"
+    fi
+
+    # CLI-042 AC7: the NaN credential reaches the daemon through
+    # `dotf secrets run`, never through a file. `hive service install` above owns
+    # hive.service and exposes no flag to change its ExecStart, so the override
+    # is a systemd DROP-IN. That also makes it survive the next re-install --
+    # which the hive-upgrade.timer can trigger every 15 minutes, and which would
+    # silently clobber a competing hive.service shipped from this repo.
+    if command -v systemctl >/dev/null 2>&1; then
+        HIVE_DROPIN_SRC="$CURRENT_DIR/systemd/hive.service.d/10-dotf-secrets.conf"
+        HIVE_DROPIN_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/hive.service.d"
+        HIVE_DROPIN_DST="$HIVE_DROPIN_DIR/10-dotf-secrets.conf"
+        if [ -f "$HIVE_DROPIN_SRC" ]; then
+            ensure_directory "$HIVE_DROPIN_DIR"
+            # Compare before writing. deploy_file writes unconditionally, and a
+            # daemon restarted on every setup run is NOT idempotent -- it would
+            # drop live MCP sessions on each pass. Content equality is the
+            # convergence test, so only a real change earns a restart and a
+            # re-run reports changed=0.
+            if [ -f "$HIVE_DROPIN_DST" ] && cmp -s "$HIVE_DROPIN_SRC" "$HIVE_DROPIN_DST"; then
+                log_info "hive.service credential drop-in already current (no restart)"
+            else
+                deploy_file "$HIVE_DROPIN_SRC" "$HIVE_DROPIN_DST"
+                systemctl --user daemon-reload >/dev/null 2>&1 || true
+                if systemctl --user restart hive.service >/dev/null 2>&1; then
+                    log_success "hive daemon takes NAN_API_KEY from dotf secrets run (nothing on disk)"
+                else
+                    log_warning "hive.service restart failed; drop-in deployed but the running daemon keeps the old ExecStart"
+                fi
+            fi
+        fi
     fi
 
     # ADR-025 + HARNESS-024 (#446): the hive serve daemon is a systemd --user

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1390,20 +1390,15 @@ $rootMcpSrc = "$DotfilesDir\mcp-servers.json"
 if ((Test-Path $mcpServersSrc) -and (Test-Path $rootMcpSrc) -and (Get-Command jq -ErrorAction SilentlyContinue)) {
     Write-Info "Consolidating Antigravity MCP servers..."
 
-    # Recover OpenRouter key from existing master config.
     # NOTE: canonical agy schema uses `mcpServers` (not `servers`).
-    $oldKey = $env:OPENROUTER_API_KEY
-    if ([string]::IsNullOrEmpty($oldKey)) {
-        $existingMaster = Join-Path $GeminiHome "config\mcp_config.json"
-        if (Test-Path $existingMaster) {
-            $oldKey = & jq -r '.mcpServers["hive-vault"].env.OPENROUTER_API_KEY // empty' $existingMaster 2>$null | Where-Object { $_ -ne "null" }
-        }
-    }
-
+    #
+    # CLI-042 AC8: the OpenRouter key recovery that stood here is gone with the
+    # provider. hive's worker is NaN-only since mlorentedev/hive#384, so an
+    # OPENROUTER_API_KEY handed to hive-vault buys nothing, and recovering it
+    # from the existing master config kept a live credential in mcp_config.json
+    # in plaintext across every redeploy. Parity with setup-linux.sh.
+    # opencode's own OpenRouter provider is a different consumer and untouched.
     $mcpConfigJson = Get-Content $mcpServersSrc -Raw | ConvertFrom-Json
-    if (-not [string]::IsNullOrEmpty($oldKey) -and $oldKey -ne '${OPENROUTER_API_KEY}') {
-        $mcpConfigJson.mcpServers."hive-vault".env.OPENROUTER_API_KEY = $oldKey
-    }
 
     # Substitute ${VAULT_PATH} placeholder with the canonical Windows vault dir.
     # The committed JSON uses ${VAULT_PATH} so it's OS-portable; agy does NOT

--- a/specs/CLI-042-dotf-agent-run/features.json
+++ b/specs/CLI-042-dotf-agent-run/features.json
@@ -183,22 +183,29 @@
   },
   {
     "id": "CLI-042-dotf-agent-run-f15",
-    "behavior": "AC7 — the hive service unit invokes `dotf secrets run -- hive serve`, and the deployed environment.d fragment carries no credential",
-    "verification": "~/.local/bin/bats tests/hive-service-secret-delivery.bats",
+    "behavior": "AC7 — the hive service unit invokes `dotf secrets run` and carries BOTH halves of the worker contract (HIVE_WORKER_API_KEY via the registry id, HIVE_WORKER_BASE_URL in the unit); no credential lands in the unit, the environment.d fragment, or any deployed file",
+    "verification": "out=$(~/.local/bin/bats tests/agent-runtime-deployment.bats --filter 'AC7' 2>&1) && n=$(printf '%s' \"$out\" | grep -c '^ok ') && [ \"$n\" -ge 8 ] && ! printf '%s' \"$out\" | grep -q '^not ok'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f16",
-    "behavior": "AC8 — no configuration this repo deploys still names Ollama or OpenRouter for hive's WORKER (opencode's own provider catalogue is out of scope and must survive)",
-    "verification": "~/.local/bin/bats tests/hive-provider-drop.bats",
+    "behavior": "AC8 — no configuration this repo deploys still names Ollama or OpenRouter for hive's WORKER, asserted as a class over hive-vault's declared env (opencode's own provider catalogue is out of scope and must survive)",
+    "verification": "out=$(~/.local/bin/bats tests/agent-runtime-deployment.bats --filter 'AC8' 2>&1) && n=$(printf '%s' \"$out\" | grep -c '^ok ') && [ \"$n\" -ge 3 ] && ! printf '%s' \"$out\" | grep -q '^not ok'",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CLI-042-dotf-agent-run-f17",
-    "behavior": "AC9 — `dotf doctor` fails when a backend probes present but can serve no model, so 'zero reachable models' is caught at diagnostic time",
-    "verification": "cd cli && out=$(go test ./internal/doctor/ -run '^TestBackendReachability$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestBackendReachability'",
+    "behavior": "AC9 — `dotf doctor` FAILS when hive probes present but is missing either half of its worker contract, so 'serves nothing' is caught at diagnostic time rather than under dispatch load",
+    "verification": "cd cli && out=$(go test -count=1 ./internal/doctor/ -run '^TestHiveBackendCanServe' -v 2>&1) && n=$(printf '%s' \"$out\" | grep -c '^--- PASS: TestHiveBackendCanServe') && [ \"$n\" -ge 8 ] && ! printf '%s' \"$out\" | grep -q '^--- FAIL'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-042-dotf-agent-run-f30",
+    "behavior": "AC7 — `dotf secrets run` forwards SIGINT/SIGTERM to its child rather than dying and orphaning it, because the hive unit makes it a supervisor and a MainPID for the first time",
+    "verification": "cd cli && out=$(go test -count=1 ./internal/cmd/ -run '^TestRunChild_ForwardsSIGTERMToChild$' -v 2>&1) && printf '%s' \"$out\" | grep -q '^--- PASS: TestRunChild_ForwardsSIGTERMToChild'",
     "state": "pending",
     "evidence": ""
   }

--- a/specs/CLI-042-dotf-agent-run/proposal.md
+++ b/specs/CLI-042-dotf-agent-run/proposal.md
@@ -263,6 +263,17 @@ Observable outcomes. Each must be testable.
       `dotf secrets run -- hive serve`, and the deployed `environment.d` fragment contains no
       credential. Asserted by a test reading the rendered unit and grepping the deployed fragment,
       verified by consequence (the daemon answers) rather than by printing the value.
+      **Widened 2026-08-24 by measurement, not by preference.** The criterion as first written names
+      only the credential, and a unit satisfying exactly that still serves nothing: hive's worker
+      contract has TWO halves, `HIVE_WORKER_API_KEY` **and** `HIVE_WORKER_BASE_URL`, and neither is
+      `NAN_API_KEY` — the variable the first implementation injected. Measured on msi: `hive.service`
+      had been `active (running)` for 2h40m while the daemon's own `worker_status` reported
+      `Configured: no — set HIVE_WORKER_BASE_URL`. So AC7 now requires the unit to carry both halves.
+      The base URL is configuration rather than a secret and belongs in the unit; the credential
+      reaches it through `dotf secrets run --only NAN_API_KEY`, whose token is the registry **id**,
+      which selects every var that secret exposes — `secrets/registry.yaml` gains
+      `HIVE_WORKER_API_KEY` as a second exposed name over the one Bitwarden item, so there remains
+      one credential and one rotation.
 - [ ] **AC8 — the drop of Ollama and OpenRouter from hive's worker is complete, not partial.** No
       configuration this repo deploys still names either **for hive's worker**, and
       `ai/agy/mcp_servers.json`'s `HIVE_OLLAMA_ENDPOINT` is removed in the same change.

--- a/specs/CLI-042-dotf-agent-run/tasks.md
+++ b/specs/CLI-042-dotf-agent-run/tasks.md
@@ -179,17 +179,47 @@ Added while implementing D:
 
 ### PR E — the deployment, as IaC
 
-- [ ] [AC7] Failing test: the rendered hive service unit invokes `dotf secrets run -- hive serve`
-- [ ] [AC7] Implement the unit and its deployment in `setup-linux.sh`, verified idempotent
-      (`changed=0` on re-run)
-- [ ] [AC7] Assert no credential in the deployed `environment.d` fragment; verify the daemon by
-      consequence (it answers), never by printing the value
-- [ ] [P] [AC8] Remove `HIVE_OLLAMA_ENDPOINT` from `ai/agy/mcp_servers.json` and any other config this
-      repo deploys naming Ollama or OpenRouter for hive's worker
-- [ ] [AC8] Assertion that the removal stays removed — the incident-to-guard rule
-- [ ] [P] [AC9] Failing test: `dotf doctor` fails when a backend probes present but can serve nothing
-- [ ] [AC9] Implement the reachability check, so "zero models" is caught at diagnostic time rather
-      than under dispatch load
+- [x] [AC7] Failing test: the rendered hive service unit invokes `dotf secrets run -- hive serve`
+- [x] [AC7] Implement the unit and its deployment in `setup-linux.sh`, verified idempotent
+      (`changed=0` on re-run). Shipped as a systemd **drop-in**
+      (`systemd/hive.service.d/10-dotf-secrets.conf`): `hive service install` owns `hive.service`
+      and exposes no flag to change its `ExecStart`, and a competing unit shipped from this repo
+      would be clobbered by the next re-install — which `hive-upgrade.timer` can trigger every 15
+      minutes. Idempotence is a content compare before the write, so only a real change restarts
+      the daemon and a second pass reports `changed=0`.
+- [x] [AC7] Assert no credential in the deployed `environment.d` fragment.
+      **The by-consequence half is NOT done — see `verification.md`.** The deploy is deferred to the
+      next release cut, so the before/after `worker_status` pair is recorded as owed, not claimed.
+- [x] [AC7] **A widening found by measurement, not preference.** hive reads `HIVE_WORKER_API_KEY`
+      and `HIVE_WORKER_BASE_URL`, never `NAN_API_KEY` — the variable the first implementation
+      injected. It would have deployed with 9 green tests while the worker stayed unconfigured,
+      because those tests asserted the unit's SHAPE and never its effect. The registry gains the
+      second exposed name over the same Bitwarden item (`expose.env` list form, parsed since day one
+      and never exercised until now, so one credential keeps one rotation); the base URL is
+      configuration and lives in the unit.
+- [x] [AC7] `dotf secrets run` forwards SIGINT/SIGTERM to its child. This criterion makes it a
+      systemd MainPID and a daemon supervisor for the first time, and it was dying on the first
+      signal and orphaning the child. Guarded with a nested helper so a regression reports a red
+      assertion instead of killing the test runner.
+- [x] [P] [AC8] Remove `HIVE_OLLAMA_ENDPOINT` from `ai/agy/mcp_servers.json` and any other config
+      this repo deploys naming Ollama or OpenRouter for hive's worker. **Wider than the endpoint
+      line:** both setup scripts recovered `OPENROUTER_API_KEY` and baked it into `mcp_config.json`
+      in plaintext on every redeploy, `setup-linux.sh` ending that cascade in `dotf secrets show`.
+      Dropping the provider removes a file the credential lived in — AC7's rule reaching the same
+      daemon from the other side.
+- [x] [AC8] Assertion that the removal stays removed — the incident-to-guard rule. Written as a
+      CLASS over hive-vault's declared env, keys *and* values, not a grep for one string: proven
+      against a restored `HIVE_OLLAMA_ENDPOINT` and against a renamed key whose value still points
+      at ollama. A companion assertion pins the scope boundary — `ai/opencode/opencode.jsonc` must
+      KEEP its ollama/openrouter providers, so an over-eager future sweep fails here first.
+- [x] [P] [AC9] Failing test: `dotf doctor` fails when a backend probes present but can serve nothing
+- [x] [AC9] Implement the reachability check, so "zero models" is caught at diagnostic time rather
+      than under dispatch load. A **proxy**, deliberately: hive's `worker_status` MCP tool is the
+      stronger surface (hive#384 built it for exactly this), but reaching it from `dotf doctor`
+      means an MCP client in Go — the dependency and drift-prone handshake PR D rejected for the
+      backend, and no better a trade for a diagnostic. The proxy asks whether the unit carries both
+      halves of the worker contract: free, and sound in the one direction that matters. Its limit
+      is stated in the code rather than hidden — a present-but-wrong key still reads as configured.
 
 ## Closing
 

--- a/specs/CLI-042-dotf-agent-run/verification.md
+++ b/specs/CLI-042-dotf-agent-run/verification.md
@@ -133,6 +133,69 @@ Brief log of non-obvious trade-offs or course corrections taken during the work.
   validated map, covered in the `agent` package; the command-layer test was rewritten to assert the
   consequence that IS reachable — no record, empty stdout, exit 1 and never 3.
 
+## PR E — the deployment (2026-08-24)
+
+### Verified in this session
+
+| What | Evidence |
+|---|---|
+| Go layer | `go build ./...`, `go vet ./...`, `GOOS=windows go vet ./...` all clean; `golangci-lint` (pinned 2.12.2) **0 issues** |
+| Go tests | `go test -count=1 ./...` exit 0, including 9 new `TestHiveBackendCanServe_*`, `TestRunChild_ForwardsSIGTERMToChild`, `TestResolveOnly_IdWinsWhenIdAndVarNameCollide` |
+| Shell layer | `bash -n` + `zsh -n` clean on all four changed scripts; `shellcheck` reports nothing new |
+| bats | `tests/agent-runtime-deployment.bats` 14/14 |
+| features.json | f15, f16, f17, f30 each **executed as written** and passing; proven non-vacuous — the same command with a filter selecting nothing FAILS |
+| Multi-var registry, by consequence | `dotf secrets run --only NAN_API_KEY` puts **both** `NAN_API_KEY` and `HIVE_WORKER_API_KEY` in the child env, and `OPENAI_API_KEY` stays out (scoping holds). `dotf secrets verify` → 35 ok, 0 missing, 0 failed |
+
+### Guards proven able to fail
+
+Per the guard-can-fail discipline (#1203, #1206), each new guard was run against
+the shape it exists to refuse:
+
+- **Signal forwarding** — with `signal.Notify` removed, the test reports
+  `forwarder helper exited -1 … stdout=""` and **the runner survives to report
+  it**. That containment is the design: a guard whose failure mode is "the test
+  harness dies" gets muted by whoever hits it.
+- **AC8 provider drop** — caught both a restored `HIVE_OLLAMA_ENDPOINT` key and
+  a *renamed* key whose value still pointed at ollama, which is what makes it a
+  class assertion rather than a string grep.
+
+### NOT verified, and owed
+
+**The by-consequence half of AC7, and all of AC6's end-to-end smoke.** Both need
+`./setup-linux.sh` to have run, and the deploy is deferred to the next release
+cut by the repo owner's decision. Nothing here may be read as evidence the
+daemon answers.
+
+The measurement to capture on either side of that deploy, which is the whole
+point of the criterion:
+
+| | Command | Expected |
+|---|---|---|
+| Before | hive `worker_status` | `Configured: no — set HIVE_WORKER_BASE_URL` *(captured 2026-08-24)* |
+| After | hive `worker_status` | `Configured: yes`, provider reachable |
+| After | `dotf doctor` | the *hive backend reachability* section flips FAIL → PASS |
+| After | `dotf agent run --backend hive --tier mid` | answers, record reports `pool: nan` |
+| Idempotence | second `./setup-linux.sh` | `hive.service credential drop-in already current (no restart)` |
+
+Until that runs, **AC6 and AC7 are not closed and CLI-042 must not archive.**
+The doctor section going red on this machine right now is not a defect in the
+check — it is the check working, and the deploy is what turns it green.
+
+### The finding that shaped this PR
+
+The first implementation of AC7 injected `NAN_API_KEY` and passed 9 of 9 new
+tests. It would have deployed and changed nothing, because hive's worker reads
+`HIVE_WORKER_API_KEY` and `HIVE_WORKER_BASE_URL` and ignores `NAN_API_KEY`
+entirely.
+
+Every one of those 9 tests asserted the unit's **shape** — does it invoke
+`secrets run`, does it carry `--only`, is the `ExecStart` list reset — and not
+one asserted its **effect**. What broke the tie was asking the daemon:
+`worker_status` answered `Configured: no`. Same class as lesson 229 the day
+before: a check on the form of a thing, standing in for a check on what it does.
+This is why the owed measurements above are stated as a before/after pair rather
+than a box to tick.
+
 ## Promotion candidates
 
 Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.

--- a/systemd/hive.service.d/10-dotf-secrets.conf
+++ b/systemd/hive.service.d/10-dotf-secrets.conf
@@ -1,0 +1,62 @@
+# CLI-042 AC7 — the NaN credential never lands in a file.
+#
+# Why a DROP-IN and not a unit this repo ships: `hive service install` (upstream)
+# owns hive.service and offers no flag to control its ExecStart. A drop-in
+# survives every re-install -- systemd merges .d/*.conf over the base unit, and
+# `hive service install` rewrites the base unit but never this directory. Shipping
+# a competing hive.service would instead be silently clobbered on the next
+# upgrade, which the hive-upgrade.timer performs every 15 minutes.
+[Unit]
+Documentation=https://github.com/mlorentedev/dotfiles/issues/1190
+
+# The base unit ships Restart=on-failure with RestartSec=1. Under that policy a
+# boot where the Bitwarden vault is still locked exhausts systemd's default start
+# limit (5 starts within 10s) in about five seconds, and the unit then sits in
+# `failed` even after the user unlocks -- recovering it needs a
+# `systemctl --user reset-failed` that nobody knows to run. Dropping the limit and
+# backing the retry off to 30s makes the daemon CONVERGE on the first unlock
+# instead of demanding an intervention. This is the cost side of AC7's trade:
+# the credential is never on disk, so the daemon cannot start before the vault is
+# reachable, and it must wait rather than fail permanently.
+StartLimitIntervalSec=0
+
+[Service]
+RestartSec=30
+
+# The worker's contract has TWO halves and a daemon holding one of them serves
+# exactly as little as one holding neither. Measured 2026-08-24 on this machine:
+# hive.service had been `active (running)` for 2h40m while `worker_status`
+# reported `Configured: no — set HIVE_WORKER_BASE_URL`.
+#
+# The base URL is configuration, not a credential, so it belongs in the unit
+# rather than in the secrets path. It is scoped to THIS unit rather than put in
+# environment.d, which the user manager applies to every --user service: hive's
+# endpoint is hive's business, and environment.d stays paths-only as its own
+# comment in setup-linux.sh says.
+Environment=HIVE_WORKER_BASE_URL=https://api.nan.builders/v1
+
+# `dotf secrets run` resolves the credential and hands it to THIS child's
+# environment only -- no EnvironmentFile, no environment.d fragment, nothing on
+# disk to leak, to sync, or to forget to rotate.
+#
+# --only is not optional. A bare `run` injects the whole registry, and this child
+# is a long-lived daemon: it would hold every mapped secret for as long as the
+# session lasts, for the sake of one.
+#
+# NAN_API_KEY here is the registry ID, not the variable name, and the difference
+# is load-bearing: a --only token matching an id selects ALL of that secret's
+# exposed vars (Registry.Selector), so this one flag delivers both NAN_API_KEY
+# and HIVE_WORKER_API_KEY from the single nan-api-key item. hive reads the
+# latter; naming only the former as a VAR would inject a variable hive ignores
+# and leave the worker exactly as unconfigured as before.
+#
+# The empty ExecStart= resets the list. systemd rejects a second ExecStart on a
+# Type=simple unit without it, so omitting the reset does not override the base
+# unit -- it refuses to load.
+#
+# %h resolves to the user home (ADR-025: no literal path), matching
+# hive-upgrade.service and dotfiles-selfupdate.service. Absolute rather than a
+# bare `dotf`, because a --user unit gets a minimal PATH that may omit
+# ~/.local/bin -- the same reason those two units spell it out.
+ExecStart=
+ExecStart=%h/.local/bin/dotf secrets run --only NAN_API_KEY -- %h/.local/bin/hive serve

--- a/tests/agent-runtime-deployment.bats
+++ b/tests/agent-runtime-deployment.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+# CLI-042 PR E — the deployment of the agent executor seam, as IaC.
+#
+# AC7: the NaN credential never lands in a file — the hive daemon takes it from
+#      `dotf secrets run`, not from an EnvironmentFile or an environment.d
+#      fragment.
+# AC8: the drop of Ollama and OpenRouter from hive's WORKER is complete, not
+#      partial — asserted as a class over hive-vault's declared environment
+#      rather than as a grep for one endpoint string.
+# AC9: `dotf doctor` catches "probes present but can serve nothing" at
+#      diagnostic time (the Go half lives in cli/internal/doctor).
+
+load 'lib/refute'
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    DROPIN="$DOTFILES_DIR/systemd/hive.service.d/10-dotf-secrets.conf"
+    export DROPIN
+}
+
+# --- AC7: the drop-in is the credential seam ---
+
+@test "AC7: the hive.service drop-in exists in the repo's systemd SSOT" {
+    [ -f "$DROPIN" ]
+}
+
+@test "AC7: the drop-in invokes hive serve through dotf secrets run" {
+    grep -qE '^ExecStart=%h/\.local/bin/dotf secrets run .* -- %h/\.local/bin/hive serve$' "$DROPIN"
+}
+
+# A second ExecStart on a Type=simple unit is a load-time ERROR unless the list
+# is reset first. Without the empty assignment the drop-in does not override the
+# base unit -- systemd refuses to load it, and the daemon keeps running with no
+# credential, which is the exact state AC7 exists to end.
+@test "AC7: the drop-in resets ExecStart before setting its own" {
+    run grep -c '^ExecStart=' "$DROPIN"
+    [ "$output" -eq 2 ]
+    # The reset must come first, or it clears the value we just set.
+    run grep -n '^ExecStart=$' "$DROPIN"
+    reset_line="${output%%:*}"
+    run grep -n '^ExecStart=%h' "$DROPIN"
+    set_line="${output%%:*}"
+    [ "$reset_line" -lt "$set_line" ]
+}
+
+# A bare `run` injects the entire registry. This child is a long-lived daemon:
+# it would hold every mapped secret for the life of the session, for the sake of
+# one.
+@test "AC7: the injection is scoped with --only, not the whole registry" {
+    grep -qF -- '--only NAN_API_KEY' "$DROPIN"
+}
+
+# The worker contract has TWO halves. hive reads HIVE_WORKER_BASE_URL and
+# HIVE_WORKER_API_KEY -- NOT NAN_API_KEY -- and a daemon holding one half serves
+# exactly as little as one holding neither. Measured 2026-08-24: worker_status
+# reported `Configured: no — set HIVE_WORKER_BASE_URL` while systemd called the
+# unit active (running).
+@test "AC7: the unit declares the worker base URL, the non-secret half" {
+    grep -qE '^Environment=HIVE_WORKER_BASE_URL=https://' "$DROPIN"
+}
+
+# --only takes the registry ID here, and an id selects every var the secret
+# exposes -- which is how HIVE_WORKER_API_KEY reaches hive from a flag naming
+# only NAN_API_KEY. The registry must therefore actually expose both names, or
+# the drop-in injects a variable hive ignores and the worker stays unconfigured.
+@test "AC7: the registry exposes HIVE_WORKER_API_KEY from the same secret" {
+    run python3 - "$DOTFILES_DIR/secrets/registry.yaml" <<'PY'
+import sys, yaml
+doc = yaml.safe_load(open(sys.argv[1]))
+for s in doc.get("secrets", []):
+    if s.get("id") == "NAN_API_KEY":
+        env = s.get("expose", {}).get("env")
+        names = env if isinstance(env, list) else [env]
+        print("OK" if "HIVE_WORKER_API_KEY" in names else "MISSING:" + str(names))
+        break
+else:
+    print("NO_SUCH_SECRET")
+PY
+    [ "$status" -eq 0 ]
+    [ "$output" = "OK" ]
+}
+
+# ADR-025: no literal home path. %h is what the two units already in systemd/
+# use, and a --user unit's minimal PATH is why the binary is spelled absolutely
+# rather than as a bare `dotf`.
+@test "AC7: the drop-in uses %h, never a literal home, and never a bare binary" {
+    refute_grep '^ExecStart=.*/home/' "$DROPIN"
+    refute_grep '^ExecStart=dotf ' "$DROPIN"
+}
+
+# The base unit's Restart=on-failure/RestartSec=1 would exhaust systemd's default
+# start limit in ~5s on a boot where the vault is still locked, leaving the unit
+# `failed` until someone runs reset-failed. The drop-in must neutralise that, or
+# AC7's trade (no credential on disk) turns into a daemon that never comes back.
+@test "AC7: the drop-in disables the start limit and backs the retry off" {
+    grep -qF 'StartLimitIntervalSec=0' "$DROPIN"
+    run grep -oE '^RestartSec=[0-9]+' "$DROPIN"
+    [ -n "$output" ]
+    [ "${output#RestartSec=}" -ge 10 ]
+}
+
+# StartLimitIntervalSec is a [Unit] directive; RestartSec is a [Service] one.
+# systemd warns and ignores the former if it is put in [Service], which would
+# silently restore the failure this drop-in exists to prevent.
+@test "AC7: StartLimitIntervalSec is under [Unit], RestartSec under [Service]" {
+    run awk '/^\[/{s=$0} /^StartLimitIntervalSec=/{print s}' "$DROPIN"
+    [ "$output" = "[Unit]" ]
+    run awk '/^\[/{s=$0} /^RestartSec=/{print s}' "$DROPIN"
+    [ "$output" = "[Service]" ]
+}
+
+@test "AC7: no credential value is written into the drop-in itself" {
+    refute_grep 'NAN_API_KEY=' "$DROPIN"
+    refute_grep '^Environment=.*_KEY=' "$DROPIN"
+    refute_grep '^EnvironmentFile=' "$DROPIN"
+}
+
+@test "AC7: setup-linux.sh deploys the drop-in directory" {
+    grep -qF 'hive.service.d' "$DOTFILES_DIR/setup-linux.sh"
+}
+
+# --- AC8: the provider drop is complete, as a class ---
+
+# The criterion is about hive's WORKER, so the assertion is scoped to the
+# hive-vault entry's declared environment -- not a repo-wide grep, which would
+# fire on ai/opencode/opencode.jsonc, where ollama and openrouter are the TUI's
+# own providers and must survive. #1223's lesson applies: a guard that greps a
+# whole file passes or fails for the wrong reason.
+@test "AC8: hive-vault's declared env names no dropped provider" {
+    run python3 - "$DOTFILES_DIR/ai/agy/mcp_servers.json" <<'PY'
+import json, re, sys
+doc = json.load(open(sys.argv[1]))
+env = doc.get("mcpServers", {}).get("hive-vault", {}).get("env", {})
+bad = [k for k in env if re.search(r'ollama|openrouter', k, re.I)]
+bad += [k for k, v in env.items() if isinstance(v, str) and re.search(r'ollama|openrouter', v, re.I)]
+print("OFFENDERS:" + ",".join(sorted(set(bad))) if bad else "CLEAN")
+PY
+    [ "$status" -eq 0 ]
+    [ "$output" = "CLEAN" ]
+}
+
+# The removal must stay removed in the deployers too: either script re-adding a
+# dropped provider into hive-vault's env would put the credential back on disk
+# without touching the JSON this suite reads.
+@test "AC8: neither setup script assigns a dropped provider into hive-vault's env" {
+    refute_grep 'mcpServers\["hive-vault"\]\.env\.OPENROUTER_API_KEY' "$DOTFILES_DIR/setup-linux.sh"
+    refute_grep 'mcpServers\["hive-vault"\]\.env\.HIVE_OLLAMA_ENDPOINT' "$DOTFILES_DIR/setup-linux.sh"
+    refute_grep 'hive-vault"\.env\.OPENROUTER_API_KEY' "$DOTFILES_DIR/setup-windows.ps1"
+    refute_grep 'hive-vault"\.env\.HIVE_OLLAMA_ENDPOINT' "$DOTFILES_DIR/setup-windows.ps1"
+}
+
+# The scope boundary, asserted rather than trusted: the spec explicitly keeps
+# opencode's provider catalogue, and a future over-eager "remove ollama
+# everywhere" sweep would be an unrelated regression wearing AC8's clothes.
+@test "AC8: opencode's own provider catalogue is NOT collateral" {
+    grep -qiE 'ollama|openrouter' "$DOTFILES_DIR/ai/opencode/opencode.jsonc"
+}

--- a/tests/nan-scripts-secrets.bats
+++ b/tests/nan-scripts-secrets.bats
@@ -2,10 +2,13 @@
 # Secret-resolution contract for the nan-* helper scripts (ADR-028 Phase 1,
 # spec CLI-024-secrets-retire-loadsecrets / #587).
 #
-# The nan-* scripts must resolve NAN_API_KEY through the `dotf secrets` facade
-# (`dotf secrets show NAN_API_KEY`, or injected by `dotf secrets run`), never by
-# sourcing the retired `load-secrets` twin. Structural (grep-based) like the
-# other RC/script contract tests in this suite.
+# The nan-* scripts must resolve NAN_API_KEY through the `dotf secrets` facade —
+# injected by `dotf secrets run`, or self-resolved by re-exec'ing through it —
+# never by sourcing the retired `load-secrets` twin. Structural (grep-based) like
+# the other RC/script contract tests in this suite.
+#
+# The facade verb changed in CLI-042 (#1190): `dotf secrets show` no longer
+# resolves this secret, because it is now multi-var. See the test below.
 
 load 'lib/refute'
 
@@ -32,9 +35,42 @@ setup() {
     done
 }
 
-@test "nan-* scripts self-fetch NAN_API_KEY via dotf secrets show, using the real registry id" {
+# CLI-042 (#1190) replaced the `dotf secrets show` self-fetch this test used to
+# pin. Two reasons, and the first is forced:
+#
+# `show` REFUSES a multi-var secret -- one value on stdout is ambiguous for one --
+# and nan-api-key now exposes a second name (HIVE_WORKER_API_KEY) for hive's
+# worker. The second reason is that re-exec'ing through `run` is stronger anyway:
+# the credential reaches the process environment instead of a shell variable that
+# `set -x`, an `env` in a subshell, or a core dump can spill.
+#
+# The invariant this file guards is unchanged -- the scripts resolve through the
+# `dotf secrets` facade and never the retired load-secrets twin. Only the facade
+# verb moved.
+@test "nan-* scripts self-resolve NAN_API_KEY by re-exec'ing through dotf secrets run" {
     for s in "${NAN_SCRIPTS[@]}"; do
-        grep -qF 'dotf secrets show NAN_API_KEY' "$SCRIPTS_DIR/$s" || { echo "no 'dotf secrets show NAN_API_KEY': $s"; return 1; }
+        grep -qE 'exec dotf secrets run --only NAN_API_KEY -- "\$0"' "$SCRIPTS_DIR/$s" \
+            || { echo "no 'exec dotf secrets run --only NAN_API_KEY -- \$0' re-exec: $s"; return 1; }
+    done
+}
+
+# `show` cannot resolve this secret any more, so a script still calling it would
+# fail at runtime with a message about ambiguity rather than about the thing the
+# user asked for. Guard the regression rather than trusting the rewrite.
+@test "nan-* scripts no longer call dotf secrets show, which cannot resolve a multi-var secret" {
+    for s in "${NAN_SCRIPTS[@]}"; do
+        refute_grep_fixed 'dotf secrets show NAN_API_KEY' "$SCRIPTS_DIR/$s"
+    done
+}
+
+# An unbounded re-exec would spin if `run` ever returned without injecting. Each
+# script carries a sentinel that bounds it to one hop.
+@test "nan-* scripts bound the re-exec with a sentinel so it cannot loop" {
+    for s in "${NAN_SCRIPTS[@]}"; do
+        grep -qE '\[ -z "\$\{NAN_[A-Z]+_REEXEC:-\}" \]' "$SCRIPTS_DIR/$s" \
+            || { echo "no re-exec sentinel guard: $s"; return 1; }
+        grep -qE 'NAN_[A-Z]+_REEXEC=1 exec dotf' "$SCRIPTS_DIR/$s" \
+            || { echo "sentinel not set on the re-exec: $s"; return 1; }
     done
 }
 


### PR DESCRIPTION
PR E of the CLI-042 sequence (spec `specs/CLI-042-dotf-agent-run/`, tracked by issue 1190).

**This PR deliberately carries no closing keyword.** Two of its criteria cannot be
verified until `./setup-linux.sh` runs, and that deploy is deferred to the next
release cut. Closing the epic here would close it over an unverified daemon.

## What was wrong

The hive backend has been a declared route of `dotf agent run` with no reachable
provider, for an unknown length of time. Measured on msi:

- `hive.service` reported `active (running)` for 2h40m
- the daemon's own `worker_status` answered `Configured: no — set HIVE_WORKER_BASE_URL`
- `/proc/<pid>/environ` held **zero** credential-shaped variables

The unit's `EnvironmentFile=-/home/…/hive.env` points at a file that does not
exist, and the `-` prefix makes that silent. Nothing was ever going to notice:
systemd reports process health, and process health is not capability health.

## What this does

**AC7 — the credential never lands in a file.** A systemd drop-in
(`systemd/hive.service.d/10-dotf-secrets.conf`) runs the daemon under
`dotf secrets run`, so the value lives in the process environment and in no file.
A drop-in rather than a unit this repo ships: `hive service install` owns
`hive.service` and offers no flag to change its `ExecStart`, and a competing unit
would be clobbered by the next re-install — which `hive-upgrade.timer` can fire
every 15 minutes.

The drop-in also neutralises the base unit's `Restart=on-failure` +
`RestartSec=1`, which would exhaust systemd's default start limit in ~5s on a boot
where the vault is still locked and leave the unit `failed` until someone ran
`reset-failed`. That is the cost side of the trade, stated rather than discovered.

**AC8 — the provider drop is complete.** Wider than the endpoint line: both setup
scripts recovered `OPENROUTER_API_KEY` and baked it into `mcp_config.json` in
plaintext on every redeploy, `setup-linux.sh` ending that cascade in
`dotf secrets show`. Dropping the provider removes a file the credential lived in.
`ai/opencode/opencode.jsonc` keeps its ollama/openrouter providers — different
consumer, explicitly in scope of the spec's own wording — and a test asserts it,
so an over-eager future sweep fails here first.

**AC9 — caught at diagnostic time.** `dotf doctor` fails when hive probes present
but is missing either half of its worker contract. It reads the unit rather than
probing the worker: hive's `worker_status` is the stronger surface, but reaching
it would put an MCP client inside a diagnostic — the dependency and drift-prone
handshake PR D already rejected for the backend. The proxy's limit is written in
its own doc comment, not implied.

**In scope because this PR caused it:** `dotf secrets run` now forwards
SIGINT/SIGTERM to its child. This change makes it a systemd MainPID and a daemon
supervisor for the first time, and it was dying on the first signal and orphaning
what held the secret.

## The finding worth reading

The first implementation of AC7 injected `NAN_API_KEY` and passed 9 of 9 new
tests. It would have deployed and changed nothing — hive reads
`HIVE_WORKER_API_KEY` and `HIVE_WORKER_BASE_URL` and ignores `NAN_API_KEY`.

Every one of those tests asserted the unit's **shape** and none its **effect**.
What broke the tie was asking the daemon. Written up as
`docs/lessons/lesson-230-*`, and it is why AC9's check exists at all.

The registry now exposes `HIVE_WORKER_API_KEY` as a second name over the same
Bitwarden item (`expose.env` list form — parsed since day one, never exercised),
so one credential keeps one rotation. `--only NAN_API_KEY` names the registry
**id**, which selects every var the secret exposes; that resolution order is
pinned by a new test, because swapping the two loops in `Selector` would strip
hive's credential silently.

## Verification

| Layer | Result |
|---|---|
| `go build` / `go vet` / `GOOS=windows go vet` | clean |
| `golangci-lint` (pinned 2.12.2) | **0 issues** |
| `go test -count=1 ./...` | exit 0 |
| `bats tests/*.bats` | **1517 ok / 0 not ok**, exit 0 |
| `bash -n` + `zsh -n`, all changed scripts | clean |
| `dotf secrets verify` | 35 ok, 0 missing, 0 failed |
| Multi-var injection, by consequence | both names present in the child env; `OPENAI_API_KEY` stays out |
| `features.json` f15/f16/f17/f30 | executed as written, all pass; proven non-vacuous (an empty selection fails) |

**Guards proven able to fail**, per #1203/#1206 — each run against the shape it
refuses:

- signal forwarding: with `signal.Notify` removed the test reports
  `forwarder helper exited -1`, **and the runner survives to report it**. That
  containment is deliberate: a guard whose failure mode is "the harness dies"
  gets muted by whoever hits it.
- AC8 class guard: caught a restored `HIVE_OLLAMA_ENDPOINT` *and* a renamed key
  whose value still pointed at ollama.

## What is NOT verified

The by-consequence half of AC7 and all of AC6's end-to-end smoke. Both need the
deploy. `verification.md` records the owed before/after pair rather than claiming
it, and **CLI-042 must not archive until they land**.

The `dotf doctor` section this PR adds goes **red on this machine right now**.
That is the check working, not a defect — the deploy is what turns it green.

## Notes for the reviewer

- `secrets/registry.yaml` is also being edited by a parallel session (adding
  `ci:mlorentedev/web` to the same entry's `consumers:`). Different lines of the
  same block; a trivial list-element merge if both land.
- The systemd work is Linux-only. Windows supervises the daemon through a
  Scheduled Task, and the equivalent there is deferred to a session at that box
  rather than written blind; the AC9 check skips on Windows and says so.
- `setup-windows.ps1` carries the AC8 removals (text-editable from here);
  empirical verification of that leg is deferred to the same session.