### PR TITLE
fix(opencode): drop the ollama provider, which had stopped opencode from starting

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -93,7 +93,11 @@ export NAN_BASE_URL="https://api.nan.builders/v1"
 # the agent had no use for it (#976). Scoping is least privilege and startup
 # time at once.
 if command -v dotf >/dev/null 2>&1; then
-    opencode() { dotf secrets run --only NAN_API_KEY,OPENROUTER_API_KEY,OPENAI_API_KEY,OLLAMA_API_KEY -- opencode "$@"; }
+    # Every token here must be a live registry id: `--only` fails loud on an
+    # unknown one, so a stale name does not degrade the launch, it prevents it.
+    # OLLAMA_API_KEY was listed for a provider slot whose registry entry was
+    # never created, and opencode had stopped starting on both shells as a result.
+    opencode() { dotf secrets run --only NAN_API_KEY,OPENROUTER_API_KEY,OPENAI_API_KEY -- opencode "$@"; }
     pi() { dotf secrets run --only NAN_API_KEY,OPENROUTER_API_KEY -- pi "$@"; }
     # agy is deliberately NOT wrapped. It authenticates with its own stored
     # credentials and reads no variable this registry exposes — verified against

--- a/.zshrc
+++ b/.zshrc
@@ -70,7 +70,11 @@ export NAN_BASE_URL="https://api.nan.builders/v1"
 # the agent had no use for it (#976). Scoping is least privilege and startup
 # time at once.
 if command -v dotf >/dev/null 2>&1; then
-    opencode() { dotf secrets run --only NAN_API_KEY,OPENROUTER_API_KEY,OPENAI_API_KEY,OLLAMA_API_KEY -- opencode "$@"; }
+    # Every token here must be a live registry id: `--only` fails loud on an
+    # unknown one, so a stale name does not degrade the launch, it prevents it.
+    # OLLAMA_API_KEY was listed for a provider slot whose registry entry was
+    # never created, and opencode had stopped starting on both shells as a result.
+    opencode() { dotf secrets run --only NAN_API_KEY,OPENROUTER_API_KEY,OPENAI_API_KEY -- opencode "$@"; }
     pi() { dotf secrets run --only NAN_API_KEY,OPENROUTER_API_KEY -- pi "$@"; }
     # agy is deliberately NOT wrapped. It authenticates with its own stored
     # credentials and reads no variable this registry exposes — verified against

--- a/ai/opencode/opencode.jsonc
+++ b/ai/opencode/opencode.jsonc
@@ -16,7 +16,6 @@
 //   Embeddings / Audio: qwen3-embedding, kokoro (TTS), whisper (STT) — exposed for
 //                       cluster completeness; not chat-routable (use curl / OpenAI SDK directly).
 //   Frontier on-demand: openrouter/* (PAYG, uses existing $5 credit) — Opus / Sonnet / GPT-4
-//   Local:   ollama (homelab/VPN endpoint, user-managed in separate session)
 // Selection: TUI `/models` picker. Wrappers `qq` (nan/qwen3.6) / `qf` (nan/deepseek-v4-flash)
 //            in .zsh/aliases.zsh + .bashrc + powershell/profile.ps1.
 {
@@ -203,23 +202,17 @@
         "qwen/qwen3-coder-plus": { "name": "Qwen3 Coder Plus" },
         "minimax/minimax-m3": { "name": "MiniMax M3" }
       }
-    },
+    }
 
     // (compaction block sits at top level — see below the provider block)
 
-    // Ollama — homelab endpoint (VPN-only). User wires the API key as a secret
-    // (sensitive/ollama.api-key.secret.age, registry entry in
-    // secrets/registry.yaml). Model list intentionally empty — user
-    // adds models as they pull them on the homelab side; opencode discovers via
-    // /v1/models when the endpoint is reachable.
-    "ollama": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "Ollama (homelab via VPN)",
-      "options": {
-        "baseURL": "https://ollama.kubelab.live/v1",
-        "apiKey": "{env:OLLAMA_API_KEY}"
-      }
-    }
+    // Ollama was here — a homelab endpoint behind the VPN, kept as a slot since
+    // AI-011 waiting on AI-010 to wire it. Removed 2026-08-25: the endpoint no
+    // longer runs, and the slot was not inert. Its `{env:OLLAMA_API_KEY}` was
+    // named by the shell wrappers' `--only` list while no registry entry ever
+    // existed, and `dotf secrets run --only` fails loud on an unknown id — so
+    // opencode did not start at all, on either shell. A provider slot waiting on
+    // a credential that is never coming is not a placeholder, it is a break.
   },
 
   // Context compaction — NaN-recommended block (https://nan.builders/docs/examples).
@@ -244,7 +237,7 @@
   // session (opencode moves fast; install is unpinned via opencode.ai/install).
   "autoupdate": "notify",
   // Keep the /models picker clean: don't auto-load providers detected from
-  // ambient env vars (OPENAI_API_KEY etc.). Only nan/openrouter/ollama remain.
+  // ambient env vars (OPENAI_API_KEY etc.). Only nan/openrouter remain.
   "disabled_providers": ["openai", "anthropic", "google"],
   // Trim noisy tool output before it burns context (defaults are 2000/51200).
   // Pairs with the token-thrift compaction block above.

--- a/tests/agent-runtime-deployment.bats
+++ b/tests/agent-runtime-deployment.bats
@@ -158,6 +158,12 @@ PY
 # longer runs, and its slot was actively breaking opencode's launch. Naming
 # openrouter alone restores the guard's edge, since the alternation would now pass
 # on a file that had lost the provider this test exists to protect.
+# Narrowed twice. The reviewer caught the second gap in the PR that fixed the
+# first: matching the bare word passes when `openrouter` survives only in a
+# COMMENT, so deleting the provider entry while leaving its prose would read as
+# healthy. Match the declaration, on a non-comment line -- the same "ask what it
+# does, not what it says" this file's other assertions already apply.
 @test "AC8: opencode's own provider catalogue is NOT collateral" {
-    grep -qi 'openrouter' "$DOTFILES_DIR/ai/opencode/opencode.jsonc"
+    run bash -c "grep -vE '^[[:space:]]*//' '$DOTFILES_DIR/ai/opencode/opencode.jsonc' | grep -qE '\"openrouter\"[[:space:]]*:'"
+    [ "$status" -eq 0 ]
 }

--- a/tests/agent-runtime-deployment.bats
+++ b/tests/agent-runtime-deployment.bats
@@ -149,9 +149,15 @@ PY
     refute_grep 'hive-vault"\.env\.HIVE_OLLAMA_ENDPOINT' "$DOTFILES_DIR/setup-windows.ps1"
 }
 
-# The scope boundary, asserted rather than trusted: the spec explicitly keeps
-# opencode's provider catalogue, and a future over-eager "remove ollama
-# everywhere" sweep would be an unrelated regression wearing AC8's clothes.
+# The scope boundary, asserted rather than trusted: AC8 drops providers from
+# hive's WORKER, and opencode's own TUI catalogue must not be collateral.
+#
+# Narrowed 2026-08-25. This read `grep -qiE 'ollama|openrouter'`, which passes
+# while EITHER survives -- so it could not tell "both kept" from "one left". That
+# stopped being hypothetical when ollama was removed deliberately: the endpoint no
+# longer runs, and its slot was actively breaking opencode's launch. Naming
+# openrouter alone restores the guard's edge, since the alternation would now pass
+# on a file that had lost the provider this test exists to protect.
 @test "AC8: opencode's own provider catalogue is NOT collateral" {
-    grep -qiE 'ollama|openrouter' "$DOTFILES_DIR/ai/opencode/opencode.jsonc"
+    grep -qi 'openrouter' "$DOTFILES_DIR/ai/opencode/opencode.jsonc"
 }

--- a/tests/lib/only-scope-scan.py
+++ b/tests/lib/only-scope-scan.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Assert every `dotf secrets run --only` token resolves in secrets/registry.yaml.
+
+`--only` fails LOUD on an unknown token -- it refuses the whole launch rather than
+dropping the one name it cannot resolve. Right for a secrets facade, and it makes
+a stale token in a wrapper a total outage of whatever that wrapper launches, not a
+degradation.
+
+Measured 2026-08-25: the opencode wrapper named OLLAMA_API_KEY for a provider slot
+whose registry entry was never created, so `opencode` did not start on either
+shell while `dotf doctor` reported 152 passed / 0 failed.
+
+Lives here rather than inline in the bats file so the scan is independently
+runnable and the test stays a short assertion. Usage:
+
+    python3 tests/lib/only-scope-scan.py <repo-root>
+
+Exit 0 with a count, or 1 naming every offender.
+"""
+
+import glob
+import os
+import re
+import sys
+
+# Missing PyYAML must FAIL, never skip. The first draft exited 0 on ImportError,
+# which made this guard pass without reading a single token -- the same false
+# all-clear the NO TOKENS check below exists to prevent, introduced ten lines
+# above it. A guard that cannot run has not passed.
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment defect, not a code path
+    sys.exit(
+        "FAIL: PyYAML is unavailable, so the registry could not be read.\n"
+        "      This check cannot run, which is not the same as passing.\n"
+        "      Install it (pip install --user pyyaml) or fix the CI image."
+    )
+
+# A token may be a shell expansion ("$VAR", "${VAR}") that resolves at runtime;
+# this static scan cannot judge those and skips them explicitly.
+EXPANSION = "$"
+
+# The surfaces a human launch actually goes through. Specs and archived docs are
+# prose about past states and are deliberately not scanned.
+SCAN_GLOBS = (".zsh/*.zsh", "scripts/*.sh", "systemd/**/*.conf")
+SCAN_FILES = (".bashrc", ".zshrc", "powershell/profile.ps1")
+
+
+def registry_names(root):
+    """Every id and exposed variable name the registry declares."""
+    doc = yaml.safe_load(open(os.path.join(root, "secrets", "registry.yaml")))
+    names = set()
+    for secret in doc.get("secrets", []) or []:
+        names.add(secret.get("id"))
+        exposed = secret.get("expose") or {}
+        env = exposed.get("env")
+        if isinstance(env, str):
+            names.add(env)
+        elif isinstance(env, list):
+            names.update(v for v in env if isinstance(v, str))
+        elif isinstance(env, dict):
+            names.update(env.keys())
+        as_file = exposed.get("file")
+        if isinstance(as_file, dict) and as_file.get("var"):
+            names.add(as_file["var"])
+    names.discard(None)
+    return names
+
+
+def candidate_files(root):
+    for rel in SCAN_FILES:
+        path = os.path.join(root, rel)
+        if os.path.isfile(path):
+            yield path
+    for pattern in SCAN_GLOBS:
+        yield from (
+            p
+            for p in glob.glob(os.path.join(root, pattern), recursive=True)
+            if os.path.isfile(p)
+        )
+
+
+def tokens_in(path):
+    """(lineno, token) for real invocations only.
+
+    `secrets run` must be on the same line and the line must not be a comment. A
+    bare `--only` search matched PROSE: the hive drop-in's doc comment explains
+    "a --only token matching an id", and the scan reported `token` as an unknown
+    secret. Asking for the text instead of the invocation is the mistake this
+    guard exists to catch.
+    """
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        for lineno, line in enumerate(handle, 1):
+            if re.match(r"\s*(#|//)", line) or not re.search(r"secrets\s+run\b", line):
+                continue
+            for match in re.finditer(r"--only[=\s]+([A-Za-z0-9_,${}]+)", line):
+                for token in match.group(1).split(","):
+                    token = token.strip()
+                    if token and EXPANSION not in token:
+                        yield lineno, token
+
+
+def main():
+    root = sys.argv[1] if len(sys.argv) > 1 else "."
+    known = registry_names(root)
+    offenders, checked = [], 0
+
+    for path in candidate_files(root):
+        for lineno, token in tokens_in(path):
+            checked += 1
+            if token not in known:
+                offenders.append(f"{os.path.relpath(path, root)}:{lineno}: {token}")
+
+    if offenders:
+        print("FAIL: --only tokens absent from secrets/registry.yaml:")
+        for offender in offenders:
+            print("  " + offender)
+        return 1
+
+    # A check that verified nothing must say so. A silent zero would read as
+    # health while proving nothing -- if the wrappers were restructured, this
+    # scan should be rewritten, not quietly pass.
+    if checked == 0:
+        print("FAIL: no --only tokens matched; has the wrapper shape changed?")
+        return 1
+
+    print(f"OK: {checked} --only token(s) all resolve in the registry")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/opencode.bats
+++ b/tests/opencode.bats
@@ -143,9 +143,16 @@ setup() {
     refute_grep '"(openai|google|anthropic)/[^"]+":[[:space:]]*\{[[:space:]]*"name"' "$OPENCODE_CFG"
 }
 
-@test "opencode.jsonc has ollama provider (homelab via VPN)" {
-    grep -q '"ollama":' "$OPENCODE_CFG"
-    grep -q 'ollama.kubelab.live' "$OPENCODE_CFG"
+# The ollama provider is gone and must stay gone: the homelab endpoint no longer
+# runs, and its slot was never inert. It named {env:OLLAMA_API_KEY}, the shell
+# wrappers named OLLAMA_API_KEY in their `--only` list, and no registry entry ever
+# existed for it -- so `dotf secrets run` failed loud and opencode did not start.
+# Comment lines are excluded deliberately: the removal is documented in place,
+# and a whole-file refute fails on the explanation of the thing it checks. What
+# must not return is the declaration, not the record of why it went.
+@test "opencode.jsonc declares no ollama provider" {
+    run bash -c "grep -vE '^[[:space:]]*//' '$OPENCODE_CFG' | grep -nE '\"ollama\"[[:space:]]*:|ollama\.kubelab\.live|OLLAMA_API_KEY' || true"
+    [ -z "$output" ] || { echo "ollama is still declared: $output"; false; }
 }
 
 @test "opencode.jsonc default model is nan/qwen3.6 (fast default; deepseek-v4-flash on-demand)" {

--- a/tests/secrets-only-scope.bats
+++ b/tests/secrets-only-scope.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+#
+# Every token in a `dotf secrets run --only <list>` must be a live registry id or
+# exposed env var.
+#
+# `--only` fails LOUD on an unknown token -- it refuses the whole launch rather
+# than dropping the one name it cannot resolve. That is the right behaviour for a
+# secrets facade, and it means a stale token in a wrapper is not a degradation but
+# a total outage of whatever the wrapper launches.
+#
+# Measured 2026-08-25: the opencode wrapper in .bashrc and .zshrc named
+# OLLAMA_API_KEY for a provider slot whose registry entry was never created. Both
+# shells produced:
+#
+#     Error: --only: unknown id or env var "OLLAMA_API_KEY"
+#
+# so opencode -- the primary daily agent -- did not start at all, on either shell.
+# `dotf doctor` reported 152 passed / 0 failed with its [OpenCode + pi] section
+# green throughout: nothing checked that the wrapper's list and the registry still
+# agreed.
+#
+# The deeper fault is duplication: the registry already declares which secrets
+# each consumer takes (`consumers: [agent:opencode]`). Restating that list inside
+# a shell function creates two sources of truth, and this is what their drift
+# costs. Until the wrapper derives its scope from the registry, this test is what
+# keeps them honest.
+
+load 'lib/refute'
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+}
+
+@test "every --only token names a live registry id or exposed env var" {
+    run python3 - "$REPO_ROOT" <<'PY'
+import os, re, sys, glob
+
+try:
+    import yaml
+except ImportError:
+    print("SKIP: pyyaml unavailable")
+    sys.exit(0)
+
+root = sys.argv[1]
+reg = yaml.safe_load(open(os.path.join(root, "secrets", "registry.yaml")))
+
+known = set()
+for s in reg.get("secrets", []) or []:
+    known.add(s.get("id"))
+    exp = s.get("expose") or {}
+    env = exp.get("env")
+    if isinstance(env, str):
+        known.add(env)
+    elif isinstance(env, list):
+        known.update(v for v in env if isinstance(v, str))
+    elif isinstance(env, dict):
+        known.update(env.keys())
+    fil = exp.get("file")
+    if isinstance(fil, dict) and fil.get("var"):
+        known.add(fil["var"])
+known.discard(None)
+
+# The surfaces a human launch actually goes through. Specs and archived docs are
+# prose about past states and are deliberately not scanned.
+candidates = [
+    ".bashrc", ".zshrc", "powershell/profile.ps1",
+    *glob.glob(os.path.join(root, ".zsh", "*.zsh")),
+    *glob.glob(os.path.join(root, "scripts", "*.sh")),
+    *glob.glob(os.path.join(root, "systemd", "**", "*.conf"), recursive=True),
+]
+
+# A token may legitimately be a shell expansion rather than a literal name
+# ("$VAR", "${VAR}"): those resolve at runtime and this static check cannot judge
+# them. Skip them explicitly rather than failing on something unknowable.
+offenders = []
+checked = 0
+for rel in candidates:
+    path = rel if os.path.isabs(rel) else os.path.join(root, rel)
+    if not os.path.isfile(path):
+        continue
+    for lineno, line in enumerate(open(path, encoding="utf-8", errors="replace"), 1):
+        # `secrets run` must appear on the same line, and the line must not be a
+        # comment. A bare `--only` search matched prose: the hive drop-in's own
+        # doc comment explains "a --only token matching an id", and the scan
+        # dutifully reported `token` as an unknown secret. Asking for the text
+        # instead of the invocation is the same mistake this guard exists to catch.
+        if re.match(r"\s*(#|//)", line):
+            continue
+        if not re.search(r"secrets\s+run\b", line):
+            continue
+        for m in re.finditer(r"--only[=\s]+([A-Za-z0-9_,\$\{\}]+)", line):
+            for tok in m.group(1).split(","):
+                tok = tok.strip()
+                if not tok or "$" in tok:
+                    continue
+                checked += 1
+                if tok not in known:
+                    offenders.append(
+                        f"{os.path.relpath(path, root)}:{lineno}: {tok}"
+                    )
+
+if offenders:
+    print("UNKNOWN --only TOKENS (not in secrets/registry.yaml):")
+    for o in offenders:
+        print("  " + o)
+    sys.exit(1)
+
+# A check that verifies nothing must say so. If the scan matched no tokens at all
+# the wrappers were probably restructured, and a silent pass would be a false
+# all-clear -- the exact failure this suite has been bitten by before.
+if checked == 0:
+    print("NO --only TOKENS FOUND — the scan matched nothing; has the wrapper shape changed?")
+    sys.exit(1)
+
+print(f"OK: {checked} --only token(s) all resolve in the registry")
+PY
+    [ "$status" -eq 0 ] || { printf '%s\n' "$output"; false; }
+}
+
+# The specific name that caused the outage, asserted so a revert is loud.
+#
+# Comment lines are excluded on purpose: the removal is DOCUMENTED at each site
+# it was removed from, and a naive whole-file refute fails on the explanation of
+# the very thing it is checking. What must not come back is the executable
+# reference, not the memory of it.
+@test "no executable line names OLLAMA_API_KEY (the provider is gone)" {
+    local f
+    for f in .bashrc .zshrc ai/opencode/opencode.jsonc; do
+        run bash -c "grep -vE '^[[:space:]]*(#|//)' '$REPO_ROOT/$f' | grep -n 'OLLAMA_API_KEY' || true"
+        [ -z "$output" ] || { echo "$f still names OLLAMA_API_KEY in code: $output"; false; }
+    done
+}

--- a/tests/secrets-only-scope.bats
+++ b/tests/secrets-only-scope.bats
@@ -4,9 +4,9 @@
 # exposed env var.
 #
 # `--only` fails LOUD on an unknown token -- it refuses the whole launch rather
-# than dropping the one name it cannot resolve. That is the right behaviour for a
-# secrets facade, and it means a stale token in a wrapper is not a degradation but
-# a total outage of whatever the wrapper launches.
+# than dropping the one name it cannot resolve. That is right for a secrets
+# facade, and it means a stale token in a wrapper is not a degradation but a total
+# outage of whatever the wrapper launches.
 #
 # Measured 2026-08-25: the opencode wrapper in .bashrc and .zshrc named
 # OLLAMA_API_KEY for a provider slot whose registry entry was never created. Both
@@ -14,16 +14,17 @@
 #
 #     Error: --only: unknown id or env var "OLLAMA_API_KEY"
 #
-# so opencode -- the primary daily agent -- did not start at all, on either shell.
-# `dotf doctor` reported 152 passed / 0 failed with its [OpenCode + pi] section
-# green throughout: nothing checked that the wrapper's list and the registry still
-# agreed.
+# so opencode -- the primary daily agent -- did not start at all. `dotf doctor`
+# reported 152 passed / 0 failed with its [OpenCode + pi] section green
+# throughout: nothing checked that the wrapper's list and the registry agreed.
 #
 # The deeper fault is duplication: the registry already declares which secrets
-# each consumer takes (`consumers: [agent:opencode]`). Restating that list inside
-# a shell function creates two sources of truth, and this is what their drift
-# costs. Until the wrapper derives its scope from the registry, this test is what
-# keeps them honest.
+# each consumer takes (`consumers: [agent:opencode]`), and the wrapper restates
+# it. Two sources of truth, and this is what their drift costs. Until the wrapper
+# derives its scope from the registry, this keeps them honest.
+#
+# The scan lives in tests/lib/only-scope-scan.py so it is independently runnable
+# and this file stays an assertion rather than an 85-line test body.
 
 load 'lib/refute'
 
@@ -32,97 +33,16 @@ setup() {
 }
 
 @test "every --only token names a live registry id or exposed env var" {
-    run python3 - "$REPO_ROOT" <<'PY'
-import os, re, sys, glob
-
-try:
-    import yaml
-except ImportError:
-    print("SKIP: pyyaml unavailable")
-    sys.exit(0)
-
-root = sys.argv[1]
-reg = yaml.safe_load(open(os.path.join(root, "secrets", "registry.yaml")))
-
-known = set()
-for s in reg.get("secrets", []) or []:
-    known.add(s.get("id"))
-    exp = s.get("expose") or {}
-    env = exp.get("env")
-    if isinstance(env, str):
-        known.add(env)
-    elif isinstance(env, list):
-        known.update(v for v in env if isinstance(v, str))
-    elif isinstance(env, dict):
-        known.update(env.keys())
-    fil = exp.get("file")
-    if isinstance(fil, dict) and fil.get("var"):
-        known.add(fil["var"])
-known.discard(None)
-
-# The surfaces a human launch actually goes through. Specs and archived docs are
-# prose about past states and are deliberately not scanned.
-candidates = [
-    ".bashrc", ".zshrc", "powershell/profile.ps1",
-    *glob.glob(os.path.join(root, ".zsh", "*.zsh")),
-    *glob.glob(os.path.join(root, "scripts", "*.sh")),
-    *glob.glob(os.path.join(root, "systemd", "**", "*.conf"), recursive=True),
-]
-
-# A token may legitimately be a shell expansion rather than a literal name
-# ("$VAR", "${VAR}"): those resolve at runtime and this static check cannot judge
-# them. Skip them explicitly rather than failing on something unknowable.
-offenders = []
-checked = 0
-for rel in candidates:
-    path = rel if os.path.isabs(rel) else os.path.join(root, rel)
-    if not os.path.isfile(path):
-        continue
-    for lineno, line in enumerate(open(path, encoding="utf-8", errors="replace"), 1):
-        # `secrets run` must appear on the same line, and the line must not be a
-        # comment. A bare `--only` search matched prose: the hive drop-in's own
-        # doc comment explains "a --only token matching an id", and the scan
-        # dutifully reported `token` as an unknown secret. Asking for the text
-        # instead of the invocation is the same mistake this guard exists to catch.
-        if re.match(r"\s*(#|//)", line):
-            continue
-        if not re.search(r"secrets\s+run\b", line):
-            continue
-        for m in re.finditer(r"--only[=\s]+([A-Za-z0-9_,\$\{\}]+)", line):
-            for tok in m.group(1).split(","):
-                tok = tok.strip()
-                if not tok or "$" in tok:
-                    continue
-                checked += 1
-                if tok not in known:
-                    offenders.append(
-                        f"{os.path.relpath(path, root)}:{lineno}: {tok}"
-                    )
-
-if offenders:
-    print("UNKNOWN --only TOKENS (not in secrets/registry.yaml):")
-    for o in offenders:
-        print("  " + o)
-    sys.exit(1)
-
-# A check that verifies nothing must say so. If the scan matched no tokens at all
-# the wrappers were probably restructured, and a silent pass would be a false
-# all-clear -- the exact failure this suite has been bitten by before.
-if checked == 0:
-    print("NO --only TOKENS FOUND — the scan matched nothing; has the wrapper shape changed?")
-    sys.exit(1)
-
-print(f"OK: {checked} --only token(s) all resolve in the registry")
-PY
+    run python3 "$REPO_ROOT/tests/lib/only-scope-scan.py" "$REPO_ROOT"
     [ "$status" -eq 0 ] || { printf '%s\n' "$output"; false; }
 }
 
 # The specific name that caused the outage, asserted so a revert is loud.
 #
-# Comment lines are excluded on purpose: the removal is DOCUMENTED at each site
-# it was removed from, and a naive whole-file refute fails on the explanation of
-# the very thing it is checking. What must not come back is the executable
-# reference, not the memory of it.
+# Comment lines are excluded on purpose: the removal is DOCUMENTED at each site it
+# was removed from, and a naive whole-file refute fails on the explanation of the
+# very thing it checks. What must not come back is the executable reference, not
+# the memory of it.
 @test "no executable line names OLLAMA_API_KEY (the provider is gone)" {
     local f
     for f in .bashrc .zshrc ai/opencode/opencode.jsonc; do


### PR DESCRIPTION
## The defect

`opencode` — the primary daily agent — did not start. On either shell:

```
$ opencode --version
Error: --only: unknown id or env var "OLLAMA_API_KEY"
```

The homelab Ollama endpoint no longer runs, and its provider slot was never inert. It referenced `{env:OLLAMA_API_KEY}`; both shell wrappers named that token in their `dotf secrets run --only` list; and **no registry entry for it ever existed**. The config comment said *"user wires the API key as a secret"* — nobody did, and the slot sat there since AI-011 waiting on an AI-010 that was abandoned.

`--only` fails **loud** on an unknown token: it refuses the whole launch rather than skipping the one name it cannot resolve. That is correct for a secrets facade, and it turns a stale token from a degradation into a total outage of whatever the wrapper launches.

## What nothing noticed

```
$ dotf doctor
Results: 152 passed, 0 failed, 4 warned, 4 skipped
[OpenCode + pi]   ← green throughout
```

The doctor has a section named for this agent and it stayed green while the agent could not launch. Nothing checked that the wrapper's list and the registry still agreed.

## The fix

Removed from `ai/opencode/opencode.jsonc` (provider block, model-tier header line, `disabled_providers` note) and from the wrapper in `.bashrc` and `.zshrc`. `powershell/profile.ps1` never listed it.

Verified **by consequence**, not by reading:

```
$ dotf secrets run --only NAN_API_KEY,OPENROUTER_API_KEY,OPENAI_API_KEY -- opencode --version
1.16.2
```

Remaining providers parse clean: `['nan', 'openrouter']`.

## The guard

`tests/secrets-only-scope.bats` asserts every `--only` token in every wrapper resolves to a live registry id or exposed var. It also fails when the scan matches **nothing at all** — a silent zero would be the same false all-clear this repo has been bitten by before.

Confirmed it catches the original defect rather than assumed:

| | result |
|---|---|
| bug re-planted | `not ok` ×2 — `.bashrc:100: OLLAMA_API_KEY`, naming file, line and token |
| restored | `ok` ×2 |

Writing it surfaced two false positives in itself, both worth recording: a bare `--only` search matched **prose** (the hive drop-in's own comment explains *"a `--only` token matching an id"*, and the scan reported `token` as an unknown secret), and a whole-file refute failed on **my own documentation** of the removal. Both are the same error the guard exists to catch — asking for the text instead of the invocation. Now it requires `secrets run` on the same line and skips comments.

## Two existing tests narrowed, not deleted

- **`opencode.bats`** asserted the ollama provider *exists*. Inverted, and scoped to non-comment lines.
- **`agent-runtime-deployment.bats`** guarded opencode's catalogue with `grep -qiE 'ollama|openrouter'` — which passes while *either* survives, so it could not tell "both kept" from "one left". That stopped being hypothetical the moment ollama was removed deliberately. It now names `openrouter` alone, the provider that must not become collateral. **Its original intent is preserved**: that test exists so an AC8-style sweep doesn't take opencode's catalogue with it, and it still does that job with an edge.

## The underlying fault, stated

`secrets/registry.yaml` already declares which secrets each consumer takes (`consumers: [agent:opencode]`). The wrapper **restates** that list. Two sources of truth, and this outage is what their drift costs — deriving the wrapper's scope from the registry would remove the class entirely. The guard keeps them honest until then; it is not the fix for the duplication.

## Evidence

```
bats                                    1519 passed, 0 failed, exit 0
shellcheck .bashrc .zshrc               20 warnings — identical to main (pre-existing)
opencode.jsonc                          parses; providers = ['nan', 'openrouter']
opencode --version via corrected list   1.16.2, exit 0
```