### PR TITLE
docs(lessons): record the PATH-ordering diagnosis and index five orphaned lessons

### DIFF
--- a/cli/internal/cmd/mem_handoff.go
+++ b/cli/internal/cmd/mem_handoff.go
@@ -36,9 +36,14 @@ func newMemHandoffWriteCmd() *cobra.Command {
 		Long: `handoff-write replaces one thread's sub-block under "## Session Handoff",
 reading the body from stdin. Every other thread is left byte-identical.
 
-The thread key defaults to this working directory's worktree (e.g. wt-pi-harness),
-because that is what distinguishes two concurrent sessions — not the agent and not
-the date. A checkout that is not a worktree resolves to "main".
+A thread is a LINE OF WORK, and git already names it: the branch. So the key
+defaults to the current branch (e.g. feat-x), which means work resumed tomorrow on
+another machine lands in the same thread. Ambient work on main/master is qualified
+by host (main@msi), because two machines' main are not one line of work, and a
+detached HEAD falls back to worktree@host rather than guessing.
+
+Pass --thread to override — a session that switches branches mid-flight re-keys
+otherwise, and the line of work may well be the one it started on.
 
 Skills should call this instead of instructing an Edit: the merge is the part that
 was being got wrong, and it belongs where it can be tested.`,
@@ -103,7 +108,7 @@ was being got wrong, and it belongs where it can be tested.`,
 	}
 
 	cmd.Flags().StringVar(&memoryPath, "memory", "", "path to the project's MEMORY.md")
-	cmd.Flags().StringVar(&thread, "thread", "", "thread key (default: this worktree)")
+	cmd.Flags().StringVar(&thread, "thread", "", "thread key (default: this checkout's branch)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print the result instead of writing it")
 	return cmd
 }
@@ -123,10 +128,13 @@ func newMemThreadCmd() *cobra.Command {
 		Short: "Print this session's handoff thread key and journal filename",
 		Long: `thread answers "which session am I" from the working directory.
 
-Journal files were named <date>-<project>-<agent>.md, so two WORKTREES on one day
-collided into -2 and -3 suffixes encoding nothing — six such files exist across
-two days, and no session could derive its own. With the worktree in the key, it
-is derivable rather than remembered.`,
+Journal files were named <date>-<project>-<agent>.md, so two concurrent sessions
+on one day collided into -2 and -3 suffixes encoding nothing — six such files
+exist across two days, and no session could derive its own. With the thread in
+the key, it is derivable rather than remembered.
+
+The key is the branch, so the same line of work resumed on another machine
+resolves to the same journal. See handoff-write for the full rule.`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			key := mem.ThreadKeyForCwd()

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -9,8 +9,13 @@ tags: [lessons, index, dotfiles]
 
 # Dotfiles — Lessons Learned Index
 
-> Granular project-bound lessons, gotchas, and post-mortems for dotfiles (212 entries).
+> Granular project-bound lessons, gotchas, and post-mortems for dotfiles.
 > Individual lessons live alongside this index as `lesson-NNN-*.md` files.
+>
+> The entry count used to be stated here. It was a third copy of a fact the
+> directory listing and this table already hold, it drifted from both (it read
+> 212 against 234 files and 230 rows), and a stale count reads as authoritative.
+> Count the files.
 
 | Lesson | Date | Scope |
 |---|---|---|
@@ -244,3 +249,8 @@ tags: [lessons, index, dotfiles]
 | [228 - A calendar date is not a timestamp, and UTC is the wrong zone for one](lesson-228-a-calendar-date-is-not-a-timestamp-utc-is-wrong-for.md) | 2026-08-23 |  |
 | [229 - An empty secret is not an error, so a job with no credential fails as if the work failed](lesson-229-an-empty-secret-is-not-an-error-so-a-job-with-no-cr.md) | 2026-08-24 |  |
 | [230 - A config that parses is not a config the consumer reads](lesson-230-a-config-that-parses-is-not-a-config-the-consumer-re.md) | 2026-08-24 |  |
+| [231 - A hand-wired dev symlink outranks the managed install, and the host fails closed](lesson-231-a-hand-wired-dev-symlink-outranks-the-managed-instal.md) | 2026-08-26 |  |
+| [232 - Detect the shape that is wrong, not the shape that is merely absent](lesson-232-detect-the-shape-that-is-wrong-not-the-shape-that.md) | 2026-08-26 |  |
+| [233 - Piping a single-element array into ConvertTo-Json unwraps it](lesson-233-piping-a-single-element-array-into-convertto-json-un.md) | 2026-08-26 |  |
+| [234 - Orchestrating Orca ADE declarative configuration and bidirectional settings capture](lesson-234-orchestrating-orca-ade-declarative-configuration-and-bi.md) | 2026-08-26 |  |
+| [235 - Reproducing a bug from an environment that already works measures the environment, not the bug](lesson-235-reproducing-a-bug-from-an-environment-that-alread.md) | 2026-08-27 |  |

--- a/docs/lessons/lesson-235-reproducing-a-bug-from-an-environment-that-alread.md
+++ b/docs/lessons/lesson-235-reproducing-a-bug-from-an-environment-that-alread.md
@@ -1,0 +1,109 @@
+# Lesson 235 — reproducing a bug from an environment that already works measures the environment, not the bug
+
+**Date:** 2026-08-27
+**Context:** #1283 — `pi` reported "No models available" in fresh terminals.
+**Category:** shell, PATH, diagnosis, false negatives
+
+## What happened
+
+`pi` failed to start with *"No models available"*. It was intermittent in the
+way that matters most: it failed in some terminals and worked in others, with no
+edit in between.
+
+Four explanations were proposed, each tested, each discarded:
+
+| Hypothesis | How it was tested | Result |
+|---|---|---|
+| Stale terminal holding an old function | opened a new terminal, re-ran | "works" |
+| Duplicate `pi` under nvm shadowing the real one | `which -a pi`, removed the duplicate | "works" |
+| Secrets vault locked, so injection failed | `dotf secrets unlock`, re-ran | "works" |
+| Retired `OLLAMA_API_KEY` in the `--only` scope | checked the registry, already fixed | "works" |
+
+Four rounds, four false negatives. **The tell was that they all agreed** — a
+system that is genuinely broken does not return "works" to four unrelated probes.
+
+## The actual defect
+
+The agent-wrapper block in `.zshrc` / `.bashrc` is guarded by:
+
+```sh
+if command -v dotf >/dev/null 2>&1; then
+    pi() { dotf secrets run --only NAN_API_KEY,OPENROUTER_API_KEY -- pi "$@"; }
+fi
+```
+
+The guard is evaluated at **line ~87**. `~/.local/bin` — where `dotf` lives — is
+prepended to PATH at **line ~129**. In `.bashrc` the line before that prepend
+*replaces* `PATH` outright.
+
+So the guard passed only when the parent process happened to already export
+`~/.local/bin`. A terminal spawned from a configured shell inherited it and
+wrapped the agents. A fresh desktop terminal, an IDE, or an ADE did not — the
+whole block was skipped, `pi` ran unwrapped without its JIT credentials, and
+found no providers.
+
+**No error, because a guard that fails is silence.** `if` evaluating false is
+not an exceptional condition; it is the construct working as designed.
+
+## Why the measurements lied
+
+Every reproduction attempt was run from a shell that had already sourced a
+working rc file, or was launched by one. **The instrument shared the very
+variable under test.** Asking that shell to reproduce a PATH bug is asking a
+thermometer held in your fist to measure the room.
+
+The failure only appeared once PATH was *controlled* rather than inherited:
+
+```
+$ env -i PATH=/usr/local/bin:/usr/bin:/bin zsh -ic 'type pi'
+pi is /home/manu/.nvm/versions/node/v24.16.0/bin/pi      # unwrapped — the bug
+
+$ env -i PATH=/usr/local/bin:/usr/bin:/bin zsh -ic 'type pi'   # with the fix
+pi is a shell function                                    # wrapped
+```
+
+Two commands, differing only in the rc file, and the ambiguity was gone.
+
+## The fix
+
+Make the guard independent of the thing it runs before:
+
+```sh
+if command -v dotf >/dev/null 2>&1 || [ -x "$HOME/.local/bin/dotf" ]; then
+```
+
+Only the **guard** is evaluated at source time. The function **body** runs at
+call time, when PATH is complete and plain `dotf` resolves normally — so the
+PATH block does not need to move, and nothing about ordering has to be
+remembered by the next person to edit these files.
+
+## The lesson
+
+**"I cannot reproduce it" is a statement about the instrument before it is a
+statement about the system.** When a report says a thing is broken and your
+measurement says it is fine, the disagreement is data. Enumerate what your
+measurement inherits from its environment — PATH, cwd, env vars, an open
+session, a warm cache, an unlocked credential — and neutralise each one before
+concluding the report was wrong.
+
+Two corollaries earned here:
+
+**Anything read before the block that satisfies it is a latent ordering bug.**
+In an rc file, "before" is invisible: there is no import graph and no compiler to
+complain. Grep for guards that reference a command, and check where the PATH
+granting it is set.
+
+**The red herring was what made the bug findable.** The duplicate nvm install —
+chased for an hour as the culprit — is the only reason `pi` resolved to
+*something* when unwrapped. Without it the unwrapped call would have been
+`command not found`, which names the problem in its first line. A second copy of
+a tool converts a loud failure into a quiet wrong answer.
+
+## Related
+
+- `lesson-227` — a test suite inherits the developer's installed applications,
+  and PATH is the door. Same variable, opposite direction: there the inherited
+  environment made a test pass that should have failed.
+- `lesson-230` / `lesson-231` / `lesson-232` — the "shape is not effect" family.
+  This is its diagnostic sibling: a *measurement* whose shape is right and whose
+  effect is nil.


### PR DESCRIPTION
## What

Adds **lesson 235** and gives **lessons 231–235** their rows in `docs/lessons/_index.md`.

## Why

### The lesson

`pi` reported *"No models available"* in fresh terminals (#1283). The guard around the agent-wrapper block in `.zshrc`/`.bashrc` is evaluated ~40 lines **before** `~/.local/bin` — where `dotf` lives — is prepended to PATH; in `.bashrc` the line before that prepend *replaces* PATH outright. So the block ran only when the parent process happened to export that directory already, and a terminal with a clean PATH skipped it entirely and ran `pi` unwrapped, with no credentials and no error.

Four hypotheses were tested first — stale terminal, duplicate nvm install, locked vault, retired `OLLAMA_API_KEY` — and all four came back "works". They came back "works" because every measurement ran from a shell whose PATH already hid the defect. The transferable part is the instrument, not the ordering bug: **"I cannot reproduce it" is a statement about the instrument before it is a statement about the system**, and four probes agreeing is itself the tell.

### The index gap

Four lesson files (231–234) had been written and **none had an index row** — undiscoverable through the only surface that lists them. Measured **234 files against 230 rows**.

The check that exists for this, `mem.lessonsStaleness`, stats `_index.md`'s **mtime** over a 14-day window. The index had been edited 3 days earlier — just not for these lessons — so it reported green the whole time. That is a proxy where an invariant is available (every `lesson-NNN-*.md` has a row); ticketed rather than fixed here, since it is guards machinery and this PR is docs-only.

Both directions now verified by hand: 235 files / 235 rows, and every one of the 235 link targets resolves to an existing file.

### The header count

Dropped `(212 entries)` from the header rather than correcting it. It was a third copy of a fact the directory listing and the table already hold, it had drifted from both, and a stale count reads as authoritative.

## Verification

```
files: 235
rows:  235
link check done      # zero broken targets across all rows
```

Docs-only; no production LOC.

---

## Second commit: `handoff-write --help` described the keying it replaced

Found while reading `--help` to check for a `--thread` override. The Long text still said the key defaults to *"this working directory's worktree (e.g. wt-pi-harness)"* and that *"a checkout that is not a worktree resolves to main"* — the #1279 behaviour that **#1280 replaced the same day**. The key is the branch; `main`/`master` are host-qualified; a detached HEAD falls back to `worktree@host`.

Same defect class as the rest of this PR — a declared shape that no longer matches effect — and it matters more here than in a comment, because `--help` is the surface an agent reads to decide how threads key, so a stale one propagates into every skill that follows it.

Also documents what `--thread` is actually for: a session that switches branches mid-flight re-keys, and the line of work may well be the one it started on. (This PR is that case: the session began on `fix/shell-wrapper-path-ordering` and branched here.)

Help text only, no behaviour change. Verified:

```
go build ./... && go vet ./... && GOOS=windows go vet ./... \
  && go test ./internal/cmd/... ./internal/mem/...
ok  github.com/mlorentedev/dotfiles/cli/internal/cmd
ok  github.com/mlorentedev/dotfiles/cli/internal/mem
```
