### PR TITLE
chore(harness): bind cyclomatic complexity to builder and reviewer personas

### DIFF
--- a/harness/agents/builder/AGENT.md
+++ b/harness/agents/builder/AGENT.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/agents/definitions/builder/AGENT.md
-generated_sha: 0664eb62ec575941
+generated_sha: 93ccd2139b3bc8dc
 id: agent-builder
 type: agent
 status: active
@@ -11,7 +11,7 @@ description: Build-phase persona. Invoke to implement a change whose shape is al
 kind: invocable
 model: mid
 capabilities: [read, search, edit, shell]
-skills: [golang-pro, async-python-patterns, test, test-driven-development, mcp-builder, debug-hardware, systematic-debugging, creating-skills]
+skills: [golang-pro, async-python-patterns, cyclomatic-complexity, test, test-driven-development, mcp-builder, debug-hardware, systematic-debugging, creating-skills]
 owner: manu
 ---
 
@@ -33,7 +33,7 @@ Make the change work and prove it does. Working code is not a finished change: w
 
 ## Forced skills
 
-Your phase's skills are enforced by hook, not left to memory: `golang-pro`, `async-python-patterns`, `test`, `test-driven-development`, `mcp-builder`, `debug-hardware`, `systematic-debugging`, `creating-skills`. Reach for the one the task calls for rather than improvising.
+Your phase's skills are enforced by hook, not left to memory: `golang-pro`, `async-python-patterns`, `cyclomatic-complexity`, `test`, `test-driven-development`, `mcp-builder`, `debug-hardware`, `systematic-debugging`, `creating-skills`. Reach for the one the task calls for rather than improvising.
 
 ## Boundaries
 

--- a/harness/agents/reviewer/AGENT.md
+++ b/harness/agents/reviewer/AGENT.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/agents/definitions/reviewer/AGENT.md
-generated_sha: c862e6900b577020
+generated_sha: 30ebff1738957f64
 id: agent-reviewer
 type: agent
 status: active
@@ -11,7 +11,7 @@ description: Verify-phase persona. Invoke to check a change against what it clai
 kind: invocable
 model: mid
 capabilities: [read, search, shell]
-skills: [audit, verification-before-completion, adversarial-review]
+skills: [audit, verification-before-completion, adversarial-review, cyclomatic-complexity]
 owner: manu
 ---
 
@@ -33,7 +33,7 @@ Try to refute the claim. Your job is not to confirm that a change appears reason
 
 ## Forced skills
 
-Your phase's skills are enforced by hook, not left to memory: `audit`, `verification-before-completion`, `adversarial-review`. Reach for the one that fits rather than improvising.
+Your phase's skills are enforced by hook, not left to memory: `audit`, `verification-before-completion`, `adversarial-review`, `cyclomatic-complexity`. Reach for the one that fits rather than improvising.
 
 ## Boundaries
 

--- a/harness/skills/adversarial-review/SKILL.md
+++ b/harness/skills/adversarial-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/skills/adversarial-review/SKILL.md
-generated_sha: aa1087f44d2d30af
+generated_sha: 39d465d82660be6e
 id: adversarial-review-skill
 type: skill
 status: active
@@ -188,7 +188,7 @@ The rubric is mechanically aggregable — useful when N agents review N changes 
 | **Verification** | Evidence proves each criterion with reproducible commands + outputs | Evidence covers criteria but not reproducible without context | Anecdotal or unverifiable evidence | No verification artifacts |
 | **Scope** | Diff matches proposal exactly; no creep | Diff mostly matches; minor side-changes documented | Significant unrelated changes mixed in | Diff materially diverges from proposal |
 | **Reliability** | Error paths handled, idempotent, rollback safe | Most error paths handled, partial idempotency | Several error paths unhandled / unclear | Crashes or silent failures on common errors |
-| **Maintainability** | Clear naming, ≤40-line fns, no dead code, comments explain WHY | Acceptable structure with minor smells | Confusing structure, smells, or no tests for new logic | Unreviewable; needs rewrite |
+| **Maintainability** | Clear naming, ≤40-line fns, Cyclomatic Complexity ≤10 per function (checked with `cyclomatic-complexity`), no dead code, comments explain WHY | Acceptable structure with CC ≤15 | CC >15, confusing structure, smells, or no tests for new logic | Unreviewable; needs rewrite |
 | **Handoff-readiness** | Spec updates included, lessons captured if applicable, clear next steps | Spec updates included but lesson capture deferred | Implementation only; spec stale | No spec touch; lessons lost |
 
 ### Aggregation rule (rubric → verdict)

--- a/harness/skills/audit/SKILL.md
+++ b/harness/skills/audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/skills/audit/SKILL.md
-generated_sha: 74065d13a1af05e4
+generated_sha: c1a6813adc17676d
 id: audit-skill
 type: skill
 status: active
@@ -28,7 +28,7 @@ Analyze code for vulnerabilities, performance issues, and bad practices.
 | Auth | Missing validation, broken access control, CSRF |
 | Performance | N+1 queries, unbounded loops, blocking in async |
 | Resilience | Unhandled errors, missing timeouts, race conditions |
-| Quality | Magic numbers, deep nesting, missing types, dead code |
+| Quality | Cyclomatic complexity > 10 (use `/cyclomatic-complexity`), deep nesting, magic numbers, missing types, dead code |
 
 ## Output Format
 


### PR DESCRIPTION
## Summary

Updates `builder` and `reviewer` agent persona definitions and audit skills to bind the `cyclomatic-complexity` skill into their forced skills roster and checklists.

## SDD skip rationale

Declarative update to committed harness persona and skill records (<20 LOC diff).

## Verification

- `bats tests/triggers-registry.bats tests/skills-pipeline.bats tests/compile-harness.bats tests/agents-md.bats`: 118 tests passed (0 failures).
- `./scripts/compile-harness.sh --check`: OK, zero harness drift.