### PR TITLE
fix(cli-042): the post-deploy check reported FAIL when healthy and SKIP when dead

### DIFF
--- a/docs/lessons/lesson-230-a-config-that-parses-is-not-a-config-the-consumer-re.md
+++ b/docs/lessons/lesson-230-a-config-that-parses-is-not-a-config-the-consumer-re.md
@@ -91,3 +91,52 @@ it done. The tool that would have told me in one call was already installed.
   from `dotf doctor` would put an MCP client inside a diagnostic. A proxy whose
   limit is written down is honest; one whose limit is implied is this lesson
   repeating.
+
+## Recurrence — 2026-08-25, three more instances in the guard written for this lesson
+
+The verification script added to close CLI-042 carried this same defect three
+times over. All three were found by running it on a deployed machine, and none
+was visible from reading it:
+
+| Check | Asked the form | What it should ask |
+|---|---|---|
+| AC9 | does `dotf doctor` print the verdict string? | doctor **summarises** passing sections, so the string appears only under `--verbose` — the passing branch was unreachable and reported FAIL on a satisfied criterion |
+| AC7 daemon | does `MainPID` hold the credential? | `dotf secrets run` forks and stays as supervisor, so `MainPID` is the supervisor, whose environment correctly has no credential — the serving child had it all along |
+| AC7 state | is the daemon running? | "not running" conflates *never started* with *started and died*; a crash-looping daemon was reported as a benign SKIP |
+
+A fourth was caught by the reviewer on the PR fixing the first three: the new
+failure detector **enumerated** `Result=` failure modes and missed `watchdog`,
+reintroducing the same false-benign report one value along. Fixed by inverting
+the test — `success` is the only value whose meaning is fixed; anything else is
+a failure, including values systemd has not defined yet.
+
+**Every one failed in the direction that reads as health.** A satisfied criterion
+reported as broken is the benign direction and it still cost a session; the other
+three would have signed off on a dead daemon.
+
+The sharpest instance is AC7: the script printed *"the running daemon does NOT
+hold HIVE_WORKER_API_KEY"* ten lines above *"hive answered; record reports
+pool=nan"*. **The output contradicted itself and the run still exited 1 on the
+wrong criterion.** Two checks of the same system disagreeing is a signal to
+believe the one that measures consequence.
+
+## Recurrence — the mirror failure, same day
+
+The same session nearly shipped a fix for a defect that did not exist. hive
+crash-looped after the deploy; its journal said `exec: "bw": executable file not
+found in $PATH`, and I wrote up a finding — as fact — that the drop-in's
+convergence design was defeated and the daemon would never recover. The implied
+fix was rendering the nvm bin directory into the unit's PATH at setup.
+
+`dotf secrets` resolves over the **bw serve daemon**, not the CLI. The CLI is a
+fallback consulted only while the vault is locked. One `dotf secrets unlock`
+later the daemon converged on its next retry with the PATH untouched, exactly as
+the drop-in's own comment said it would.
+
+So this lesson has two directions, not one. Reasoning about an artifact instead
+of measuring its consumer produces **false greens** when you are writing a check
+and **false reds** when you are writing a finding. The remedy is identical and it
+is not more tests: *run the thing and ask the consumer*. Ticketed as #1237,
+because the misleading message is real — it names the fallback's incidental
+problem instead of the actionable cause, and it appears in the journal, which is
+read during an incident by someone who does not yet know why the service is down.

--- a/specs/CLI-042-dotf-agent-run/verify-deployment.sh
+++ b/specs/CLI-042-dotf-agent-run/verify-deployment.sh
@@ -53,13 +53,56 @@ case "$ENVIRON" in
 esac
 
 # NAMES only. A count is evidence; a value in a transcript is an incident.
+# The credential lands in the process that SERVES, and that is not the process systemd
+# calls Main. `dotf secrets run` forks and stays on as supervisor -- #1230 gave it
+# SIGINT/SIGTERM forwarding precisely because that change made it a daemon supervisor
+# for the first time -- so MainPID is `dotf secrets run` itself, and its OWN environment
+# correctly holds no credential. The injection targets the child, which is the point:
+# the supervisor resolves the secret without ever putting it in its own environment.
+#
+# Measured 2026-08-25 on msi with the daemon healthy and AC6 green:
+#   162154  dotf secrets run --only NAN_API_KEY -- .../hive serve   <- MainPID, 56 vars, no credential
+#   162175  .../python3 .../hive serve                              <- 58 vars, HIVE_WORKER_API_KEY present
+#
+# Reading MainPID printed "the running daemon does NOT hold HIVE_WORKER_API_KEY" on a
+# machine where hive was answering dispatches over that very credential -- a FAIL on a
+# criterion that was satisfied, contradicted by the AC6 check ten lines below it.
+#
+# So: scan every process in the unit's cgroup rather than one PID. That is robust to
+# fork-vs-exec and to which process systemd happens to consider Main. MainPID is folded
+# in as well, to stay correct if `dotf secrets run` ever exec's instead of forking.
+CGROUP="$(systemctl --user show hive.service -p ControlGroup --value 2>/dev/null)"
 PID="$(systemctl --user show hive.service -p MainPID --value 2>/dev/null)"
-if [ -n "$PID" ] && [ "$PID" != "0" ] && [ -r "/proc/$PID/environ" ]; then
-    if tr '\0' '\n' < "/proc/$PID/environ" | cut -d= -f1 | grep -qx 'HIVE_WORKER_API_KEY'; then
-        ok "the RUNNING daemon holds HIVE_WORKER_API_KEY (name observed, value never read)"
-    else
-        bad "the running daemon does NOT hold HIVE_WORKER_API_KEY — restart it, or the injection failed"
+UNIT_PIDS=""
+if [ -n "$CGROUP" ] && [ -r "/sys/fs/cgroup${CGROUP}/cgroup.procs" ]; then
+    UNIT_PIDS="$(cat "/sys/fs/cgroup${CGROUP}/cgroup.procs" 2>/dev/null)"
+fi
+if [ -n "$PID" ] && [ "$PID" != "0" ]; then
+    UNIT_PIDS="$UNIT_PIDS
+$PID"
+fi
+
+# Line-by-line, never `for p in $UNIT_PIDS`: zsh does not word-split an unquoted
+# parameter, so that form yields one field holding every pid. Same prohibited-pattern
+# row that made the on-disk scan a false all-clear on #1232.
+HOLDER=""
+INSPECTED=0
+while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    [ -r "/proc/$p/environ" ] || continue
+    INSPECTED=$((INSPECTED + 1))
+    if tr '\0' '\n' < "/proc/$p/environ" 2>/dev/null | cut -d= -f1 | grep -qx 'HIVE_WORKER_API_KEY'; then
+        HOLDER="$p"
+        break
     fi
+done <<UNIT_PID_LIST
+$UNIT_PIDS
+UNIT_PID_LIST
+
+if [ -n "$HOLDER" ]; then
+    ok "a process in hive.service holds HIVE_WORKER_API_KEY (pid $HOLDER; name observed, value never read)"
+elif [ "$INSPECTED" -gt 0 ]; then
+    bad "none of the $INSPECTED process(es) in hive.service holds HIVE_WORKER_API_KEY — the injection failed"
 else
     # "Not running" is two different states and only one of them is benign. A unit that
     # was never started is genuinely un-inspectable, and a SKIP is honest. A unit that

--- a/specs/CLI-042-dotf-agent-run/verify-deployment.sh
+++ b/specs/CLI-042-dotf-agent-run/verify-deployment.sh
@@ -120,14 +120,24 @@ else
     STATE="$(systemctl --user show hive.service -p ActiveState --value 2>/dev/null)"
     RESULT="$(systemctl --user show hive.service -p Result --value 2>/dev/null)"
     RESTARTS="$(systemctl --user show hive.service -p NRestarts --value 2>/dev/null)"
-    case "${STATE}/${RESULT}" in
-        failed/*|*/exit-code|*/signal|*/core-dump|*/timeout|*/oom-kill)
-            bad "hive.service STARTED AND DIED (ActiveState=$STATE Result=$RESULT NRestarts=${RESTARTS:-0}) — journalctl --user -u hive.service -n 20"
-            ;;
-        *)
-            note "daemon not running (ActiveState=${STATE:-unknown}), so its environment could not be inspected"
-            ;;
-    esac
+    # Test for success, never for a list of failures. The first draft enumerated
+    # exit-code|signal|core-dump|timeout|oom-kill and thereby missed `watchdog`, which
+    # would have been reported as a benign SKIP -- the very bug this block exists to
+    # fix, reintroduced one value along. Caught by the reviewer on this PR.
+    #
+    # systemd defines at least ten Result= values (success, protocol, timeout,
+    # exit-code, signal, core-dump, watchdog, start-limit-hit, resources, oom-kill) and
+    # is free to add more. Any enumeration of failure modes is a list that goes stale;
+    # `success` is the one value whose meaning is fixed. Inverting the test also fails
+    # in the safe direction: an unrecognised Result reads as a failure, not as health.
+    #
+    # ActiveState=failed is kept as a separate arm because a unit can be failed while
+    # Result= has not yet been set to anything meaningful.
+    if [ "$STATE" = "failed" ] || { [ -n "$RESULT" ] && [ "$RESULT" != "success" ]; }; then
+        bad "hive.service STARTED AND DIED (ActiveState=$STATE Result=$RESULT NRestarts=${RESTARTS:-0}) — journalctl --user -u hive.service -n 20"
+    else
+        note "daemon not running (ActiveState=${STATE:-unknown}), so its environment could not be inspected"
+    fi
 fi
 
 # The whole point of AC7: nothing on disk. A credential in an EnvironmentFile or

--- a/specs/CLI-042-dotf-agent-run/verify-deployment.sh
+++ b/specs/CLI-042-dotf-agent-run/verify-deployment.sh
@@ -61,7 +61,30 @@ if [ -n "$PID" ] && [ "$PID" != "0" ] && [ -r "/proc/$PID/environ" ]; then
         bad "the running daemon does NOT hold HIVE_WORKER_API_KEY — restart it, or the injection failed"
     fi
 else
-    note "daemon not running, so its environment could not be inspected"
+    # "Not running" is two different states and only one of them is benign. A unit that
+    # was never started is genuinely un-inspectable, and a SKIP is honest. A unit that
+    # STARTED AND DIED is a failure, and a SKIP there reports the criterion as merely
+    # unverified while the daemon crash-loops in the background.
+    #
+    # Measured 2026-08-25 on msi: hive.service sat in `activating (auto-restart)` after
+    # five consecutive exit-code failures, and this block printed its SKIP. The run
+    # reported pass=5 fail=2 with the daemon dead -- and neither failure was this one.
+    # Only AC6's dispatch caught it, for an unrelated reason.
+    #
+    # Result= is the discriminator, not ActiveState=: a crash-looping unit reads
+    # ActiveState=activating (indistinguishable from a healthy slow start) while
+    # Result= already records exit-code.
+    STATE="$(systemctl --user show hive.service -p ActiveState --value 2>/dev/null)"
+    RESULT="$(systemctl --user show hive.service -p Result --value 2>/dev/null)"
+    RESTARTS="$(systemctl --user show hive.service -p NRestarts --value 2>/dev/null)"
+    case "${STATE}/${RESULT}" in
+        failed/*|*/exit-code|*/signal|*/core-dump|*/timeout|*/oom-kill)
+            bad "hive.service STARTED AND DIED (ActiveState=$STATE Result=$RESULT NRestarts=${RESTARTS:-0}) — journalctl --user -u hive.service -n 20"
+            ;;
+        *)
+            note "daemon not running (ActiveState=${STATE:-unknown}), so its environment could not be inspected"
+            ;;
+    esac
 fi
 
 # The whole point of AC7: nothing on disk. A credential in an EnvironmentFile or
@@ -149,8 +172,24 @@ CANDIDATE_LIST
 
 hdr "AC9 — doctor catches 'probes present, serves nothing'"
 
+# --verbose is load-bearing, not cosmetic. `dotf doctor` SUMMARISES a section whose
+# checks all pass -- it prints "(1 checks, all ok)" and never the check's own message --
+# so the healthy verdict this block greps for is emitted ONLY under --verbose. Without
+# it the `ok` branch below is unreachable: a healthy machine falls through to "printed
+# neither verdict" and the criterion reports FAIL precisely when it is satisfied.
+#
+# Measured 2026-08-25 on msi, after the deploy that made this check green:
+#   dotf doctor           -> [hive backend reachability (dotf agent run)]
+#                            (1 checks, all ok)
+#   dotf doctor --verbose -> [ OK ] hive.service carries both halves of the worker
+#                            contract -- the backend can reach its pool
+#
+# Third time this spec has shipped a check that asks the FORM of a thing instead of
+# what it does (lesson 230). The failing half worked -- 'can serve nothing' is printed
+# unconditionally, because a FAILING check is never summarised away. Only the passing
+# half was unreachable, which is why nothing caught it until a green machine ran it.
 if command -v dotf >/dev/null 2>&1; then
-    DOC="$(dotf doctor 2>&1)"
+    DOC="$(dotf doctor --verbose 2>&1)"
     if printf '%s' "$DOC" | grep -q 'can serve nothing'; then
         bad "dotf doctor still reports the backend serving nothing — the deploy did not take"
     elif printf '%s' "$DOC" | grep -q 'can reach its pool'; then


### PR DESCRIPTION
## What

Two defects in `specs/CLI-042-dotf-agent-run/verify-deployment.sh`, both surfaced by running it on the machine the deploy had just made green.

### 1. The AC9 branch could never pass on a healthy machine

It greps `dotf doctor` for the verdict `can reach its pool`. `dotf doctor` **summarises** a section whose checks all pass — it prints `(1 checks, all ok)` and never the check's own message — so that string is emitted only under `--verbose`.

```
$ dotf doctor
[hive backend reachability (dotf agent run)]
  (1 checks, all ok)

$ dotf doctor --verbose
  [ OK ] hive.service carries both halves of the worker contract — the backend can reach its pool
```

The passing branch was unreachable: a healthy machine fell through to `printed neither verdict` and the criterion reported **FAIL precisely when it was satisfied**. The failing half worked all along, because a failing check is never summarised away — which is why nothing caught this until a green machine ran it.

### 2. A crash-looping daemon was reported as SKIP

The AC7 probe treated "not running" as one state. A unit that was never started is genuinely un-inspectable and a SKIP is honest. A unit that **started and died** is a failure.

Measured here: `hive.service` sat in `activating (auto-restart)` after five consecutive `exit-code` failures, and the run still reported `pass=5` — with neither of its two failures being that one. Only AC6's dispatch caught the dead daemon, and for an unrelated reason.

`Result=` is the discriminator, not `ActiveState=`: a crash-looping unit reads `ActiveState=activating`, indistinguishable from a healthy slow start, while `Result=` already records `exit-code`.

## Evidence

Run against the live crash loop, `bash` and `zsh`, identical output:

| | before | after |
|---|---|---|
| AC9 | `[FAIL] printed neither verdict` | `[OK] can reach its pool` |
| AC7 daemon | `[SKIP] daemon not running` | `[FAIL] STARTED AND DIED (NRestarts=14)` |

`NRestarts` incremented 14 → 15 between the bash and zsh runs, confirming the loop was live rather than a stale state.

```
shellcheck  clean
bash -n     OK
zsh  -n     OK
```

## Notes

Third time this spec has shipped a check that asks the **form** of a thing instead of what it does (lesson 230). Both defects fail in the direction that reads as health: one reported a satisfied criterion as broken, the other reported a dead daemon as merely unverified.

No issue footer, on purpose — this is a sub-PR of a multi-PR sequence and release-please aggregates any footer issue mention into the release's `closes` list regardless of keyword. That hazard fired for the fourth time on the last release.

SDD: 12 executable lines, obvious-cause bug fixes to spec verification machinery; touches `specs/CLI-042-dotf-agent-run/` either way.