### PR TITLE
fix(cli): Windows deploy defects measured on a real box

### DIFF
--- a/cli/internal/deploy/deploy.go
+++ b/cli/internal/deploy/deploy.go
@@ -139,7 +139,12 @@ func ExpandDst(dst, home string, resolve func(string) string) (string, error) {
 	if len(bad) > 0 {
 		return "", fmt.Errorf("destination %q: unresolvable path variable(s) %s", dst, strings.Join(bad, ", "))
 	}
-	return out, nil
+	// The manifest spells destinations with "/" on every OS; the resolved
+	// {HOME} is native. Normalise so the result is a path in the OS's own form
+	// rather than `C:\Users\u/.pi/agent/models.json` — accepted by the syscall,
+	// but never equal to the filepath.Join'ed path a check compares it against
+	// (CLI-054/#1301).
+	return filepath.Clean(filepath.FromSlash(out)), nil
 }
 
 // Renderer materialises {env:VAR} placeholders in a staged file. The seam exists

--- a/cli/internal/deploy/deploy_native_test.go
+++ b/cli/internal/deploy/deploy_native_test.go
@@ -1,0 +1,22 @@
+package deploy
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// The manifest spells destinations with "/" on every OS. The result must be in
+// the OS's own form: on Windows `{HOME}` resolves to `C:\Users\u`, and the
+// literal tail used to stay `/.pi/agent/models.json` — a path the syscall
+// accepts but that no filepath.Join'ed path ever string-equals, which is the
+// comparison every doctor check makes (CLI-054/#1301).
+func TestExpandDst_ReturnsAnOSNativePath(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	got, err := ExpandDst("{HOME}/.pi/agent/models.json", home, noResolve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(home, ".pi", "agent", "models.json"); got != want {
+		t.Errorf("want the OS-native path %q, got %q", want, got)
+	}
+}

--- a/cli/internal/deploy/deploy_test.go
+++ b/cli/internal/deploy/deploy_test.go
@@ -199,7 +199,7 @@ func TestExpandDst_UnresolvableTokenIsAnErrorNotAnEmptySegment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != "/opt/pi/models.json" {
+	if got != filepath.FromSlash("/opt/pi/models.json") {
 		t.Errorf("want the resolved path, got %q", got)
 	}
 }

--- a/cli/internal/doctor/checks_deploy.go
+++ b/cli/internal/doctor/checks_deploy.go
@@ -328,6 +328,39 @@ func checkOpenCode(sys *System, cfg *Config, rep *Report) {
 			rep.Skip("pi models.json substitution — age identity absent ({env:} resolves at runtime)")
 		}
 	}
+
+	// Launchability. Everything above is a static predicate — files and PATH —
+	// and every one of them was green on a box where `pi` could not start
+	// (WIN-012/#1293). The shell wrappers (profile.ps1, .zshrc, .bashrc) run
+	// both agents under `dotf secrets run`, which resolves their keys BEFORE
+	// exec'ing the binary; while those keys live in a locked Bitwarden vault the
+	// resolution fails and the agent never launches. Report the precondition the
+	// wrappers actually depend on, not a proxy for it.
+	if piConfigured || pathExists(cfgPath) {
+		reportAgentLaunchability(sys, rep)
+	}
+}
+
+// reportAgentLaunchability reports whether the agent wrappers' key resolution
+// can succeed right now. WARN, never FAIL: every reboot locks the vault, and a
+// doctor that is red on every fresh boot is one nobody reads. Silent while no
+// registry entry resolves through Bitwarden — the keys then come from the age
+// floor, which needs no daemon — and while the registry is unreadable, which
+// checkBitwardenReach already reports with its own reason.
+func reportAgentLaunchability(sys *System, rep *Report) {
+	live, err := sys.BWBackedSecrets()
+	if err != nil || live == 0 {
+		return
+	}
+	st, err := sys.BWServeStatus()
+	if err != nil {
+		return // checkBWServeDaemon reports the unreadable state
+	}
+	if st == "unlocked" {
+		rep.Pass("agent wrappers can resolve their keys (bw serve daemon unlocked)")
+		return
+	}
+	rep.Warn("pi/opencode wrappers will refuse to launch: their keys resolve through Bitwarden and no unlocked bw serve daemon is reachable — run `dotf secrets unlock` (once per boot; the daemon then serves every terminal)")
 }
 
 // checkHarnessDrift reproduces healthcheck section 11's harness/skill-record
@@ -506,7 +539,16 @@ const (
 // file with nothing to match it in the un-appended repo source. Without
 // dropping it, checkInstructionDrift reported drift on every target
 // immediately after a clean --deploy — caught in review before merge.
+//
+// Line endings are normalised first. A deployed copy written by a Windows
+// tool arrives CRLF while the repo source is LF (`.gitattributes` `*.md
+// eol=lf`), and with a bare "\n" split every line kept a trailing "\r": the
+// END marker never matched, so the strip swallowed the rest of the file, and
+// every other line differed anyway — a drift FAIL no redeploy could clear
+// (WIN-008/#1289). EOL is not content; the writer is fixed separately, and
+// this keeps the comparator honest about the next writer that is not.
 func stripHarnessRegions(content string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
 	lines := strings.Split(content, "\n")
 	out := make([]string, 0, len(lines))
 	skip, endMarker := false, ""

--- a/cli/internal/doctor/checks_dr.go
+++ b/cli/internal/doctor/checks_dr.go
@@ -102,6 +102,24 @@ func reportAbsentEscrow(rep *Report, escrow string, live int, regErr error) {
 	rep.Skip("no DR escrow at " + escrow + " — no secret resolves through Bitwarden yet, so nothing depends on it")
 }
 
+// escrowPath locates the DR escrow the same way its writer places it: in the
+// CHECKOUT (`dotf secrets backup` writes env.RepoSensitiveDir + "dr", because
+// the escrow is version-controlled state — #635 durability class), falling
+// back to the deploy mirror only when no checkout is found. The mirror is
+// copy-only and by construction never fresher than the checkout; reading it
+// first only ever agreed on Linux because setup-linux.sh happens to copy
+// sensitive/ recursively. setup-windows.ps1 did not, and doctor there reported
+// total-loss risk over an escrow sitting in the checkout (WIN-011/#1292).
+func escrowPath(sys *System, cfg *Config) string {
+	const rel = "bitwarden-export.age"
+	if repo := resolveRepoDir(sys); repo != "" {
+		if p := filepath.Join(repo, "sensitive", "dr", rel); pathExists(p) {
+			return p
+		}
+	}
+	return filepath.Join(cfg.DotfilesDir, "sensitive", "dr", rel)
+}
+
 func checkDisasterRecovery(sys *System, cfg *Config, rep *Report) {
 	rep.Section("Disaster recovery")
 
@@ -125,7 +143,7 @@ func checkDisasterRecovery(sys *System, cfg *Config, rep *Report) {
 	// indistinguishable from "no problem here".
 	live, regErr := sys.BWBackedSecrets()
 
-	escrow := filepath.Join(cfg.DotfilesDir, "sensitive", "dr", "bitwarden-export.age")
+	escrow := escrowPath(sys, cfg)
 	switch info, err := os.Stat(escrow); {
 	case os.IsNotExist(err):
 		reportAbsentEscrow(rep, escrow, live, regErr)

--- a/cli/internal/doctor/checks_dr_checkout_test.go
+++ b/cli/internal/doctor/checks_dr_checkout_test.go
@@ -1,0 +1,39 @@
+package doctor
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The escrow lives in the checkout — that is where `dotf secrets backup` writes
+// it — and the deploy mirror is copy-only. setup-windows.ps1 mirrored sensitive/
+// without its dr/ subdirectory, and doctor reported total-loss risk for 28
+// secrets over a 140 KB escrow sitting in the checkout (WIN-011/#1292). The
+// checkout copy must count, whatever the mirror holds.
+func TestDR_EscrowIsReadFromTheCheckoutTheWriterUses(t *testing.T) {
+	now := time.Now()
+	repo := t.TempDir()
+	touchAt(t, filepath.Join(repo, "sensitive", "dr", "bitwarden-export.age"), now.Add(-24*time.Hour))
+	sys := drSysExposed(t, now, 28, nil)
+	sys.Getenv = func(k string) string {
+		if k == "DOTFILES_REPO_DIR" {
+			return repo
+		}
+		return ""
+	}
+	cfg := &Config{DotfilesDir: t.TempDir()} // the mirror: no dr/ at all
+
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	checkDisasterRecovery(sys, cfg, rep)
+
+	if line := lineContaining(buf.String(), "DR escrow"); !strings.Contains(line, "[ OK ]") {
+		t.Fatalf("the checkout escrow must count, got: %s\n%s", line, buf.String())
+	}
+	if rep.Failures() != 0 {
+		t.Errorf("no failure expected\n%s", buf.String())
+	}
+}

--- a/cli/internal/doctor/checks_dr_test.go
+++ b/cli/internal/doctor/checks_dr_test.go
@@ -31,14 +31,26 @@ func lineContaining(out, substr string) string {
 // drSys builds a System for the DR check with NO bw-backed secrets, i.e. the
 // pre-migration machine where an absent escrow costs nothing. Severity is keyed
 // to that count (#997), so most tests need to state it; this is the neutral one.
-func drSys(now time.Time) *System { return drSysExposed(now, 0, nil) }
+func drSys(t *testing.T, now time.Time) *System { return drSysExposed(t, now, 0, nil) }
 
 // drSysExposed states the exposure explicitly: how many registry entries resolve
 // through Bitwarden, and whether the registry could be read at all. Those two
 // are the only inputs that move this check's severity.
-func drSysExposed(now time.Time, bwBacked int, regErr error) *System {
+//
+// The checkout it points at is an EMPTY temp dir: escrowPath prefers the
+// checkout's escrow over the mirror's, and without this the test cwd (inside
+// the real checkout) would walk up to the real escrow and every absence case
+// would see it.
+func drSysExposed(t *testing.T, now time.Time, bwBacked int, regErr error) *System {
+	t.Helper()
+	repo := t.TempDir()
 	return &System{
-		Getenv:          func(string) string { return "" },
+		Getenv: func(k string) string {
+			if k == "DOTFILES_REPO_DIR" {
+				return repo
+			}
+			return ""
+		},
 		LookPath:        func(n string) (string, error) { return "/usr/bin/" + n, nil },
 		Now:             func() time.Time { return now },
 		BWBackedSecrets: func() (int, error) { return bwBacked, regErr },
@@ -67,7 +79,7 @@ func TestDR_NoDrillRecorded_Warns(t *testing.T) {
 	var buf bytes.Buffer
 	rep := capture(&buf)
 
-	checkDisasterRecovery(drSys(time.Now()), cfg, rep)
+	checkDisasterRecovery(drSys(t, time.Now()), cfg, rep)
 
 	if rep.Failures() != 0 {
 		t.Fatalf("an unproven backup is not a broken one; want WARN not FAIL:\n%s", buf.String())
@@ -88,7 +100,7 @@ func TestDR_RecentDrillPasses(t *testing.T) {
 	var buf bytes.Buffer
 	rep := capture(&buf)
 
-	checkDisasterRecovery(drSys(now), cfg, rep)
+	checkDisasterRecovery(drSys(t, now), cfg, rep)
 
 	if !strings.Contains(buf.String(), "recovery drill run 30 days ago") {
 		t.Errorf("want the drill PASS with its age, got: %s", buf.String())
@@ -105,7 +117,7 @@ func TestDR_StaleDrillWarns(t *testing.T) {
 	var buf bytes.Buffer
 	rep := capture(&buf)
 
-	checkDisasterRecovery(drSys(now), cfg, rep)
+	checkDisasterRecovery(drSys(t, now), cfg, rep)
 
 	if !strings.Contains(buf.String(), "last recovery drill was 400 days ago") {
 		t.Errorf("want the staleness warning with its age, got: %s", buf.String())
@@ -149,7 +161,7 @@ func TestDR_EscrowSeverityFollowsExposure(t *testing.T) {
 			var buf bytes.Buffer
 			rep := capture(&buf)
 
-			checkDisasterRecovery(drSysExposed(now, tt.bwBacked, tt.regErr), cfg, rep)
+			checkDisasterRecovery(drSysExposed(t, now, tt.bwBacked, tt.regErr), cfg, rep)
 
 			out := buf.String()
 			escrowLine := lineContaining(out, "DR escrow")
@@ -192,7 +204,7 @@ func TestDR_StaleEscrowWithExposure_StillWarns(t *testing.T) {
 	var buf bytes.Buffer
 	rep := capture(&buf)
 
-	checkDisasterRecovery(drSysExposed(now, 28, nil), cfg, rep)
+	checkDisasterRecovery(drSysExposed(t, now, 28, nil), cfg, rep)
 
 	if rep.Failures() != 0 {
 		t.Fatalf("a stale escrow is degraded, not absent; want WARN not FAIL:\n%s", buf.String())
@@ -229,7 +241,7 @@ func TestDR_UnreadableEscrowWarnsRatherThanClaimingAbsence(t *testing.T) {
 	var buf bytes.Buffer
 	rep := capture(&buf)
 
-	checkDisasterRecovery(drSysExposed(time.Now(), 28, nil), cfg, rep)
+	checkDisasterRecovery(drSysExposed(t, time.Now(), 28, nil), cfg, rep)
 
 	if rep.Failures() != 0 {
 		t.Fatalf("an unreadable escrow is not a proven-absent one; want WARN not FAIL:\n%s", buf.String())
@@ -248,7 +260,7 @@ func TestDR_StaleEscrowWarns(t *testing.T) {
 	var buf bytes.Buffer
 	rep := capture(&buf)
 
-	checkDisasterRecovery(drSys(now), cfg, rep)
+	checkDisasterRecovery(drSys(t, now), cfg, rep)
 
 	if !strings.Contains(buf.String(), "DR escrow is 120 days old") {
 		t.Errorf("want the escrow staleness warning, got: %s", buf.String())
@@ -315,7 +327,7 @@ func TestDR_NoManifest_SkipsWithTheRemedy(t *testing.T) {
 	var buf bytes.Buffer
 	rep := capture(&buf)
 
-	checkDisasterRecovery(drSys(time.Now()), &Config{DotfilesDir: dir}, rep)
+	checkDisasterRecovery(drSys(t, time.Now()), &Config{DotfilesDir: dir}, rep)
 
 	if rep.Failures() != 0 {
 		t.Fatalf("a pre-existing escrow is not a broken one:\n%s", buf.String())
@@ -330,7 +342,7 @@ func TestDR_NoManifest_SkipsWithTheRemedy(t *testing.T) {
 func TestDR_NoVaultListing_SkipsRatherThanPasses(t *testing.T) {
 	dir := t.TempDir()
 	escrowWith(t, dir, storedManifest(t, "1", "2"))
-	sys := drSys(time.Now())
+	sys := drSys(t, time.Now())
 	sys.BWItemRevisions = func() ([]secrets.ItemRevision, error) {
 		return nil, errors.New("bw serve: daemon is locked")
 	}
@@ -351,7 +363,7 @@ func TestDR_NoVaultListing_SkipsRatherThanPasses(t *testing.T) {
 func TestDR_MatchingVaultIsSilentlyFine(t *testing.T) {
 	dir := t.TempDir()
 	escrowWith(t, dir, storedManifest(t, "1", "2"))
-	sys := drSys(time.Now())
+	sys := drSys(t, time.Now())
 	sys.BWItemRevisions = liveVault(t, "2", "1") // same set, different order
 	var buf bytes.Buffer
 	rep := capture(&buf)
@@ -371,7 +383,7 @@ func TestDR_MatchingVaultIsSilentlyFine(t *testing.T) {
 func TestDR_DeletionIsSeenEvenWhenNothingIsNewer(t *testing.T) {
 	dir := t.TempDir()
 	escrowWith(t, dir, storedManifest(t, "1", "2", "3"))
-	sys := drSys(time.Now())
+	sys := drSys(t, time.Now())
 	sys.BWItemRevisions = liveVault(t, "1", "2")
 	var buf bytes.Buffer
 	rep := capture(&buf)
@@ -411,7 +423,7 @@ func TestDR_UnreadableManifest_WarnsRatherThanClaimingAbsence(t *testing.T) {
 
 	var buf bytes.Buffer
 	rep := capture(&buf)
-	checkDisasterRecovery(drSys(time.Now()), &Config{DotfilesDir: dir}, rep)
+	checkDisasterRecovery(drSys(t, time.Now()), &Config{DotfilesDir: dir}, rep)
 
 	out := buf.String()
 	if strings.Contains(out, "has no manifest") {
@@ -428,7 +440,7 @@ func TestDR_EmptyOrZeroDigestManifest_Warns(t *testing.T) {
 	var buf bytes.Buffer
 	rep := capture(&buf)
 
-	checkDisasterRecovery(drSys(time.Now()), &Config{DotfilesDir: dir}, rep)
+	checkDisasterRecovery(drSys(t, time.Now()), &Config{DotfilesDir: dir}, rep)
 
 	out := buf.String()
 	if !strings.Contains(out, "carries no digest") {
@@ -448,7 +460,7 @@ func TestDR_AbsentEscrowWithLeftoverManifest_OnlyReportsEscrowMissing(t *testing
 	var buf bytes.Buffer
 	rep := capture(&buf)
 
-	checkDisasterRecovery(drSys(time.Now()), &Config{DotfilesDir: dir}, rep)
+	checkDisasterRecovery(drSys(t, time.Now()), &Config{DotfilesDir: dir}, rep)
 
 	out := buf.String()
 	if strings.Contains(out, "describes the vault") {

--- a/cli/internal/doctor/checks_instruction_drift_crlf_test.go
+++ b/cli/internal/doctor/checks_instruction_drift_crlf_test.go
@@ -1,0 +1,39 @@
+package doctor
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A deployed instruction file that differs from its repo source only by line
+// endings is not drift (WIN-008/#1289). setup-windows.ps1's catalog injection
+// rewrote copilot-instructions.md CRLF, and the check then failed on every run
+// with a remedy (`compile-harness.sh --deploy`) that does not exist on Windows.
+// The copilot target also carries the injected catalog region, as on a real
+// box, so the strip and the normalisation are exercised together.
+func TestCheckInstructionDrift_CRLFDeployedCopyIsNotDrift(t *testing.T) {
+	repo, home := t.TempDir(), t.TempDir()
+	for _, tgt := range deployedInstructionTargets {
+		src := "# " + tgt.repoRel + "\n\nshared content\n"
+		writeFile(t, filepath.Join(repo, tgt.repoRel), src)
+		deployed := strings.ReplaceAll(src, "\n", "\r\n")
+		if tgt.requiresCommand == "copilot" {
+			deployed += "\r\n<!-- BEGIN HARNESS GENERATED (sha256:abc) -- skill catalog -->\r\n- **x** -- y\r\n<!-- END HARNESS GENERATED -->\r\n"
+		}
+		writeFile(t, filepath.Join(home, tgt.homeRel), deployed)
+	}
+	sys := newSys(map[string]string{"HOME": home, "DOTFILES_REPO_DIR": repo}, []string{"copilot"}, nil)
+
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	checkInstructionDrift(sys, rep)
+
+	if rep.Failures() != 0 {
+		t.Fatalf("a CRLF-only difference must not be drift\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "(4 checked)") {
+		t.Errorf("all four targets should have been compared\n%s", buf.String())
+	}
+}

--- a/cli/internal/doctor/checks_instruction_drift_test.go
+++ b/cli/internal/doctor/checks_instruction_drift_test.go
@@ -62,6 +62,15 @@ func TestStripHarnessRegions(t *testing.T) {
 			in:   "para one\n\npara two\n",
 			want: "para one\n\npara two\n",
 		},
+		{
+			// A deployed copy written CRLF by a Windows tool (WIN-008/#1289):
+			// the END marker must still close the region — a "\r"-suffixed
+			// marker used to leave skip mode on to EOF — and no "\r" survives
+			// into the comparison.
+			name: "CRLF input: the region closes and line endings normalise",
+			in:   "before\r\n<!-- BEGIN HARNESS GENERATED (sha256:abc) -->\r\ninjected\r\n<!-- END HARNESS GENERATED -->\r\nafter\r\n",
+			want: "before\nafter\n",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cli/internal/doctor/checks_launchability_test.go
+++ b/cli/internal/doctor/checks_launchability_test.go
@@ -1,0 +1,42 @@
+package doctor
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Launchability (WIN-012/#1293): the shell wrappers resolve the agents' keys
+// through `dotf secrets run` before the binary starts, so a locked vault with
+// no unlocked daemon means the agent never launches — while every file and
+// PATH predicate in the section stays green. WARN with the literal remedy;
+// PASS when the daemon is unlocked; silent while no key is bw-backed, because
+// the age floor needs no daemon.
+func TestCheckOpenCode_ReportsWrapperLaunchability(t *testing.T) {
+	cfg := &Config{Versions: map[string]string{"PI_VERSION": "0.79.1", "OPENCODE_VERSION": "1.0.0"}}
+	run := func(t *testing.T, bwBacked int, status string) string {
+		t.Helper()
+		home := t.TempDir()
+		writeFile(t, filepath.Join(home, ".pi", "agent", "models.json"), `{"models":{}}`)
+		sys := newSys(map[string]string{"HOME": home}, []string{"pi"}, map[string]string{"pi --version": "pi 0.79.1"})
+		sys.BWBackedSecrets = func() (int, error) { return bwBacked, nil }
+		sys.BWServeStatus = func() (string, error) { return status, nil }
+		var buf bytes.Buffer
+		checkOpenCode(sys, cfg, capture(&buf))
+		return buf.String()
+	}
+
+	if out := run(t, 28, "absent"); !strings.Contains(out, "[WARN]") || !strings.Contains(out, "dotf secrets unlock") {
+		t.Errorf("bw-backed keys and no daemon: must WARN with the remedy\n%s", out)
+	}
+	if out := run(t, 28, "locked"); !strings.Contains(out, "dotf secrets unlock") {
+		t.Errorf("a locked daemon is the same outage\n%s", out)
+	}
+	if out := run(t, 28, "unlocked"); !strings.Contains(out, "agent wrappers can resolve their keys") {
+		t.Errorf("an unlocked daemon must PASS\n%s", out)
+	}
+	if out := run(t, 0, "absent"); strings.Contains(out, "wrappers") {
+		t.Errorf("no bw-backed key: the age floor needs no daemon, so stay silent\n%s", out)
+	}
+}

--- a/cli/internal/secrets/bwserve_windows.go
+++ b/cli/internal/secrets/bwserve_windows.go
@@ -4,13 +4,30 @@ package secrets
 
 import "syscall"
 
-// bwServeDetachAttr detaches the daemon from this process's console group
-// (CREATE_NEW_PROCESS_GROUP) so a Ctrl+C to the CLI does not also kill the
-// daemon. Windows has no POSIX setsid equivalent, so this is a narrower
-// guarantee than bwserve_unix.go's — live Windows daemon-lifecycle behavior
-// (surviving the CLI exiting entirely, not just a Ctrl+C) is explicitly
-// deferred to empirical validation on Windows (proposal.md's Out of scope),
-// not asserted here.
+// detachedProcess is Win32's DETACHED_PROCESS creation flag. The syscall
+// package exports CREATE_NEW_PROCESS_GROUP but not this one; golang.org/x/sys
+// does, but promoting it to a direct dependency for a single constant is not
+// worth the diff — the value is documented and fixed.
+const detachedProcess = 0x00000008
+
+// bwServeDetachAttr detaches the daemon from this process's console so it
+// outlives the terminal that started it — the whole point of one unlock
+// serving every later `dotf` call (bwserve.go). Two flags, two different
+// properties, and only together do they give the Windows analogue of
+// bwserve_unix.go's Setsid:
+//
+//   - CREATE_NEW_PROCESS_GROUP re-routes Ctrl+C so a Ctrl+C to the CLI does
+//     not also hit the daemon. It does NOT detach from the console.
+//   - DETACHED_PROCESS creates the child with no console at all. Without it a
+//     console-subsystem child stays attached to its parent's console, and when
+//     that console closes Windows delivers CTRL_CLOSE_EVENT and terminates the
+//     child — measured on the Windows work box (WIN-012/#1293): unlock in one
+//     terminal, close it, and every wrapper in every other terminal failed at
+//     once with "no bw serve daemon is running". The CLI exiting was never the
+//     problem (stdio is NUL, and Windows has no parent→child kill); the
+//     terminal closing was.
+//
+// TestBWServeDetachAttr_ChildHasNoConsole asserts the property by effect.
 func bwServeDetachAttr() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+	return &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | detachedProcess}
 }

--- a/cli/internal/secrets/bwserve_windows_test.go
+++ b/cli/internal/secrets/bwserve_windows_test.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package secrets
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestHelperConsoleProbe is the child half of
+// TestBWServeDetachAttr_ChildHasNoConsole. Re-executed as a helper process, it
+// reports whether it owns a console: GetConsoleWindow returns NULL for a
+// process created with DETACHED_PROCESS and a window handle for one attached
+// to its parent's console. Skipped (not failed) when run as an ordinary test.
+func TestHelperConsoleProbe(t *testing.T) {
+	if os.Getenv("DOTF_CONSOLE_PROBE") != "1" {
+		t.Skip("helper process only")
+	}
+	hwnd, _, _ := syscall.NewLazyDLL("kernel32.dll").NewProc("GetConsoleWindow").Call()
+	if hwnd == 0 {
+		_, _ = os.Stdout.WriteString("console=none\n")
+	} else {
+		_, _ = os.Stdout.WriteString("console=attached\n")
+	}
+	os.Exit(0)
+}
+
+func probeConsole(t *testing.T, attr *syscall.SysProcAttr) string {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHelperConsoleProbe$") //nolint:gosec // re-exec of the test binary itself
+	cmd.Env = append(os.Environ(), "DOTF_CONSOLE_PROBE=1")
+	cmd.SysProcAttr = attr
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("helper process: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// The property WIN-012/#1293 needs, asserted by effect rather than by reading
+// the flag back: a child spawned with bwServeDetachAttr() owns no console, so a
+// closing terminal has no CTRL_CLOSE_EVENT to deliver it. The control spawn
+// (no attr) proves the environment can tell the two states apart — where the
+// test process itself has no console both probes read "none" and nothing is
+// proven, so the test says so instead of passing vacuously.
+func TestBWServeDetachAttr_ChildHasNoConsole(t *testing.T) {
+	if got := probeConsole(t, nil); got != "console=attached" {
+		t.Skipf("test process has no console (control probe: %q); detachment cannot be observed here", got)
+	}
+	if got := probeConsole(t, bwServeDetachAttr()); got != "console=none" {
+		t.Fatalf("child spawned with bwServeDetachAttr() still owns a console (%q): it dies with the terminal that started it", got)
+	}
+}

--- a/scripts/check-bats-names.sh
+++ b/scripts/check-bats-names.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # check-bats-names.sh: catch bats @test names the runner silently fails to
 # register.

--- a/tests/precommit-hooks-portable.bats
+++ b/tests/precommit-hooks-portable.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+# Every `language: script` hook in .pre-commit-config.yaml is executed by
+# pre-commit through the script's SHEBANG, and on Windows pre-commit resolves
+# that shebang as a literal path: `#!/bin/bash` becomes
+#   Executable `/bin/bash` not found
+# and the commit is refused. The precedent guard covers one hook
+# (validate-commit-msg.bats); scripts/check-bats-names.sh escaped it and blocked
+# the first commit attempted from the Windows work box (2026-08-27). This guard
+# derives the hook list from the config, so the next hook is covered by
+# construction rather than by remembering.
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    export CONFIG="$DOTFILES_DIR/.pre-commit-config.yaml"
+}
+
+# Prints the entry script of every hook declared with `language: script`
+# (first token of `entry:`, so an entry carrying arguments still resolves).
+script_hook_entries() {
+    awk '
+        /^[[:space:]]*-[[:space:]]*id:/ { entry = "" }
+        /^[[:space:]]*entry:/ { entry = $2 }
+        /^[[:space:]]*language:[[:space:]]*script/ { if (entry != "") print entry }
+    ' "$CONFIG"
+}
+
+@test "the config declares script hooks, so the guard below checks something" {
+    run script_hook_entries
+    [[ $status -eq 0 ]]
+    [[ -n "$output" ]]
+}
+
+@test "every script hook resolves its interpreter via env so pre-commit can run it on Windows" {
+    bad=()
+    while IFS= read -r entry; do
+        [[ -n "$entry" ]] || continue
+        first="$(head -n 1 "$DOTFILES_DIR/$entry")"
+        [[ "$first" == '#!/usr/bin/env '* ]] || bad+=("$entry: $first")
+    done < <(script_hook_entries)
+    if (( ${#bad[@]} > 0 )); then
+        printf 'hook script with a shebang pre-commit cannot resolve on Windows:\n'
+        printf '  %s\n' "${bad[@]}"
+        return 1
+    fi
+}


### PR DESCRIPTION
## Summary

Five defects measured on 2026-08-27 by running `.\setup-windows.ps1` and `dotf doctor` on the Windows work box, each with a test that fails without its fix (mutation-checked). One `chore` commit first: the commit itself could not be made from Windows until it landed.

| Defect | Root cause | Fix |
|---|---|---|
| `pi`/`opencode` wrappers fail in every terminal after the unlocking one closes (WIN-012, #1293) | `bw serve` spawned with `CREATE_NEW_PROCESS_GROUP` only: that re-routes Ctrl+C, it does **not** detach from the console, so the terminal closing delivers `CTRL_CLOSE_EVENT` to the daemon. Linux uses `Setsid`. | `DETACHED_PROCESS` added to the creation flags. Asserted by effect on Windows: a child spawned with the attr owns no console, the control spawn does. |
| `[OpenCode + pi]` all green on a box where `pi` cannot start (WIN-012) | Every predicate is a file/PATH check; the wrappers' real precondition (keys resolvable through `dotf secrets run`) was never asserted. | WARN with the literal remedy (`dotf secrets unlock`) when keys are bw-backed and no unlocked daemon is reachable. PASS when unlocked; silent when nothing is bw-backed. WARN, not FAIL: every reboot locks the vault. |
| `.copilot/copilot-instructions.md` drift FAIL that no redeploy clears (WIN-008, #1289) | Deployed copy is CRLF (67 CR), source is LF. `stripHarnessRegions` split on `\n`: the END marker never matched and the strip swallowed the rest of the file; every other line differed by `\r` anyway. | Normalise `\r\n` before splitting. The writer (`Set-Content` in `setup-windows.ps1`) is fixed in the PowerShell PR. |
| `[Disaster recovery]` FAIL over an escrow that exists (WIN-011, #1292) | doctor read the deploy mirror; `dotf secrets backup` writes the checkout by contract, and `setup-windows.ps1` mirrors `sensitive/` non-recursively (no `dr/`). | Read the checkout first (same subject the writer uses), fall back to the mirror. The `-Recurse` is in the PowerShell PR. |
| `C:\Users\u/.pi/agent/models.json` (CLI-054, #1301) | `ExpandDst` substituted `{HOME}` and left the `/` tail. | `filepath.Clean(filepath.FromSlash(...))`. |

Also: `scripts/check-bats-names.sh` had `#!/bin/bash`; pre-commit on Windows resolves a script hook's shebang as a literal path and refused every commit with *Executable `/bin/bash` not found*. Fixed to `#!/usr/bin/env bash`, and `tests/precommit-hooks-portable.bats` now derives every `language: script` hook from `.pre-commit-config.yaml` and asserts the portable form (the precedent guard in `validate-commit-msg.bats` covered one hook by name).

Closes #1293. Part of #1289, #1292, #1301 (their PowerShell / call-site halves follow in separate PRs so each stays atomic).

## Evidence (this session, Windows work box)

- `go build ./... && go vet ./... && GOOS=linux go vet ./... && go test ./...` — all green.
- `golangci-lint run ./...` (pinned 2.12.2) — 0 issues.
- Mutation: removing the CRLF normalisation fails `TestStripHarnessRegions/CRLF_input…` and `TestCheckInstructionDrift_CRLFDeployedCopyIsNotDrift`; restoring passes both.
- `TestBWServeDetachAttr_ChildHasNoConsole` run from a real Win32 console: PASS (control probe `console=attached`, detached probe `console=none`). It self-skips with a stated reason where the test process owns no console (Git Bash pty, some runners).
- Guard mutation: reverting the shebang fails `precommit-hooks-portable.bats` naming the script.

## SDD skip rationale

Raw production diff is 104 lines; **executable** lines are ~31 across five independent fixes, each under the 20-line bug-fix exemption with an obvious, measured cause. The remainder is the explanatory comments this codebase keeps next to every non-obvious fix. No public contract, dependency or schema changes. Breakdown: `bwserve_windows.go` 3 executable (one flag, one const), `checks_deploy.go` 1 (normalise) + 16 (launchability report), `checks_dr.go` 10 (`escrowPath`), `deploy.go` 1.

## Acceptance on the real box (after merge + `setup-windows.ps1`)

`dotf secrets unlock` in terminal A → close A → new terminal → `pi --version` through the wrapper exits 0. That is the only proof the daemon fix landed; recorded on #1293 when done.
