### PR TITLE
feat(harness): declare where model ids are pinned, and check they resolve

### DIFF
--- a/cli/internal/doctor/checks_model_pins.go
+++ b/cli/internal/doctor/checks_model_pins.go
@@ -1,0 +1,192 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/harness"
+)
+
+// checkModelPins reports routing pins in DEPLOYED files that the routing
+// registry no longer resolves (HARNESS-067, #902).
+//
+// WHY THIS IS DOCTOR AND NOT CI. The repo half of this guard is a Go test, which
+// runs anywhere. This half reads files on one machine — ~/.pi/agent/settings.json
+// and its neighbours — and CI never sees a machine. Same split as the pi
+// extension check next door: a check that cannot run where the defect lives is
+// not a guard.
+//
+// THE DEFECT, measured 2026-08-26. The deployed pi settings carried
+// `nan/deepseek-v4-flash-0731`, an id that no longer resolves — pi printed
+// `Warning: No models match pattern "nan/deepseek-v4-flash-0731"` on EVERY start
+// — plus three `openrouter/*` entries for a provider this repo retired in August
+// 2026. Nobody noticed until an unrelated investigation read the file, because
+// the repo cannot converge it: `ai/pi/settings.json` is seed-if-missing, pi owns
+// the live copy (#754), and no check looked.
+//
+// IT NEVER WRITES. Repairing would mean a surgical merge into a file the tool
+// rewrites at runtime, which is the same disposition question the hand-wired
+// extension symlinks raised in #1243 — asked, not defaulted. There is
+// deliberately no --fix here, and the check is not even given the flag.
+//
+// SEVERITY FOLLOWS CONSEQUENCE, not tidiness. A dead scalar routing pin
+// (`defaultModel`) decides what a real session runs on, so it fails. A dead
+// entry in a catalog array costs a warning line at startup and a stale picker
+// row, so it warns. Reporting both identically would either cry wolf about a
+// picker or under-report a broken default.
+func checkModelPins(sys *System, cfg *Config, rep *Report) {
+	rep.Section("Model pin drift")
+
+	pins, err := harness.LoadModelPins(cfg.DotfilesDir)
+	if err != nil {
+		// C15: an unreadable registry is not an empty one. Both would produce
+		// "no drift found"; they mean opposite things.
+		rep.Fail(fmt.Sprintf("%v\n    This check reads the deployed copy; if the file exists in your checkout, re-run setup to mirror it.", err))
+		return
+	}
+	m, err := harness.LoadModelMap(cfg.DotfilesDir)
+	if err != nil {
+		rep.Fail(fmt.Sprintf("routing registry unreadable, so no pin can be resolved: %v", err))
+		return
+	}
+	qualified, bare := harness.DeclaredModels(m)
+
+	sites := 0
+	values := 0
+	findings := 0
+
+	for _, site := range pins.Sites {
+		if site.Scope != "deployed" {
+			continue
+		}
+		path := expandHome(sys, site.File)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				rep.Skip(fmt.Sprintf("%s not deployed on this machine", site.File))
+				continue
+			}
+			rep.Warn(fmt.Sprintf("%s unreadable: %v", site.File, err))
+			continue
+		}
+		sites++
+
+		for _, p := range site.Pins {
+			raw, err := harness.Extract(p, content)
+			if err != nil {
+				// A locator that stopped matching reports zero values, and zero
+				// values look exactly like zero drift. Say which one it is.
+				rep.Warn(fmt.Sprintf("%s: %v", site.File, err))
+				continue
+			}
+			isCatalog := strings.HasSuffix(p.Locator, "[]")
+			for _, v := range raw {
+				values++
+				switch harness.Check(p, v, qualified, bare) {
+				case harness.VerdictOK:
+				case harness.VerdictWrongPool:
+					findings++
+					rep.Warn(fmt.Sprintf("%s %s: %q is a model the map knows, but not under pool %q",
+						site.File, p.ID, v, p.Pool))
+				case harness.VerdictUnknown:
+					if isCatalog {
+						// A CATALOG entry the map does not route is normally
+						// legitimate — that is #1244's whole point, and
+						// `nan/gemma4` is a live NaN model nobody routes. So an
+						// unrouted catalog id is not reported. Only two shapes
+						// are, because only these two mean something is WRONG
+						// rather than merely unrouted.
+						if retired := retiredProvider(v); retired != "" {
+							findings++
+							rep.Warn(fmt.Sprintf("%s %s: %q names %q, a provider this repository retired\n    Catalog entry: a stale picker row, not a broken default.",
+								site.File, p.ID, v, retired))
+							continue
+						}
+						if base := staleSnapshotOf(v, p, bare); base != "" {
+							findings++
+							rep.Warn(fmt.Sprintf("%s %s: %q is a frozen snapshot of %q, and no longer resolves\n    Catalog entry: pi prints `No models match pattern` for it on every start.",
+								site.File, p.ID, v, base))
+						}
+						continue
+					}
+					findings++
+					msg := fmt.Sprintf("%s %s: %q resolves to nothing the routing registry declares", site.File, p.ID, v)
+					if retired := retiredProvider(v); retired != "" {
+						msg = fmt.Sprintf("%s %s: %q names %q, a provider this repository retired",
+							site.File, p.ID, v, retired)
+					}
+					rep.Fail(msg + "\n    This decides what a real session runs on.")
+				}
+			}
+		}
+	}
+
+	if sites == 0 {
+		rep.Skip("no deployed pin sites present on this machine")
+		return
+	}
+	if values == 0 {
+		// Never render as "clean": a sweep that inspected nothing is the failure
+		// this check exists to catch, one level up.
+		rep.Fail("deployed pin sites were read but no pin was extracted — the locators have rotted, this is not a clean result")
+		return
+	}
+	if findings == 0 {
+		rep.Pass(fmt.Sprintf("%d deployed routing pins across %d files all resolve in the map", values, sites))
+	}
+}
+
+// staleSnapshotOf reports the declared model a catalog id is a frozen snapshot
+// of, or "" when it is not one.
+//
+// THE DISTINCTION THIS DRAWS, and why the naive version is wrong. A catalog id
+// the map does not route is USUALLY fine: `nan/gemma4` is a live NaN model that
+// nothing routes, exactly as `qwen3.8-flash` and `glm5.3-flash` are (#1244).
+// Reporting every unrouted catalog entry would fire on a recorded decision — the
+// failure this registry's own $comment warns against, and one that was written
+// into the first version of this check before a real run caught it.
+//
+// `nan/deepseek-v4-flash-0731` is different in a way that is mechanical rather
+// than a matter of taste: it is a declared id (`deepseek-v4-flash`) plus a date
+// stamp. That makes it a pin to a frozen snapshot of a model that is still
+// alive under its rolling name — a thing that goes stale by construction, and
+// which pi rejects outright (`No models match pattern`). Only that shape, and a
+// retired provider, are reported.
+//
+// Providers publish these as `-MMDD`, `-YYYYMMDD` or `-YYYY-MM-DD`; the suffix
+// is required to be digits and separators so an ordinary versioned name like
+// `qwen3.6-plus` can never match.
+func staleSnapshotOf(raw string, p harness.Pin, bare map[string]bool) string {
+	id := raw
+	if p.Prefix != "" {
+		id = strings.TrimPrefix(id, p.Prefix)
+	}
+	for base := range bare {
+		suffix, ok := strings.CutPrefix(id, base+"-")
+		if !ok || suffix == "" {
+			continue
+		}
+		if strings.IndexFunc(suffix, func(r rune) bool {
+			return (r < '0' || r > '9') && r != '-'
+		}) >= 0 {
+			continue
+		}
+		return base
+	}
+	return ""
+}
+
+// retiredProvider names a provider prefix this repository has retired, so the
+// diagnostic says WHY an id cannot resolve rather than only that it cannot. The
+// map's own $comment records both as decisions rather than oversights: openrouter
+// was deleted upstream in August 2026, and codex is no longer used by this
+// operator.
+func retiredProvider(raw string) string {
+	for _, p := range []string{"openrouter", "codex"} {
+		if strings.HasPrefix(raw, p+"/") || strings.HasPrefix(raw, p+":") {
+			return p
+		}
+	}
+	return ""
+}

--- a/cli/internal/doctor/checks_model_pins_test.go
+++ b/cli/internal/doctor/checks_model_pins_test.go
@@ -1,0 +1,184 @@
+package doctor
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// pinFixture builds a dotfiles dir carrying the two registries plus a fake $HOME
+// holding a deployed pi settings.json with the given enabledModels/defaultModel.
+func pinFixture(t *testing.T, defaultModel string, enabled []string) (*System, *Config, string) {
+	t.Helper()
+	root := t.TempDir()
+	home := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(root, "harness"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The real registries, so the fixture cannot drift from what ships.
+	for _, f := range []string{"model-pins.json", "model-map.json", "model-map.schema.json"} {
+		src := filepath.Join(repoRootForDoctorTest(t), "harness", f)
+		b, err := os.ReadFile(src)
+		if err != nil {
+			t.Fatalf("read %s: %v", src, err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "harness", f), b, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	settings := filepath.Join(home, ".pi", "agent", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settings), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	doc := `{"defaultProvider":"nan","defaultModel":"` + defaultModel + `","enabledModels":["` +
+		strings.Join(enabled, `","`) + `"]}`
+	if err := os.WriteFile(settings, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	return piSys(home), &Config{DotfilesDir: root}, settings
+}
+
+func pinRun(t *testing.T, sys *System, cfg *Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	rep := NewReport(&buf, true)
+	checkModelPins(sys, cfg, rep)
+	rep.flush()
+	return buf.String()
+}
+
+// AC5 — a deployed catalog id that is a frozen snapshot of a live model is
+// reported. This is the exact value measured on the real machine 2026-08-26.
+func TestModelPinsReportsAFrozenSnapshot(t *testing.T) {
+	sys, cfg, _ := pinFixture(t, "qwen3.6", []string{"nan/qwen3.6", "nan/deepseek-v4-flash-0731"})
+	out := pinRun(t, sys, cfg)
+
+	if !strings.Contains(out, "deepseek-v4-flash-0731") {
+		t.Fatalf("the dead dated id was not reported:\n%s", out)
+	}
+	if !strings.Contains(out, "frozen snapshot") {
+		t.Errorf("the diagnostic does not say WHY it is stale:\n%s", out)
+	}
+	if strings.Contains(out, cfg.DotfilesDir) || strings.Contains(out, sys.home()) {
+		t.Errorf("a literal path was printed (ADR-025):\n%s", out)
+	}
+}
+
+// AC6 — a retired provider reads differently from an unresolvable model id,
+// because they are different problems with different fixes.
+func TestModelPinsDistinguishesARetiredProvider(t *testing.T) {
+	sys, cfg, _ := pinFixture(t, "qwen3.6", []string{"nan/qwen3.6", "openrouter/minimax/minimax-m3"})
+	out := pinRun(t, sys, cfg)
+
+	if !strings.Contains(out, "retired") {
+		t.Fatalf("a retired-provider entry was not named as such:\n%s", out)
+	}
+	if strings.Contains(out, "frozen snapshot") {
+		t.Errorf("a retired provider was misreported as a snapshot:\n%s", out)
+	}
+}
+
+// AC4's deployed half, and a regression guard on a false positive this check
+// SHIPPED WITH before a real run caught it.
+//
+// `nan/gemma4` is a live NaN model that the map does not route, exactly as
+// `qwen3.8-flash` and `glm5.3-flash` are (#1244). The first version of this
+// check reported every unrouted catalog id, which would have fired on all three
+// — the very failure the registry's own $comment warns against.
+func TestModelPinsDoesNotReportAnUnroutedCatalogModel(t *testing.T) {
+	sys, cfg, _ := pinFixture(t, "qwen3.6", []string{
+		"nan/qwen3.6", "nan/gemma4", "nan/qwen3.8-flash", "nan/glm5.3-flash",
+	})
+	out := pinRun(t, sys, cfg)
+
+	for _, legit := range []string{"gemma4", "qwen3.8-flash", "glm5.3-flash"} {
+		if strings.Contains(out, legit) {
+			t.Errorf("%q is a catalog model the map does not route, which is not drift:\n%s", legit, out)
+		}
+	}
+	if !strings.Contains(out, "[ OK ]") {
+		t.Errorf("a clean machine must report OK:\n%s", out)
+	}
+}
+
+// A dead SCALAR routing pin fails rather than warns: it decides what a real
+// session runs on.
+func TestModelPinsFailsOnADeadDefaultModel(t *testing.T) {
+	sys, cfg, _ := pinFixture(t, "deepseek-v4-flash-0731", []string{"nan/qwen3.6"})
+	out := pinRun(t, sys, cfg)
+
+	if !strings.Contains(out, "[FAIL]") {
+		t.Fatalf("a dead defaultModel must FAIL, not warn:\n%s", out)
+	}
+	if !strings.Contains(out, "what a real session runs on") {
+		t.Errorf("the diagnostic does not say why this is worse than a catalog row:\n%s", out)
+	}
+}
+
+// AC8 — the check never writes. Asserted rather than assumed, because the file
+// it reads is pi's own runtime state and repairing it is an open question, not a
+// default.
+func TestModelPinsNeverWrites(t *testing.T) {
+	sys, cfg, settings := pinFixture(t, "qwen3.6", []string{
+		"nan/deepseek-v4-flash-0731", "openrouter/minimax/minimax-m3",
+	})
+	before, err := os.ReadFile(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	statBefore, err := os.Stat(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if out := pinRun(t, sys, cfg); !strings.Contains(out, "[WARN]") {
+		t.Fatalf("fixture should have produced findings:\n%s", out)
+	}
+
+	after, err := os.ReadFile(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Error("the check modified the deployed settings.json")
+	}
+	statAfter, err := os.Stat(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !statBefore.ModTime().Equal(statAfter.ModTime()) {
+		t.Error("the check touched the deployed settings.json")
+	}
+}
+
+// AC7's doctor half — an unreadable registry is a loud FAIL, never a clean sweep.
+func TestModelPinsFailsLoudlyWithoutARegistry(t *testing.T) {
+	sys, _, _ := pinFixture(t, "qwen3.6", []string{"nan/qwen3.6"})
+	out := pinRun(t, sys, &Config{DotfilesDir: t.TempDir()})
+
+	if !strings.Contains(out, "[FAIL]") {
+		t.Fatalf("a missing registry must FAIL:\n%s", out)
+	}
+	for _, banned := range []string{"[ OK ]", "all resolve"} {
+		if strings.Contains(out, banned) {
+			t.Errorf("a broken guard reported %q:\n%s", banned, out)
+		}
+	}
+}
+
+// An absent deployed file is a SKIP, not a failure: not every machine runs pi.
+func TestModelPinsSkipsWhenNotDeployed(t *testing.T) {
+	sys, cfg, settings := pinFixture(t, "qwen3.6", []string{"nan/qwen3.6"})
+	if err := os.Remove(settings); err != nil {
+		t.Fatal(err)
+	}
+	out := pinRun(t, sys, cfg)
+	if !strings.Contains(out, "[SKIP]") {
+		t.Fatalf("an undeployed site must SKIP:\n%s", out)
+	}
+}

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -98,6 +98,7 @@ func Run(opts Options) (int, error) {
 		checkOpenCode(sys, cfg, rep)
 		checkGolangciLint(sys, cfg, rep)
 		checkModelMap(cfg, rep)
+		checkModelPins(sys, cfg, rep)
 		checkPiExtensions(sys, cfg, rep, opts.Fix)
 		checkHarnessDrift(sys, cfg, rep, opts.Fix)
 		checkDeployDrift(sys, cfg, rep)

--- a/cli/internal/harness/model_pins.go
+++ b/cli/internal/harness/model_pins.go
@@ -1,0 +1,322 @@
+package harness
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// ModelPinsFile is the pin-site registry (HARNESS-067, #902).
+const ModelPinsFile = "harness/model-pins.json"
+
+// ModelPins is harness/model-pins.json: where a model id is pinned for ROUTING
+// outside the map, and how each site spells it.
+type ModelPins struct {
+	Version int       `json:"version"`
+	Sites   []PinSite `json:"sites"`
+}
+
+// PinSite is one file carrying routing pins.
+type PinSite struct {
+	File  string `json:"file"`
+	Scope string `json:"scope"` // "repo" | "deployed"
+	Why   string `json:"why"`
+	Pins  []Pin  `json:"pins"`
+}
+
+// Pin is one routing decision inside a site.
+type Pin struct {
+	ID      string `json:"id"`
+	Kind    string `json:"kind"` // "json-path" | "toml-key" | "regex" | "regex-all"
+	Locator string `json:"locator"`
+	Prefix  string `json:"prefix"`
+	Pool    string `json:"pool"`
+	Why     string `json:"why"`
+}
+
+// LoadModelPins reads and validates the registry.
+//
+// Every failure is loud and none of them can render as "no pin sites declared"
+// — constraint C15, and for the same reason it applies to the map next door: a
+// registry that cannot be read and a registry that declares nothing produce
+// identical downstream behaviour (zero drift reported) while meaning opposite
+// things. One is a configuration, the other is a broken guard.
+func LoadModelPins(repoRoot string) (*ModelPins, error) {
+	path := filepath.Join(repoRoot, ModelPinsFile)
+	doc, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w\nthis is not an empty pin registry — a guard that cannot read its own declaration reports no drift", ModelPinsFile, err)
+	}
+	var pins ModelPins
+	if err := json.Unmarshal(doc, &pins); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", ModelPinsFile, err)
+	}
+	if len(pins.Sites) == 0 {
+		return nil, fmt.Errorf("%s declares no sites — refusing to report a clean sweep over nothing", ModelPinsFile)
+	}
+	seen := map[string]string{}
+	for _, s := range pins.Sites {
+		if s.Scope != "repo" && s.Scope != "deployed" {
+			return nil, fmt.Errorf("%s: site %q has scope %q, want repo or deployed", ModelPinsFile, s.File, s.Scope)
+		}
+		if len(s.Pins) == 0 {
+			return nil, fmt.Errorf("%s: site %q declares no pins", ModelPinsFile, s.File)
+		}
+		for _, p := range s.Pins {
+			if p.Why == "" {
+				return nil, fmt.Errorf("%s: pin %q has no why — a pin nobody can justify is one to delete", ModelPinsFile, p.ID)
+			}
+			if prev, dup := seen[p.ID]; dup {
+				return nil, fmt.Errorf("%s: pin id %q declared twice (%s and %s)", ModelPinsFile, p.ID, prev, s.File)
+			}
+			seen[p.ID] = s.File
+			switch p.Kind {
+			case "json-path", "toml-key", "regex", "regex-all":
+			default:
+				return nil, fmt.Errorf("%s: pin %q has unknown kind %q", ModelPinsFile, p.ID, p.Kind)
+			}
+			if p.Kind == "regex" || p.Kind == "regex-all" {
+				re, err := regexp.Compile(p.Locator)
+				if err != nil {
+					return nil, fmt.Errorf("%s: pin %q locator does not compile: %w", ModelPinsFile, p.ID, err)
+				}
+				if re.NumSubexp() != 1 {
+					return nil, fmt.Errorf("%s: pin %q locator needs exactly one capture group, has %d", ModelPinsFile, p.ID, re.NumSubexp())
+				}
+			}
+		}
+	}
+	return &pins, nil
+}
+
+// DeclaredModels reports what the map routes, as a set of `pool:id` and a set of
+// bare ids.
+//
+// TWO SETS, NOT ONE, because the map's own $comment records that tiers are keyed
+// by whatever CONSUMES the model id, which is not always a pool: `claude` and
+// `opencode` key by harness there, while `nan` keys by pool. Collapsing that into
+// one pool-qualified set would invent pool attributions the map never made and
+// report them as drift.
+//
+// So `chains` — the one block that is unambiguously `pool:id` — populates the
+// qualified set, and every block contributes to the bare set. A pin whose id is
+// absent from the bare set names a model the map does not know at all, which is
+// real drift. A pin present in the bare set but not under its declared pool is a
+// weaker signal, reported as such.
+func DeclaredModels(m map[string]any) (qualified map[string]bool, bare map[string]bool) {
+	qualified, bare = map[string]bool{}, map[string]bool{}
+
+	if chains, ok := m["chains"].(map[string]any); ok {
+		for _, v := range chains {
+			for _, entry := range toStrings(v) {
+				qualified[entry] = true
+				if pool, id, found := strings.Cut(entry, ":"); found {
+					bare[id] = true
+					qualified[pool+":"+id] = true
+				}
+			}
+		}
+	}
+	if tiers, ok := m["tiers"].(map[string]any); ok {
+		for _, v := range tiers {
+			entry, ok := v.(map[string]any)
+			if !ok {
+				continue
+			}
+			for consumer, model := range entry {
+				id, ok := model.(string)
+				if !ok {
+					continue
+				}
+				bare[id] = true
+				// Recorded as qualified only when the consumer is itself a
+				// declared pool. A harness key is not a pool, and pretending
+				// otherwise is the invention this function exists to avoid.
+				if pools, ok := m["pools"].(map[string]any); ok {
+					if _, isPool := pools[consumer]; isPool {
+						qualified[consumer+":"+id] = true
+					}
+				}
+			}
+		}
+	}
+	if services, ok := m["services"].(map[string]any); ok {
+		for _, v := range services {
+			svc, ok := v.(map[string]any)
+			if !ok {
+				continue
+			}
+			id, _ := svc["model"].(string)
+			pool, _ := svc["pool"].(string)
+			if id == "" {
+				continue
+			}
+			bare[id] = true
+			if pool != "" {
+				qualified[pool+":"+id] = true
+			}
+		}
+	}
+	return qualified, bare
+}
+
+// Verdict is what checking one extracted value produced.
+type Verdict int
+
+const (
+	// VerdictOK — the map routes this exact pool and model.
+	VerdictOK Verdict = iota
+	// VerdictWrongPool — the map knows the model, but not under this pin's pool.
+	VerdictWrongPool
+	// VerdictUnknown — the map does not declare this model at all. Real drift:
+	// `nan/deepseek-v4-flash-0731` and the retired `openrouter/*` ids both land
+	// here.
+	VerdictUnknown
+)
+
+// Finding is one pin value that did not resolve cleanly.
+type Finding struct {
+	Site    string
+	PinID   string
+	Raw     string
+	Norm    string
+	Verdict Verdict
+}
+
+// Normalize turns a site's spelling into `pool:id` using the pin's declared
+// rule. Declared, never inferred: one model has three correct spellings across
+// these files (`nan:mimo-v2.5`, `openai/mimo-v2.5`, bare `mimo-v2.5`), so a
+// guess would be wrong for two of them.
+func Normalize(p Pin, raw string) string {
+	id := raw
+	if p.Prefix != "" {
+		id = strings.TrimPrefix(id, p.Prefix)
+	}
+	// A site may still qualify with some other provider prefix — a retired one,
+	// for instance. Keep it in the id so the diagnostic names what is actually
+	// written rather than a silently trimmed version of it.
+	return p.Pool + ":" + id
+}
+
+// Check resolves one raw value against the map.
+func Check(p Pin, raw string, qualified, bare map[string]bool) Verdict {
+	norm := Normalize(p, raw)
+	if qualified[norm] {
+		return VerdictOK
+	}
+	_, id, _ := strings.Cut(norm, ":")
+	if bare[id] {
+		return VerdictWrongPool
+	}
+	return VerdictUnknown
+}
+
+// Extract pulls every value a pin locates out of the file's content.
+//
+// It returns an error rather than an empty slice when a locator matches nothing,
+// and that distinction is the whole guard: a locator that has silently stopped
+// matching produces zero values, and zero values check clean. "No pins found" and
+// "no drift" must never be the same outcome.
+func Extract(p Pin, content []byte) ([]string, error) {
+	switch p.Kind {
+	case "json-path":
+		return extractJSONPath(p, content)
+	case "toml-key":
+		return extractTOMLKey(p, content)
+	case "regex", "regex-all":
+		re, err := regexp.Compile(p.Locator)
+		if err != nil {
+			return nil, fmt.Errorf("pin %q: %w", p.ID, err)
+		}
+		matches := re.FindAllStringSubmatch(string(content), -1)
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("pin %q: locator matched nothing — the file changed shape, or the pattern rotted", p.ID)
+		}
+		if p.Kind == "regex" && len(matches) > 1 {
+			return nil, fmt.Errorf("pin %q: locator matched %d times but kind is regex (exactly one); use regex-all", p.ID, len(matches))
+		}
+		out := make([]string, 0, len(matches))
+		for _, m := range matches {
+			out = append(out, m[1])
+		}
+		return out, nil
+	}
+	return nil, fmt.Errorf("pin %q: unknown kind %q", p.ID, p.Kind)
+}
+
+// extractJSONPath supports a top-level key, and `key[]` for a top-level array of
+// strings. Deliberately not a JSONPath engine: every pin site here is a flat
+// top-level key, and a general query language would be more surface than the
+// registry needs.
+//
+// The content is read as JSONC-tolerant — opencode.jsonc carries comments.
+func extractJSONPath(p Pin, content []byte) ([]string, error) {
+	var doc map[string]any
+	if err := json.Unmarshal(stripJSONComments(content), &doc); err != nil {
+		return nil, fmt.Errorf("pin %q: %w", p.ID, err)
+	}
+	key, isArray := strings.CutSuffix(p.Locator, "[]")
+	v, ok := doc[key]
+	if !ok {
+		return nil, fmt.Errorf("pin %q: key %q not present — the file changed shape", p.ID, key)
+	}
+	if isArray {
+		out := toStrings(v)
+		if len(out) == 0 {
+			return nil, fmt.Errorf("pin %q: %q is empty or not a string array", p.ID, key)
+		}
+		return out, nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return nil, fmt.Errorf("pin %q: %q is not a string", p.ID, key)
+	}
+	return []string{s}, nil
+}
+
+var tomlKeyLine = `(?m)^\s*%s\s*=\s*"([^"]+)"`
+
+// extractTOMLKey reads a bare `key = "value"` line. `.pr_agent.toml` puts these
+// at section scope, and pulling in a TOML parser to read two string keys would
+// be a dependency this check does not need.
+func extractTOMLKey(p Pin, content []byte) ([]string, error) {
+	re, err := regexp.Compile(fmt.Sprintf(tomlKeyLine, regexp.QuoteMeta(p.Locator)))
+	if err != nil {
+		return nil, fmt.Errorf("pin %q: %w", p.ID, err)
+	}
+	m := re.FindStringSubmatch(string(content))
+	if m == nil {
+		return nil, fmt.Errorf("pin %q: key %q not found", p.ID, p.Locator)
+	}
+	return []string{m[1]}, nil
+}
+
+var (
+	jsoncBlock = regexp.MustCompile(`(?s)/\*.*?\*/`)
+	jsoncLine  = regexp.MustCompile(`(?m)^\s*//.*$`)
+)
+
+// stripJSONComments removes the comment forms opencode.jsonc uses. Only
+// whole-line `//` comments are stripped, never trailing ones, because a `//`
+// inside a string value ("https://...") is not a comment and removing it would
+// corrupt the very ids being checked.
+func stripJSONComments(b []byte) []byte {
+	b = jsoncBlock.ReplaceAll(b, nil)
+	return jsoncLine.ReplaceAll(b, nil)
+}
+
+// SortedSiteFiles lists declared files for a scope, for stable diagnostics.
+func (mp *ModelPins) SortedSiteFiles(scope string) []string {
+	var out []string
+	for _, s := range mp.Sites {
+		if s.Scope == scope {
+			out = append(out, s.File)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cli/internal/harness/model_pins_test.go
+++ b/cli/internal/harness/model_pins_test.go
@@ -1,0 +1,205 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// AC1 — the registry is well-formed, every pin justified, ids unique, locators
+// compile with exactly one capture.
+func TestModelPinsRegistryIsWellFormed(t *testing.T) {
+	pins, err := LoadModelPins(repoRootForTest(t))
+	if err != nil {
+		t.Fatalf("registry does not load: %v", err)
+	}
+	if len(pins.Sites) == 0 {
+		t.Fatal("no sites declared")
+	}
+	repo := pins.SortedSiteFiles("repo")
+	if len(repo) == 0 {
+		t.Error("no repo-scoped sites — nothing would be checkable in CI")
+	}
+	if len(pins.SortedSiteFiles("deployed")) == 0 {
+		t.Error("no deployed-scoped sites — the drift that motivated this lives there")
+	}
+}
+
+// AC2 — the load-bearing one. Every routing pin in a COMMITTED file resolves to
+// something harness/model-map.json declares.
+//
+// It reads the real repository, not a fixture: a guard over a fixture proves the
+// guard parses, never that this repository agrees with its own routing registry.
+func TestEveryRepoRoutingPinResolvesInTheMap(t *testing.T) {
+	root := repoRootForTest(t)
+	pins, err := LoadModelPins(root)
+	if err != nil {
+		t.Fatalf("registry does not load: %v", err)
+	}
+	m, err := LoadModelMap(root)
+	if err != nil {
+		t.Fatalf("model map does not load: %v", err)
+	}
+	qualified, bare := DeclaredModels(m)
+
+	checked := 0
+	for _, site := range pins.Sites {
+		if site.Scope != "repo" {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(root, site.File))
+		if err != nil {
+			t.Errorf("%s: declared as a pin site but unreadable: %v", site.File, err)
+			continue
+		}
+		for _, p := range site.Pins {
+			values, err := Extract(p, content)
+			if err != nil {
+				// A locator that matches nothing is the failure this check
+				// exists to prevent, not a reason to skip the site.
+				t.Errorf("%s: %v", site.File, err)
+				continue
+			}
+			for _, raw := range values {
+				checked++
+				switch Check(p, raw, qualified, bare) {
+				case VerdictOK:
+				case VerdictWrongPool:
+					t.Errorf("%s pin %q: %q normalizes to %q — the map knows the model but not under pool %q",
+						site.File, p.ID, raw, Normalize(p, raw), p.Pool)
+				case VerdictUnknown:
+					t.Errorf("%s pin %q: %q normalizes to %q, which harness/model-map.json does not declare",
+						site.File, p.ID, raw, Normalize(p, raw))
+				}
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("checked 0 pins — a sweep that inspects nothing reports clean, which is the defect this guards")
+	}
+	t.Logf("resolved %d routing pins across %d repo files", checked, len(pins.SortedSiteFiles("repo")))
+}
+
+// AC3 — the guard fails on a bad pin, so it cannot pass vacuously. Every
+// assertion above is worthless without this one.
+func TestGuardRejectsAnUnresolvablePin(t *testing.T) {
+	m, err := LoadModelMap(repoRootForTest(t))
+	if err != nil {
+		t.Fatalf("model map does not load: %v", err)
+	}
+	qualified, bare := DeclaredModels(m)
+	p := Pin{ID: "injected", Kind: "json-path", Locator: "defaultModel", Prefix: "nan/", Pool: "nan"}
+
+	// The real id measured in the deployed settings.json on 2026-08-26.
+	if got := Check(p, "nan/deepseek-v4-flash-0731", qualified, bare); got != VerdictUnknown {
+		t.Errorf("a dead dated id must be VerdictUnknown, got %v", got)
+	}
+	// A retired provider's model.
+	if got := Check(p, "openrouter/deepseek/deepseek-v4-pro", qualified, bare); got != VerdictUnknown {
+		t.Errorf("a retired-provider id must be VerdictUnknown, got %v", got)
+	}
+	// And the control: a live one still passes, so the check is not simply
+	// failing everything.
+	if got := Check(p, "nan/qwen3.6", qualified, bare); got != VerdictOK {
+		t.Errorf("a live id must be VerdictOK, got %v", got)
+	}
+}
+
+// AC4 — a CATALOG entry the map does not route is NOT drift.
+//
+// qwen3.8-flash and glm5.3-flash are in pi's and opencode's pickers deliberately
+// and deliberately absent from the map: availability on a promotional allocation
+// pending a community vote (#1244). The guard must not fire on a recorded
+// decision, and the way it does not is by checking only the pins the registry
+// declares — never the catalogs those files also carry.
+func TestCatalogEntriesAreNotCheckedAsRouting(t *testing.T) {
+	pins, err := LoadModelPins(repoRootForTest(t))
+	if err != nil {
+		t.Fatalf("registry does not load: %v", err)
+	}
+	for _, site := range pins.Sites {
+		if site.Scope != "repo" {
+			continue
+		}
+		for _, p := range site.Pins {
+			if strings.HasSuffix(p.Locator, "[]") {
+				t.Errorf("%s pin %q locates an array in a repo-scoped site: catalogs are not routing, and checking one would fire on #1244's recorded decision",
+					site.File, p.ID)
+			}
+			if p.Locator == "enabledModels" || p.Locator == "models" {
+				t.Errorf("%s pin %q points at a catalog key", site.File, p.ID)
+			}
+		}
+	}
+}
+
+// AC7 — a registry that cannot be read fails loudly and never as "no sites".
+func TestModelPinsRefusesToReadAsEmpty(t *testing.T) {
+	for _, tc := range []struct{ name, body, want string }{
+		{"absent", "", "not an empty pin registry"},
+		{"unparseable", `{"sites": [`, "parse"},
+		{"no sites", `{"version":1,"sites":[]}`, "declares no sites"},
+		{"site with no pins", `{"version":1,"sites":[{"file":"x","scope":"repo","pins":[]}]}`, "declares no pins"},
+		{"pin with no why", `{"version":1,"sites":[{"file":"x","scope":"repo","pins":[{"id":"a","kind":"regex","locator":"(x)","pool":"nan"}]}]}`, "no why"},
+		{"bad scope", `{"version":1,"sites":[{"file":"x","scope":"elsewhere","pins":[{"id":"a","kind":"regex","locator":"(x)","pool":"nan","why":"w"}]}]}`, "scope"},
+		{"unknown kind", `{"version":1,"sites":[{"file":"x","scope":"repo","pins":[{"id":"a","kind":"telepathy","locator":"x","pool":"nan","why":"w"}]}]}`, "unknown kind"},
+		{"locator without a capture", `{"version":1,"sites":[{"file":"x","scope":"repo","pins":[{"id":"a","kind":"regex","locator":"x","pool":"nan","why":"w"}]}]}`, "capture group"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.body != "" {
+				if err := os.MkdirAll(filepath.Join(dir, "harness"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, ModelPinsFile), []byte(tc.body), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			_, err := LoadModelPins(dir)
+			if err == nil {
+				t.Fatalf("%s loaded clean — a broken registry must never read as no drift", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// A locator that has silently stopped matching must be an error, never an empty
+// result — "found no pins" and "found no drift" are different facts.
+func TestExtractRefusesAnEmptyMatch(t *testing.T) {
+	p := Pin{ID: "rotted", Kind: "regex-all", Locator: `opencode run -m (\S+)`, Pool: "nan"}
+	if _, err := Extract(p, []byte("nothing here resembles the pattern\n")); err == nil {
+		t.Fatal("a locator matching nothing must error, not return zero values")
+	}
+
+	// And a `regex` (exactly one) locator that starts matching twice is a
+	// registry error rather than a silent pick-the-first.
+	single := Pin{ID: "ambiguous", Kind: "regex", Locator: `model=(\S+)`, Pool: "nan"}
+	if _, err := Extract(single, []byte("model=a\nmodel=b\n")); err == nil {
+		t.Fatal("kind=regex matching twice must error rather than silently choosing one")
+	}
+}
+
+// DeclaredModels must not invent a pool attribution the map never made: tiers
+// are keyed by whatever consumes the id, and `claude`/`opencode` key by harness
+// there while `nan` keys by pool.
+func TestDeclaredModelsDoesNotInventPoolsFromHarnessKeys(t *testing.T) {
+	m, err := LoadModelMap(repoRootForTest(t))
+	if err != nil {
+		t.Fatalf("model map does not load: %v", err)
+	}
+	qualified, bare := DeclaredModels(m)
+	if len(bare) == 0 || len(qualified) == 0 {
+		t.Fatal("declared nothing from a valid map")
+	}
+	pools, _ := m["pools"].(map[string]any)
+	for q := range qualified {
+		pool, _, _ := strings.Cut(q, ":")
+		if _, ok := pools[pool]; !ok {
+			t.Errorf("qualified entry %q names %q, which is not a declared pool", q, pool)
+		}
+	}
+}

--- a/cli/internal/harness/model_pins_test.go
+++ b/cli/internal/harness/model_pins_test.go
@@ -183,6 +183,40 @@ func TestExtractRefusesAnEmptyMatch(t *testing.T) {
 	}
 }
 
+// A tier key that is NOT a declared pool contributes to `bare` only, so a pin
+// claiming that model under some pool reports VerdictWrongPool rather than OK.
+//
+// That behaviour is deliberate — without a pool declaration nothing establishes
+// where the model lives, and WrongPool is a warning while Unknown would be a
+// failure — but it is subtle enough that the PR reviewer on #1256 flagged it as
+// a possible flaw. It was latent rather than live: every tier key in the shipped
+// map (`claude`, `nan`, `opencode`) IS a declared pool, so the reviewer's own
+// example could not occur. This pins the behaviour on a synthetic map so a
+// future edit that introduces a non-pool tier key finds a test rather than a
+// comment.
+func TestTierKeyThatIsNotAPoolStaysUnqualified(t *testing.T) {
+	m := map[string]any{
+		"pools": map[string]any{"nan": map[string]any{}},
+		"tiers": map[string]any{
+			"mid": map[string]any{"somewhere-else": "orphan-model"},
+		},
+		"chains":   map[string]any{},
+		"services": map[string]any{},
+	}
+	qualified, bare := DeclaredModels(m)
+
+	if !bare["orphan-model"] {
+		t.Error("a tier's model must always reach the bare set")
+	}
+	if qualified["somewhere-else:orphan-model"] {
+		t.Error("a non-pool tier key must not produce a qualified entry — that would invent an attribution the map never made")
+	}
+	p := Pin{ID: "x", Kind: "regex", Locator: "(x)", Prefix: "", Pool: "nan"}
+	if got := Check(p, "orphan-model", qualified, bare); got != VerdictWrongPool {
+		t.Errorf("want VerdictWrongPool (a warning: the model is known, its pool is not), got %v", got)
+	}
+}
+
 // DeclaredModels must not invent a pool attribution the map never made: tiers
 // are keyed by whatever consumes the id, and `claude`/`opencode` key by harness
 // there while `nan` keys by pool.

--- a/docs/lessons/lesson-232-detect-the-shape-that-is-wrong-not-the-shape-that.md
+++ b/docs/lessons/lesson-232-detect-the-shape-that-is-wrong-not-the-shape-that.md
@@ -1,0 +1,68 @@
+# Lesson 232 — detect the shape that is wrong, not the shape that is merely absent
+
+**Date:** 2026-08-26
+**Context:** HARNESS-067 / #902 — the model-pin drift guard.
+**Category:** guards, false positives, registries
+
+## What happened
+
+The guard checks that model ids pinned around the repository resolve in
+`harness/model-map.json`. Its registry's own `$comment` says, at length, that a
+**catalog is not routing** — a picker may offer models nothing routes, and
+reporting those would fire on a recorded decision (#1244).
+
+The first implementation then reported every catalog id the map does not route.
+Its first run against the real machine:
+
+```
+[WARN] "nan/gemma4" resolves to nothing the routing registry declares
+[WARN] "nan/deepseek-v4-flash-0731" resolves to nothing the routing registry declares
+[WARN] "openrouter/deepseek/deepseek-v4-pro" ...
+```
+
+The first line is wrong. `gemma4` is a live NaN model that nothing routes —
+exactly as legitimate as `qwen3.8-flash` and `glm5.3-flash`, whose deliberate
+absence from the map is tracked in #1244. The warning the check was written to
+avoid was written into the check, by the session that wrote the warning.
+
+## The lesson
+
+**"Not declared" is the cheap predicate and it is almost always the wrong one.**
+Absence from a registry is the normal state of most things. A guard keyed on it
+fires on every legitimate extension, and a guard that cries wolf gets muted,
+which is worse than no guard.
+
+Find the predicate that means something is *wrong* rather than merely *absent*.
+Here it was mechanical once the question was asked properly:
+
+| Id | Absent from the map? | Wrong? |
+|---|---|---|
+| `nan/gemma4` | yes | **no** — unrouted, which is what a catalog is for |
+| `nan/deepseek-v4-flash-0731` | yes | **yes** — a declared id (`deepseek-v4-flash`) plus a date stamp |
+| `openrouter/minimax/minimax-m3` | yes | **yes** — names a provider this repo retired |
+
+`-0731` is a *frozen snapshot* of a model still alive under its rolling name. It
+goes stale by construction, and the tool rejects it outright (`No models match
+pattern`). `gemma4` bears no such relation to anything. Two narrow, defensible
+rules replaced one broad, indefensible one — and the check went from 5 findings
+with 1 false positive to 4 findings with none.
+
+## Two things that made the difference
+
+**Running it against real data, early.** The false positive was invisible in
+review and obvious in the first live run. A guard's first execution on real
+state *is* its design review; budget for changing the design afterwards.
+
+**A regression test that names the legitimate case.**
+`TestModelPinsDoesNotReportAnUnroutedCatalogModel` asserts `gemma4`,
+`qwen3.8-flash` and `glm5.3-flash` are all silent. Guards get broadened under
+pressure — someone will want to catch "one more thing" — and the test is what
+makes the narrowing survive that.
+
+## The uncomfortable part
+
+This is the same family as `lesson-230` (a config that parses is not a config
+the consumer reads) and `lesson-231` (declaration is not effect). The variant
+worth naming: **writing the warning does not exempt you from the mistake.** The
+prose describing the trap and the code falling into it were authored minutes
+apart. Prose is not a guard; only the test is.

--- a/harness/model-pins.json
+++ b/harness/model-pins.json
@@ -1,0 +1,206 @@
+{
+  "$comment": [
+    "The pin-site registry (HARNESS-067, #902). It declares WHERE a model id is",
+    "pinned for ROUTING outside harness/model-map.json, and how that site spells",
+    "it, so a guard can check the two agree.",
+    "",
+    "WHY THIS FILE EXISTS. model-map.json has a schema, a validating loader and",
+    "real compile-time consumers, and it binds no leaf. A model id is pinned in",
+    "roughly seven live places and nothing makes any of them agree with the map.",
+    "Measured 2026-08-26: ~/.pi/agent/settings.json carried",
+    "`nan/deepseek-v4-flash-0731`, which no longer resolves — pi printed",
+    "`No models match pattern` on EVERY start — plus three `openrouter/*` entries",
+    "for a provider retired in August 2026. Nobody noticed until an unrelated",
+    "investigation happened to read the file.",
+    "",
+    "CATALOG IS NOT ROUTING, and the distinction is the whole design. A leaf may",
+    "OFFER models the map does not route: `qwen3.8-flash` and `glm5.3-flash` are",
+    "in pi's and opencode's pickers deliberately and deliberately absent from the",
+    "map — availability on a promotional allocation pending a community vote",
+    "(#1244). A guard reading `leaf offers what the map does not know` as drift",
+    "would fire on a recorded decision. So only the pins listed here are checked,",
+    "each one a place that DECIDES WHICH MODEL DOES WORK, and a catalog superset",
+    "is never drift.",
+    "",
+    "NORMALIZATION IS DECLARED, NEVER INFERRED. One model, three correct",
+    "spellings: `nan:mimo-v2.5` here, `openai/mimo-v2.5` in .pr_agent.toml",
+    "(litellm treats NaN as an OpenAI-compatible provider, so the prefix names a",
+    "wire protocol rather than a vendor), and bare `mimo-v2.5` in",
+    "ai/pi/models.json. A grep-shaped guard cannot check that. Each entry below",
+    "carries the rule for turning its own spelling into a map-resolvable",
+    "`pool:id`.",
+    "",
+    "ALIASES ARE NOT DRIFT. model-map.json pins `opus`/`sonnet`/`haiku` for claude",
+    "because Claude Code resolves those to the current member of each family, so",
+    "rotation costs nothing there; every other pool takes a canonical id. A check",
+    "demanding canonical ids uniformly would break that asymmetry, which is why",
+    "resolution is against what the map declares rather than against a pattern.",
+    "",
+    "NOT LISTED, and each absence is a decision:",
+    "  harness/reviewer-pool.json  separate from the map BY DECISION (its own",
+    "                              $comment). Its `agy/gemini-3.1-pro-high` entry",
+    "                              is unroutable today — a question about the",
+    "                              map's completeness, filed as #1253.",
+    "  cli/internal/agent/backends.go  Go rather than JSON on purpose.",
+    "  HIVE_EMBED_BASE_URL         an endpoint, not a model id (#1231).",
+    "",
+    "Fields:",
+    "  file      repo-relative path, or a `$HOME`-rooted one for a deployed file",
+    "            (never a literal home — ADR-025).",
+    "  scope     `repo` (committed, checkable in CI) or `deployed` (machine",
+    "            state, checkable only by dotf doctor — CI never sees a machine).",
+    "  pins      each routing pin: how to find it and how to normalize it.",
+    "    id      stable name for the pin, used in diagnostics.",
+    "    kind    `json-path` (top-level key, or `key[]` for a string array),",
+    "            `toml-key`, `regex` (exactly one match) or `regex-all` (every",
+    "            match must resolve). Both regex kinds need exactly one capture",
+    "            group, and both ERROR when the locator matches nothing: a",
+    "            pattern that has rotted reports zero values, and zero values",
+    "            check clean.",
+    "    locator the path/key/pattern that extracts the raw value.",
+    "    prefix  the site's provider prefix, stripped and replaced by `pool`.",
+    "            An empty string means the site writes a bare id.",
+    "    pool    the model-map pool the normalized id must resolve in.",
+    "  why       what this pin decides. A pin nobody can justify is one to delete."
+  ],
+  "version": 1,
+  "sites": [
+    {
+      "file": "ai/pi/settings.json",
+      "scope": "repo",
+      "why": "pi's interactive default — the model a bare `pi` session runs on. NOTE this file is seed-if-missing (#754): it is checked, and it will never be generated, because pi rewrites it at runtime and a rendered copy would reach a fresh machine and never an existing one.",
+      "pins": [
+        {
+          "id": "pi-default-model",
+          "kind": "json-path",
+          "locator": "defaultModel",
+          "prefix": "",
+          "pool": "nan",
+          "why": "Deliberately `qwen3.6` (the low tier) rather than the mid tier's deepseek-v4-flash: it is the latency-optimised daily driver for interactive use. The divergence from `tiers.mid` is intentional, which is exactly what #902 asked to be declared rather than rediscovered."
+        }
+      ]
+    },
+    {
+      "file": "$HOME/.pi/agent/settings.json",
+      "scope": "deployed",
+      "why": "The live file pi actually reads. It is the one surface the repo cannot converge, so it is the one that drifted: measured 2026-08-26 carrying a dead dated id and three retired-provider entries.",
+      "pins": [
+        {
+          "id": "pi-deployed-default-model",
+          "kind": "json-path",
+          "locator": "defaultModel",
+          "prefix": "",
+          "pool": "nan",
+          "why": "The default a real session runs on, which had drifted to deepseek-v4-flash against the repo's qwen3.6."
+        },
+        {
+          "id": "pi-deployed-enabled-models",
+          "kind": "json-path",
+          "locator": "enabledModels[]",
+          "prefix": "nan/",
+          "pool": "nan",
+          "why": "The picker catalog. Checked ONLY for ids that cannot resolve at all (a dead dated stamp, a retired provider) — never for being a superset of the map, which is what #1244 makes legitimate."
+        }
+      ]
+    },
+    {
+      "file": ".pr_agent.toml",
+      "scope": "repo",
+      "why": "The CI reviewer. Read from the repository by the workflow, so it can be checked and must never be rendered.",
+      "pins": [
+        {
+          "id": "pr-agent-primary",
+          "kind": "toml-key",
+          "locator": "model",
+          "prefix": "openai/",
+          "pool": "nan",
+          "why": "The model every PR review runs on. The `openai/` prefix is litellm's protocol name for NaN, not a vendor — the single clearest case for declaring normalization instead of guessing it."
+        },
+        {
+          "id": "pr-agent-weak",
+          "kind": "toml-key",
+          "locator": "model_weak",
+          "prefix": "openai/",
+          "pool": "nan",
+          "why": "The cheap model for mechanical sub-tasks."
+        }
+      ]
+    },
+    {
+      "file": "ai/opencode/opencode.jsonc",
+      "scope": "repo",
+      "why": "The daily-driver TUI's default. Owned by the deploy pipeline, so this is the first surface generation should claim in phase 2.",
+      "pins": [
+        {
+          "id": "opencode-default-model",
+          "kind": "json-path",
+          "locator": "model",
+          "prefix": "nan/",
+          "pool": "nan",
+          "why": "The model `oc` opens on."
+        }
+      ]
+    },
+    {
+      "file": ".zsh/aliases.zsh",
+      "scope": "repo",
+      "why": "The qq/qf one-shot wrappers. Three copies of the same two pins exist across shells, which is itself the drift this registry makes visible.",
+      "pins": [
+        {
+          "id": "qq-zsh",
+          "kind": "regex",
+          "locator": "alias qq='noglob _qq_call ([^ ]+)",
+          "prefix": "nan/",
+          "pool": "nan",
+          "why": "The quick-question model."
+        },
+        {
+          "id": "qf-zsh",
+          "kind": "regex",
+          "locator": "alias qf='noglob _qq_call ([^ ]+)",
+          "prefix": "nan/",
+          "pool": "nan",
+          "why": "The long-context model."
+        }
+      ]
+    },
+    {
+      "file": ".bashrc",
+      "scope": "repo",
+      "why": "The bash twins of the two wrappers above. Kept in sync by hand today.",
+      "pins": [
+        {
+          "id": "qq-bash",
+          "kind": "regex",
+          "locator": "qq\\(\\) \\{ _qq_call ([^ ]+)",
+          "prefix": "nan/",
+          "pool": "nan",
+          "why": "Must agree with qq-zsh; nothing enforces that today."
+        },
+        {
+          "id": "qf-bash",
+          "kind": "regex",
+          "locator": "qf\\(\\) \\{ _qq_call ([^ ]+)",
+          "prefix": "nan/",
+          "pool": "nan",
+          "why": "Must agree with qf-zsh; nothing enforces that today."
+        }
+      ]
+    },
+    {
+      "file": "powershell/profile.ps1",
+      "scope": "repo",
+      "why": "The Windows twins. A third copy of the same two pins, and the one least likely to be noticed when the other two are edited — the Linux-only verification loop cannot see it, the same gap GOOS=windows vet exists to close for Go.",
+      "pins": [
+        {
+          "id": "qq-qf-pwsh",
+          "kind": "regex-all",
+          "locator": "opencode run -m (\\S+)",
+          "prefix": "nan/",
+          "pool": "nan",
+          "why": "Both wrappers invoke the same form, so EVERY match must resolve rather than one regex per wrapper. Deliberate: a pattern clever enough to tell qq from qf across a multi-line PowerShell function is a pattern that silently matches nothing after an unrelated edit — and a locator that matches nothing is indistinguishable from a site with no drift. `regex-all` fails when there are zero matches, so it cannot pass vacuously."
+        }
+      ]
+    }
+  ]
+}

--- a/specs/HARNESS-067-model-pin-drift/features.json
+++ b/specs/HARNESS-067-model-pin-drift/features.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "HARNESS-067-model-pin-drift-f1",
+    "behavior": "AC1 - harness/model-pins.json declares every routing pin site with a normalization rule, a pool and a non-empty why, ids are unique, and every regex locator compiles with exactly one capture group",
+    "verification": "cd cli && go test ./internal/harness/ -run TestModelPinsRegistryIsWellFormed",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-067-model-pin-drift-f2",
+    "behavior": "AC2 - every routing pin in a committed file resolves to a pool/model harness/model-map.json declares, checked against the real repository rather than a fixture, and refusing to report clean if it inspected zero pins",
+    "verification": "cd cli && go test ./internal/harness/ -run TestEveryRepoRoutingPinResolvesInTheMap",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-067-model-pin-drift-f3",
+    "behavior": "AC3 - the guard rejects an unresolvable pin (a dated snapshot and a retired-provider id) while still accepting a live one, so it cannot pass vacuously",
+    "verification": "cd cli && go test ./internal/harness/ -run TestGuardRejectsAnUnresolvablePin",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-067-model-pin-drift-f4",
+    "behavior": "AC4 - a catalog model the map does not route is not drift: no repo-scoped pin points at a catalog key, and the deployed check stays silent on gemma4, qwen3.8-flash and glm5.3-flash",
+    "verification": "cd cli && go test ./internal/harness/ -run TestCatalogEntriesAreNotCheckedAsRouting && go test ./internal/doctor/ -run TestModelPinsDoesNotReportAnUnroutedCatalogModel",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-067-model-pin-drift-f5",
+    "behavior": "AC5 - dotf doctor reports a deployed catalog id that is a frozen dated snapshot of a routed model, naming why it is stale, and printing no literal home path",
+    "verification": "cd cli && go test ./internal/doctor/ -run TestModelPinsReportsAFrozenSnapshot",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-067-model-pin-drift-f6",
+    "behavior": "AC6 - a retired provider is reported distinctly from an unresolvable model id and is never misreported as a snapshot; a dead scalar routing pin FAILs rather than warns",
+    "verification": "cd cli && go test ./internal/doctor/ -run 'TestModelPinsDistinguishesARetiredProvider|TestModelPinsFailsOnADeadDefaultModel'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-067-model-pin-drift-f7",
+    "behavior": "AC7 - an absent, unparseable or empty registry fails loudly in both layers and never renders as a clean sweep; a locator that matches nothing is an error, not zero findings",
+    "verification": "cd cli && go test ./internal/harness/ -run 'TestModelPinsRefusesToReadAsEmpty|TestExtractRefusesAnEmptyMatch' && go test ./internal/doctor/ -run TestModelPinsFailsLoudlyWithoutARegistry",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "HARNESS-067-model-pin-drift-f8",
+    "behavior": "AC8 - the doctor check performs no writes: content and mtime of the deployed settings.json are unchanged after a run that produced findings",
+    "verification": "cd cli && go test ./internal/doctor/ -run TestModelPinsNeverWrites",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/HARNESS-067-model-pin-drift/proposal.md
+++ b/specs/HARNESS-067-model-pin-drift/proposal.md
@@ -1,0 +1,125 @@
+---
+id: "HARNESS-067-model-pin-drift"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-08-27"
+issue: "mlorentedev/dotfiles#902"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# HARNESS-067-model-pin-drift
+
+> The `created:` date above reads 2026-08-27 for work done on the evening of
+> 2026-08-26. `dotf spec init` stamps that field from a UTC clock — **#1225**,
+> still open, and left uncorrected here so a second instance of the evidence
+> survives the fix.
+
+## Why
+
+A model id is pinned in roughly seven live places and `harness/model-map.json`
+binds none of them. The map has a schema, a validating loader and real
+compile-time consumers (`ResolveTier`, `dotf agent` dispatch, the doctor tier
+check) — what it does not have is any mechanism making a leaf agree with it.
+
+The gap is not theoretical. Measured 2026-08-26:
+
+- **One model, three spellings.** `nan:mimo-v2.5` in the map, `openai/mimo-v2.5`
+  in `.pr_agent.toml` (litellm treats NaN as OpenAI-compatible), bare
+  `mimo-v2.5` in `ai/pi/models.json`.
+- **A dead id in a deployed file.** `~/.pi/agent/settings.json` carries
+  `nan/deepseek-v4-flash-0731`, and pi prints
+  `Warning: No models match pattern "nan/deepseek-v4-flash-0731"` on *every*
+  start. It also carries three `openrouter/*` entries for a provider this repo
+  retired in August 2026. Nothing detects either, and nobody noticed until an
+  unrelated investigation read the file.
+- **The adversarial-review gate's independence arm is unroutable.**
+  `harness/reviewer-pool.json` routes `agy/gemini-3.1-pro-high` as its
+  provider-diverse fallback. The map declares pools `nan`, `claude`, `copilot`,
+  `opencode`, sets `harnesses.agy.pools: ["nan"]`, and the string `gemini`
+  appears nowhere in it.
+
+## What
+
+A declared **pin-site registry** plus two detectors, in the layering #1248 just
+established:
+
+1. `harness/model-pins.json` — one entry per pin site: the file, which pins in it
+   are **routing** pins, and the **normalization** rule for turning that site's
+   spelling into a map-resolvable `pool:id`.
+2. **Repo pins vs the map** — a Go test over committed files. Runs anywhere,
+   including CI.
+3. **Deployed drift** — a `dotf doctor` check. Machine state, which CI never sees.
+
+## Out of scope
+
+- **Generation.** #902 asks for it and it is right for the surfaces the pipeline
+  owns (`ai/pi/models.json`, `ai/opencode/opencode.jsonc`, the shell rc files).
+  Detect first: a generator whose correctness nothing checks is the same class of
+  unguarded claim this issue exists to end. Phase 2, recorded on #902.
+- **`ai/pi/settings.json` will never be rendered.** It is seed-if-missing because
+  pi rewrites it at runtime, a contract #754 established after the previous shape
+  reset the user's theme and default model on every setup run. A generated
+  `enabledModels` reaches a fresh machine and never an existing one — the
+  opposite of the requirement. Reported, never written.
+- **Repairing deployed drift.** The doctor check WARNs; there is no `--fix`.
+  `~/.pi/agent/settings.json` is pi's own runtime state, and writing into a
+  tool-owned file is the same disposition question the extension symlinks raised
+  in #1243. It gets asked, not defaulted.
+- **`harness/reviewer-pool.json`.** Separate from the map **by decision** — its
+  own `$comment` records that it was kept out so H-044 need not migrate it. The
+  `agy/gemini-3.1-pro-high` gap above is real, but it is a question about the
+  *map's* completeness, not about drift. Filed as **#1253**.
+- **`cli/internal/agent/backends.go`.** Go rather than JSON on purpose; its own
+  comment says so.
+
+## Risks / open questions
+
+- **Catalog is not routing, and conflating them would fire on a recorded
+  decision.** `qwen3.8-flash` and `glm5.3-flash` are in pi's and opencode's
+  catalogs and deliberately absent from the map — picker availability on a
+  promotional allocation pending a community vote (**#1244**). A guard reading
+  "leaf offers a model the map does not know" as drift would flag them.
+  **Resolved**: only *routing* pins are checked — `defaultModel`, tier entries,
+  `.pr_agent.toml`'s `model` / `model_weak`, the `qq`/`qf` wrapper arguments.
+  A catalog superset is never drift.
+- **Normalization cannot be inferred.** Three spellings of one model, each
+  correct for its consumer. **Resolved**: the rule is declared per pin site in
+  the registry, as data, and the check reads it rather than guessing.
+- **Rotation costs nothing where a harness self-rotates.** Claude Code resolves
+  `opus`/`sonnet`/`haiku` to the current family member, which is why the map
+  pins aliases there and canonical ids everywhere else. A check that demanded
+  canonical ids uniformly would break that deliberate asymmetry.
+- **Open**: whether `HIVE_EMBED_BASE_URL` (#1231's eight-place base URL) belongs
+  in this registry or stays a separate axis. It is an endpoint, not a model id.
+  Left out of this PR; #1231 stays open.
+
+## Acceptance criteria
+
+- [ ] **AC1** — `harness/model-pins.json` declares every routing pin site, each
+      with its normalization rule and a non-empty `why`, and is schema-validated.
+- [ ] **AC2** — every routing pin in a committed file resolves to a pool/model
+      the map declares, proven by a test that runs in CI.
+- [ ] **AC3** — the guard is shown to **fail** on an injected bad pin, so it
+      cannot pass vacuously.
+- [ ] **AC4** — a catalog entry absent from the map is **not** reported as drift
+      (`qwen3.8-flash`, `glm5.3-flash`), and the test asserts that explicitly.
+- [ ] **AC5** — `dotf doctor` reports a deployed routing pin that no longer
+      resolves, demonstrated against the live `nan/deepseek-v4-flash-0731`.
+- [ ] **AC6** — the deployed check reports a pin naming a retired provider
+      (`openrouter/*`), distinctly from an unresolvable model id.
+- [ ] **AC7** — an unreadable or malformed registry fails loudly and is never
+      read as "no pin sites declared" (constraint C15).
+- [ ] **AC8** — the doctor check performs no writes, asserted rather than
+      assumed.
+
+## References
+
+- Bitácora board: `mlorentedev/dotfiles#902`; consolidates #1231, #1170, #1244.
+- The layering precedent: #1248 / AI-030 AC11 — repo-level facts in CI, machine
+  state in doctor, because CI never sees this machine.
+- The contract this design works around: `ai/pi/README.md`, `tests/pi-config.bats`
+  and #754 on seed-if-missing.
+- The registry this checks against: `harness/model-map.json`, ADR-032, ADR-035.
+- Prior art for "declarative table, one behaviour": `ai/pi/packages.json`
+  (AI-030) and `ai/deploy.json` (CLI-039).

--- a/specs/HARNESS-067-model-pin-drift/tasks.md
+++ b/specs/HARNESS-067-model-pin-drift/tasks.md
@@ -1,0 +1,56 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-27"
+---
+
+# Tasks - HARNESS-067-model-pin-drift
+
+## Build
+
+- [x] [AC1] Declare `harness/model-pins.json`: every routing pin site, its
+      normalization rule, its pool, and a `why` per pin
+- [x] [AC1] [AC7] Load and validate it in Go with every failure loud — absent,
+      unparseable, no sites, a site with no pins, a pin with no `why`, a
+      duplicate id, an unknown kind, a locator with the wrong capture count
+- [x] [AC2] Resolve a normalized pin against `harness/model-map.json`, keeping
+      the two declared sets separate so a harness-keyed tier never invents a pool
+- [x] [AC2] Extract values by `json-path`, `toml-key`, `regex` and `regex-all`,
+      erroring rather than returning empty when a locator matches nothing
+- [x] [AC2] [AC3] [AC4] Go test over the REAL repository files, plus an injected
+      bad pin so the guard cannot pass vacuously
+- [x] [AC5] [AC6] [AC8] `dotf doctor` check for deployed sites, distinguishing a
+      frozen snapshot from a retired provider, and writing nothing
+- [x] [AC4] Narrow the catalog rule after a live run reported `nan/gemma4` — an
+      unrouted catalog model is not drift; a dated snapshot of a routed one is
+
+## Closing
+
+- [x] Every acceptance criterion is covered by at least one test or a recorded
+      scenario run
+- [x] Every acceptance criterion has an entry in `features.json` with a
+      non-vacuous verification command
+- [x] `go build`, `go vet`, and `GOOS=windows go vet` all pass
+- [x] `go test ./...` — 18/18 packages
+- [x] `golangci-lint run` on the pinned 2.12.2 — 0 issues
+- [x] The check was run against the live machine and its findings recorded
+- [x] No unrelated changes in the diff — staged by explicit path, because this
+      worktree also carries another session's uncommitted work (#1244)
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+- [ ] Independent adversarial review before archive (`dotf spec review`) — the
+      implementing session cannot be the reviewer
+
+## Out of this PR, recorded rather than dropped
+
+- **Generation** for the three surfaces the pipeline owns — phase 2 on #902.
+- **`ai/pi/settings.json` is never generated**: seed-if-missing (#754).
+- **Repairing deployed drift**: an open disposition question, like #1243's.
+- **`harness/reviewer-pool.json`**: its unroutable `agy/gemini-3.1-pro-high` is
+  filed as **#1253**.
+- **`HIVE_EMBED_BASE_URL`**: an endpoint, not a model id — #1231 stays open.
+
+## Machine-readable features
+
+`features.json` is the harness-facing contract. The agent may not write
+`"state": "passing"`; only the harness may, after running `verification` and
+capturing exit code 0.

--- a/specs/HARNESS-067-model-pin-drift/verification.md
+++ b/specs/HARNESS-067-model-pin-drift/verification.md
@@ -1,0 +1,110 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-27"
+---
+
+# Verification - HARNESS-067-model-pin-drift
+
+## Evidence
+
+| AC | Proof |
+|---|---|
+| AC1 registry well-formed, justified, unique ids, locators compile | `go test ./internal/harness/ -run TestModelPinsRegistryIsWellFormed` |
+| AC2 every repo routing pin resolves in the map | `go test ./internal/harness/ -run TestEveryRepoRoutingPinResolvesInTheMap` — `resolved 10 routing pins across 6 repo files`. Reads the real repository, not a fixture |
+| AC3 the guard fails on a bad pin | `go test ./internal/harness/ -run TestGuardRejectsAnUnresolvablePin` — the two live bad values (`nan/deepseek-v4-flash-0731`, `openrouter/deepseek/deepseek-v4-pro`) are `VerdictUnknown`, and a live id is still `VerdictOK` so it is not simply failing everything |
+| AC4 a catalog entry absent from the map is not drift | `TestCatalogEntriesAreNotCheckedAsRouting` (repo half) + `TestModelPinsDoesNotReportAnUnroutedCatalogModel` (deployed half, asserting `gemma4`, `qwen3.8-flash` and `glm5.3-flash` are all silent) |
+| AC5 doctor reports a deployed pin that no longer resolves | Live run: `[WARN] $HOME/.pi/agent/settings.json pi-deployed-enabled-models: "nan/deepseek-v4-flash-0731" is a frozen snapshot of "deepseek-v4-flash", and no longer resolves`. Unit: `TestModelPinsReportsAFrozenSnapshot` |
+| AC6 a retired provider reads distinctly | Live run: three `[WARN] … names "openrouter", a provider this repository retired`. Unit: `TestModelPinsDistinguishesARetiredProvider`, which also asserts it is **not** misreported as a snapshot |
+| AC7 an unreadable registry fails loudly | `TestModelPinsRefusesToReadAsEmpty` (8 broken shapes) + `TestModelPinsFailsLoudlyWithoutARegistry`, which additionally bans the strings `[ OK ]` and `all resolve` from the output |
+| AC8 the check performs no writes | `TestModelPinsNeverWrites` — content **and** mtime compared before/after a run that produced findings |
+
+## Test status
+
+```
+$ cd cli && go test ./internal/harness/ -run 'ModelPins|EveryRepo|GuardRejects|Catalog|Extract|DeclaredModels'
+ok      7 tests, resolved 10 routing pins across 6 repo files
+
+$ go test ./internal/doctor/ -run TestModelPins
+ok      7 tests
+
+$ go test ./...
+18/18 packages ok
+
+$ go build ./... && go vet ./... && GOOS=windows go vet ./...
+OK (linux + windows)
+
+$ golangci-lint run          # pinned 2.12.2, matching versions.conf
+0 issues.
+```
+
+### The live machine, before any repair
+
+```
+$ DOTFILES_DIR=<checkout> dotf doctor
+[Model pin drift]
+  [WARN] $HOME/.pi/agent/settings.json pi-deployed-enabled-models:
+         "nan/deepseek-v4-flash-0731" is a frozen snapshot of "deepseek-v4-flash",
+         and no longer resolves
+  [WARN] … "openrouter/deepseek/deepseek-v4-pro" names "openrouter", a provider
+         this repository retired
+  [WARN] … "openrouter/qwen/qwen3-coder-plus"   (same)
+  [WARN] … "openrouter/minimax/minimax-m3"      (same)
+```
+
+Four findings, all real, none repaired — the check does not write. `nan/gemma4`,
+present in the same array, is correctly silent.
+
+## Decisions made during implementation
+
+- **The first version of this check was wrong, and a real run caught it.** It
+  reported every catalog id the map does not route, which fired on `nan/gemma4` —
+  a live NaN model nobody routes, exactly as `qwen3.8-flash` and `glm5.3-flash`
+  are (#1244). That is precisely the failure `harness/model-pins.json`'s own
+  `$comment` warns against, written into the check by the same session that wrote
+  the warning. The fix is a mechanical distinction rather than a matter of taste:
+  a **frozen snapshot** is a declared id plus a date stamp (`deepseek-v4-flash` +
+  `-0731`), so it pins a moment of a model that is still alive under its rolling
+  name. `gemma4` bears no such relation to anything. Only that shape and a
+  retired provider are reported. Regression-guarded by
+  `TestModelPinsDoesNotReportAnUnroutedCatalogModel`.
+- **Severity follows consequence.** A dead **scalar** routing pin (`defaultModel`)
+  decides what a real session runs on, so it FAILs. A dead **catalog** entry costs
+  a startup warning and a stale picker row, so it WARNs. Reporting both alike
+  would either cry wolf about a picker or under-report a broken default.
+- **`DeclaredModels` returns two sets, not one.** The map's `$comment` records
+  that tiers are keyed by whatever *consumes* the id — `claude` and `opencode`
+  key by harness there, `nan` by pool. Collapsing that into one pool-qualified
+  set would invent attributions the map never made and report them as drift. So
+  `chains` (unambiguously `pool:id`) populates the qualified set, everything
+  contributes to the bare set, and a tier key is qualified only when it is itself
+  a declared pool. Asserted by
+  `TestDeclaredModelsDoesNotInventPoolsFromHarnessKeys`.
+- **A locator that matches nothing is an error, never an empty result.** "Found
+  no pins" and "found no drift" are different facts that look identical
+  downstream. `Extract` errors on zero matches, `kind: regex` errors when it
+  matches more than once rather than silently taking the first, and the doctor
+  check FAILs when it read sites but extracted nothing.
+- **The PowerShell wrappers are one `regex-all` pin, not two clever ones.** The
+  first draft used two multi-line patterns to tell `qq` from `qf`. A pattern
+  clever enough to do that across a PowerShell function is a pattern that
+  silently matches nothing after an unrelated edit. Both wrappers use
+  `opencode run -m <model>`, so every match is checked and zero matches is an
+  error.
+- **No `--fix`, and the check is not even given the flag.** Repairing means a
+  surgical merge into a file pi rewrites at runtime. That is the same disposition
+  question the hand-wired extension symlinks raised in #1243, and it gets asked
+  rather than defaulted.
+- **`expandHome` was reused, not rewritten.** The registry writes `$HOME/...`
+  rather than `~/...` so the existing `fs.go` helper resolves it — a second
+  path-expansion function in the same package is the drift this spec is about,
+  one layer down.
+
+## Promotion candidates
+
+- **Nothing for the vault yet.** The pin sites, the litellm `openai/` prefix and
+  the seed-if-missing constraint are all specific to this repository's
+  deployment.
+- The one genuinely cross-project candidate — *"a guard that detects `not
+  declared` fires on every legitimate extension; detect the shape that is
+  **wrong**, not the shape that is merely **absent**"* — is a strong pattern and
+  should wait for a second instance outside this repo before promotion.


### PR DESCRIPTION
`harness/model-map.json` has a schema, a validating loader and real compile-time
consumers — and it binds no leaf. A model id is pinned in roughly seven live
places and nothing makes any of them agree with it.

Not theoretical. Measured 2026-08-26, the deployed `~/.pi/agent/settings.json`
carried `nan/deepseek-v4-flash-0731`, an id that no longer resolves — pi printed
`Warning: No models match pattern` on **every** start — plus three `openrouter/*`
entries for a provider this repo retired in August 2026. Nobody noticed until an
unrelated investigation read the file, because the repo cannot converge it:
`ai/pi/settings.json` is seed-if-missing and pi owns the live copy (#754).

## What this adds

`harness/model-pins.json` declares each **routing** pin — the places that decide
which model does work — with its pool and its normalization rule.

**Normalization is declared, never inferred**, because one model has three
correct spellings across these files:

| Spelling | File | Why |
|---|---|---|
| `nan:mimo-v2.5` | `model-map.json` | the registry's `pool:id` form |
| `openai/mimo-v2.5` | `.pr_agent.toml` | litellm's protocol name for NaN, not a vendor |
| `mimo-v2.5` | `ai/pi/models.json` | bare id |

Then two checks, matching the split shipped in #1248: **repo pins are a Go test**
that runs anywhere, **deployed pins are a `dotf doctor` check**, because CI never
sees a machine.

## The design decision worth reviewing

**A catalog is not routing.** A picker may offer models nothing routes — that is
what a picker is for — and `qwen3.8-flash` / `glm5.3-flash` are absent from the
map by a recorded decision (#1244).

The first version of this check reported every unrouted catalog id and fired on
`nan/gemma4`, a live NaN model nobody routes. The registry's own `$comment` warns
against precisely that; the check fell into it anyway, minutes after the warning
was written. Two narrow rules replaced one broad one:

- a **retired provider** (`openrouter/`, `codex/`), and
- a **frozen snapshot** — a declared id plus a date stamp (`deepseek-v4-flash` +
  `-0731`), pinning a moment of a model still alive under its rolling name.

Findings went from 5-with-1-false-positive to **4 with none**. Regression-guarded
by `TestModelPinsDoesNotReportAnUnroutedCatalogModel`, which names all three
legitimate cases. Recorded as `docs/lessons/lesson-232-...`.

## Live output, before any repair

```
[Model pin drift]
  [WARN] $HOME/.pi/agent/settings.json pi-deployed-enabled-models:
         "nan/deepseek-v4-flash-0731" is a frozen snapshot of "deepseek-v4-flash",
         and no longer resolves
  [WARN] ... "openrouter/deepseek/deepseek-v4-pro" names "openrouter", a provider
         this repository retired
  [WARN] ... "openrouter/qwen/qwen3-coder-plus"    (same)
  [WARN] ... "openrouter/minimax/minimax-m3"       (same)
```

`nan/gemma4`, in the same array, is correctly silent.

**No `--fix`, and the check is not given the flag.** Repairing means a surgical
merge into a file pi rewrites at runtime — the same disposition question the
extension symlinks raised in #1243, asked rather than defaulted. AC8 asserts
content *and* mtime are unchanged.

## Verification

| Check | Result |
|---|---|
| `go test ./internal/harness/` | 7 new tests; `resolved 10 routing pins across 6 repo files` |
| `go test ./internal/doctor/` | 7 new tests |
| `go test ./...` | 18/18 packages |
| `go build` + `go vet` + `GOOS=windows go vet` | pass |
| `golangci-lint run` (pinned 2.12.2) | 0 issues |
| Every `features.json` command | executed, exit 0 |

AC3 exists so the guard cannot pass vacuously: it asserts the two live bad values
are rejected **and** that a live id still passes.

## Scope

Detect only. Generation for the three surfaces the pipeline owns is phase 2 on
#902; `ai/pi/settings.json` is never generated. `harness/reviewer-pool.json` is
out of scope and its unroutable `agy/gemini-3.1-pro-high` is filed as **#1253**.
`HIVE_EMBED_BASE_URL` is an endpoint, not a model id — #1231 stays open.

Refs #902; consolidates #1231, #1170, #1244. Amendment rationale posted on #902.
