### PR TITLE
fix(doctor): parse the real ExecStart record, and add one-command post-deploy verification

### DIFF
--- a/cli/internal/doctor/checks_agent_reach.go
+++ b/cli/internal/doctor/checks_agent_reach.go
@@ -67,7 +67,7 @@ func checkHiveBackendCanServe(sys *System, rep *Report) {
 	for _, line := range strings.Split(out, "\n") {
 		switch {
 		case strings.HasPrefix(line, "ExecStart="):
-			execStart = strings.TrimPrefix(line, "ExecStart=")
+			execStart = execArgv(strings.TrimPrefix(line, "ExecStart="))
 		case strings.HasPrefix(line, "Environment="):
 			environment = strings.TrimPrefix(line, "Environment=")
 		}
@@ -113,4 +113,31 @@ func checkHiveBackendCanServe(sys *System, rep *Report) {
 	}
 
 	rep.Pass("hive.service carries both halves of the worker contract — the backend can reach its pool")
+}
+
+// execArgv pulls the command line out of the record `systemctl show -p ExecStart`
+// actually prints, which is NOT a bare command:
+//
+//	ExecStart={ path=/u/bin/hive ; argv[]=/u/bin/hive serve ; ignore_errors=no ; … }
+//
+// Matching against the whole record would let an unrelated field satisfy the
+// check — `path=` alone repeats the binary, and the trailing status fields are
+// attacker-free but noise. Reading `argv[]` narrows the match to the command the
+// unit will actually run.
+//
+// A plain value (no `argv[]=`) is returned unchanged: `--value` output and the
+// empty string for an unknown unit both take that path, and neither should be
+// mangled here.
+func execArgv(record string) string {
+	const key = "argv[]="
+	i := strings.Index(record, key)
+	if i < 0 {
+		return record
+	}
+	rest := record[i+len(key):]
+	// Fields are ` ; `-separated inside the record.
+	if j := strings.Index(rest, " ; "); j >= 0 {
+		rest = rest[:j]
+	}
+	return strings.TrimSpace(rest)
 }

--- a/cli/internal/doctor/checks_agent_reach_test.go
+++ b/cli/internal/doctor/checks_agent_reach_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 )
 
-// found/notFound build the LookPath seam for a set of binaries that resolve.
+// lookPathFor builds the LookPath seam: the named binaries resolve, everything
+// else reports "not found". The check keys three distinct outcomes off this
+// (no systemctl, no hive, both present), so each test states its host exactly.
 func lookPathFor(present ...string) func(string) (string, error) {
 	set := map[string]bool{}
 	for _, p := range present {
@@ -21,13 +23,32 @@ func lookPathFor(present ...string) func(string) (string, error) {
 	}
 }
 
-// unitSeam fakes `systemctl show -p ExecStart -p Environment`, which returns one
-// Key=value line per requested directive.
+// unitSeam fakes `systemctl show -p ExecStart -p Environment` in the format it
+// REALLY prints. ExecStart is not a bare command but a record:
+//
+//	ExecStart={ path=… ; argv[]=… ; ignore_errors=no ; start_time=[n/a] ; … }
+//
+// The first version of these tests fed a plain command string, so all seven
+// passed against a format systemd never emits. Captured verbatim from
+// `systemctl --user show hive.service` on msi, 2026-08-24 — the same defect
+// lesson 230 in this very PR is about, caught by the reviewer rather than by me.
+//
+// An empty execStart reproduces an unknown unit, where systemctl prints no
+// ExecStart line at all.
 func unitSeam(execStart, environment string) func(string, ...string) (string, error) {
-	out := "ExecStart=" + execStart + "\nEnvironment=" + environment + "\n"
+	var out string
+	if execStart != "" {
+		bin, _, _ := strings.Cut(execStart, " ")
+		out = "ExecStart={ path=" + bin + " ; argv[]=" + execStart +
+			" ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }\n"
+	}
+	out += "Environment=" + environment + "\n"
 	return func(_ string, _ ...string) (string, error) { return out, nil }
 }
 
+// failingSeam makes the systemctl shell-out fail, which is a DIFFERENT state
+// from an empty reading: an unanswered question must never be reported as a
+// clean bill of health.
 func failingSeam(err error) func(string, ...string) (string, error) {
 	return func(_ string, _ ...string) (string, error) { return "", err }
 }
@@ -38,6 +59,30 @@ const (
 	goodExecStart = "/home/u/.local/bin/dotf secrets run --only NAN_API_KEY -- /home/u/.local/bin/hive serve"
 	goodEnv       = "HIVE_WORKER_BASE_URL=https://api.nan.builders/v1"
 )
+
+// The record format, pinned against output captured verbatim from this machine
+// rather than against what the fake produces — otherwise the fake and the parser
+// can agree with each other forever while both disagree with systemd.
+func TestExecArgv_ParsesTheRecordSystemdActuallyPrints(t *testing.T) {
+	const captured = `{ path=/home/manu/.local/bin/hive ; argv[]=/home/manu/.local/bin/hive serve ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }`
+
+	if got, want := execArgv(captured), "/home/manu/.local/bin/hive serve"; got != want {
+		t.Errorf("execArgv = %q, want %q", got, want)
+	}
+	// A record whose argv is fine must not be satisfied by the trailing status
+	// fields, nor truncated by them.
+	if strings.Contains(execArgv(captured), "ignore_errors") {
+		t.Error("execArgv leaked a trailing record field into the command line")
+	}
+	// Plain values pass through: `--value` output and the empty string for an
+	// unknown unit both take that path.
+	if got := execArgv("/u/bin/dotf secrets run -- /u/bin/hive serve"); got != "/u/bin/dotf secrets run -- /u/bin/hive serve" {
+		t.Errorf("a plain command must pass through unchanged, got %q", got)
+	}
+	if got := execArgv(""); got != "" {
+		t.Errorf("empty must stay empty, got %q", got)
+	}
+}
 
 // The criterion's case, and the one measured on this machine: the daemon is
 // supervised and running, every probe says hive is present, and its ExecStart
@@ -128,7 +173,7 @@ func TestHiveBackendCanServe_CredentialInjectedPasses(t *testing.T) {
 	var buf bytes.Buffer
 	rep := capture(&buf)
 	sys := &System{
-		LookPath: lookPathFor("systemctl", "hive"),
+		LookPath:      lookPathFor("systemctl", "hive"),
 		CommandOutput: unitSeam(goodExecStart, goodEnv),
 	}
 

--- a/specs/CLI-042-dotf-agent-run/verification.md
+++ b/specs/CLI-042-dotf-agent-run/verification.md
@@ -166,20 +166,65 @@ the shape it exists to refuse:
 cut by the repo owner's decision. Nothing here may be read as evidence the
 daemon answers.
 
-The measurement to capture on either side of that deploy, which is the whole
-point of the criterion:
+`verify-deployment.sh` in this folder runs every owed check in one command, so
+the closing session reads output rather than re-deriving what to look at:
 
-| | Command | Expected |
-|---|---|---|
-| Before | hive `worker_status` | `Configured: no — set HIVE_WORKER_BASE_URL` *(captured 2026-08-24)* |
-| After | hive `worker_status` | `Configured: yes`, provider reachable |
-| After | `dotf doctor` | the *hive backend reachability* section flips FAIL → PASS |
-| After | `dotf agent run --backend hive --tier mid` | answers, record reports `pool: nan` |
-| Idempotence | second `./setup-linux.sh` | `hive.service credential drop-in already current (no restart)` |
+```bash
+./specs/CLI-042-dotf-agent-run/verify-deployment.sh
+```
 
-Until that runs, **AC6 and AC7 are not closed and CLI-042 must not archive.**
-The doctor section going red on this machine right now is not a defect in the
-check — it is the check working, and the deploy is what turns it green.
+It never prints a credential — it reports variable NAMES and counts, and proves
+the key works by consequence (the daemon answers).
+
+**The BEFORE state, captured 2026-08-25T03:25Z, before any deploy.** This is
+perishable evidence: it stops existing the moment `./setup-linux.sh` runs, so it
+is frozen here rather than described.
+
+```
+=== AC7 — the credential reaches the daemon, and lives in no file ===
+[FAIL] drop-in NOT deployed — ./setup-linux.sh has not run, or its hive block was skipped
+[FAIL] loaded ExecStart has NO credential injection (the drop-in did not take effect)
+[FAIL] HIVE_WORKER_BASE_URL absent — the worker stays unconfigured even WITH a key
+[FAIL] the running daemon does NOT hold HIVE_WORKER_API_KEY — restart it, or the injection failed
+[OK]   no credential-shaped assignment in hive.env or any environment.d fragment
+
+=== AC9 — doctor catches 'probes present, serves nothing' ===
+[FAIL] dotf doctor printed neither verdict — is the installed binary older than this check?
+
+=== AI-030 — the pi packages the same deploy installs ===
+[FAIL] pi packages: 0 installed, manifest declares 9
+
+pass=1 fail=6 skip=1   (--no-dispatch)
+```
+
+Corroborated independently at the same moment, from the daemon itself and from
+the kernel:
+
+| Source | Reading |
+|---|---|
+| hive `worker_status` | `Configured: no — set HIVE_WORKER_BASE_URL` |
+| `systemctl show -p ExecStart` | `argv[]=/home/manu/.local/bin/hive serve` — no injection |
+| `systemctl show -p Environment` | `VAULT_PATH=…` only |
+| `/proc/<pid>/environ`, NAMES only | **0** credential-shaped variables |
+| `~/.config/systemd/user/hive.service.d/` | does not exist |
+
+**The AFTER state is what the same script must print**: every line `[OK]`, exit 0,
+including the live dispatch answering with `pool: nan`.
+
+**A third thing the deploy fixes, found while writing this:** the installed
+`~/.local/bin/dotf` has **no `agent run` subcommand at all**. The binary predates
+PR B. Every PR of this epic is merged to main and not one of them is live on this
+machine — the two-tier deploy rule in its purest form, and the reason the script
+checks the installed binary rather than the source tree.
+
+Until this runs, **AC6 and AC7 are not closed and CLI-042 must not archive.**
+The doctor section going red here is not a defect in the check — it is the check
+working, and the deploy is what turns it green.
+
+**Idempotence** is not asserted by the script: run `./setup-linux.sh` a second
+time and confirm it prints `hive.service credential drop-in already current (no
+restart)` and installs 0 pi packages. A deploy that changes something on every
+pass is not IaC.
 
 ### The finding that shaped this PR
 

--- a/specs/CLI-042-dotf-agent-run/verify-deployment.sh
+++ b/specs/CLI-042-dotf-agent-run/verify-deployment.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# CLI-042 — post-deploy verification, by consequence.
+#
+# The criteria this closes cannot be verified from the repository. AC6 asks
+# whether hive ANSWERS and AC7 asks whether the daemon holds a credential it was
+# never given at rest — both are properties of a machine after `./setup-linux.sh`
+# has run, not of a diff.
+#
+# Run this AFTER the deploy. It replaces the checklist in verification.md with a
+# single command, so the closing session reads output instead of re-deriving what
+# to check.
+#
+#   ./specs/CLI-042-dotf-agent-run/verify-deployment.sh
+#   ./specs/CLI-042-dotf-agent-run/verify-deployment.sh --no-dispatch   # skip the live request
+#
+# SECRETS: this script never prints a credential. It reports variable NAMES and
+# counts, and proves the credential works by CONSEQUENCE (the daemon answers).
+# Printing a value to show it exists is the failure, not the verification.
+
+set -uo pipefail
+
+DISPATCH=1
+[ "${1:-}" = "--no-dispatch" ] && DISPATCH=0
+
+pass=0; fail=0; skip=0
+ok()   { printf '[OK]   %s\n' "$1"; pass=$((pass + 1)); }
+bad()  { printf '[FAIL] %s\n' "$1"; fail=$((fail + 1)); }
+note() { printf '[SKIP] %s\n' "$1"; skip=$((skip + 1)); }
+hdr()  { printf '\n=== %s ===\n' "$1"; }
+
+hdr "AC7 — the credential reaches the daemon, and lives in no file"
+
+DROPIN="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/hive.service.d/10-dotf-secrets.conf"
+if [ -f "$DROPIN" ]; then
+    ok "drop-in deployed at $DROPIN"
+else
+    bad "drop-in NOT deployed — ./setup-linux.sh has not run, or its hive block was skipped"
+fi
+
+# The unit systemd actually loaded, not the file on disk: a drop-in that failed
+# to parse leaves the base unit in force and `systemctl` is the only witness.
+EXECSTART="$(systemctl --user show hive.service -p ExecStart 2>/dev/null)"
+case "$EXECSTART" in
+    *"secrets run"*NAN_API_KEY*) ok "loaded ExecStart injects the credential via dotf secrets run" ;;
+    "")                          bad "hive.service not found — is the daemon installed?" ;;
+    *)                           bad "loaded ExecStart has NO credential injection (the drop-in did not take effect)" ;;
+esac
+
+ENVIRON="$(systemctl --user show hive.service -p Environment 2>/dev/null)"
+case "$ENVIRON" in
+    *HIVE_WORKER_BASE_URL=*) ok "loaded unit declares HIVE_WORKER_BASE_URL (the contract's other half)" ;;
+    *)                       bad "HIVE_WORKER_BASE_URL absent — the worker stays unconfigured even WITH a key" ;;
+esac
+
+# NAMES only. A count is evidence; a value in a transcript is an incident.
+PID="$(systemctl --user show hive.service -p MainPID --value 2>/dev/null)"
+if [ -n "$PID" ] && [ "$PID" != "0" ] && [ -r "/proc/$PID/environ" ]; then
+    if tr '\0' '\n' < "/proc/$PID/environ" | cut -d= -f1 | grep -qx 'HIVE_WORKER_API_KEY'; then
+        ok "the RUNNING daemon holds HIVE_WORKER_API_KEY (name observed, value never read)"
+    else
+        bad "the running daemon does NOT hold HIVE_WORKER_API_KEY — restart it, or the injection failed"
+    fi
+else
+    note "daemon not running, so its environment could not be inspected"
+fi
+
+# The whole point of AC7: nothing on disk. A credential in an EnvironmentFile or
+# an environment.d fragment would satisfy every check above and defeat the criterion.
+LEAK=0
+for f in "$HOME/.config/hive/hive.env" "${XDG_CONFIG_HOME:-$HOME/.config}"/environment.d/*.conf; do
+    [ -f "$f" ] || continue
+    if grep -qE '^[[:space:]]*(export[[:space:]]+)?[A-Za-z_]*(API_KEY|TOKEN|SECRET|PASSWORD)[A-Za-z_]*=' "$f"; then
+        bad "a credential-shaped assignment is on disk in $f"
+        LEAK=1
+    fi
+done
+[ "$LEAK" -eq 0 ] && ok "no credential-shaped assignment in hive.env or any environment.d fragment"
+
+hdr "AC9 — doctor catches 'probes present, serves nothing'"
+
+if command -v dotf >/dev/null 2>&1; then
+    DOC="$(dotf doctor 2>&1)"
+    if printf '%s' "$DOC" | grep -q 'can serve nothing'; then
+        bad "dotf doctor still reports the backend serving nothing — the deploy did not take"
+    elif printf '%s' "$DOC" | grep -q 'can reach its pool'; then
+        ok "dotf doctor reports the hive backend can reach its pool"
+    else
+        bad "dotf doctor printed neither verdict — is the installed binary older than this check?"
+    fi
+else
+    note "dotf not on PATH"
+fi
+
+hdr "AC6 — the backend actually answers (one live request)"
+
+if [ "$DISPATCH" -eq 0 ]; then
+    note "live dispatch skipped by --no-dispatch"
+elif ! command -v dotf >/dev/null 2>&1; then
+    note "dotf not on PATH"
+elif ! dotf agent run --help >/dev/null 2>&1; then
+    bad "the INSTALLED dotf has no 'agent run' — the binary predates the epic; re-run ./setup-linux.sh"
+else
+    REC="$(dotf agent run --backend hive --tier mid --role reviewer \
+            --task 'Reply with the single word: ok' --timeout 2m 2>/dev/null)"
+    STATUS="$(printf '%s' "$REC" | jq -r '.status // "unparseable"' 2>/dev/null)"
+    POOL="$(printf '%s' "$REC" | jq -r '.pool // "-"' 2>/dev/null)"
+    if [ "$STATUS" = "ok" ] && [ "$POOL" = "nan" ]; then
+        ok "hive answered; record reports pool=nan as the chain declared"
+    else
+        bad "dispatch did not answer as expected (status=$STATUS pool=$POOL)"
+    fi
+fi
+
+hdr "AI-030 — the pi packages the same deploy installs"
+
+PI_SETTINGS="$HOME/.pi/agent/settings.json"
+DECLARED="$(jq -r '.packages | length' "$(git rev-parse --show-toplevel)/ai/pi/packages.json" 2>/dev/null || echo 0)"
+LIVE="$(jq -r '.packages // [] | length' "$PI_SETTINGS" 2>/dev/null || echo 0)"
+if [ "$DECLARED" -gt 0 ] && [ "$LIVE" -ge "$DECLARED" ]; then
+    ok "$LIVE pi packages installed (manifest declares $DECLARED)"
+else
+    bad "pi packages: $LIVE installed, manifest declares $DECLARED"
+fi
+
+hdr "Idempotence"
+printf 'Not asserted here — run ./setup-linux.sh a SECOND time and confirm it prints\n'
+printf '  "hive.service credential drop-in already current (no restart)"\n'
+printf 'and installs 0 pi packages. A deploy that changes something on every pass is not IaC.\n'
+
+printf '\n%s\n' "----------------------------------------"
+printf 'pass=%d fail=%d skip=%d\n' "$pass" "$fail" "$skip"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Follow-up to #1230. This is the reviewer fix that **missed that PR's merge by
five minutes** — #1230 merged at 03:04:33Z containing only its first commit, the
branch was deleted, and my push at 03:09:36Z re-created it. The push reported
`[new branch]` and I did not read it. Disclosed rather than quietly re-landed.

## What is wrong on main right now

`systemctl show -p ExecStart` does not return a command line. It returns a record:

```
ExecStart={ path=/home/manu/.local/bin/hive ; argv[]=/home/manu/.local/bin/hive serve ; ignore_errors=no ; start_time=[n/a] ; … }
```

**The check on main is not broken** — its substring matches survive, because
`argv[]` carries the same text. **Its tests are.** The seam feeds a plain command
string, so all seven cases pass against a format systemd never emits. They
validate a fiction, and would keep passing through a rewrite that broke the real
parse.

## What this changes

- `execArgv` extracts the `argv[]` field, narrowing the match to the command the
  unit will actually run rather than letting an unrelated record field satisfy it.
- The test seam emits the real record format, captured verbatim from
  `systemctl --user show hive.service` on msi.
- A new `TestExecArgv_ParsesTheRecordSystemdActuallyPrints` pins that format
  against the captured string, so the fake and the parser cannot agree with each
  other while both disagree with systemd.
- Splits two doc comments a bad insertion had merged into one attributed to the
  wrong function; documents the remaining test seams (CodeRabbit's coverage
  warning on #1230).

## Why it matters beyond the tests

This is the same defect as `docs/lessons/lesson-230-*`, which #1230 itself adds:
asserting the shape of a thing instead of what it does. Committed by the author
of that lesson, in the PR that introduces it, caught by the reviewer. The lesson
now has a second instance and the check has a real format test.

## Verification

`go build` / `go vet` / `GOOS=windows go vet` clean · `go test -count=1 ./...`
exit 0 · `golangci-lint` (pinned 2.12.2) **0 issues** ·
`bats tests/agent-runtime-deployment.bats` 14/14.