### PR TITLE
fix(shell): the agent-wrapper guard ran before the PATH that satisfies it

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -92,7 +92,21 @@ export NAN_BASE_URL="https://api.nan.builders/v1"
 # latency before the agent started, and died on the first locked entry even when
 # the agent had no use for it (#976). Scoping is least privilege and startup
 # time at once.
-if command -v dotf >/dev/null 2>&1; then
+#
+# THE GUARD MUST NOT DEPEND ON $PATH. It runs here, but `~/.local/bin` — where
+# dotf lives — is prepended ~40 lines below, and the line before that REPLACES
+# PATH outright. So `command -v dotf` succeeds only when the parent process
+# happened to export it already.
+#
+# Measured 2026-08-27: a terminal with a clean PATH skipped this whole block, so
+# `pi` and `opencode` were never wrapped, ran without their injected credentials,
+# and reported "No models available" — silently, because a guard that fails says
+# nothing. A shell that inherited a good PATH worked, which is why it looked
+# intermittent and could not be reproduced from an already-configured shell.
+#
+# Only the GUARD is evaluated at source time; the function BODY runs at call
+# time, when PATH is complete and plain `dotf` resolves normally.
+if command -v dotf >/dev/null 2>&1 || [ -x "$HOME/.local/bin/dotf" ]; then
     # Every token here must be a live registry id: `--only` fails loud on an
     # unknown one, so a stale name does not degrade the launch, it prevents it.
     # OLLAMA_API_KEY was listed for a provider slot whose registry entry was

--- a/.zshrc
+++ b/.zshrc
@@ -69,7 +69,22 @@ export NAN_BASE_URL="https://api.nan.builders/v1"
 # latency before the agent started, and died on the first locked entry even when
 # the agent had no use for it (#976). Scoping is least privilege and startup
 # time at once.
-if command -v dotf >/dev/null 2>&1; then
+# THE GUARD MUST NOT DEPEND ON $PATH, because it runs ~40 lines before the PATH
+# that would satisfy it. `~/.local/bin` — where dotf lives — is prepended further
+# down; here, `command -v dotf` succeeds only when the parent process happened to
+# export it already.
+#
+# Measured 2026-08-27: a terminal launched with a clean PATH (a fresh desktop
+# terminal, an IDE, an ADE) skipped this whole block, so `pi` and `opencode` were
+# never wrapped, ran without their injected credentials, and reported "No models
+# available" — with no error, because a guard that fails is silence. A terminal
+# that inherited a good PATH worked, which is why it looked intermittent and why
+# it could not be reproduced from an already-configured shell.
+#
+# Checking the known location fixes it without moving the PATH block: only the
+# GUARD is evaluated at source time. The function BODY runs at call time, by
+# which point PATH is complete and plain `dotf` resolves normally.
+if command -v dotf >/dev/null 2>&1 || [ -x "$HOME/.local/bin/dotf" ]; then
     # Every token here must be a live registry id: `--only` fails loud on an
     # unknown one, so a stale name does not degrade the launch, it prevents it.
     # OLLAMA_API_KEY was listed for a provider slot whose registry entry was


### PR DESCRIPTION
`pi` and `opencode` reported **"No models available"** in a fresh terminal — silently, and apparently at random. Root cause is an ordering defect in the shell rc files.

## The defect

| Line | What happens |
|---|---|
| `.zshrc:72` | `if command -v dotf …` ← the wrapper guard |
| `.zshrc:114` | `export PATH="$HOME/.local/bin:$PATH"` ← where `dotf` lives |

In `.bashrc` it is worse: line 124 **replaces** `PATH` outright, and `~/.local/bin` is only prepended at 137 — the guard is at 95.

So the guard passes **only when the parent process happened to export that directory already**.

- A terminal that inherited a good PATH → agents wrapped → works
- A terminal with a clean PATH (fresh desktop terminal, IDE, ADE) → block skipped → `pi` runs **unwrapped**, never receives its JIT-injected credentials, finds no providers

**No error appears, because a guard that fails is silence.** That is why it looked intermittent — and why it could not be reproduced from an already-configured shell: every diagnostic run inherited a PATH that hid it.

## The fix

Only the **guard** is evaluated at source time. The function **body** runs at call time, when PATH is complete and plain `dotf` resolves normally. So checking the known location alongside PATH fixes it without moving the PATH block and without touching precedence:

```sh
if command -v dotf >/dev/null 2>&1 || [ -x "$HOME/.local/bin/dotf" ]; then
```

## Verification — reproduced, then observed fixed, under an identical clean PATH

```
$ PATH=/usr/local/bin:/usr/bin:/bin zsh -c '. <deployed .zshrc>; type pi'
pi is /home/manu/.nvm/versions/node/v24.16.0/bin/pi     <- the reported bug, same path

$ PATH=/usr/local/bin:/usr/bin:/bin zsh -c '. <fixed .zshrc>; type pi'
pi is a shell function

$ PATH=/usr/local/bin:/usr/bin:/bin bash -i -c 'source <fixed .bashrc>; type -t pi'
function
```

`bash -n` and `zsh -n` clean; `shellcheck` unchanged.

## Why this took a while to find

Three wrong explanations were tested and discarded first — a stale terminal, a duplicate pi install under nvm, a locked secrets vault. Each was measured and each came back "works", because **every measurement ran from a shell whose PATH already hid the defect**. The reproduction only worked once the PATH itself was controlled.

The duplicate nvm install is real but unrelated: it made the failure *visible* by giving the unwrapped `pi` something to resolve to, rather than a `command not found` that would have pointed here immediately.

Refs #1242.