### PR TITLE
fix(cli): stamp spec init created field with local calendar date

### DIFF
--- a/cli/internal/cmd/spec.go
+++ b/cli/internal/cmd/spec.go
@@ -15,9 +15,10 @@ import (
 	"github.com/mlorentedev/dotfiles/cli/internal/spec"
 )
 
-// now is the clock used to stamp created: in scaffolded specs. It is a package
-// var so tests can pin it deterministically.
-var now = func() time.Time { return time.Now().UTC() }
+// now is the clock used to stamp created: in scaffolded specs and session dates.
+// It is a package var so tests can pin it deterministically. Calendar dates are
+// local (lesson 228); instants are UTC.
+var now = func() time.Time { return time.Now() }
 
 func newSpecCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/cli/internal/cmd/spec_test.go
+++ b/cli/internal/cmd/spec_test.go
@@ -199,6 +199,7 @@ func TestSpecInit_UsesLocalCalendarDate(t *testing.T) {
 	}
 }
 
+// readFile reads the full contents of path as a string or fails the test.
 func readFile(t *testing.T, path string) string {
 	t.Helper()
 	b, err := os.ReadFile(path)

--- a/cli/internal/cmd/spec_test.go
+++ b/cli/internal/cmd/spec_test.go
@@ -169,6 +169,36 @@ func TestSpecInitUnresolvableRepoFails(t *testing.T) {
 	}
 }
 
+// TestSpecInit_UsesLocalCalendarDate guards CLI-044 / lesson 228: spec created:
+// is a calendar date and must be formatted from the local clock, not UTC. An
+// evening spec at 18:30 in MDT (-0600) is 00:30 the next day in UTC; stamping it
+// in UTC dates the spec tomorrow.
+func TestSpecInit_UsesLocalCalendarDate(t *testing.T) {
+	root := makeRepo(t)
+	denver := time.FixedZone("MDT", -6*60*60)
+	evening := time.Date(2026, 8, 24, 19, 30, 0, 0, denver)
+	if evening.UTC().Format("2006-01-02") == evening.Format("2006-01-02") {
+		t.Fatal("fixture is not timezone-sensitive; it cannot catch the regression")
+	}
+
+	prev := now
+	now = func() time.Time { return evening }
+	t.Cleanup(func() { now = prev })
+
+	_, _, err := execute(t, "spec", "init", "AI-030-demo", "--force-no-gate")
+	if err != nil {
+		t.Fatalf("spec init: %v", err)
+	}
+
+	proposal := readFile(t, filepath.Join(root, "specs", "AI-030-demo", "proposal.md"))
+	if !strings.Contains(proposal, `created: "2026-08-24"`) {
+		t.Errorf("expected local date 2026-08-24 in created field, got:\n%s", proposal)
+	}
+	if strings.Contains(proposal, `created: "2026-08-25"`) {
+		t.Errorf("created field erroneously stamped in UTC (tomorrow):\n%s", proposal)
+	}
+}
+
 func readFile(t *testing.T, path string) string {
 	t.Helper()
 	b, err := os.ReadFile(path)


### PR DESCRIPTION
## Summary

Fixes #1225 (CLI-044) by ensuring `dotf spec init` formats the calendar date using the local clock rather than UTC (per lesson 228: *instants are UTC, calendar dates are local*). Previously, specs created after 18:00 MDT were stamped with tomorrow's date.

## SDD skip rationale

Targeted bugfix (<50 LOC) with deterministic regression test.

## Verification

- Added `TestSpecInit_UsesLocalCalendarDate` in `cli/internal/cmd/spec_test.go` simulating an 18:30 MDT evening timestamp.
- All Go unit tests passed (`go test ./...`).
- 100 bats tests passed.