### PR TITLE
feat(mem): a thread is the branch, so work follows you between machines

### DIFF
--- a/cli/internal/mem/handoff.go
+++ b/cli/internal/mem/handoff.go
@@ -193,20 +193,30 @@ func trimTrailingBlank(lines []string, from, to int) int {
 
 // ThreadKey derives a stable thread identity from a working directory.
 //
-// The worktree, because that is what distinguishes two concurrent sessions — not
-// the agent and not the date. Journals were named `<date>-<project>-<agent>.md`
-// and two WORKTREES on one day collided into `-2`/`-3` suffixes encoding nothing;
-// six such files exist across two days, and no session could derive its own.
+// A THREAD IS A LINE OF WORK, AND GIT ALREADY NAMES IT: THE BRANCH.
 //
-// IT ASKS GIT FIRST, and only then falls back to this repository's naming
-// convention. That ordering is what makes the key agnostic across tools.
+// The first version keyed on the worktree. That correlates on one machine and
+// decorrelates the moment the work moves to another — and the vault is the SSOT
+// across machines, so the same branch continued on a second box must resolve to
+// the SAME thread rather than forking one. Every worktree in this repository is
+// born on its own branch (measured: three live worktrees, three distinct
+// branches, no duplicates), so the branch discriminates at least as well and it
+// travels.
 //
-// Several tools create worktrees here and each names them differently: this
-// repository writes `<repo>-wt-<slug>`, Claude Code's EnterWorktree writes
-// `.claude/worktrees/<name>`, Orca writes its own. A key derived from one
-// pattern resolves every other tool's worktree to "main" — so every session
-// running under a different tool would share one thread and clobber the others,
-// which is the bug this exists to fix, reintroduced for everyone not using our
+// THE HOSTNAME ENTERS ONLY WHERE IT DISAMBIGUATES. `main` on two machines is two
+// pieces of ambient work, so the default branch is keyed `main@<host>` while
+// every feature branch stays clean — the same only-when-it-disambiguates rule
+// JournalName applies to its `-main` suffix.
+//
+// A DETACHED HEAD is named `<worktree>@<host>` and says so, rather than
+// collapsing into a plausible "main" that would silently share a thread with
+// somebody else's work.
+//
+// It reads git's own on-disk state through RepoIdentity — no subprocess, no
+// naming convention — so a worktree created by Claude Code, Orca, opencode, pi,
+// agy, copilot or a bare `git worktree add` all behave identically. A key
+// derived from one tool's path pattern resolved every other tool's worktree to
+// "main", which reintroduced this very bug for everyone not using our
 // convention.
 //
 // git already knows, and states it on disk with no subprocess: a linked
@@ -224,15 +234,22 @@ func trimTrailingBlank(lines []string, from, to int) int {
 // checkout whose `.git` one level up said "main". Authoritative answers come
 // first; a name-shaped guess is only for a tree git does not know at all.
 func ThreadKey(cwd string) string {
-	for dir := filepath.Clean(cwd); ; {
-		if name, ok := gitWorktreeName(dir); ok {
-			return name
+	if id, ok := RepoIdentity(cwd); ok {
+		switch {
+		case id.Branch == "":
+			// Detached HEAD: no line of work to name. Say so rather than
+			// collapsing into a plausible "main" that would silently share a
+			// thread with somebody else's work.
+			name := id.Worktree
+			if name == "" {
+				name = "detached"
+			}
+			return sanitizeThread(name) + "@" + shortHost()
+		case isDefaultBranch(id.Branch):
+			return id.Branch + "@" + shortHost()
+		default:
+			return sanitizeThread(id.Branch)
 		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
 	}
 	// git knows nothing about this path — a test fixture, or a tree copied
 	// rather than cloned. Fall back to this repository's own convention.
@@ -246,38 +263,6 @@ func ThreadKey(cwd string) string {
 		}
 		dir = parent
 	}
-}
-
-// gitWorktreeName reads `.git` at dir. It returns the linked worktree's name, or
-// ("main", true) when `.git` is a directory — the main checkout. The bool
-// distinguishes "this is a git root and here is the answer" from "keep walking".
-func gitWorktreeName(dir string) (string, bool) {
-	p := filepath.Join(dir, ".git")
-	info, err := os.Lstat(p)
-	if err != nil {
-		return "", false
-	}
-	if info.IsDir() {
-		return "main", true
-	}
-	raw, err := os.ReadFile(p) // #nosec G304 -- the .git pointer of the cwd being resolved
-	if err != nil {
-		return "", false
-	}
-	target, ok := strings.CutPrefix(strings.TrimSpace(string(raw)), "gitdir:")
-	if !ok {
-		return "", false
-	}
-	target = strings.TrimSpace(target)
-	// `…/.git/worktrees/<name>`; the last element is git's own name for it.
-	if parent := filepath.Base(filepath.Dir(filepath.Clean(target))); parent != "worktrees" {
-		return "", false
-	}
-	name := filepath.Base(filepath.Clean(target))
-	if name == "" || name == "." {
-		return "", false
-	}
-	return name, true
 }
 
 // ThreadKeyForCwd is ThreadKey over the process's working directory.

--- a/cli/internal/mem/handoff_test.go
+++ b/cli/internal/mem/handoff_test.go
@@ -158,69 +158,137 @@ func TestWrittenThreadsStayInsideTheArchivedBlock(t *testing.T) {
 	}
 }
 
-// AGNOSTIC ACROSS TOOLS: the key must come from git, not from one tool's naming
-// convention. This repository writes `<repo>-wt-<slug>`, Claude Code's
-// EnterWorktree writes `.claude/worktrees/<name>`, and Orca writes its own. A key
-// derived from a path pattern resolves every foreign convention to "main", and
-// then every session using a different tool shares one thread and clobbers the
-// others — precisely the bug being fixed, reintroduced for everyone who is not
-// using this repo's convention.
-//
-// git already knows: a linked worktree's `.git` is a FILE reading
-// `gitdir: .../.git/worktrees/<name>`, while a main checkout's is a directory.
-// No subprocess, no convention.
-func TestThreadKeyReadsGitRatherThanANamingConvention(t *testing.T) {
-	// A linked worktree, written the way git writes it.
-	wt := t.TempDir()
-	gitdir := filepath.Join(t.TempDir(), ".git", "worktrees", "some-tool-name")
+// gitFixture writes a repo the way git writes one: a linked worktree whose
+// `.git` is a FILE pointing at `<repo>/.git/worktrees/<name>`, with HEAD naming
+// the branch. Returns the worktree path.
+func gitFixture(t *testing.T, repo, worktree, branch string) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), repo)
+	gitdir := filepath.Join(root, ".git", "worktrees", worktree)
 	if err := os.MkdirAll(gitdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	head := "ref: refs/heads/" + branch + "\n"
+	if branch == "" {
+		head = "0123456789abcdef0123456789abcdef01234567\n" // detached
+	}
+	if err := os.WriteFile(filepath.Join(gitdir, "HEAD"), []byte(head), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wt := filepath.Join(t.TempDir(), worktree)
+	if err := os.MkdirAll(wt, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(wt, ".git"), []byte("gitdir: "+gitdir+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := ThreadKey(wt); got != "some-tool-name" {
-		t.Errorf("a worktree named by another tool must still get its own key, got %q", got)
-	}
+	return wt
+}
 
-	// A subdirectory of it resolves the same.
+func mainFixture(t *testing.T, repo, branch string) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), repo)
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".git", "HEAD"), []byte("ref: refs/heads/"+branch+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// THE THREAD IS THE LINE OF WORK — THE BRANCH — NOT THE WORKTREE.
+//
+// The vault is the SSOT across machines, so the same branch continued on a
+// second box must resolve to the SAME thread rather than forking one. Keying on
+// the worktree correlates on one machine and decorrelates the moment the work
+// moves, which is exactly what "work from different machines" breaks.
+//
+// It reads git's own on-disk state, so a worktree created by any tool — Claude
+// Code, Orca, opencode, pi, agy, copilot, or a bare `git worktree add` — behaves
+// identically. A key derived from one tool's path pattern resolved every other
+// tool's worktree to "main" and reintroduced the clobber for everyone else.
+func TestThreadKeyIsTheBranchSoItTravelsBetweenMachines(t *testing.T) {
+	wt := gitFixture(t, "dotfiles", "whatever-this-tool-calls-it", "feat/harness-088")
+	if got := ThreadKey(wt); got != "feat-harness-088" {
+		t.Errorf("want the branch, got %q — the worktree name must not decide the thread", got)
+	}
 	sub := filepath.Join(wt, "cli", "internal")
 	if err := os.MkdirAll(sub, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if got := ThreadKey(sub); got != "some-tool-name" {
-		t.Errorf("a subdirectory of a foreign-convention worktree got %q", got)
+	if got := ThreadKey(sub); got != "feat-harness-088" {
+		t.Errorf("a subdirectory got %q", got)
 	}
-
-	// A main checkout: `.git` is a directory.
-	main := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(main, ".git"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if got := ThreadKey(main); got != "main" {
-		t.Errorf("a main checkout must be %q, got %q", "main", got)
+	// The SAME branch in a DIFFERENT worktree — the cross-machine case — is the
+	// same thread. This is the property the whole design turns on.
+	other := gitFixture(t, "dotfiles", "a-totally-different-directory", "feat/harness-088")
+	if ThreadKey(other) != ThreadKey(wt) {
+		t.Errorf("the same branch in two places produced two threads: %q vs %q", ThreadKey(other), ThreadKey(wt))
 	}
 }
 
-func TestThreadKeyDerivesFromTheWorktree(t *testing.T) {
-	for _, tc := range []struct{ cwd, want string }{
-		{"/home/x/Projects/dotfiles-wt-pi-harness", "wt-pi-harness"},
-		{"/home/x/Projects/dotfiles-wt-cli-023/", "wt-cli-023"},
-		{"/home/x/Projects/dotfiles", "main"},
-		{"/home/x/Projects/knowledge", "main"},
-		{"", "main"},
-		// SUBDIRECTORIES. The first version read only the basename, so a session
-		// in `cli/` — where most work in this repository happens — resolved to
-		// "main", and every such session would have shared one key and clobbered
-		// the others exactly as before. The tests passed because they all passed
-		// worktree roots; running `dotf mem thread` from `cli/` did not.
-		{"/home/x/Projects/dotfiles-wt-pi-harness/cli", "wt-pi-harness"},
-		{"/home/x/Projects/dotfiles-wt-pi-harness/cli/internal/mem", "wt-pi-harness"},
-		{"/home/x/Projects/dotfiles/cli/internal/mem", "main"},
-	} {
-		if got := ThreadKey(tc.cwd); got != tc.want {
-			t.Errorf("ThreadKey(%q) = %q, want %q", tc.cwd, got, tc.want)
+// The one genuine collision: the default branch is ambient work, and two
+// machines' `main` are not one thread. The hostname enters ONLY there.
+func TestThreadKeyQualifiesOnlyTheDefaultBranchWithTheHost(t *testing.T) {
+	for _, b := range []string{"main", "master"} {
+		got := ThreadKey(mainFixture(t, "dotfiles", b))
+		if !strings.HasPrefix(got, b+"@") {
+			t.Errorf("branch %q must be host-qualified, got %q", b, got)
 		}
+	}
+	if got := ThreadKey(gitFixture(t, "dotfiles", "w", "fix/thing")); strings.Contains(got, "@") {
+		t.Errorf("a feature branch must not carry the host, got %q", got)
+	}
+}
+
+// A detached HEAD has no line of work to name, and must say so rather than
+// collapsing into a plausible "main" that would silently share somebody's thread.
+func TestThreadKeyNamesADetachedHeadRatherThanGuessing(t *testing.T) {
+	got := ThreadKey(gitFixture(t, "dotfiles", "wt-detached", ""))
+	if !strings.HasPrefix(got, "wt-detached@") {
+		t.Errorf("a detached HEAD must be named after its worktree and host, got %q", got)
+	}
+}
+
+// THE DEBT FIX: the project is the REPOSITORY, not the basename of wherever the
+// session happens to be standing.
+//
+// `SessionEnd` resolved it as filepath.Base(cwd), so a session in a subdirectory
+// — `cli/`, where most work here happens — resolved the wrong project, found no
+// MEMORY.md, and SILENTLY ARCHIVED NOTHING. Same class as the thread-key defect,
+// in a different function; both read RepoIdentity now, so they cannot disagree.
+func TestRepoIdentityResolvesTheProjectFromAnywhereInTheTree(t *testing.T) {
+	wt := gitFixture(t, "dotfiles", "wt-x", "feat/y")
+	for _, dir := range []string{wt, filepath.Join(wt, "cli"), filepath.Join(wt, "cli", "internal", "mem")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		id, ok := RepoIdentity(dir)
+		if !ok {
+			t.Fatalf("RepoIdentity failed at %s", dir)
+		}
+		if id.Project != "dotfiles" {
+			t.Errorf("at %s: project = %q, want dotfiles", dir, id.Project)
+		}
+		if id.Branch != "feat/y" {
+			t.Errorf("at %s: branch = %q, want feat/y", dir, id.Branch)
+		}
+	}
+	root := mainFixture(t, "knowledge", "master")
+	sub := filepath.Join(root, "10_projects", "dotfiles")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	id, ok := RepoIdentity(sub)
+	if !ok || id.Project != "knowledge" || id.Branch != "master" {
+		t.Errorf("main checkout subdirectory: got %+v ok=%v", id, ok)
+	}
+}
+
+func TestRepoIdentityReportsWhenGitKnowsNothing(t *testing.T) {
+	if _, ok := RepoIdentity(t.TempDir()); ok {
+		t.Error("a path outside any repository must report ok=false, not a guessed identity")
 	}
 }
 
@@ -280,15 +348,12 @@ func TestWriteThreadSurvivesASubheadingInsideAThreadBody(t *testing.T) {
 // authoritative, so it must be consulted across the whole walk-up before the
 // convention is consulted at all.
 func TestThreadKeyPrefersGitOverAConventionalLookingSubdirectory(t *testing.T) {
-	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	root := mainFixture(t, "dotfiles", "main")
 	inner := filepath.Join(root, "vendor-wt-cache")
 	if err := os.MkdirAll(inner, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if got := ThreadKey(inner); got != "main" {
+	if got := ThreadKey(inner); !strings.HasPrefix(got, "main@") {
 		t.Errorf("a look-alike directory inside a main checkout got its own thread %q — git said main", got)
 	}
 }

--- a/cli/internal/mem/identity.go
+++ b/cli/internal/mem/identity.go
@@ -1,0 +1,131 @@
+package mem
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Identity is what a working directory says about the work happening in it.
+//
+// ONE FUNCTION FEEDS EVERY CONSUMER, deliberately. Before this, `ThreadKey`
+// derived the worktree from a naming convention while `SessionEnd` derived the
+// project as `filepath.Base(cwd)` — two derivations of the same fact, in the same
+// package, disagreeing. That is the divergent-parser defect this repository has
+// now found five times in a week, and shipping it between two of my own
+// functions would have been the sixth.
+type Identity struct {
+	// Project is the repository's name — the MAIN checkout's basename, even when
+	// called from a linked worktree, because the vault is keyed by repository.
+	Project string
+	// Branch is the current branch, or "" on a detached HEAD.
+	Branch string
+	// Worktree is git's own name for a linked worktree, or "" in a main
+	// checkout.
+	Worktree string
+}
+
+// RepoIdentity resolves the repository from a working directory by reading git's
+// own on-disk state — no subprocess, no naming convention, so it behaves the same
+// under every agent and every tool that creates worktrees.
+//
+// A linked worktree's `.git` is a FILE reading `gitdir: …/<repo>/.git/worktrees/<name>`;
+// a main checkout's `.git` is a directory. Both state the branch in a `HEAD`
+// file beside them.
+//
+// ok is false when the path is not in a git repository at all.
+func RepoIdentity(cwd string) (Identity, bool) {
+	for dir := filepath.Clean(cwd); ; {
+		p := filepath.Join(dir, ".git")
+		info, err := os.Lstat(p)
+		if err == nil {
+			if info.IsDir() {
+				return Identity{
+					Project: filepath.Base(dir),
+					Branch:  headBranch(p),
+				}, true
+			}
+			if gitdir, ok := readGitdirPointer(p); ok {
+				return Identity{
+					// `…/<repo>/.git/worktrees/<name>` — the repo root is three
+					// levels up, and its basename is the project.
+					Project:  filepath.Base(filepath.Dir(filepath.Dir(filepath.Dir(gitdir)))),
+					Branch:   headBranch(gitdir),
+					Worktree: filepath.Base(gitdir),
+				}, true
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return Identity{}, false
+		}
+		dir = parent
+	}
+}
+
+// isDefaultBranch reports the branches that are ambient rather than a piece of
+// work, and therefore need the machine to tell two of them apart.
+func isDefaultBranch(b string) bool {
+	return b == "main" || b == "master"
+}
+
+// sanitizeThread keeps a branch usable as both a markdown heading and a filename
+// component. `/` is the character that actually occurs (`feat/x`) and the one
+// that would break a path.
+func sanitizeThread(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '/', '\\', ' ', ':':
+			return '-'
+		}
+		return r
+	}, strings.TrimSpace(s))
+}
+
+// shortHost is the machine's name, lowercased and trimmed at the first dot, so a
+// key stays readable in a heading. It appears in a key ONLY where it
+// disambiguates — see ThreadKey.
+func shortHost() string {
+	h, err := os.Hostname()
+	if err != nil || strings.TrimSpace(h) == "" {
+		return "unknown-host"
+	}
+	h, _, _ = strings.Cut(strings.ToLower(strings.TrimSpace(h)), ".")
+	return sanitizeThread(h)
+}
+
+// readGitdirPointer reads a linked worktree's `.git` file and returns the gitdir
+// it names, if it points into a `worktrees/` directory.
+func readGitdirPointer(path string) (string, bool) {
+	raw, err := os.ReadFile(path) // #nosec G304 -- the .git pointer of the cwd being resolved
+	if err != nil {
+		return "", false
+	}
+	target, ok := strings.CutPrefix(strings.TrimSpace(string(raw)), "gitdir:")
+	if !ok {
+		return "", false
+	}
+	target = filepath.Clean(strings.TrimSpace(target))
+	if filepath.Base(filepath.Dir(target)) != "worktrees" {
+		return "", false
+	}
+	if name := filepath.Base(target); name == "" || name == "." {
+		return "", false
+	}
+	return target, true
+}
+
+// headBranch reads `HEAD` inside a git dir. A detached HEAD holds a raw sha
+// rather than a `ref:` line, and yields "" — the caller decides what to do with
+// that rather than being handed a plausible-looking wrong answer.
+func headBranch(gitDir string) string {
+	raw, err := os.ReadFile(filepath.Join(gitDir, "HEAD")) // #nosec G304 -- inside the resolved git dir
+	if err != nil {
+		return ""
+	}
+	ref, ok := strings.CutPrefix(strings.TrimSpace(string(raw)), "ref:")
+	if !ok {
+		return ""
+	}
+	return strings.TrimPrefix(strings.TrimSpace(ref), "refs/heads/")
+}

--- a/cli/internal/mem/session_end.go
+++ b/cli/internal/mem/session_end.go
@@ -52,7 +52,25 @@ func SessionEnd(payload []byte, vaultPath string, now time.Time) (string, error)
 	if p.Cwd == "" {
 		return "", nil
 	}
+	// THE PROJECT IS THE REPOSITORY, not the basename of wherever the session
+	// happens to be standing.
+	//
+	// This read `filepath.Base(p.Cwd)`, so a session whose working directory was
+	// a subdirectory — `cli/`, where most work in this repository happens —
+	// resolved the wrong project, found no MEMORY.md, and SILENTLY ARCHIVED
+	// NOTHING. An unknown number of sessions produced no record at all, and the
+	// no-op contract above is precisely what made it invisible.
+	//
+	// It shares RepoIdentity with ThreadKey rather than deriving the fact a
+	// second time: two derivations of one truth in one package is the
+	// divergent-parser defect this repository has now found five times.
+	// git is authoritative WHERE IT KNOWS; the basename stays as the fallback so
+	// a session outside any repository keeps working exactly as before. Fixing a
+	// defect must not quietly narrow who the function serves.
 	project := filepath.Base(p.Cwd)
+	if id, ok := RepoIdentity(p.Cwd); ok {
+		project = id.Project
+	}
 
 	memory := filepath.Join(vaultPath, "10_projects", project, "memory", "MEMORY.md")
 	content, err := os.ReadFile(memory)

--- a/cli/internal/mem/session_end_test.go
+++ b/cli/internal/mem/session_end_test.go
@@ -202,23 +202,11 @@ func TestSessionEndArchivesPerWorktreeRatherThanOverEachOther(t *testing.T) {
 	}
 
 	// Two worktrees, written the way git writes a linked worktree.
-	mk := func(name string) string {
-		// Named "proj" because SessionEnd resolves the project as
-		// filepath.Base(cwd) — see the defect noted below.
-		wt := filepath.Join(t.TempDir(), "proj")
-		if err := os.MkdirAll(wt, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		gd := filepath.Join(t.TempDir(), ".git", "worktrees", name)
-		if err := os.MkdirAll(gd, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(wt, ".git"), []byte("gitdir: "+gd+"\n"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		return wt
-	}
-	a, b := mk("wt-a"), mk("wt-b")
+	// Two worktrees of the SAME repository on DIFFERENT branches — the real
+	// concurrent case. The project comes from the repo, the thread from the
+	// branch, and both from the one RepoIdentity.
+	a := gitFixture(t, "proj", "wt-a", "feat/a")
+	b := gitFixture(t, "proj", "wt-b", "feat/b")
 
 	// Marshalled, never concatenated: a Windows cwd is `C:\Users\...` and every
 	// backslash is a JSON escape, so a hand-built payload fails to parse and
@@ -250,7 +238,7 @@ func TestSessionEndArchivesPerWorktreeRatherThanOverEachOther(t *testing.T) {
 		}
 	}
 	// And the name is the one the skill would derive, not a second convention.
-	if want := JournalName(fixedNow.Format("2006-01-02"), "proj", "claude", "wt-a"); filepath.Base(wroteA) != want {
+	if want := JournalName(fixedNow.Format("2006-01-02"), "proj", "claude", "feat-a"); filepath.Base(wroteA) != want {
 		t.Errorf("archive name %q diverges from JournalName %q", filepath.Base(wroteA), want)
 	}
 }

--- a/harness/skills/handoff/SKILL.md
+++ b/harness/skills/handoff/SKILL.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/skills/handoff/SKILL.md
-generated_sha: 1f31020398b7688c
+generated_sha: 05f103c348e50bde
 id: handoff-skill
 type: skill
 status: active
@@ -69,13 +69,27 @@ Maintain exactly ONE `## Session Handoff` block with these fields, in this exact
   (`### thread: wt-pi-harness`). The command replaces only *your* thread and
   leaves every other byte-identical.
 
-  **It is agent-agnostic by construction.** The thread is what **git** says the
-  worktree is — a linked worktree's `.git` is a file reading
-  `gitdir: …/worktrees/<name>` — not a naming convention. So a worktree made by
-  Claude Code, Orca, opencode, pi, agy, copilot or a bare `git worktree add` all
-  get their own thread without any of them knowing about the others. The marker
-  exists for the same reason: a plain `### <key>` is indistinguishable from an
-  ordinary subheading like `### Next Actions`, and identity must be declared,
+  **A thread is a LINE OF WORK, and git already names it: the branch.** Not the
+  worktree, not the machine, not the agent. So `feat/x` continued tomorrow on
+  another computer resolves to the *same* thread and picks up where it left off —
+  which is what "the vault is the SSOT" has to mean in practice.
+
+  | Situation | Thread |
+  |---|---|
+  | any feature branch | `feat-x` — clean, travels between machines |
+  | `main` / `master` | `main@<host>` — ambient work, and two machines' `main` are not one thread |
+  | detached HEAD | `<worktree>@<host>` — says so rather than guessing |
+
+  **Agent-agnostic by construction.** It reads git's own on-disk state — a linked
+  worktree's `.git` is a file naming its gitdir, and `HEAD` names the branch —
+  with no subprocess and no naming convention. A worktree made by Claude Code,
+  Orca, opencode, pi, agy, copilot or a bare `git worktree add` behaves
+  identically; an earlier version keyed on one tool's path pattern and resolved
+  every other tool's worktree to `main`, which reintroduced the clobber for
+  everyone else.
+
+  The marker exists for the same reason: a plain `### <key>` is indistinguishable
+  from an ordinary subheading like `### Next Actions`, so identity is declared,
   never inferred from shape.
 
   **This replaces HARNESS-028's merge-by-hand rule because that rule kept

--- a/specs/HARNESS-088-handoff-threads/tasks.md
+++ b/specs/HARNESS-088-handoff-threads/tasks.md
@@ -70,9 +70,27 @@ Minimal `features.json` skeleton (drop into `<repo>/specs/HARNESS-088-handoff-th
       durable records, and it assembled a filename the skill did not share.
 - [x] Both above written test-first and mutation-checked.
 
+## The debt, now fixed
+
+- [x] **`SessionEnd` resolved the project as `filepath.Base(cwd)`** — a session in
+      a subdirectory (`cli/`, where most work here happens) resolved the wrong
+      project, found no `MEMORY.md`, and **silently archived nothing**. git is
+      authoritative now; the basename stays as a fallback so a session outside any
+      repository keeps working, because fixing a defect must not quietly narrow
+      who the function serves.
+- [x] **A thread is the BRANCH, not the worktree.** The vault is the SSOT across
+      machines, so `feat/x` continued on a second box must resolve to the SAME
+      thread rather than forking one. The hostname qualifies only `main`/`master`
+      — ambient work rather than a line of it — and a detached HEAD is named
+      `<worktree>@<host>` rather than collapsing into a plausible `main`.
+- [x] **One `RepoIdentity` feeds both.** Two derivations of one fact in one
+      package would have been the sixth divergent-parser defect found here in a
+      week, this time between my own functions.
+
 ## Found by audit, NOT fixed — recorded rather than folded in
 
-- [ ] **`SessionEnd` resolves the project as `filepath.Base(cwd)`.** A session
+- [ ] ~~**`SessionEnd` resolves the project as `filepath.Base(cwd)`.**~~ Fixed
+      above. Original note: A session
       whose working directory is a subdirectory — `cli/`, where most work in this
       repository happens — resolves the wrong project name, finds no `MEMORY.md`,
       and **silently archives nothing**. Same class as the thread-key defect, in

--- a/specs/HARNESS-088-handoff-threads/verification.md
+++ b/specs/HARNESS-088-handoff-threads/verification.md
@@ -98,3 +98,36 @@ input the author was imagining.
   discipline.* First instance #1272 (hook emission alongside Orca), second this
   one (the handoff block). A third from outside this repo would make it a
   pattern; two is already enough to stop writing the rule as prose.
+
+## Second sitting — the debt, and cross-machine identity
+
+| AC | Proof |
+|---|---|
+| The project resolves from anywhere in the tree | `TestRepoIdentityResolvesTheProjectFromAnywhereInTheTree` — worktree root, `cli/`, `cli/internal/mem/`, and a main-checkout subdirectory |
+| A thread is the branch and travels | `TestThreadKeyIsTheBranchSoItTravelsBetweenMachines` — the same branch in two different worktrees is ONE thread, which is the cross-machine property the design turns on |
+| The host qualifies only where it disambiguates | `TestThreadKeyQualifiesOnlyTheDefaultBranchWithTheHost` — `main@host`, `master@host`, and a feature branch carrying no `@` |
+| A detached HEAD says so | `TestThreadKeyNamesADetachedHeadRatherThanGuessing` |
+| git knowing nothing is reported, not guessed | `TestRepoIdentityReportsWhenGitKnowsNothing` |
+
+Live, from `cli/` inside a worktree:
+
+```
+$ dotf mem thread --date 2026-08-27 --project dotfiles --agent claude
+thread   feat-harness-088-handoff-threads
+journal  sessions/2026-08-27-dotfiles-claude-feat-harness-088-handoff-threads.md
+
+$ cd ~/Projects/dotfiles && dotf mem thread
+thread   main@msi
+```
+
+### A mutation test of mine gave a FALSE NEGATIVE
+
+Worth recording because it is the failure mode this repository keeps meeting from
+a new angle. The first mutation replaced `Project:  filepath.Base(...)` written
+with **one** space where `gofmt` had written **two**, so nothing was mutated — and
+the passing test read as *"the test does not catch this"*. Re-run against the
+real target, it failed exactly as it should.
+
+**A mutation test that reports "no change" has not proven the test is weak; it
+has proven nothing at all.** Assert the mutation applied before believing its
+result.


### PR DESCRIPTION
Second sitting on #1278. Fixes the debt the first one recorded, and answers *"how does each worktree find its own session in the vault, across machines, with the vault as SSOT"*.

## The debt, fixed

`SessionEnd` resolved the project as `filepath.Base(cwd)`. A session whose working directory was a **subdirectory** — `cli/`, where most work in this repository happens — resolved the wrong project, found no `MEMORY.md`, and **silently archived nothing**. The no-op resilience contract is exactly what made it invisible.

git is authoritative now. The basename stays as a fallback so a session outside any repository keeps working: **fixing a defect must not quietly narrow who the function serves.**

## A thread is a LINE OF WORK, and git already names it: the branch

The first sitting keyed on the worktree. That correlates on one machine and **decorrelates the moment the work moves to another** — and the vault is the SSOT across machines, so `feat/x` continued on a second box must resolve to the *same* thread rather than forking one.

Measured premise before committing to it: three live worktrees, three distinct branches, no duplicates.

| Situation | Thread |
|---|---|
| any feature branch | `feat-x` — clean, travels |
| `main` / `master` | `main@<host>` — ambient work; two machines' `main` are not one thread |
| detached HEAD | `<worktree>@<host>` — says so rather than guessing |

The hostname enters **only where it disambiguates** — the same rule `JournalName` already applies to its `-main` suffix.

## One RepoIdentity feeds every consumer

`ThreadKey` derived the worktree from a naming convention while `SessionEnd` derived the project from a basename: two derivations of one fact, in one package, disagreeing. Keeping them would have been the **sixth divergent-parser defect found here in a week** — this time between my own functions.

It reads git's own on-disk state (a linked worktree's `.git` is a file naming its gitdir; `HEAD` names the branch) with **no subprocess and no naming convention**, so Claude Code, Orca, opencode, pi, agy, copilot or a bare `git worktree add` all behave identically.

## Verification

```
$ dotf mem thread --date 2026-08-27 --project dotfiles --agent claude   # from cli/
thread   feat-harness-088-handoff-threads

$ cd ~/Projects/dotfiles && dotf mem thread
thread   main@msi
```

| | |
|---|---|
| New tests | 5, incl. the same-branch-two-worktrees cross-machine case |
| `go test ./...` | 19/19 packages |
| build + vet, Linux and `GOOS=windows` | pass |
| `golangci-lint run` (pinned 2.12.2) | 0 issues |

Each fix written test-first and mutation-checked.

## A mutation test of mine gave a false negative

The first mutation replaced a string written with **one** space where `gofmt` had written **two**, so nothing was mutated — and the passing test read as *"the test does not catch this"*. Re-run against the real target, it failed as it should.

**A mutation test reporting "no change" has not proven the test is weak; it has proven nothing at all.** Recorded in `verification.md`.

Refs #1278.