### PR TITLE
fix(pi): a hand-wired extension symlink shadowed the packaged one, and pi would not start

### DIFF
--- a/cli/internal/doctor/checks_pi_extensions.go
+++ b/cli/internal/doctor/checks_pi_extensions.go
@@ -1,0 +1,235 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// checkPiExtensions reports hand-wired pi extensions that shadow a package the
+// manifest installs (AI-030 / #1243).
+//
+// THE DEFECT THIS EXISTS FOR, measured 2026-08-26. `pi -p` exited 1 with:
+//
+//	Error: Failed to load extension ".../npm/node_modules/pi-subagents/index.ts":
+//	       Tool "subagent" conflicts with /home/manu/.pi/agent/extensions/subagent/index.ts
+//
+// pi did not start at all. Two `subagent` tools existed: one from
+// `npm:pi-subagents@0.56.0`, which ai/pi/packages.json declares and setup
+// reconciles, and one hand-symlinked on 2026-08-09 into pi's OWN bundled
+// examples directory under a specific nvm node version. The hand-wired copy
+// won, and the declared one is the one that never loaded.
+//
+// WHY THE EXISTING VERIFICATION COULD NOT SEE IT. AI-030's reconcile proves the
+// `packages` array of the live settings.json converges on the manifest, and
+// specs/AI-030-pi-packages-manifest/verify-reconcile.sh drives the real block to
+// prove it. Both are correct and both are blind here: a package can be
+// installed, declared, and counted while a file elsewhere stops it loading.
+// Counting declarations is not observing effect — the failure this repository
+// has now catalogued seven times inside this one spec family.
+//
+// THE RULE, and why it is this rule rather than a name list. A shadow is an
+// entry under ~/.pi/agent/extensions/ that resolves, through a symlink, into a
+// node_modules tree. That shape means exactly one thing: someone linked a
+// package's own source or example code in by hand. Nothing reproduces it — not
+// setup, not the manifest, not a fresh machine — and it is pinned to whichever
+// node version happened to be active the day it was made.
+//
+// It is deliberately NOT "any extension the manifest does not declare".
+// ~/.pi/agent/extensions/ also holds files written by other tools (three
+// orca-*.ts appeared there while this check was being written), and claiming
+// the whole directory for the manifest would report a live external writer as
+// drift. The symlink-into-node_modules rule catches the defect and leaves
+// genuinely hand-authored extensions alone.
+func checkPiExtensions(sys *System, cfg *Config, rep *Report, fix bool) {
+	rep.Section("pi extensions")
+
+	agentDir := filepath.Join(sys.home(), ".pi", "agent")
+	extDir := filepath.Join(agentDir, "extensions")
+
+	entries, err := os.ReadDir(extDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			rep.Skip("no ~/.pi/agent/extensions — pi has no hand-placed extensions to shadow anything")
+			return
+		}
+		rep.Warn(fmt.Sprintf("cannot read %s: %v", extDir, err))
+		return
+	}
+
+	installed := installedPiPackages(agentDir)
+
+	var shadows []piShadow
+	for _, e := range entries {
+		name := e.Name()
+		dir := filepath.Join(extDir, name)
+		for _, link := range symlinksInto(dir, "node_modules") {
+			shadows = append(shadows, piShadow{
+				extension: name,
+				link:      link.path,
+				target:    link.target,
+				// A shadow is CONFIRMED when a package of the same name is also
+				// installed: that is the pair that races for one tool name. An
+				// unconfirmed one is still unreproducible, but it is not
+				// currently breaking anything, so it warns rather than fails.
+				collides: installed[name],
+			})
+		}
+	}
+
+	if len(shadows) == 0 {
+		rep.Pass(fmt.Sprintf("no hand-wired extension shadows a manifest package (%d extension entries, %d packages declared)",
+			len(entries), piPackagesManifest(cfg.DotfilesDir)))
+		return
+	}
+
+	sort.Slice(shadows, func(i, j int) bool { return shadows[i].link < shadows[j].link })
+
+	for _, s := range shadows {
+		detail := fmt.Sprintf("%s -> %s", short(sys, s.link), short(sys, s.target))
+		if !s.collides {
+			rep.Warn(fmt.Sprintf(
+				"hand-wired extension link, not reproduced by setup: %s\n"+
+					"    Nothing installs this on a fresh machine, and it is pinned to one node version.", detail))
+			continue
+		}
+		rep.Fail(fmt.Sprintf(
+			"extension %q shadows the installed package of the same name: %s\n"+
+				"    pi refuses to start when both provide the same tool. Re-check with: pi -p 'ok'", s.extension, detail))
+	}
+
+	if !fix {
+		if anyCollides(shadows) {
+			rep.Info("re-run with --fix to remove the hand-wired links and let the declared package load")
+		}
+		return
+	}
+
+	repairPiShadows(sys, rep, shadows)
+}
+
+type piShadow struct {
+	extension string
+	link      string
+	target    string
+	collides  bool
+}
+
+func anyCollides(ss []piShadow) bool {
+	for _, s := range ss {
+		if s.collides {
+			return true
+		}
+	}
+	return false
+}
+
+type symlink struct{ path, target string }
+
+// symlinksInto returns the symlinks directly under dir whose resolved target
+// contains a path segment equal to segment. Resolution is EvalSymlinks so a
+// chain of links is followed to whatever it really ends at; a link that dangles
+// is reported on its raw target instead, because a broken hand-wired link is
+// still a hand-wired link.
+func symlinksInto(dir, segment string) []symlink {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var out []symlink
+	for _, e := range entries {
+		if e.Type()&os.ModeSymlink == 0 {
+			continue
+		}
+		p := filepath.Join(dir, e.Name())
+		target, err := filepath.EvalSymlinks(p)
+		if err != nil {
+			if target, err = os.Readlink(p); err != nil {
+				continue
+			}
+		}
+		if slices.Contains(strings.Split(filepath.ToSlash(target), "/"), segment) {
+			out = append(out, symlink{path: p, target: target})
+		}
+	}
+	return out
+}
+
+// installedPiPackages reports which packages are unpacked under
+// ~/.pi/agent/npm/node_modules, keyed by the name a tool namespace would use.
+// `pi install` unpacks there as well as writing the settings.json array, so this
+// reads what is ON DISK rather than what is declared — the whole point of the
+// check is that the two can disagree.
+//
+// A scoped package (@scope/pi-thing) is keyed on its unscoped half, and every
+// key is also recorded with a leading "pi-" stripped, because the extension
+// directory is named for the tool ("subagent") while the package is named
+// "pi-subagents". Matching is therefore generous by design: this map only
+// decides FAIL versus WARN, and both dispositions name the same file.
+func installedPiPackages(agentDir string) map[string]bool {
+	root := filepath.Join(agentDir, "npm", "node_modules")
+	found := map[string]bool{}
+
+	record := func(name string) {
+		if name == "" {
+			return
+		}
+		found[name] = true
+		if trimmed, ok := strings.CutPrefix(name, "pi-"); ok {
+			found[trimmed] = true
+			found[strings.TrimSuffix(trimmed, "s")] = true
+		}
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return found
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(e.Name(), "@") {
+			scoped, err := os.ReadDir(filepath.Join(root, e.Name()))
+			if err != nil {
+				continue
+			}
+			for _, s := range scoped {
+				record(s.Name())
+			}
+			continue
+		}
+		record(e.Name())
+	}
+	return found
+}
+
+// short renders a path under $HOME as ~/... so the diagnostic is readable and
+// carries no machine-specific prefix (ADR-025: never print a literal home).
+func short(sys *System, p string) string {
+	home := sys.home()
+	if home != "" && strings.HasPrefix(p, home+string(filepath.Separator)) {
+		return "~" + string(filepath.Separator) + p[len(home)+1:]
+	}
+	return p
+}
+
+// piPackagesManifest is the declaration setup reconciles against. Read only to
+// report how many packages are at stake when a shadow is found.
+func piPackagesManifest(dotfilesDir string) int {
+	doc, err := os.ReadFile(filepath.Join(dotfilesDir, "ai", "pi", "packages.json"))
+	if err != nil {
+		return 0
+	}
+	var parsed struct {
+		Packages []json.RawMessage `json:"packages"`
+	}
+	if json.Unmarshal(doc, &parsed) != nil {
+		return 0
+	}
+	return len(parsed.Packages)
+}

--- a/cli/internal/doctor/checks_pi_extensions_repair.go
+++ b/cli/internal/doctor/checks_pi_extensions_repair.go
@@ -1,0 +1,89 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// piQuarantineDir is where --fix moves a shadowing link, and it is deliberately
+// OUTSIDE ~/.pi/agent/extensions/.
+//
+// The obvious place is a .disabled/ subdirectory beside the link. It is wrong,
+// and wrong in this spec's signature way. pi's own docs state the two
+// auto-discovery patterns (docs/extensions.md, measured against 0.84.2):
+//
+//	~/.pi/agent/extensions/*.ts        global
+//	~/.pi/agent/extensions/*/index.ts  global, subdirectory form
+//
+// A .disabled/ directory holding an index.ts matches the second pattern. Whether
+// pi's glob skips a leading dot is not documented either way, so the safe
+// reading is that quarantining there is a candidate extension named ".disabled"
+// carrying the same file — the same tool, the same conflict, one directory
+// deeper. A repair that relocates a defect inside the surface that reads it
+// reports success and changes nothing. Moving it out of the scanned tree
+// removes the question rather than betting on the answer.
+const piQuarantineDir = ".disabled-extensions"
+
+// repairPiShadows quarantines the links checkPiExtensions found. It runs ONLY
+// under --fix, so the user has opted in; the check itself never writes.
+//
+// WHAT MOVES AND WHAT DOES NOT. Only the link under ~/.pi is in scope. Its
+// target lives inside pi's own npm package —
+// .../pi-coding-agent/examples/extensions/subagent/index.ts — and is never
+// touched, which is why quarantine loses nothing: the example code this link
+// pointed at survives in the package, reinstalled on every pi upgrade.
+//
+// Quarantine over deletion because these links were a deliberate choice on
+// 2026-08-09. They are unreproducible and they stop pi starting, so they must
+// stop being loaded; but the repo has no standing to decide the user no longer
+// wants them, only that pi cannot keep both. Renaming says that and stays
+// reversible; os.Remove says more than doctor knows.
+//
+// The relative shape is preserved (extensions/subagent/index.ts becomes
+// .disabled-extensions/subagent/index.ts) so restoring one is a mv with the two
+// paths visible, not an archaeology exercise.
+func repairPiShadows(sys *System, rep *Report, shadows []piShadow) {
+	moved := 0
+	for _, s := range shadows {
+		if !s.collides {
+			// An unconfirmed hand-wired link is unreproducible but is not
+			// currently breaking anything. --fix repairs the outage it can name;
+			// it does not tidy the directory on the user's behalf.
+			continue
+		}
+
+		extRoot := filepath.Join(sys.home(), ".pi", "agent", "extensions")
+		rel, err := filepath.Rel(extRoot, s.link)
+		if err != nil {
+			rep.Warn(fmt.Sprintf("cannot place %s under quarantine: %v", short(sys, s.link), err))
+			continue
+		}
+		dst := filepath.Join(sys.home(), ".pi", "agent", piQuarantineDir, rel)
+
+		// Never clobber an earlier quarantine. Two runs that both "succeed"
+		// while the second silently destroys the first is the failure mode this
+		// whole check exists to catch.
+		if _, err := os.Lstat(dst); err == nil {
+			rep.Warn(fmt.Sprintf("%s already quarantined at %s — leaving %s in place, resolve by hand",
+				rel, short(sys, dst), short(sys, s.link)))
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			rep.Warn(fmt.Sprintf("cannot create %s: %v", short(sys, filepath.Dir(dst)), err))
+			continue
+		}
+		if err := os.Rename(s.link, dst); err != nil {
+			rep.Warn(fmt.Sprintf("cannot quarantine %s: %v", short(sys, s.link), err))
+			continue
+		}
+		rep.Fix(fmt.Sprintf("quarantined %s -> %s (restore with mv, the link target was not touched)",
+			short(sys, s.link), short(sys, dst)))
+		moved++
+	}
+
+	if moved > 0 {
+		rep.Info("re-check that pi now starts: pi -p 'ok'")
+	}
+}

--- a/cli/internal/doctor/checks_pi_extensions_test.go
+++ b/cli/internal/doctor/checks_pi_extensions_test.go
@@ -1,0 +1,238 @@
+package doctor
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// piExtFixture builds a fake $HOME carrying a pi agent tree and returns it.
+//
+//	extensions/<name>/<file>  -> symlink to target, when target != ""
+//	extensions/<name>/<file>  -> plain file, when target == ""
+//
+// installed names are unpacked under npm/node_modules, which is what
+// installedPiPackages reads: the check's whole premise is that what is ON DISK
+// and what settings.json DECLARES can disagree, so the fixture never writes the
+// declaration.
+type piExtEntry struct {
+	dir    string
+	file   string
+	target string
+}
+
+func piExtFixture(t *testing.T, installed []string, entries []piExtEntry) string {
+	t.Helper()
+	home := t.TempDir()
+	agent := filepath.Join(home, ".pi", "agent")
+
+	for _, name := range installed {
+		if err := os.MkdirAll(filepath.Join(agent, "npm", "node_modules", name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, e := range entries {
+		dir := filepath.Join(agent, "extensions", e.dir)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		p := filepath.Join(dir, e.file)
+		if e.target == "" {
+			if err := os.WriteFile(p, []byte("// plain extension\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+		// The target must exist, so EvalSymlinks resolves rather than falling
+		// back to the raw link — the production path this exercises.
+		if err := os.MkdirAll(filepath.Dir(e.target), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(e.target, []byte("// linked source\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(e.target, p); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return home
+}
+
+func piExtRun(t *testing.T, home string, fix bool) string {
+	t.Helper()
+	var buf bytes.Buffer
+	rep := NewReport(&buf, true)
+	checkPiExtensions(piSys(home), &Config{DotfilesDir: t.TempDir()}, rep, fix)
+	rep.flush()
+	return buf.String()
+}
+
+func requireSymlinks(t *testing.T) {
+	t.Helper()
+	// Creating a symlink on Windows needs either developer mode or elevation,
+	// and the Windows leg of CI compiles and runs this package. Skipping is
+	// honest; the behaviour under test is a POSIX-only tree (~/.pi wired by
+	// hand on Linux), so there is nothing to assert on the other platform.
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is privileged on Windows; the shadow shape is POSIX-only")
+	}
+}
+
+// The measured defect, 2026-08-26: extensions/subagent/index.ts symlinked into
+// pi's own bundled examples under node_modules, while npm:pi-subagents@0.56.0 is
+// installed. pi exited 1 with `Tool "subagent" conflicts`.
+func TestPiExtensionsShadowFailsWhenPackageInstalled(t *testing.T) {
+	requireSymlinks(t)
+	nm := filepath.Join(t.TempDir(), "node_modules", "@earendil-works", "pi-coding-agent", "examples", "extensions", "subagent")
+	home := piExtFixture(t,
+		[]string{"pi-subagents"},
+		[]piExtEntry{{dir: "subagent", file: "index.ts", target: filepath.Join(nm, "index.ts")}},
+	)
+
+	out := piExtRun(t, home, false)
+	if !strings.Contains(out, "[FAIL]") {
+		t.Fatalf("a shadow over an installed package must FAIL, got:\n%s", out)
+	}
+	for _, want := range []string{"subagent", "shadows the installed package"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("diagnostic missing %q, got:\n%s", want, out)
+		}
+	}
+	// ADR-025: a literal home must never be printed.
+	if strings.Contains(out, home) {
+		t.Errorf("diagnostic printed a literal $HOME:\n%s", out)
+	}
+}
+
+// The same link with nothing installed under that name is unreproducible but is
+// not breaking anything. Warning, not failure — and --fix must leave it alone.
+func TestPiExtensionsShadowWarnsWhenNoPackageCollides(t *testing.T) {
+	requireSymlinks(t)
+	nm := filepath.Join(t.TempDir(), "node_modules", "some-pkg")
+	link := piExtEntry{dir: "handwired", file: "index.ts", target: filepath.Join(nm, "index.ts")}
+	home := piExtFixture(t, nil, []piExtEntry{link})
+
+	out := piExtRun(t, home, true)
+	if strings.Contains(out, "[FAIL]") {
+		t.Errorf("a non-colliding hand-wired link must not FAIL, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[WARN]") {
+		t.Errorf("a non-colliding hand-wired link must WARN, got:\n%s", out)
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".pi", "agent", "extensions", "handwired", "index.ts")); err != nil {
+		t.Errorf("--fix moved a link it only warned about: %v", err)
+	}
+}
+
+// The scoping rule, and the reason it is symlink-into-node_modules rather than
+// "anything the manifest does not declare": ~/.pi/agent/extensions/ has a live
+// external writer. Three orca-*.ts files appeared there while this check was
+// being written. Claiming the directory would report that writer as drift.
+func TestPiExtensionsIgnoresPlainFilesAndUnrelatedLinks(t *testing.T) {
+	requireSymlinks(t)
+	elsewhere := filepath.Join(t.TempDir(), "sources", "thing.ts")
+	home := piExtFixture(t,
+		[]string{"pi-subagents"},
+		[]piExtEntry{
+			{dir: ".", file: "orca-titlebar-spinner.ts"},         // plain file, external writer
+			{dir: "mine", file: "index.ts"},                      // plain hand-authored extension
+			{dir: "linked", file: "index.ts", target: elsewhere}, // symlink, but not into node_modules
+		},
+	)
+
+	out := piExtRun(t, home, false)
+	if strings.Contains(out, "[FAIL]") || strings.Contains(out, "[WARN]") {
+		t.Fatalf("no entry here is a shadow, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[ OK ]") {
+		t.Fatalf("expected an OK, got:\n%s", out)
+	}
+	for _, banned := range []string{"orca", "mine", "linked"} {
+		if strings.Contains(out, banned) {
+			t.Errorf("check reported %q, which it does not own:\n%s", banned, out)
+		}
+	}
+}
+
+func TestPiExtensionsSkipsWhenNoExtensionsDir(t *testing.T) {
+	out := piExtRun(t, t.TempDir(), false)
+	if !strings.Contains(out, "[SKIP]") {
+		t.Fatalf("an absent extensions dir must SKIP, got:\n%s", out)
+	}
+}
+
+// The property that makes quarantine a repair rather than a relocation: the
+// destination is OUTSIDE the tree pi auto-discovers (docs/extensions.md lists
+// `extensions/*/index.ts` as a discovery pattern, which a .disabled/ subdir
+// would match), and therefore outside the tree this check re-reads. A second
+// run must report the machine as clean.
+func TestPiExtensionsFixQuarantinesOutsideTheScannedTree(t *testing.T) {
+	requireSymlinks(t)
+	nm := filepath.Join(t.TempDir(), "node_modules", "pi-coding-agent", "examples", "extensions", "subagent")
+	target := filepath.Join(nm, "index.ts")
+	home := piExtFixture(t,
+		[]string{"pi-subagents"},
+		[]piExtEntry{{dir: "subagent", file: "index.ts", target: target}},
+	)
+
+	out := piExtRun(t, home, true)
+	if !strings.Contains(out, "[FIX ]") {
+		t.Fatalf("--fix must repair a colliding shadow, got:\n%s", out)
+	}
+
+	agent := filepath.Join(home, ".pi", "agent")
+	if _, err := os.Lstat(filepath.Join(agent, "extensions", "subagent", "index.ts")); !os.IsNotExist(err) {
+		t.Errorf("the shadowing link is still in the scanned tree (err=%v)", err)
+	}
+	quarantined := filepath.Join(agent, piQuarantineDir, "subagent", "index.ts")
+	if _, err := os.Lstat(quarantined); err != nil {
+		t.Fatalf("quarantined link not at the documented path: %v", err)
+	}
+	if strings.HasPrefix(quarantined, filepath.Join(agent, "extensions")+string(filepath.Separator)) {
+		t.Error("quarantine landed inside extensions/, where pi may still discover it")
+	}
+	// The target belongs to pi's npm package and is never in scope.
+	if _, err := os.Stat(target); err != nil {
+		t.Errorf("--fix touched the link target, which it must never do: %v", err)
+	}
+
+	// A second run sees a clean machine: the quarantine is not re-reported.
+	again := piExtRun(t, home, false)
+	if !strings.Contains(again, "[ OK ]") {
+		t.Fatalf("after --fix the check must report OK, got:\n%s", again)
+	}
+}
+
+// Two --fix runs where the first was restored by hand must not silently destroy
+// the earlier quarantine. Two runs that both report success while the second
+// overwrites the first is the failure mode this whole check exists to catch.
+func TestPiExtensionsFixNeverClobbersAnEarlierQuarantine(t *testing.T) {
+	requireSymlinks(t)
+	nm := filepath.Join(t.TempDir(), "node_modules", "pi-subagents-src")
+	home := piExtFixture(t,
+		[]string{"pi-subagents"},
+		[]piExtEntry{{dir: "subagent", file: "index.ts", target: filepath.Join(nm, "index.ts")}},
+	)
+	agent := filepath.Join(home, ".pi", "agent")
+
+	if out := piExtRun(t, home, true); !strings.Contains(out, "[FIX ]") {
+		t.Fatalf("first --fix did not repair:\n%s", out)
+	}
+	// Simulate the user restoring the link, then running --fix again.
+	relinked := filepath.Join(agent, "extensions", "subagent", "index.ts")
+	if err := os.Symlink(filepath.Join(nm, "index.ts"), relinked); err != nil {
+		t.Fatal(err)
+	}
+
+	out := piExtRun(t, home, true)
+	if !strings.Contains(out, "already quarantined") {
+		t.Errorf("second --fix must refuse rather than clobber, got:\n%s", out)
+	}
+	if _, err := os.Lstat(relinked); err != nil {
+		t.Errorf("the link was moved over an existing quarantine: %v", err)
+	}
+}

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -98,6 +98,7 @@ func Run(opts Options) (int, error) {
 		checkOpenCode(sys, cfg, rep)
 		checkGolangciLint(sys, cfg, rep)
 		checkModelMap(cfg, rep)
+		checkPiExtensions(sys, cfg, rep, opts.Fix)
 		checkHarnessDrift(sys, cfg, rep, opts.Fix)
 		checkDeployDrift(sys, cfg, rep)
 		checkRepoDirResolves(rep)

--- a/docs/lessons/lesson-231-a-hand-wired-dev-symlink-outranks-the-managed-instal.md
+++ b/docs/lessons/lesson-231-a-hand-wired-dev-symlink-outranks-the-managed-instal.md
@@ -1,0 +1,88 @@
+# Lesson 231 — a hand-wired dev symlink outranks the managed install, and the host fails closed
+
+**Date:** 2026-08-26
+**Context:** AI-030 / #1243 — `pi` would not start on this machine.
+**Category:** tooling, extension hosts, declaration-vs-effect
+
+## What happened
+
+`pi -p 'ok'` exited **1**:
+
+```
+Error: Failed to load extension ".../npm/node_modules/pi-subagents/index.ts":
+       Tool "subagent" conflicts with /home/manu/.pi/agent/extensions/subagent/index.ts
+Hint: Start without extensions using "pi -ne".
+```
+
+Two providers of one tool name. One came from `npm:pi-subagents@0.56.0`, which
+`ai/pi/packages.json` declares and `setup-linux.sh` reconciles on every run. The
+other was a symlink placed by hand on 2026-08-09 into pi's *own bundled
+examples*, under one specific nvm node version:
+
+```
+~/.pi/agent/extensions/subagent/index.ts
+  -> ~/.nvm/versions/node/v24.16.0/lib/node_modules/
+     @earendil-works/pi-coding-agent/examples/extensions/subagent/index.ts
+```
+
+The hand-wired one won. The declared one is the one that never loaded.
+
+## Three things worth keeping
+
+**1. The extension host failed closed, and that was a gift.** pi refused to
+start at all rather than picking a winner silently. Had it resolved the conflict
+by precedence and carried on, the machine would have run for months on a
+year-old example extension while every check reported the packaged one as
+installed. A hard failure at startup is the cheapest possible signalling for an
+ambiguity the host cannot resolve. Prefer it when building anything similar.
+
+**2. The hand-wired dev symlink is a class, not an incident.** It has three
+properties that make it worse than it looks: nothing reproduces it (no fresh
+machine gets it, so it is invisible to any container or CI verification), it is
+pinned to whatever node version was active the day it was made (so it rots when
+that version is uninstalled), and it silently outranks the managed install it
+duplicates. `~/.pi/agent/extensions/` has a live external writer too — three
+`orca-*.ts` files appeared there during this work — so the guard cannot simply
+claim the directory. The rule that works is narrower and mechanical: **an entry
+under the extensions dir that resolves through a symlink into a `node_modules`
+tree is hand-wired by definition**, because a package manager never links that
+way.
+
+**3. Quarantine must leave the tree the host reads.** The obvious repair is a
+`.disabled/` directory beside the link. pi's own docs list its discovery
+patterns:
+
+| Pattern | Scope |
+|---|---|
+| `~/.pi/agent/extensions/*.ts` | global |
+| `~/.pi/agent/extensions/*/index.ts` | global, subdirectory form |
+
+A `.disabled/index.ts` matches the second one. Whether the glob skips a leading
+dot is undocumented, so quarantining there is a bet that the same file under a
+new name stops being found — the same conflict, one directory deeper. **A repair
+that relocates a defect inside the surface that reads it reports success and
+changes nothing.** The quarantine went to `~/.pi/agent/.disabled-extensions/`,
+outside the scanned tree, which removes the question instead of answering it.
+
+## Why AI-030's own verification could not see this
+
+AC1–AC10 all held while pi refused to start. They prove the manifest is
+well-formed and pinned, that the reconcile is idempotent, that a missing
+toolchain warns once — and `verify-reconcile.sh` proves it by driving the real
+block extracted from `setup-linux.sh`, which is the right shape. All of it
+counts entries in an array. **A package can be installed, declared, counted and
+still not load.** The criterion that was missing is AC11: a declared package is
+also a loaded one, observed as effect.
+
+This is the same failure this repository has now catalogued repeatedly (see
+`lesson-230`, *a config that parses is not a config the consumer reads*). The
+variant worth naming here is that **the guard's own verification is not exempt**:
+the check that watches for declaration-over-effect was itself nearly written as
+"is the package in `settings.json`", which is the identical mistake one layer up.
+
+## The guard
+
+`dotf doctor` → `cli/internal/doctor/checks_pi_extensions.go`, repaired under
+`--fix`. It lives in doctor rather than CI deliberately: this is **machine
+state**, and CI never sees this machine. A check that cannot run where the defect
+lives is not a guard.

--- a/specs/AI-030-pi-packages-manifest/features.json
+++ b/specs/AI-030-pi-packages-manifest/features.json
@@ -68,5 +68,12 @@
     "verification": "bats tests/pi-packages.bats -f 'setup-windows' && python3 -c \"import sys; sys.exit(0 if sum(1 for l in open('setup-windows.ps1',encoding='utf-8') if any(ord(c)>126 for c in l)) == 10 else 1)\"",
     "state": "pending",
     "evidence": ""
+  },
+  {
+    "id": "AI-030-pi-packages-manifest-f11",
+    "behavior": "AC11 - a package that is installed and declared is also LOADED: doctor detects a hand-wired extension symlink shadowing it, quarantines it under --fix outside the tree pi auto-discovers, refuses to clobber an earlier quarantine, and leaves an external writer's plain files alone",
+    "verification": "cd cli && go test ./internal/doctor/ -run TestPiExtensions",
+    "state": "pending",
+    "evidence": ""
   }
 ]

--- a/specs/AI-030-pi-packages-manifest/proposal.md
+++ b/specs/AI-030-pi-packages-manifest/proposal.md
@@ -95,10 +95,23 @@ so.
 - [x] **AC9** — Linux installs through `$PI_BIN`, not the `pi` shell function.
 - [x] **AC10** — `setup-windows.ps1` reconciles the same manifest with the same
       semantics (parity), and adds no non-ASCII to the file.
+- [x] **AC11** — a package that is installed and declared is also **loaded**.
+      Added 2026-08-26 for #1243, and it is the criterion whose absence this
+      spec's own verification demonstrated: AC1–AC10 all hold while pi refuses
+      to start. Measured that day — `pi -p` exited 1 with
+      `Failed to load extension ".../pi-subagents/index.ts": Tool "subagent"
+      conflicts with ~/.pi/agent/extensions/subagent/index.ts`, a hand-wired
+      symlink from 2026-08-09 into pi's own bundled examples. The declared
+      package was the one that never loaded, and nothing here could see it,
+      because counting entries in an array is not observing effect.
+      Enforced by `dotf doctor` (`cli/internal/doctor/checks_pi_extensions.go`,
+      repaired under `--fix`), which is the durable surface: this is machine
+      state, so CI cannot observe it and a doctor check is the only thing that
+      runs where the defect lives.
 
 ## References
 
-- Bitácora board: `mlorentedev/dotfiles#1224`
+- Bitácora board: `mlorentedev/dotfiles#1224`, and `#1243` for AC11.
 - Upstream docs: <https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/packages.md>
 - Prior art in this repo: `ai/deploy.json` (CLI-039, #1023) — the same
   "declarative table, one behaviour, no per-OS twin logic" shape.

--- a/specs/AI-030-pi-packages-manifest/tasks.md
+++ b/specs/AI-030-pi-packages-manifest/tasks.md
@@ -42,6 +42,9 @@ created: "2026-08-25"
 - [x] [AC10] Mirror the block in `setup-windows.ps1`, with parity guards
 - [x] [AC5] [AC6] Verify behaviour by driving the real block, extracted from
       `setup-linux.sh` by anchor, against a stubbed `pi` — four scenarios
+- [x] [AC11] Add a doctor check that observes LOADING rather than declaration
+      (`cli/internal/doctor/checks_pi_extensions.go` + `_repair.go`), and prove
+      it against the live defect: `pi -p` exit 1 → exit 0 (#1243)
 
 ## Closing
 

--- a/specs/AI-030-pi-packages-manifest/verification.md
+++ b/specs/AI-030-pi-packages-manifest/verification.md
@@ -19,6 +19,7 @@ created: "2026-08-25"
 | AC8 unreadable manifest is loud | `tests/pi-packages.bats` — "refuses an unreadable manifest instead of reading it empty" |
 | AC9 Linux uses `$PI_BIN` | `tests/pi-packages.bats` — "installs through $PI_BIN, not the shell function" |
 | AC10 Windows parity, no new non-ASCII | `tests/pi-packages.bats` — three `setup-windows` cases; non-ASCII line count 10 before and 10 after |
+| AC11 a declared package actually **loads** | `dotf doctor` on the real machine — `[FAIL] extension "subagent" shadows the installed package of the same name`, then `[FIX ] quarantined ~/.pi/agent/extensions/subagent/index.ts`; effect confirmed by `pi -p` going from **exit 1** (`Failed to load extension … Tool "subagent" conflicts`) to **exit 0** answering `OK`, and a third `dotf doctor` run then reporting `[pi extensions] (1 checks, all ok)`. Unit-covered by `cli/internal/doctor/checks_pi_extensions_test.go` (6 cases: FAIL on collision, WARN without, the scoping rule that leaves an external writer's files alone, SKIP with no extensions dir, quarantine landing outside the auto-discovered tree, and no-clobber on a second `--fix`) |
 
 All on commit `2c20332` plus the spec commit that follows it.
 

--- a/specs/AI-030-pi-packages-manifest/verification.md
+++ b/specs/AI-030-pi-packages-manifest/verification.md
@@ -78,6 +78,20 @@ limitation `tests/stub-real-pairing.bats` exists to keep visible (BUG-055).
 - **`jq -er`, not `jq -r`.** A malformed manifest yields an empty want-list, and
   an empty want-list installs nothing while logging exactly like "everything is
   already present" — silent success on a broken input.
+- **The packaged `subagent` wins; the hand-wired link is quarantined** (#1243).
+  Two extensions provided the tool. The decision is for the one the manifest
+  declares — `npm:pi-subagents@0.56.0` — and against the 2026-08-09 symlink into
+  pi's bundled examples, on four grounds. It is **reproducible**: setup installs
+  it on every run and on a fresh machine, while nothing recreates the symlink.
+  It is **versioned**: the manifest pins `@0.56.0`, so upstream's publish passes
+  a diff and a reviewer, whereas the link tracks whatever the examples directory
+  happens to contain. It is **portable**: the link hard-codes
+  `~/.nvm/versions/node/v24.16.0/`, so it rots when that node version is removed
+  and is invisible to any other node. And it is **maintained**: the packaged
+  version is 0.56.0 against examples last touched in the pi release that shipped
+  them. The loser is quarantined rather than deleted — the choice is about which
+  one loads, not about discarding the user's; it is restorable with `mv` and its
+  target inside pi's npm package is never touched.
 - **The spec was written after the implementation.** The Discipline Gate trigger
   was found while measuring the diff for the PR, not while scoping. Recorded in
   `tasks.md` rather than disguised; a back-dated task list would make this folder


### PR DESCRIPTION
`pi` would not start on this machine. `pi -p 'ok'` exited **1**:

```
Error: Failed to load extension ".../npm/node_modules/pi-subagents/index.ts":
       Tool "subagent" conflicts with ~/.pi/agent/extensions/subagent/index.ts
```

Two providers of one tool name. One from `npm:pi-subagents@0.56.0`, which
`ai/pi/packages.json` declares and setup reconciles on every run; the other a
symlink placed by hand on 2026-08-09 into pi's own bundled examples, under one
specific nvm node version. The hand-wired one won, so the **declared package was
the one that never loaded**.

## Why AI-030's verification could not see it

AC1-AC10 all held while pi refused to start. Every one of them counts entries in
an array — a package can be installed, declared and counted while the agent does
not start. **AC11** adds the missing criterion: a declared package is also a
loaded one, observed as effect.

## Design notes

**The check detects the cause, not the name.** An entry under the extensions dir
resolving through a symlink into a `node_modules` tree is hand-wired by
definition, since no package manager links that way. The scoping is load-bearing:
`~/.pi/agent/extensions/` has a live external writer (three `orca-*.ts` files
appeared there during this work), so claiming the directory wholesale would
report that writer as drift.

**`--fix` quarantines OUTSIDE the tree pi auto-discovers.** pi's docs list
`extensions/*/index.ts` as a discovery pattern, which a `.disabled/` subdirectory
beside the link would match — relocating the conflict one directory deeper while
reporting success. Destination is `~/.pi/agent/.disabled-extensions/`. The link
target is never touched, so the repair is reversible with `mv` and the example
code survives in the package.

**It lives in doctor rather than CI** because this is machine state, and CI never
sees this machine.

## Verification

| Check | Result |
|---|---|
| `pi -p 'ok'` | exit **1** -> exit **0**, answering `OK` |
| `dotf doctor` on the real machine | `[FAIL]` -> `[FIX ]` -> `(1 checks, all ok)` |
| `go build` + `go vet` | pass, Linux **and** `GOOS=windows` |
| `go test ./...` | 18/18 packages |
| `golangci-lint run` (pinned 2.12.2) | 0 issues |
| AC11 command in `features.json` | executed, exit 0 |

New tests cover FAIL on collision, WARN without one, the scoping rule that leaves
an external writer's files alone, SKIP with no extensions dir, quarantine landing
outside the discovered tree, and no-clobber on a second `--fix`.

Lesson recorded: `docs/lessons/lesson-231-...`.

**Deployment note:** the check ships in the `dotf` binary. This machine is already
repaired, but `dotf doctor` will not carry the check until the installed binary is
rebuilt after merge.

fixes #1243
