### PR TITLE
fix(harness): apply the reviewer's findings on the persona gate

### DIFF
--- a/cli/internal/cmd/harness_gate.go
+++ b/cli/internal/cmd/harness_gate.go
@@ -82,6 +82,15 @@ Invoking a skill is never blocked: forbidding it would deadlock the session.`,
 				_ = harness.RecordConsumed(statePath, call.Skill)
 				return nil
 			}
+			if call.IsSkillTool {
+				// The tool IS the skill primitive but its argument was
+				// unreadable. There is nothing to record, and blocking would
+				// deadlock the session on the one action that could satisfy the
+				// gate — a well-formed payload with a missing argument, not a
+				// parse failure. Raised by the reviewer on #1272.
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "[gate] allow: skill invocation with no readable name")
+				return nil
+			}
 
 			persona := loadGatePersona(repoRoot, role)
 			result := harness.Decide(harness.GateInput{
@@ -194,21 +203,28 @@ func normaliseToolCall(harnessName string, payload []byte) (harness.ToolCall, bo
 		if json.Unmarshal(payload, &p) != nil || p.Tool == "" {
 			return harness.ToolCall{}, false
 		}
-		return harness.ToolCall{SessionID: p.SessionID, Tool: p.Tool, Skill: strings.TrimSpace(p.Skill)}, true
+		return harness.ToolCall{SessionID: p.SessionID, Tool: p.Tool, Skill: strings.TrimSpace(p.Skill), IsSkillTool: isSkillTool(p.Tool)}, true
 	default:
 		var p commandHookPayload
 		if json.Unmarshal(payload, &p) != nil || p.ToolName == "" {
 			return harness.ToolCall{}, false
 		}
-		return harness.ToolCall{SessionID: p.SessionID, Tool: p.ToolName, Skill: skillArg(p.ToolName, p.ToolInput)}, true
+		return harness.ToolCall{SessionID: p.SessionID, Tool: p.ToolName, Skill: skillArg(p.ToolName, p.ToolInput), IsSkillTool: isSkillTool(p.ToolName)}, true
 	}
 }
 
 // skillArg extracts the skill name when the tool IS the harness's skill
 // primitive. Matched case-insensitively on the tool name because the three
 // harnesses spell it differently and none of them promises stability.
+// isSkillTool reports that the tool IS the harness's skill primitive, whatever
+// its arguments turned out to say. The gate must never block it: doing so
+// forbids the only action that could satisfy the gate.
+func isSkillTool(tool string) bool {
+	return strings.EqualFold(strings.TrimSpace(tool), "skill")
+}
+
 func skillArg(tool string, args map[string]any) string {
-	if !strings.EqualFold(tool, "skill") {
+	if !isSkillTool(tool) {
 		return ""
 	}
 	for _, k := range []string{"skill", "name", "command"} {

--- a/cli/internal/harness/gate.go
+++ b/cli/internal/harness/gate.go
@@ -1,6 +1,8 @@
 package harness
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -39,8 +41,21 @@ type ToolCall struct {
 	// Tool is the harness's name for the tool about to run.
 	Tool string
 	// Skill is the skill being invoked, when Tool is the harness's skill
-	// primitive. Empty otherwise.
+	// primitive. Empty otherwise — INCLUDING when the tool IS the skill
+	// primitive but its argument could not be read, which is why IsSkillTool
+	// exists separately.
 	Skill string
+	// IsSkillTool reports that the tool is the harness's skill primitive,
+	// whether or not the skill's NAME was readable.
+	//
+	// Without it the gate deadlocks on a WELL-FORMED payload with a missing
+	// argument: `Skill` comes back empty, the call falls through to the
+	// enforcement path, and the gate blocks the very invocation that would
+	// satisfy it — permanently, because a blocked call can never record
+	// consumption. Raised by the PR reviewer on #1272 and reproduced. The
+	// deadlock guard was checking the skill's NAME when it had to check the
+	// tool's IDENTITY.
+	IsSkillTool bool
 }
 
 // GateInput is everything a decision needs.
@@ -71,8 +86,10 @@ func Decide(in GateInput) GateResult {
 	}
 
 	// Invoking a skill is never gated: that is the act the gate exists to
-	// require, and blocking it would deadlock the session.
-	if in.Call.Skill != "" {
+	// require, and blocking it would deadlock the session. Keyed on the TOOL,
+	// not on whether the skill's name parsed — an unreadable argument must never
+	// turn the one unblockable action into a blocked one.
+	if in.Call.IsSkillTool || in.Call.Skill != "" {
 		return GateResult{Decision: Allow, Reason: "skill invocation"}
 	}
 
@@ -129,6 +146,13 @@ type consumedState struct {
 // per-machine data with no business in a git-tracked tree, and a stale file
 // simply means an over-permissive gate for one session rather than corrupted
 // configuration.
+// A DIGEST IS APPENDED, not merely a sanitised name. Character-mapping alone
+// collides: `a/b` and `a.b` both flatten to `a_b`, so one session's consumption
+// record would open another session's gate. Raised by the PR reviewer on #1272.
+// Well-behaved harnesses send UUIDs and would never hit it, but a session id is
+// attacker-adjacent input that lands in a filesystem path, and "it does not
+// happen with well-behaved input" is not a property a path builder should rely
+// on. The readable prefix is kept so the directory stays diagnosable by eye.
 func StatePath(stateDir, sessionID string) string {
 	safe := strings.Map(func(r rune) rune {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
@@ -136,10 +160,14 @@ func StatePath(stateDir, sessionID string) string {
 		}
 		return '_'
 	}, sessionID)
+	if len(safe) > 48 {
+		safe = safe[:48]
+	}
 	if safe == "" {
 		safe = "unknown"
 	}
-	return filepath.Join(stateDir, "gate", safe+".json")
+	sum := sha256.Sum256([]byte(sessionID))
+	return filepath.Join(stateDir, "gate", safe+"-"+hex.EncodeToString(sum[:4])+".json")
 }
 
 // LoadConsumed reads a session's consumed skills. A missing or unreadable file

--- a/cli/internal/harness/gate_test.go
+++ b/cli/internal/harness/gate_test.go
@@ -79,6 +79,25 @@ func TestGateNeverBlocksTheSkillInvocationItself(t *testing.T) {
 	}
 }
 
+// The deadlock the PR reviewer on #1272 found: a WELL-FORMED payload naming the
+// skill primitive but carrying no readable argument.
+//
+// The original guard keyed on the skill's NAME, so an empty name fell through to
+// the enforcement path and blocked the invocation — permanently, because a
+// blocked call can never record consumption. The guard has to key on the tool's
+// IDENTITY. The earlier deadlock test passed only because it always supplied a
+// name, which is the case that was never in danger.
+func TestGateNeverBlocksASkillToolWithAnUnreadableName(t *testing.T) {
+	r := Decide(GateInput{
+		Persona:  gatePersona(SkillBinding{ID: "audit", Enforce: EnforceBlock}),
+		Call:     ToolCall{Tool: "Skill", Skill: "", IsSkillTool: true},
+		Consumed: map[string]bool{},
+	})
+	if r.Decision != Allow {
+		t.Fatalf("a skill invocation with an unreadable name must still be allowed, got %v — this deadlocks the session", r.Decision)
+	}
+}
+
 // Ambiguity resolves to Allow. A gate that blocks when it does not understand
 // its input becomes a gate whose normal state is red.
 func TestGateAllowsWhenItHasNoPersona(t *testing.T) {
@@ -131,6 +150,22 @@ func TestGateCorruptStateReadsAsEmptyNotAsAnError(t *testing.T) {
 	}
 	if got := LoadConsumed(p); len(got) != 0 {
 		t.Errorf("corrupt state must read empty, got %v", got)
+	}
+}
+
+// The collision the PR reviewer on #1272 found: character-mapping alone flattens
+// `a/b` and `a.b` to the same name, so one session's consumption record would
+// open another session's gate. UUIDs never collide, but "it does not happen with
+// well-behaved input" is not a property a path builder should rest on.
+func TestGateStatePathDoesNotCollideAcrossDistinctSessions(t *testing.T) {
+	dir := t.TempDir()
+	seen := map[string]string{}
+	for _, sid := range []string{"a/b", "a.b", "a_b", "a:b", "a b", "", "..", "x", "X"} {
+		p := StatePath(dir, sid)
+		if prev, dup := seen[p]; dup {
+			t.Errorf("session ids %q and %q map to the same state file %s", prev, sid, p)
+		}
+		seen[p] = sid
 	}
 }
 

--- a/cli/internal/harness/model_pins.go
+++ b/cli/internal/harness/model_pins.go
@@ -128,6 +128,16 @@ func DeclaredModels(m map[string]any) (qualified map[string]bool, bare map[strin
 				continue
 			}
 			for consumer, model := range entry {
+				// `$`-prefixed keys are annotations, not consumers. Measured
+				// 2026-08-27: `tiers.low` acquired a `$comment` explaining the
+				// qwen3.8-flash promotion, and without this the whole sentence
+				// entered the declared-model set as a bogus id. It only ever
+				// widened the set, so no check could fail wrongly — but a
+				// registry that treats prose as a model id is one leaf-id
+				// coincidence away from masking real drift.
+				if strings.HasPrefix(consumer, "$") {
+					continue
+				}
 				id, ok := model.(string)
 				if !ok {
 					continue

--- a/cli/internal/harness/model_pins_test.go
+++ b/cli/internal/harness/model_pins_test.go
@@ -217,6 +217,28 @@ func TestTierKeyThatIsNotAPoolStaysUnqualified(t *testing.T) {
 	}
 }
 
+// A `$comment` inside a tier is prose, not a model id. Found 2026-08-27 when
+// `tiers.low` acquired one: the whole sentence was entering the declared set.
+// Only ever widened it, so nothing could fail wrongly — but a registry that
+// treats prose as a model id is one coincidence away from masking real drift.
+func TestDeclaredModelsIgnoresAnnotationKeysInTiers(t *testing.T) {
+	m := map[string]any{
+		"pools": map[string]any{"nan": map[string]any{}},
+		"tiers": map[string]any{
+			"low": map[string]any{"nan": "qwen3.8-flash", "$comment": "some prose about the promotion"},
+		},
+		"chains":   map[string]any{},
+		"services": map[string]any{},
+	}
+	_, bare := DeclaredModels(m)
+	if !bare["qwen3.8-flash"] {
+		t.Error("the real model id must still be declared")
+	}
+	if bare["some prose about the promotion"] {
+		t.Error("a $comment's text was taken for a model id")
+	}
+}
+
 // DeclaredModels must not invent a pool attribution the map never made: tiers
 // are keyed by whatever consumes the id, and `claude`/`opencode` key by harness
 // there while `nan` keys by pool.

--- a/specs/HARNESS-045-hook-emission/verification.md
+++ b/specs/HARNESS-045-hook-emission/verification.md
@@ -59,6 +59,34 @@ a real call, same run                                   EXIT=2   (the fix did no
 - **Ambiguity resolves to Allow, everywhere.** A gate that blocks on input it
   cannot read blocks on every harness upgrade.
 
+## Reviewer findings on #1272, applied
+
+PR-Agent raised two, both real, both fixed with a regression test each.
+
+1. **A skill invocation could deadlock the session.** On a *well-formed* payload
+   naming the skill primitive but carrying no readable argument, the skill name
+   came back empty, the call fell through to enforcement, and the gate blocked
+   the one action that could satisfy it — permanently, since a blocked call never
+   records consumption. The guard keyed on the skill's **name** when it had to
+   key on the tool's **identity**. `TestGateNeverBlocksTheSkillInvocationItself`
+   passed throughout, because it always supplied a name — the case that was never
+   in danger. Pinned by `TestGateNeverBlocksASkillToolWithAnUnreadableName`.
+2. **State paths could collide.** Character-mapping alone flattens `a/b` and
+   `a.b` to one file, so one session's consumption would open another's gate.
+   UUIDs never collide, but a session id is attacker-adjacent input landing in a
+   path. A digest is appended and the readable prefix kept. Pinned by
+   `TestGateStatePathDoesNotCollideAcrossDistinctSessions`.
+
+A third came from checking whether the pin guard shipped in #1256 had gone red on
+main: `tiers.low` acquired a `$comment`, and `DeclaredModels` treated every string
+in a tier as a model id, so the whole sentence entered the declared set. It only
+ever widened the set — no check could fail wrongly — but a registry that treats
+prose as an id is one coincidence away from masking real drift.
+
+**That check worked as designed**, and it is worth recording: `qwen3.8-flash` was
+promoted to pi's routed default **and** added to the map in the same change,
+which is exactly the coupling the pin registry exists to force.
+
 ## Three defects found by running it, not by reading it
 
 1. **A malformed payload blocked every call.** `normaliseToolCall` returned a

--- a/specs/HARNESS-045-hook-emission/verification.md
+++ b/specs/HARNESS-045-hook-emission/verification.md
@@ -87,6 +87,31 @@ prose as an id is one coincidence away from masking real drift.
 promoted to pi's routed default **and** added to the map in the same change,
 which is exactly the coupling the pin registry exists to force.
 
+### Command output after the fixes (Definition of Done §5)
+
+The reviewer on #1275 was right that the section above asserted the tests pass
+without showing it. Run uncached, in this session:
+
+```
+$ go clean -testcache && go test ./internal/harness/ ./internal/cmd/
+ok  github.com/mlorentedev/dotfiles/cli/internal/harness  0.040s
+ok  github.com/mlorentedev/dotfiles/cli/internal/cmd      0.570s
+
+$ go test ./internal/harness/ -run 'TestGateNeverBlocksASkillToolWithAnUnreadableName|TestGateStatePathDoesNotCollideAcrossDistinctSessions|TestDeclaredModelsIgnoresAnnotationKeysInTiers' -v
+--- PASS: TestGateNeverBlocksASkillToolWithAnUnreadableName
+--- PASS: TestGateStatePathDoesNotCollideAcrossDistinctSessions
+--- PASS: TestDeclaredModelsIgnoresAnnotationKeysInTiers
+
+$ go test ./...
+19/19 packages ok
+
+$ go build ./... && go vet ./... && GOOS=windows go vet ./...
+(clean, both platforms)
+
+$ golangci-lint run          # pinned 2.12.2, matching versions.conf
+0 issues.
+```
+
 ## Three defects found by running it, not by reading it
 
 1. **A malformed payload blocked every call.** `normaliseToolCall` returned a


### PR DESCRIPTION
Follow-up to #1272, which merged before its review was dispositioned. PR-Agent raised two defects; both are real, both applied, each with a regression test.

## 1. A skill invocation could deadlock the session

On a **well-formed** payload naming the skill primitive but carrying no readable argument, the skill name came back empty, the call fell through to enforcement, and the gate blocked the one action that could satisfy it — permanently, since a blocked call never records consumption.

The guard keyed on the skill's **name** when it had to key on the tool's **identity**. `TestGateNeverBlocksTheSkillInvocationItself` passed throughout, because it always supplied a name — the case that was never in danger.

## 2. State paths could collide

Character-mapping alone flattens `a/b` and `a.b` to the same file, so one session's consumption record would open another session's gate. Well-behaved harnesses send UUIDs and never hit it, but a session id is attacker-adjacent input landing in a filesystem path, and "it does not happen with well-behaved input" is not a property a path builder should rest on. A digest is appended; the readable prefix stays so the directory is diagnosable by eye.

## 3. One my own guard surfaced

Found while checking whether the pin registry shipped in #1256 had gone red on main: `tiers.low` acquired a `$comment`, and `DeclaredModels` treated every string in a tier as a model id — so the whole sentence entered the declared set. It only ever **widened** the set, so no check could fail wrongly, but a registry that treats prose as an id is one coincidence away from masking real drift.

**That check worked as designed**, which is worth recording: `qwen3.8-flash` was promoted to pi's routed default **and** added to the map in the same change. That coupling is exactly what the pin registry exists to force, and it held within hours of shipping.

## Verification

| | |
|---|---|
| New regression tests | 3, one per finding |
| `go test ./...` | 19/19 packages |
| build + vet, Linux and `GOOS=windows` | pass |
| `golangci-lint run` (pinned 2.12.2) | 0 issues |

Refs #561.