### PR TITLE
feat(pi): add qwen3.8-flash and glm5.3-flash to the NaN catalog

### DIFF
--- a/ai/opencode/opencode.jsonc
+++ b/ai/opencode/opencode.jsonc
@@ -16,6 +16,12 @@
 //   Embeddings / Audio: qwen3-embedding, kokoro (TTS), whisper (STT) — exposed for
 //                       cluster completeness; not chat-routable (use curl / OpenAI SDK directly).
 //   Frontier on-demand: openrouter/* (PAYG, uses existing $5 credit) — Opus / Sonnet / GPT-4
+//   Cataloged, not routed: nan/qwen3.8-flash, nan/glm5.3-flash — added 2026-08-26,
+//                       picker-only. Both are genuine frontier-tier 2026-08-26 releases
+//                       (Alibaba / Zhipu) with real 1M context, not weak "flash" tiers —
+//                       quality is not why they're unrouted. NaN's own allocation for
+//                       them is promotional and expires end of Aug 2026; see #1244
+//                       before promoting either past the picker.
 // Selection: TUI `/models` picker. Wrappers `qq` (nan/qwen3.6) / `qf` (nan/deepseek-v4-flash)
 //            in .zsh/aliases.zsh + .bashrc + powershell/profile.ps1.
 {
@@ -163,6 +169,78 @@
             "output": ["text"]
           },
                   "options": {
+            "chat_template_kwargs": {
+              "enable_thinking": true
+            }
+          },
+          "variants": {
+            "fast": {
+              "chat_template_kwargs": {
+                "enable_thinking": false
+              }
+            },
+            "thinking": {
+              "chat_template_kwargs": {
+                "enable_thinking": true
+              }
+            }
+          }
+        },
+        // Added 2026-08-26: catalog-only, not wired as default/small_model. NaN
+        // announced this on a promotional allocation expiring end of Aug 2026 —
+        // see ai/pi/README.md's Model environment section and #1244 for the
+        // routing-revisit follow-up. Verified via scripts/nan-debug.sh on a smoke
+        // prompt (emits reasoning_content) and on this repo's own planted
+        // `((count++))`/`set -e` bug (correct diagnosis, same test that admitted
+        // mimo-v2.5 into reviewer-pool.json) — genuinely capable, not just a
+        // cheap "flash" tier. Alibaba's own release notes: NATIVE context is
+        // 262,144, extended to 1M via YaRN in the production variant NaN serves;
+        // NaN's /v1/models omits context length, so 1M here is the vendor's
+        // production default, not independently measured against NaN's endpoint.
+        "qwen3.8-flash": {
+          "name": "Qwen 3.8 Flash Next (Alibaba - 1M)",
+          "interleaved": { "field": "reasoning_content" },
+          "limit": {
+            "context": 1000000,
+            "output": 8192
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          },
+          "options": {
+            "chat_template_kwargs": {
+              "enable_thinking": true
+            }
+          },
+          "variants": {
+            "fast": {
+              "chat_template_kwargs": {
+                "enable_thinking": false
+              }
+            },
+            "thinking": {
+              "chat_template_kwargs": {
+                "enable_thinking": true
+              }
+            }
+          }
+        },
+        // Added 2026-08-26 — see the qwen3.8-flash comment above; same status,
+        // and the same planted-bug test passed correctly. Zhipu's own release
+        // notes put GLM-5.3-Flash's 1M context as NATIVE (no YaRN caveat).
+        "glm5.3-flash": {
+          "name": "GLM 5.3 Flash (Zhipu - 1M)",
+          "interleaved": { "field": "reasoning_content" },
+          "limit": {
+            "context": 1000000,
+            "output": 8192
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          },
+          "options": {
             "chat_template_kwargs": {
               "enable_thinking": true
             }

--- a/ai/pi/README.md
+++ b/ai/pi/README.md
@@ -60,7 +60,27 @@ npm install -g --ignore-scripts @earendil-works/pi-coding-agent@<PI_VERSION>
 
 NaN only — the free tier, with no paid fallback in the picker.
 
-- **NaN** (free, primary): `qwen3.6`, `gemma4`, `deepseek-v4-flash`, `mimo-v2.5`
+- **NaN** (free, primary): `qwen3.6`, `gemma4`, `deepseek-v4-flash`, `mimo-v2.5`, `qwen3.8-flash`, `glm5.3-flash`
+
+`qwen3.8-flash` and `glm5.3-flash` (added 2026-08-26) are catalog additions only — picker
+availability, not a default or routing change. Both are live, reasoning-class, and
+independently strong: verified via `scripts/nan-debug.sh` on both a smoke prompt
+(surfaced `reasoning_content`) and this repo's own planted `((count++))`/`set -e` bug —
+the same defect that admitted `mimo-v2.5` to `harness/reviewer-pool.json` — which both
+identified correctly. Published third-party benchmarks back that up: Qwen3.8-Flash-Next
+(Alibaba) and GLM-5.3-Flash (Zhipu) both launched 2026-08-26 as genuine frontier-tier
+releases with real 1M context, not marketing inflation — see #1244 for sources. Quality is
+therefore *not* the reason they stay out of routing. The reason is that NaN announced them
+on a **promotional token allocation that expires end of August 2026**, ahead of a community
+vote on whether/how they stay, and neither has been run through `reviewer-pool.json`'s own
+admission procedure yet. Neither is wired into `defaultModel`, `harness/model-map.json`,
+`.pr_agent.toml` or `harness/reviewer-pool.json` — see #1244.
+
+One capability nuance for `qwen3.8-flash` specifically: Alibaba's own release notes put its
+*native* context at 262,144 tokens, extended to 1M via YaRN — the "production" NaN-served
+variant defaults to 1M, which is what's declared here, but YaRN-extended context can behave
+differently at the far end of the window than a natively-1M model (`deepseek-v4-flash`,
+`mimo-v2.5`). `glm5.3-flash`'s 1M is native per Zhipu.
 
 The three paid OpenRouter models (`deepseek-v4-pro`, `qwen3-coder-plus`, `minimax-m3`) were
 dropped from the picker: a paid model one keystroke away in a model list is a cost you take by

--- a/ai/pi/models.json
+++ b/ai/pi/models.json
@@ -80,6 +80,42 @@
           },
           "contextWindow": 1048576,
           "maxTokens": 65536
+        },
+        {
+          "id": "qwen3.8-flash",
+          "name": "qwen3.8-flash (NaN)",
+          "api": "openai-completions",
+          "reasoning": true,
+          "input": [
+            "text",
+            "image"
+          ],
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          },
+          "contextWindow": 1048576,
+          "maxTokens": 65536
+        },
+        {
+          "id": "glm5.3-flash",
+          "name": "glm5.3-flash (NaN)",
+          "api": "openai-completions",
+          "reasoning": true,
+          "input": [
+            "text",
+            "image"
+          ],
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          },
+          "contextWindow": 1048576,
+          "maxTokens": 65536
         }
       ],
       "authHeader": false

--- a/ai/pi/settings.json
+++ b/ai/pi/settings.json
@@ -7,6 +7,8 @@
     "nan/qwen3.6",
     "nan/gemma4",
     "nan/deepseek-v4-flash",
-    "nan/mimo-v2.5"
+    "nan/mimo-v2.5",
+    "nan/qwen3.8-flash",
+    "nan/glm5.3-flash"
   ]
 }

--- a/specs/AI-033-nan-catalog-additions/features.json
+++ b/specs/AI-033-nan-catalog-additions/features.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "AI-033-nan-catalog-additions-f1",
+    "behavior": "nan/qwen3.8-flash and nan/glm5.3-flash resolve to a valid entry in ai/pi/models.json and appear in ai/pi/settings.json's enabledModels",
+    "verification": "cd /home/manu/Projects/dotfiles-wt-nan-catalog && bats tests/pi-config.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-033-nan-catalog-additions-f2",
+    "behavior": "ai/pi/README.md's model list matches settings.json's enabledModels",
+    "verification": "cd /home/manu/Projects/dotfiles-wt-nan-catalog && bats tests/pi-config.bats -f 'README.md model list matches'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-033-nan-catalog-additions-f3",
+    "behavior": "ai/opencode/opencode.jsonc carries both models under provider.nan.models with reasoning_content interleaving mapped",
+    "verification": "cd /home/manu/Projects/dotfiles-wt-nan-catalog && bats tests/opencode.bats -f 'chat NaN models' -f 'interleaved'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-033-nan-catalog-additions-f4",
+    "behavior": "Neither model is referenced by defaultModel (pi) or model/small_model (opencode)",
+    "verification": "cd /home/manu/Projects/dotfiles-wt-nan-catalog && ! grep -E '\"(defaultModel|model|small_model)\":\\s*\"nan/(qwen3\\.8-flash|glm5\\.3-flash)\"' ai/pi/settings.json ai/opencode/opencode.jsonc",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-033-nan-catalog-additions-f5",
+    "behavior": "Both models verified live and functional against the real NaN API before merge",
+    "verification": "cd /home/manu/Projects/dotfiles-wt-nan-catalog && scripts/nan-debug.sh -m qwen3.8-flash 'responde solo: pong' && scripts/nan-debug.sh -m glm5.3-flash 'responde solo: pong'",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/AI-033-nan-catalog-additions/proposal.md
+++ b/specs/AI-033-nan-catalog-additions/proposal.md
@@ -1,0 +1,82 @@
+---
+id: "AI-033-nan-catalog-additions"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-27"
+issue: "mlorentedev/dotfiles#1254"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# AI-033-nan-catalog-additions
+
+> **Naming**: file lives at `<repo>/specs/AI-033-nan-catalog-additions/proposal.md`. `AI-033-nan-catalog-additions` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #1254: AI-033: add qwen3.8-flash and glm5.3-flash to the NaN catalog (pi + opencode) -->
+
+NaN's community added two new reasoning-class models (`qwen3.8-flash`, Alibaba;
+`glm5.3-flash`, Zhipu) to its subscription on 2026-08-26. Neither pi's model picker nor
+opencode's exposes them: `ai/pi/settings.json`'s curated `enabledModels` and
+`ai/opencode/opencode.jsonc`'s `provider.nan.models` map only know the four models that
+existed before this date, so a user cannot select either even though the underlying NaN
+subscription already serves them.
+
+## What
+
+Both model ids become selectable in pi's TUI model picker and opencode's `/models`
+picker, with correct capability metadata (context window, reasoning, modalities) so the
+picker and any tooling reading it (opencode's interleaved reasoning renderer) behaves
+correctly when either is chosen. Neither becomes a default — this is catalog exposure
+only, not a routing or behavior change for existing users.
+
+## Out of scope
+
+- Wiring either model into `defaultModel`/`model`/`small_model` (default stays
+  `nan/qwen3.6`, chosen by latency, not by this change)
+- Admitting either to `harness/reviewer-pool.json`, `.pr_agent.toml`, or
+  `harness/model-map.json`'s tiers — tracked separately in #1244, gated on NaN's
+  promotional allocation surviving its community vote (expires end of Aug 2026)
+- The `ai/pi/settings.json` deploy-time contract (seed-if-missing) not propagating this
+  catalog change to a machine that already has `~/.pi/agent/settings.json` — tracked
+  separately in #1247
+
+## Risks / open questions
+
+- NaN's `/v1/models` endpoint does not expose context-window metadata, so the 1M-token
+  figures recorded here are the vendors' own published claims (Alibaba, Zhipu), not
+  independently measured against NaN's endpoint. Resolved as acceptable: matches how
+  every sibling NaN model's `contextWindow` in this repo is already sourced.
+- `qwen3.8-flash`'s 1M context is YaRN-extended from a native 262K (Alibaba's own release
+  notes); `glm5.3-flash`'s 1M is native (Zhipu's). Documented inline in
+  `ai/opencode/opencode.jsonc` so a future reader evaluating either for the reviewer pool
+  (#1244) sees the asymmetry rather than assuming parity with `deepseek-v4-flash`/
+  `mimo-v2.5`.
+- NaN's allocation is explicitly promotional (1B tokens until end of August 2026), ahead
+  of a community vote on continued availability. Resolved as acceptable for a picker-only
+  change: worst case if the vote drops them, the picker entries go stale and get removed
+  in a follow-up, no routing depends on them.
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [ ] `nan/qwen3.8-flash` and `nan/glm5.3-flash` resolve to a valid entry in
+      `ai/pi/models.json` and appear in `ai/pi/settings.json`'s `enabledModels`
+- [ ] `ai/pi/README.md`'s model list matches `settings.json`'s `enabledModels`
+      (`tests/pi-config.bats`, referential-integrity tests)
+- [ ] `ai/opencode/opencode.jsonc` carries both under `provider.nan.models` with
+      `reasoning_content` interleaving mapped (`tests/opencode.bats`)
+- [ ] Neither model is referenced by `defaultModel` (pi) or `model`/`small_model`
+      (opencode)
+- [ ] Both models verified live and functional against the real NaN API before merge
+      (not just config-valid)
+
+## References
+
+- Bitácora board: #1254 (this spec's work-gate issue)
+- Related: #1244 (reviewer-pool/model-map admission, deferred), #1247 (settings.json
+  field-level sync, deferred)
+- `docs/lessons/lesson-150-a-config-file-the-tool-itself-rewrites-must-be-see.md` —
+  why `ai/pi/settings.json` is seed-if-missing (context for the "out of scope" #1247 item)

--- a/specs/AI-033-nan-catalog-additions/tasks.md
+++ b/specs/AI-033-nan-catalog-additions/tasks.md
@@ -1,0 +1,81 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-27"
+---
+
+# Tasks - AI-033-nan-catalog-additions
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers** (optional, additive — borrowed from `github/spec-kit`, adapt-not-adopt per #141):
+> - `[P]` — this task has **no dependency on another unchecked task**, so it is safe to run in parallel (fan out to a `Workflow`, or just batch). TDD chains (test → implement → refactor of the *same* behavior) are sequential and must NOT carry `[P]`; independent behaviors can.
+> - `[AC<n>]` — this task helps satisfy **acceptance criterion #`<n>`** from `proposal.md`. Lets `/spec check` map coverage deterministically; omit it and the check falls back to semantic judgment.
+
+> **Retroactive note**: the config additions were implemented and functionally verified
+> against the live NaN API before this spec folder existed — the diff crossed the
+> spec-gate's 50-LOC threshold organically (140 LOC across 5 files) and the gate correctly
+> refused the push. Tasks below record what was actually done, in the order it happened,
+> not a plan written before implementation.
+
+## Setup
+
+- [x] Branch created from `origin/main` in an isolated worktree (`feat/nan-catalog-additions`)
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+- [x] [AC5] Live-probed both model ids against `api.nan.builders` via `scripts/nan-debug.sh`
+      before touching any config — confirmed both real and reasoning-class
+      (`reasoning_content` present) on a smoke prompt
+- [x] [AC1] Added `qwen3.8-flash` and `glm5.3-flash` entries to `ai/pi/models.json`
+      (`providers.nan.models`)
+- [x] [AC1] Added `nan/qwen3.8-flash` and `nan/glm5.3-flash` to
+      `ai/pi/settings.json`'s `enabledModels`
+- [x] [AC2] Updated `ai/pi/README.md`'s model list to match, plus a documentation note on
+      the promotional-allocation caveat and the YaRN-vs-native context nuance
+- [x] [AC3] Added both models to `ai/opencode/opencode.jsonc`'s `provider.nan.models`,
+      mirroring the `mimo-v2.5` entry shape (`interleaved`, `limit`, `modalities`,
+      `variants`)
+- [x] [AC3] Updated `tests/opencode.bats`: model-count assertions (4 -> 6) and the
+      `interleaved` DX-004 AC1 count assertion (4 -> 6)
+- [x] [AC5] Re-probed both models against this repo's own planted
+      `((count++))`/`set -e` bug (the same defect that admitted `mimo-v2.5` to
+      `harness/reviewer-pool.json`) — both diagnosed it correctly
+- [x] [AC4] Confirmed by inspection: neither model referenced by `defaultModel`
+      (`ai/pi/settings.json`) or `model`/`small_model` (`ai/opencode/opencode.jsonc`)
+
+## Closing
+
+- [x] Every acceptance criterion from `proposal.md` is covered by at least one test or
+      recorded manual verification
+- [x] Every acceptance criterion has a matching entry in `features.json` with a
+      non-vacuous verification command
+- [x] Type checks pass (`go build ./... && go vet ./...` in `cli/`, unaffected by this
+      diff but re-run to confirm no incidental breakage)
+- [x] Lint passes (pre-commit hooks: secrets scan, bats @test names, doc-path check,
+      message format)
+- [x] No unrelated changes in the diff — isolated worktree branched fresh off
+      `origin/main`, patch-applied to include only the 5 catalog/test files
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
+
+Minimal `features.json` skeleton (drop into `<repo>/specs/AI-033-nan-catalog-additions/features.json`):
+
+```json
+[
+  {
+    "id": "AI-033-nan-catalog-additions-f1",
+    "behavior": "<one-line copy of an acceptance criterion>",
+    "verification": "<single shell command; exit 0 means pass>",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/AI-033-nan-catalog-additions/verification.md
+++ b/specs/AI-033-nan-catalog-additions/verification.md
@@ -1,0 +1,65 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-27"
+---
+
+# Verification - AI-033-nan-catalog-additions
+
+## Evidence
+
+- [x] AC1 (models resolve) -> commit `1188c9f` (`ai/pi/models.json`, `ai/pi/settings.json`)
+      + `tests/pi-config.bats` "nan/* models all resolve to an id in models.json"
+- [x] AC2 (README matches) -> commit `1188c9f` (`ai/pi/README.md`)
+      + `tests/pi-config.bats` "README.md model list matches settings.json enabledModels"
+- [x] AC3 (opencode + interleaving) -> commit `1188c9f` (`ai/opencode/opencode.jsonc`,
+      `tests/opencode.bats`) + `tests/opencode.bats` "exposes 6 chat NaN models" and
+      "maps NaN reasoning_content via interleaved on all 6 chat models"
+- [x] AC4 (not wired as default) -> manual grep, `ai/pi/settings.json` `defaultModel` and
+      `ai/opencode/opencode.jsonc` `model`/`small_model` unchanged from `qwen3.6`
+- [x] AC5 (live-verified functional) -> manual: two `scripts/nan-debug.sh` runs per model
+      (smoke prompt + this repo's planted `((count++))`/`set -e` bug), both models
+      responded and both diagnosed the bug correctly; recorded on issue #1244
+
+## Test status
+
+- `~/.local/bin/bats tests/pi-config.bats tests/opencode.bats tests/pr-agent-config.bats` -> 88/88 ok
+- `~/.local/bin/bats tests/*.bats` (full suite, isolated worktree, post-merge of #1246/#1248/#1252) -> 1519/1519 ok, exit 0
+- `cd cli && go build ./... && go vet ./...` -> clean (unaffected by this diff; re-run for regression confidence)
+- Manual smoke test: `scripts/nan-debug.sh -m qwen3.8-flash` and `-m glm5.3-flash`, both
+  the trivial "responde solo: pong" prompt and the planted `((count++))` bug — both models
+  responded correctly and both emitted `reasoning_content`
+- No regressions in existing test suite: yes
+
+## Decisions made during implementation
+
+- Diff crossed the spec-gate's 50-LOC threshold (140 LOC) after the config work was
+  already done and verified; this spec folder was created retroactively against a
+  same-day issue (#1254) rather than reworking the change to duck under the threshold.
+  `tasks.md` records the actual implementation order.
+- Committed in an isolated worktree (`dotfiles-wt-nan-catalog`, branched fresh off
+  `origin/main`) rather than the shared worktree the config edits were originally made
+  in, because another live session was concurrently committing unrelated work
+  (`fix/pi-subagent-shadowing`, merged as #1248) in that shared worktree. A patch of only
+  the 5 touched files was applied there instead, to guarantee zero overlap.
+- Deliberately left `harness/model-map.json`, `.pr_agent.toml` and
+  `harness/reviewer-pool.json` untouched (see proposal's "Out of scope") — quality is not
+  the blocker per the functional verification above, but NaN's allocation for both models
+  is promotional and time-boxed; #1244 tracks the revisit.
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons/`? No — this is routine catalog maintenance
+      following the existing `mimo-v2.5` precedent; nothing new was learned about the
+      mechanism itself.
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? No — no architectural
+      decision, catalog-only per existing conventions.
+- [ ] New pattern candidate for `00_meta/patterns/`? No — single-repo, single-occurrence.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/AI-033-nan-catalog-additions/` -> `specs/archive/AI-033-nan-catalog-additions/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)

--- a/tests/opencode.bats
+++ b/tests/opencode.bats
@@ -164,8 +164,8 @@ setup() {
     grep -qE '"model":\s*"nan/qwen3.6"' "$OPENCODE_CFG"
 }
 
-@test "opencode.jsonc exposes 4 chat NaN models (non-chat models intentionally excluded - opencode schema rejects 'embedding' modality)" {
-    for m in deepseek-v4-flash qwen3.6 gemma4 mimo-v2.5; do
+@test "opencode.jsonc exposes 6 chat NaN models (non-chat models intentionally excluded - opencode schema rejects 'embedding' modality)" {
+    for m in deepseek-v4-flash qwen3.6 gemma4 mimo-v2.5 qwen3.8-flash glm5.3-flash; do
         grep -qE "\"$m\":" "$OPENCODE_CFG" || { echo "missing chat model $m" >&2; false; }
     done
     # Non-chat models must NOT appear (would break config load)
@@ -273,11 +273,11 @@ setup() {
 
 # --- DX-004: reasoning visibility (interleaved) + TUI config (tui.json) ---
 
-@test "opencode.jsonc maps NaN reasoning_content via interleaved on all 4 chat models (DX-004 AC1)" {
+@test "opencode.jsonc maps NaN reasoning_content via interleaved on all 6 chat models (DX-004 AC1)" {
     # opencode only renders NaN's reasoning chain if reasoning_content is mapped
-    # to a reasoning part. All four chat models must carry the mapping.
+    # to a reasoning part. All six chat models must carry the mapping.
     count=$(grep -cE '"interleaved":[[:space:]]*\{[[:space:]]*"field":[[:space:]]*"reasoning_content"[[:space:]]*\}' "$OPENCODE_CFG")
-    [ "$count" -eq 4 ] || { echo "expected 4 interleaved blocks, got $count" >&2; false; }
+    [ "$count" -eq 6 ] || { echo "expected 6 interleaved blocks, got $count" >&2; false; }
 }
 
 @test "opencode.jsonc reasoning comment updated off the stale 1.15.10 'renders neither' note (DX-004 AC5)" {


### PR DESCRIPTION
## Summary
- Add `qwen3.8-flash` (Alibaba) and `glm5.3-flash` (Zhipu), both launched on NaN 2026-08-26, to the pi and opencode model pickers — catalog only, no default/routing change.
- Verified live against the NaN API before merge: both respond, both emit `reasoning_content`, and both correctly diagnosed this repo's own planted `((count++))`/`set -e` bug (the same test that admitted `mimo-v2.5` to `harness/reviewer-pool.json`).
- `harness/model-map.json`, `.pr_agent.toml` and `harness/reviewer-pool.json` are deliberately untouched — NaN's allocation for both is promotional and expires end of August 2026 ahead of a community vote; tracked in #1244.

Closes #1254

Spec: `specs/AI-033-nan-catalog-additions/`

## Test plan
- [x] `bats tests/pi-config.bats tests/opencode.bats tests/pr-agent-config.bats` — 88/88 ok
- [x] `bats tests/*.bats` (full suite) — 1519/1519 ok
- [x] `cd cli && go build ./... && go vet ./...` — clean
- [x] Manual: `scripts/nan-debug.sh -m qwen3.8-flash` / `-m glm5.3-flash`, smoke prompt + planted-bug prompt, both correct