### PR TITLE
feat(harness): dotf harness mirror, one deploy-dir mirror for both OSes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,16 +317,19 @@ jobs:
           source versions.conf
           echo "BATS_VERSION=$BATS_VERSION" >> "$GITHUB_OUTPUT"
           echo "AGE_VERSION=$AGE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "GO_VERSION=$(sed -n 's/^go //p' cli/go.mod)" >> "$GITHUB_OUTPUT"
 
       - name: Build integration test container
         if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
         env:
           BATS_VERSION: ${{ steps.versions.outputs.BATS_VERSION }}
           AGE_VERSION: ${{ steps.versions.outputs.AGE_VERSION }}
+          GO_VERSION: ${{ steps.versions.outputs.GO_VERSION }}
         run: |
           docker build \
             --build-arg BATS_VERSION="$BATS_VERSION" \
             --build-arg AGE_VERSION="$AGE_VERSION" \
+            --build-arg GO_VERSION="$GO_VERSION" \
             -f tests/Dockerfile.integration \
             -t dotfiles-integration-test .
 

--- a/cli/internal/cmd/harness.go
+++ b/cli/internal/cmd/harness.go
@@ -27,6 +27,7 @@ pattern triggers, and workflow integrations.`,
 	cmd.AddCommand(newHarnessResolveTierCmd())
 	cmd.AddCommand(newHarnessResolveCapabilitiesCmd())
 	cmd.AddCommand(newHarnessGateCmd())
+	cmd.AddCommand(newHarnessMirrorCmd())
 	return cmd
 }
 

--- a/cli/internal/cmd/harness_mirror.go
+++ b/cli/internal/cmd/harness_mirror.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/env"
+	"github.com/mlorentedev/dotfiles/cli/internal/harness"
+)
+
+// newHarnessMirrorCmd mirrors the harness inputs from the checkout into the
+// deploy dir (WIN-007/#1288). One implementation for both OSes: it replaces
+// the bash+jq block setup-linux.sh carried (with its zsh word-split hazard and
+// its "jq not on PATH yet" race) and the block setup-windows.ps1 never had —
+// which is why `dotf doctor` on Windows failed the routing registry and the
+// model-pin checks after every setup, printing "re-run setup" as the remedy.
+func newHarnessMirrorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "mirror",
+		Short: "Mirror harness/ and every manifest target from the checkout into the deploy dir",
+		Long: "mirror copies the harness inputs the deploy-dir consumers read — the whole\n" +
+			"harness/ tree and every file harness/manifest.json declares as an injection\n" +
+			"target — from the dotfiles checkout into $DOTFILES_DIR, preserving paths.\n\n" +
+			"Idempotent: a file whose bytes already match is left untouched, so a re-run\n" +
+			"reports 0 updated. It never prunes; `dotf doctor --fix` removes orphans.\n\n" +
+			"A declared target the checkout does not have is named and the command exits 1\n" +
+			"after mirroring everything else — the gap is the finding, not a reason to\n" +
+			"leave the rest of the harness stale.",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			repoRoot := env.RepoDir()
+			if repoRoot == "" {
+				return fmt.Errorf("cannot locate the dotfiles checkout — set DOTFILES_REPO_DIR or run from inside it")
+			}
+			deployDir := env.DotfilesDir(env.Home())
+
+			res, err := harness.Mirror(repoRoot, deployDir)
+			switch {
+			case errors.Is(err, harness.ErrCheckoutIsDeployDir):
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "harness mirror: %s is the checkout; nothing to mirror\n", deployDir)
+				return nil
+			case errors.Is(err, harness.ErrMissingTargets):
+				for _, rel := range res.Missing {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+						"harness/manifest.json declares a target the checkout does not have: %s — not mirrored; dotf doctor will report harness drift\n", rel)
+				}
+			case err != nil:
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "harness mirror: harness/ + %d target(s) → %s (%d updated, %d unchanged)\n",
+				len(res.Targets), deployDir, res.Updated, res.Unchanged)
+			return err
+		},
+	}
+}

--- a/cli/internal/cmd/harness_mirror_test.go
+++ b/cli/internal/cmd/harness_mirror_test.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeMirrorFixture(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// runHarnessMirror runs the command the way setup does: from inside the
+// checkout. env.RepoDir prefers the .git walk-up from the cwd over
+// DOTFILES_REPO_DIR (BUG-072), so the fixture carries a .git marker and the
+// test chdirs into it; otherwise the walk-up lands on the real checkout that
+// contains this test file.
+func runHarnessMirror(t *testing.T, repo, deploy string) (stdout, stderr string, err error) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repo)
+	t.Setenv("DOTFILES_REPO_DIR", repo)
+	t.Setenv("DOTFILES_DIR", deploy)
+	var out, errb bytes.Buffer
+	cmd := newHarnessMirrorCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&errb)
+	cmd.SetArgs(nil)
+	err = cmd.Execute()
+	return out.String(), errb.String(), err
+}
+
+// The command is what both setup scripts call, so its two lines of output are
+// the contract: the counts a setup run reports, and the named gap it must not
+// hide.
+func TestHarnessMirrorCmd(t *testing.T) {
+	repo, deploy := t.TempDir(), t.TempDir()
+	writeMirrorFixture(t, filepath.Join(repo, "harness", "manifest.json"), `{"targets":[{"file":"AGENTS.md"}]}`)
+	writeMirrorFixture(t, filepath.Join(repo, "harness", "model-map.json"), `{}`)
+	writeMirrorFixture(t, filepath.Join(repo, "AGENTS.md"), "# AGENTS\n")
+
+	out, _, err := runHarnessMirror(t, repo, deploy)
+	if err != nil {
+		t.Fatalf("first run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "1 target(s)") || !strings.Contains(out, "3 updated, 0 unchanged") {
+		t.Errorf("first run must report what it mirrored:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(deploy, "harness", "model-map.json")); err != nil {
+		t.Errorf("model-map.json not mirrored: %v", err)
+	}
+
+	out, _, err = runHarnessMirror(t, repo, deploy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "0 updated, 3 unchanged") {
+		t.Errorf("re-run must report zero changes:\n%s", out)
+	}
+
+	// A declared target the checkout lacks: named on stderr, exit non-zero,
+	// everything else still mirrored.
+	writeMirrorFixture(t, filepath.Join(repo, "harness", "manifest.json"), `{"targets":[{"file":"AGENTS.md"},{"file":"ai/orca/ORCA.md"}]}`)
+	_, stderr, err := runHarnessMirror(t, repo, deploy)
+	if err == nil {
+		t.Fatal("a missing declared target must exit non-zero")
+	}
+	if !strings.Contains(stderr, "ai/orca/ORCA.md") || !strings.Contains(stderr, "not mirrored") {
+		t.Errorf("the gap must be named:\n%s", stderr)
+	}
+	got, _ := os.ReadFile(filepath.Join(deploy, "harness", "manifest.json"))
+	if !strings.Contains(string(got), "ORCA.md") {
+		t.Error("the rest of the harness must still have been mirrored")
+	}
+}
+
+func TestHarnessMirrorCmd_SaysSoWhenTheCheckoutIsTheDeployDir(t *testing.T) {
+	repo := t.TempDir()
+	writeMirrorFixture(t, filepath.Join(repo, "harness", "manifest.json"), `{"targets":[]}`)
+	out, _, err := runHarnessMirror(t, repo, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "nothing to mirror") {
+		t.Errorf("must state the outcome:\n%s", out)
+	}
+}

--- a/cli/internal/doctor/checks_deploy.go
+++ b/cli/internal/doctor/checks_deploy.go
@@ -580,20 +580,19 @@ func stripHarnessRegions(content string) string {
 
 // checkHarnessMirrorOrphans detects harness/{skills,agents} records present in
 // the deploy mirror (cfg.DotfilesDir) with no counterpart in the repo — the gap
-// BUG-058/#843 describes: setup-linux.sh's repo->mirror copy
-// (`cp -rf harness/. $DOTFILES_DIR/harness/`) is copy-only, so a record deleted
-// from the repo survives in the mirror forever and keeps failing
+// BUG-058/#843 describes: the repo->mirror copy (`dotf harness mirror`, and the
+// setup-linux.sh bash block before it) is copy-only, so a record deleted from
+// the repo survives in the mirror forever and keeps failing
 // checkCompileHarnessDrift, which runs FROM the mirror. Per #802's decided
 // semantic (doctor --fix prunes; setup only copies/warns) — generated records
 // are prunable automatically here, unlike sensitive/*.secret.age.
 //
-// Windows has no repo/mirror split — setup-windows.ps1 sets
-// `$DotfilesDir = $PSScriptRoot`, i.e. the deploy dir IS the checkout — so this
-// only applies where a distinct mirror exists.
+// This applies on every OS. It used to early-return on Windows on the belief
+// that Windows had no repo/mirror split; it did — setup-windows.ps1's
+// `$DotfilesDest` is `~/.dotfiles`, the very dir cfg.DotfilesDir resolves to —
+// it just never received harness/ (WIN-007/#1288). The "mirror IS the
+// checkout" case is the guard below, wherever it occurs.
 func checkHarnessMirrorOrphans(sys *System, cfg *Config, rep *Report, fix bool) {
-	if sys.GOOS == "windows" {
-		return
-	}
 	repo := resolveRepoDir(sys)
 	if repo == "" || filepath.Clean(repo) == filepath.Clean(cfg.DotfilesDir) {
 		return // no checkout found, or the "mirror" IS the checkout — nothing to compare

--- a/cli/internal/doctor/checks_harness_mirror_test.go
+++ b/cli/internal/doctor/checks_harness_mirror_test.go
@@ -88,7 +88,10 @@ func TestCheckHarnessMirrorOrphans(t *testing.T) {
 		}
 	})
 
-	t.Run("windows has no separate mirror -> no-op even with an orphan present", func(t *testing.T) {
+	// The mirror is a real deploy dir on Windows too (`dotf harness mirror`
+	// writes it there, WIN-007/#1288); the check used to stay silent on the
+	// belief that Windows had none, which left an orphan unreported forever.
+	t.Run("windows: an orphan in the mirror is reported like anywhere else", func(t *testing.T) {
 		repo, mirror := setup(t)
 		mkdirAll(t, filepath.Join(mirror, "harness", "skills", "retired"))
 		cfg := &Config{DotfilesDir: mirror}
@@ -99,8 +102,8 @@ func TestCheckHarnessMirrorOrphans(t *testing.T) {
 		rep := capture(&buf)
 		checkHarnessMirrorOrphans(sys, cfg, rep, false)
 
-		if rep.Failures() != 0 || buf.Len() != 0 {
-			t.Errorf("windows should be a silent no-op\n%s", buf.String())
+		if rep.Failures() != 1 || !strings.Contains(buf.String(), "retired") {
+			t.Errorf("windows must report the orphan, not stay silent\n%s", buf.String())
 		}
 	})
 

--- a/cli/internal/doctor/checks_pi_extensions.go
+++ b/cli/internal/doctor/checks_pi_extensions.go
@@ -83,7 +83,7 @@ func checkPiExtensions(sys *System, cfg *Config, rep *Report, fix bool) {
 
 	if len(shadows) == 0 {
 		rep.Pass(fmt.Sprintf("no hand-wired extension shadows a manifest package (%d extension entries, %d packages declared)",
-			len(entries), piPackagesManifest(cfg.DotfilesDir)))
+			len(entries), piPackagesManifest(sys, cfg)))
 		return
 	}
 
@@ -219,9 +219,18 @@ func short(sys *System, p string) string {
 }
 
 // piPackagesManifest is the declaration setup reconciles against. Read only to
-// report how many packages are at stake when a shadow is found.
-func piPackagesManifest(dotfilesDir string) int {
-	doc, err := os.ReadFile(filepath.Join(dotfilesDir, "ai", "pi", "packages.json"))
+// report how many packages are at stake when a shadow is found. Checkout
+// first, mirror second — the ADR-030 precedence every other registry read
+// here follows: the deploy mirror never carried ai/pi/, so this reported
+// "0 packages declared" as a PASS on Windows (WIN-007/#1288).
+func piPackagesManifest(sys *System, cfg *Config) int {
+	path := filepath.Join(cfg.DotfilesDir, "ai", "pi", "packages.json")
+	if repo := resolveRepoDir(sys); repo != "" {
+		if p := filepath.Join(repo, "ai", "pi", "packages.json"); pathExists(p) {
+			path = p
+		}
+	}
+	doc, err := os.ReadFile(path) //nolint:gosec // repo-relative, fixed name
 	if err != nil {
 		return 0
 	}

--- a/cli/internal/doctor/checks_pi_packages_source_test.go
+++ b/cli/internal/doctor/checks_pi_packages_source_test.go
@@ -1,0 +1,30 @@
+package doctor
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// The pi-packages count reads the checkout first (ADR-030 precedence). The
+// deploy mirror never carried ai/pi/, so on Windows the shadow check reported
+// "0 packages declared" as a PASS — a wrong number under a green tag
+// (WIN-007/#1288).
+func TestPiPackagesManifest_ReadsTheCheckoutBeforeTheMirror(t *testing.T) {
+	repo, mirror := t.TempDir(), t.TempDir()
+	writeFile(t, filepath.Join(repo, "ai", "pi", "packages.json"), `{"packages":[{"name":"a"},{"name":"b"}]}`)
+	sys := newSys(map[string]string{"DOTFILES_REPO_DIR": repo}, nil, nil)
+	cfg := &Config{DotfilesDir: mirror}
+
+	if got := piPackagesManifest(sys, cfg); got != 2 {
+		t.Errorf("checkout declares 2 packages, got %d", got)
+	}
+
+	// A checkout without the file: the mirror copy is the fallback, not zero.
+	// (An unresolvable DOTFILES_REPO_DIR would walk up from the test cwd into
+	// the real checkout, so the fixture uses an empty one.)
+	writeFile(t, filepath.Join(mirror, "ai", "pi", "packages.json"), `{"packages":[{"name":"a"}]}`)
+	sys = newSys(map[string]string{"DOTFILES_REPO_DIR": t.TempDir()}, nil, nil)
+	if got := piPackagesManifest(sys, cfg); got != 1 {
+		t.Errorf("mirror fallback: want 1, got %d", got)
+	}
+}

--- a/cli/internal/harness/mirror.go
+++ b/cli/internal/harness/mirror.go
@@ -1,0 +1,209 @@
+package harness
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// ManifestFile is the harness manifest, relative to the checkout root.
+const ManifestFile = "harness/manifest.json"
+
+// ErrCheckoutIsDeployDir is returned when the checkout and the deploy dir are
+// the same directory: there is nothing to mirror, and copying a tree onto
+// itself is not "unchanged", it is undefined.
+var ErrCheckoutIsDeployDir = errors.New("the checkout is the deploy dir; nothing to mirror")
+
+// ErrMissingTargets is returned (wrapped) when harness/manifest.json declares
+// a target the checkout does not have. Everything else has already been
+// mirrored by then — a broken declaration must not cost a machine the rest of
+// its harness — but the gap is named, because skipping it silently is exactly
+// how a drift check comes to evaluate a file the mirror never received
+// (#1200) and print a remedy that cannot clear it.
+var ErrMissingTargets = errors.New("harness/manifest.json declares a target the checkout does not have")
+
+// MirrorResult is what one Mirror run did.
+type MirrorResult struct {
+	// Updated counts files written because their bytes differed or they were
+	// absent; Unchanged counts files left untouched. Updated == 0 on a re-run
+	// is the idempotence evidence a setup run reports (#1266).
+	Updated, Unchanged int
+	// Targets are the manifest-declared files mirrored beside harness/.
+	Targets []string
+	// Missing are the declared targets the checkout lacks; non-empty implies
+	// the returned error wraps ErrMissingTargets.
+	Missing []string
+}
+
+// Mirror copies the harness inputs the deploy-dir consumers read — the whole
+// harness/ tree and every file harness/manifest.json declares as an injection
+// target — from the checkout at repoRoot into deployDir, preserving relative
+// paths. It replaces the bash+jq block setup-linux.sh carried and the block
+// setup-windows.ps1 never had (WIN-007/#1288): `dotf doctor` reads
+// model-map.json and model-pins.json from the deploy dir, so a Windows box
+// failed both checks after every setup, with a remedy ("re-run setup") that
+// could not clear them.
+//
+// Idempotent: a file whose bytes already match is left untouched, mtime
+// included. It never prunes — `dotf doctor --fix` owns orphan removal, the
+// semantic #802 settled for every mirror in this repository.
+//
+// The target list is DERIVED from the manifest, never restated here: the day
+// it was a hardcoded pair, a third target (#1176) needed a copy line nobody
+// wrote.
+func Mirror(repoRoot, deployDir string) (MirrorResult, error) {
+	var res MirrorResult
+	repoRoot, deployDir = filepath.Clean(repoRoot), filepath.Clean(deployDir)
+	if sameDir(repoRoot, deployDir) {
+		return res, ErrCheckoutIsDeployDir
+	}
+
+	targets, err := manifestTargets(filepath.Join(repoRoot, filepath.FromSlash(ManifestFile)))
+	if err != nil {
+		return res, err
+	}
+
+	if err := mirrorTree(repoRoot, deployDir, "harness", &res); err != nil {
+		return res, err
+	}
+	for _, rel := range targets {
+		src := filepath.Join(repoRoot, filepath.FromSlash(rel))
+		if !isRegular(src) {
+			res.Missing = append(res.Missing, rel)
+			continue
+		}
+		if err := mirrorFile(src, filepath.Join(deployDir, filepath.FromSlash(rel)), &res); err != nil {
+			return res, err
+		}
+		res.Targets = append(res.Targets, rel)
+	}
+	if len(res.Missing) > 0 {
+		return res, fmt.Errorf("%w: %v", ErrMissingTargets, res.Missing)
+	}
+	return res, nil
+}
+
+// manifestTargets reads `.targets[].file` — the same projection the bash block
+// took with jq — in declaration order, de-duplicated.
+func manifestTargets(path string) ([]string, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // repo-relative, fixed name
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", ManifestFile, err)
+	}
+	var m struct {
+		Targets []struct {
+			File string `json:"file"`
+		} `json:"targets"`
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", ManifestFile, err)
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, t := range m.Targets {
+		if t.File == "" || seen[t.File] {
+			continue
+		}
+		seen[t.File] = true
+		out = append(out, t.File)
+	}
+	return out, nil
+}
+
+// mirrorTree copies every regular file under <repoRoot>/<sub> to
+// <deployDir>/<sub>, walking in a deterministic order.
+func mirrorTree(repoRoot, deployDir, sub string, res *MirrorResult) error {
+	root := filepath.Join(repoRoot, sub)
+	if !isDir(root) {
+		return fmt.Errorf("%s: not a directory in the checkout", filepath.ToSlash(sub))
+	}
+	var files []string
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type().IsRegular() {
+			files = append(files, p)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walking %s: %w", filepath.ToSlash(sub), err)
+	}
+	sort.Strings(files)
+	for _, src := range files {
+		rel, err := filepath.Rel(repoRoot, src)
+		if err != nil {
+			return err
+		}
+		if err := mirrorFile(src, filepath.Join(deployDir, rel), res); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// mirrorFile writes src's bytes to dst only when they differ, atomically
+// (temp file in the destination dir, then rename), so a reader never sees a
+// half-written registry and an identical file keeps its mtime.
+func mirrorFile(src, dst string, res *MirrorResult) error {
+	want, err := os.ReadFile(src) //nolint:gosec // paths derive from the checkout tree
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", src, err)
+	}
+	if have, err := os.ReadFile(dst); err == nil && bytes.Equal(have, want) { //nolint:gosec // same
+		res.Unchanged++
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".mirror-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(want); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, dst); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("installing %s: %w", dst, err)
+	}
+	res.Updated++
+	return nil
+}
+
+func sameDir(a, b string) bool {
+	if a == b {
+		return true
+	}
+	fa, errA := os.Stat(a)
+	fb, errB := os.Stat(b)
+	return errA == nil && errB == nil && os.SameFile(fa, fb)
+}
+
+func isDir(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && fi.IsDir()
+}
+
+func isRegular(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && fi.Mode().IsRegular()
+}

--- a/cli/internal/harness/mirror_test.go
+++ b/cli/internal/harness/mirror_test.go
@@ -1,0 +1,151 @@
+package harness
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// mirrorRepo builds a checkout with a harness/ tree and a manifest declaring
+// two targets outside it — the shape setup-linux.sh's bash block modelled.
+func mirrorRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "harness", "manifest.json"),
+		`{"targets":[{"file":"AGENTS.md"},{"file":"ai/claude/CLAUDE.md"},{"file":"AGENTS.md"}]}`)
+	writeFile(t, filepath.Join(repo, "harness", "model-map.json"), `{"pools":{}}`)
+	writeFile(t, filepath.Join(repo, "harness", "skills", "handoff", "SKILL.md"), "# handoff\n")
+	writeFile(t, filepath.Join(repo, "AGENTS.md"), "# AGENTS\n")
+	writeFile(t, filepath.Join(repo, "ai", "claude", "CLAUDE.md"), "# CLAUDE\n")
+	return repo
+}
+
+func TestMirror_CopiesTheTreeAndEveryDeclaredTarget(t *testing.T) {
+	repo, deploy := mirrorRepo(t), t.TempDir()
+
+	res, err := Mirror(repo, deploy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, rel := range []string{
+		"harness/manifest.json", "harness/model-map.json", "harness/skills/handoff/SKILL.md",
+		"AGENTS.md", "ai/claude/CLAUDE.md",
+	} {
+		if _, err := os.Stat(filepath.Join(deploy, filepath.FromSlash(rel))); err != nil {
+			t.Errorf("%s not mirrored: %v", rel, err)
+		}
+	}
+	if res.Updated != 5 || res.Unchanged != 0 {
+		t.Errorf("first run: want 5 updated / 0 unchanged, got %d / %d", res.Updated, res.Unchanged)
+	}
+	// The duplicate declaration is one target, not two copies.
+	if got := strings.Join(res.Targets, ","); got != "AGENTS.md,ai/claude/CLAUDE.md" {
+		t.Errorf("targets: %s", got)
+	}
+}
+
+// A re-run must report zero changes — that number is the idempotence evidence
+// a setup run prints (#1266) — and must not touch an identical file's mtime.
+func TestMirror_IsIdempotentAndDoesNotRewriteIdenticalFiles(t *testing.T) {
+	repo, deploy := mirrorRepo(t), t.TempDir()
+	if _, err := Mirror(repo, deploy); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(deploy, "harness", "model-map.json")
+	before, _ := os.Stat(target)
+
+	res, err := Mirror(repo, deploy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Updated != 0 || res.Unchanged != 5 {
+		t.Errorf("re-run: want 0 updated / 5 unchanged, got %d / %d", res.Updated, res.Unchanged)
+	}
+	after, _ := os.Stat(target)
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Error("an identical file was rewritten (mtime churned)")
+	}
+
+	// A changed source is the only thing that earns a write.
+	writeFile(t, filepath.Join(repo, "harness", "model-map.json"), `{"pools":{"x":{}}}`)
+	res, err = Mirror(repo, deploy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Updated != 1 {
+		t.Errorf("one changed source: want 1 updated, got %d", res.Updated)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != `{"pools":{"x":{}}}` {
+		t.Errorf("mirror not refreshed: %s", got)
+	}
+}
+
+// A declared target the checkout lacks is named and reported as an error —
+// after everything else was mirrored. Skipping it silently reproduces #1200:
+// the drift check later evaluates a file the mirror never received.
+func TestMirror_NamesADeclaredTargetTheCheckoutLacks(t *testing.T) {
+	repo, deploy := mirrorRepo(t), t.TempDir()
+	if err := os.Remove(filepath.Join(repo, "ai", "claude", "CLAUDE.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Mirror(repo, deploy)
+	if !errors.Is(err, ErrMissingTargets) {
+		t.Fatalf("want ErrMissingTargets, got %v", err)
+	}
+	if len(res.Missing) != 1 || res.Missing[0] != "ai/claude/CLAUDE.md" {
+		t.Errorf("missing must name the target: %v", res.Missing)
+	}
+	if _, err := os.Stat(filepath.Join(deploy, "AGENTS.md")); err != nil {
+		t.Error("the other target must still have been mirrored")
+	}
+	if _, err := os.Stat(filepath.Join(deploy, "harness", "model-map.json")); err != nil {
+		t.Error("the harness tree must still have been mirrored")
+	}
+}
+
+// Mirroring never prunes: a file only the mirror has survives. Orphan removal
+// is `dotf doctor --fix`'s (#802), and a setup that deleted would be a second
+// pruner with its own idea of what is stale.
+func TestMirror_DoesNotPrune(t *testing.T) {
+	repo, deploy := mirrorRepo(t), t.TempDir()
+	orphan := filepath.Join(deploy, "harness", "skills", "retired", "SKILL.md")
+	writeFile(t, orphan, "# retired\n")
+
+	if _, err := Mirror(repo, deploy); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(orphan); err != nil {
+		t.Error("mirror must not prune; that is doctor --fix's job")
+	}
+}
+
+// The checkout and the deploy dir being the same directory is a stated
+// outcome, not a copy of a tree onto itself.
+func TestMirror_RefusesWhenTheCheckoutIsTheDeployDir(t *testing.T) {
+	repo := mirrorRepo(t)
+	if _, err := Mirror(repo, repo); !errors.Is(err, ErrCheckoutIsDeployDir) {
+		t.Fatalf("want ErrCheckoutIsDeployDir, got %v", err)
+	}
+}
+
+func TestMirror_FailsLoudWithoutAManifest(t *testing.T) {
+	repo, deploy := t.TempDir(), t.TempDir()
+	writeFile(t, filepath.Join(repo, "harness", "model-map.json"), `{}`)
+	if _, err := Mirror(repo, deploy); err == nil || !strings.Contains(err.Error(), ManifestFile) {
+		t.Fatalf("a missing manifest must name itself, got %v", err)
+	}
+}

--- a/scripts/install-dotf.ps1
+++ b/scripts/install-dotf.ps1
@@ -141,9 +141,15 @@ function Install-Dotf {
             # the semver is correct for either. (StrictMode makes `@()[-1]` throw,
             # so never index blind.)
             $verRaw = (& dotf version 2>&1 | Out-String)
-            # `dev` is what a source build reports; CI pins DOTF_VERSION=dev so the
-            # binary built from the PR under test is kept (parity with install-dotf.sh).
+            # `dev` is what a source build reports. A source build on PATH is
+            # deliberate (a dev box, or CI building the PR under test) and the
+            # release installer must not replace it; remove it to converge.
+            # Parity with install-dotf.sh.
             $current = if ($verRaw -match '(\d+\.\d+\.\d+|dev)') { $Matches[1] } else { '' }
+            if ($current -eq 'dev') {
+                Write-Host "dotf is a source build (dev); leaving it in place (remove it to converge to the $Version release)"
+                return $true
+            }
             if ($current -eq $Version) {
                 Write-Host "dotf $Version already installed; skipping"
                 return $true

--- a/scripts/install-dotf.ps1
+++ b/scripts/install-dotf.ps1
@@ -141,7 +141,9 @@ function Install-Dotf {
             # the semver is correct for either. (StrictMode makes `@()[-1]` throw,
             # so never index blind.)
             $verRaw = (& dotf version 2>&1 | Out-String)
-            $current = if ($verRaw -match '(\d+\.\d+\.\d+)') { $Matches[1] } else { '' }
+            # `dev` is what a source build reports; CI pins DOTF_VERSION=dev so the
+            # binary built from the PR under test is kept (parity with install-dotf.sh).
+            $current = if ($verRaw -match '(\d+\.\d+\.\d+|dev)') { $Matches[1] } else { '' }
             if ($current -eq $Version) {
                 Write-Host "dotf $Version already installed; skipping"
                 return $true

--- a/scripts/install-dotf.sh
+++ b/scripts/install-dotf.sh
@@ -92,7 +92,12 @@ install_dotf() {
         # and regexing the semver is correct for either. Do not tighten it to
         # stdout-only; that would silently break the idempotence skip on an old
         # binary and reinstall on every run.
-        _dotf_current="$(dotf version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
+        # `dev` is what a source build reports (cli/cmd/dotf/main.go). CI builds
+        # dotf from the PR under test and pins DOTF_VERSION=dev so this skip
+        # keeps that binary instead of replacing it with the last release --
+        # the release lags the tree, and testing it certified nothing about
+        # the change (#1305: `dotf harness mirror` did not exist in 0.51.0).
+        _dotf_current="$(dotf version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+|dev' | head -n1)"
         if [ "$_dotf_current" = "$version" ]; then
             log_info "dotf $version already installed; skipping"
             return 0

--- a/scripts/install-dotf.sh
+++ b/scripts/install-dotf.sh
@@ -92,12 +92,18 @@ install_dotf() {
         # and regexing the semver is correct for either. Do not tighten it to
         # stdout-only; that would silently break the idempotence skip on an old
         # binary and reinstall on every run.
-        # `dev` is what a source build reports (cli/cmd/dotf/main.go). CI builds
-        # dotf from the PR under test and pins DOTF_VERSION=dev so this skip
-        # keeps that binary instead of replacing it with the last release --
-        # the release lags the tree, and testing it certified nothing about
-        # the change (#1305: `dotf harness mirror` did not exist in 0.51.0).
+        # `dev` is what a source build reports (cli/cmd/dotf/main.go). A source
+        # build on PATH is deliberate -- a dev box building the tree, or CI
+        # building the PR under test -- and the release installer must not
+        # replace it: the release lags the tree, and testing it certified
+        # nothing about the change (#1305: `dotf harness mirror` did not exist
+        # in 0.51.0; and setup sources versions.conf, so a DOTF_VERSION=dev
+        # env override cannot express this). Remove the binary to converge.
         _dotf_current="$(dotf version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+|dev' | head -n1)"
+        if [ "$_dotf_current" = "dev" ]; then
+            log_info "dotf is a source build (dev); leaving it in place (remove it to converge to the $version release)"
+            return 0
+        fi
         if [ "$_dotf_current" = "$version" ]; then
             log_info "dotf $version already installed; skipping"
             return 0

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -550,64 +550,22 @@ else
 fi
 
 # Mirror the harness inputs into the deploy dir so `compile-harness.sh --check`
-# (healthcheck section 12) can verify drift offline from ~/.dotfiles. The engine
-# resolves its root from its own location, and the rootresolve regression test
-# models exactly this complete non-git copy: scripts/ (compile-harness.sh) +
-# harness/ + every file harness/manifest.json declares as an injection target.
-# This runs AFTER --refresh so the snapshot matches the refreshed repo state
-# (else the repo<->deploy drift sub-check would then see drift).
-#
-# The target list is DERIVED from the manifest, never restated here. It was a
-# hardcoded pair (AGENTS.md + ai/claude/CLAUDE.md) until #1200: adding
-# ai/orca/ORCA.md as a third target (#1176) needed a copy line nobody wrote, so
-# --check evaluated a target the mirror had never received and reported a drift
-# FAIL whose own printed remedy could not clear it — running --refresh from the
-# repo exits 0, because the repo has the file. Deriving the list means the next
-# manifest entry is mirrored by construction rather than by remembering.
-if [ "$CURRENT_DIR" != "$DOTFILES_DIR" ]; then
-    ensure_directory "$DOTFILES_DIR/harness"
-    cp -rf "$CURRENT_DIR/harness/." "$DOTFILES_DIR/harness/" 2>/dev/null || true
-    # Resolve jq by path, not by name. The installer above downloads it to
-    # ~/.local/bin, which the rc files put on PATH but THIS process may not have
-    # — measured in the integration container, where setup logs "jq installed"
-    # and then "jq not found" 22 seconds later in the same run. A `command -v`
-    # test alone therefore skips the mirror right after a successful install.
-    _jq=""
-    if command -v jq >/dev/null 2>&1; then
-        _jq="jq"
-    elif [ -x "$HOME/.local/bin/jq" ]; then
-        _jq="$HOME/.local/bin/jq"
-    fi
-    if [ -n "$_jq" ] && [ -f "$CURRENT_DIR/harness/manifest.json" ]; then
-        # Read line by line: `for f in $(jq ...)` does not word-split in zsh,
-        # which would yield ONE target containing every path (see CLAUDE.md's
-        # prohibited-pattern table — this row fails silently).
-        "$_jq" -r '.targets[].file' "$CURRENT_DIR/harness/manifest.json" 2>/dev/null \
-        | while IFS= read -r _harness_target; do
-            [ -n "$_harness_target" ] || continue
-            # A declared target the checkout does not have is a broken checkout,
-            # and skipping it silently reproduces the very defect this block
-            # fixes: the mirror ends up incomplete and `--check` fails later on
-            # a marker count that names neither the manifest nor the missing
-            # file. Name it here, where the cause is still visible. Setup does
-            # not abort — it is idempotent and long, and one absent target must
-            # not cost a machine the rest of its provisioning — but the warning
-            # is loud and `verify-setup.bats` fails on the resulting gap.
-            if [ ! -f "$CURRENT_DIR/$_harness_target" ]; then
-                log_warning "harness/manifest.json declares a target the checkout does not have: $_harness_target — not mirrored, 'dotf doctor' will report harness drift"
-                continue
-            fi
-            _harness_target_dir="$(dirname "$DOTFILES_DIR/$_harness_target")"
-            ensure_directory "$_harness_target_dir"
-            if ! safe_copy "$CURRENT_DIR/$_harness_target" "$_harness_target_dir/" 2>/dev/null; then
-                log_warning "failed to mirror harness target $_harness_target to $_harness_target_dir — 'dotf doctor' will report harness drift"
-            fi
-        done
-        unset _harness_target _harness_target_dir
-    else
-        log_warning "jq or harness/manifest.json unavailable — harness targets not mirrored to $DOTFILES_DIR; 'dotf doctor' will report harness drift"
-    fi
-    unset _jq
+# (healthcheck section 12) and `dotf doctor` read a complete snapshot from
+# ~/.dotfiles: harness/ plus every file harness/manifest.json declares as an
+# injection target. `dotf harness mirror` is the one implementation for both
+# OSes (WIN-007/#1288). It replaced the bash+jq block that lived here, which
+# derived its target list from the manifest for the reason #1200 recorded (a
+# hardcoded pair missed the third target) and resolved jq by path because the
+# lookup raced its own install (#1202) -- both now moot in Go. Runs AFTER
+# --refresh so the snapshot matches the refreshed repo state. Idempotent
+# ("N updated, M unchanged"); never prunes (doctor --fix owns orphans, #802).
+# A declared target the checkout lacks is named and exits non-zero after
+# mirroring the rest: setup does not abort (it is long and idempotent), but the
+# warning is loud and verify-setup.bats fails on the resulting gap.
+if command -v dotf >/dev/null 2>&1; then
+    dotf harness mirror || log_warning "dotf harness mirror reported a gap (above) -- 'dotf doctor' will report harness drift"
+else
+    log_warning "dotf not on PATH -- harness not mirrored to $DOTFILES_DIR; 'dotf doctor' will report harness drift"
 fi
 
 # Claude Code

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -562,11 +562,22 @@ fi
 # A declared target the checkout lacks is named and exits non-zero after
 # mirroring the rest: setup does not abort (it is long and idempotent), but the
 # warning is loud and verify-setup.bats fails on the resulting gap.
+# Resolve dotf by path, not only by name: install_dotf placed it in ~/.local/bin,
+# which the rc files put on PATH but THIS process may not have -- the integration
+# container installs dotf and then cannot see it in the same run (#1202 was the
+# identical trap with jq, and this block inherited it the moment it moved to dotf).
+_dotf=""
 if command -v dotf >/dev/null 2>&1; then
-    dotf harness mirror || log_warning "dotf harness mirror reported a gap (above) -- 'dotf doctor' will report harness drift"
-else
-    log_warning "dotf not on PATH -- harness not mirrored to $DOTFILES_DIR; 'dotf doctor' will report harness drift"
+    _dotf="dotf"
+elif [ -x "$HOME/.local/bin/dotf" ]; then
+    _dotf="$HOME/.local/bin/dotf"
 fi
+if [ -n "$_dotf" ]; then
+    "$_dotf" harness mirror || log_warning "dotf harness mirror reported a gap (above) -- 'dotf doctor' will report harness drift"
+else
+    log_warning "dotf not found (PATH or ~/.local/bin) -- harness not mirrored to $DOTFILES_DIR; 'dotf doctor' will report harness drift"
+fi
+unset _dotf
 
 # Claude Code
 ensure_directory "$HOME/.claude"

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -661,6 +661,20 @@ if (Get-Command dotf -ErrorAction SilentlyContinue) {
     }
 }
 
+# Mirror the harness inputs into the deploy dir (WIN-007/#1288): harness\ plus
+# every file harness\manifest.json declares as an injection target, so
+# `dotf doctor` reads model-map.json / model-pins.json from the copy it checks.
+# One Go implementation for both OSes (setup-linux.sh calls the same command).
+# Windows never had this block: doctor failed both registries after every setup
+# with a remedy ("re-run setup") that could not clear them. Idempotent (prints
+# "N updated, M unchanged"); never prunes (doctor --fix owns orphans, #802).
+if (Get-Command dotf -ErrorAction SilentlyContinue) {
+    dotf harness mirror
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warn "dotf harness mirror reported a gap (above); 'dotf doctor' will report harness drift"
+    }
+}
+
 # Phase C daemon supervision (HIVE-118 / hive#176). Install the supervised
 # `hive serve` Scheduled Task now that the MCP loop's prerequisite installed/upgraded
 # the tool. Gated on hive-vault >= 1.32.0 via the package version (NOT by probing

--- a/specs/WIN-007-harness-mirror/features.json
+++ b/specs/WIN-007-harness-mirror/features.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "WIN-007-harness-mirror-f1",
+    "behavior": "dotf harness mirror copies harness/ and every manifest .targets[].file into the deploy dir; a re-run reports 0 updated and rewrites nothing.",
+    "verification": "cd cli && go test ./internal/harness/ -run 'TestMirror_CopiesTheTreeAndEveryDeclaredTarget|TestMirror_IsIdempotentAndDoesNotRewriteIdenticalFiles'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "WIN-007-harness-mirror-f2",
+    "behavior": "A declared target the checkout lacks is named on stderr and the command exits 1 after mirroring everything else.",
+    "verification": "cd cli && go test ./internal/harness/ ./internal/cmd/ -run 'TestMirror_NamesADeclaredTargetTheCheckoutLacks|TestHarnessMirrorCmd$'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "WIN-007-harness-mirror-f3",
+    "behavior": "A file only the deploy dir has survives a mirror run; pruning stays with dotf doctor --fix.",
+    "verification": "cd cli && go test ./internal/harness/ -run TestMirror_DoesNotPrune",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "WIN-007-harness-mirror-f4",
+    "behavior": "Both setup scripts call dotf harness mirror and setup-linux.sh no longer carries the bash+jq mirror block.",
+    "verification": "grep -qF 'dotf harness mirror' setup-windows.ps1 && grep -qF 'dotf harness mirror' setup-linux.sh && ! grep -qF 'cp -rf \"$CURRENT_DIR/harness/.\"' setup-linux.sh",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "WIN-007-harness-mirror-f5",
+    "behavior": "dotf doctor reports harness mirror orphans on Windows as on Linux, and the pi-packages count reads the checkout first.",
+    "verification": "cd cli && go test ./internal/doctor/ -run 'TestCheckHarnessMirrorOrphans|TestPiPackagesManifest'",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/WIN-007-harness-mirror/proposal.md
+++ b/specs/WIN-007-harness-mirror/proposal.md
@@ -1,0 +1,52 @@
+---
+id: "WIN-007-harness-mirror"
+type: spec
+status: verifying # draft | implementing | verifying | archived
+created: "2026-08-27"
+issue: "mlorentedev/dotfiles#1288"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# WIN-007-harness-mirror
+
+> **Naming**: file lives at `<repo>/specs/WIN-007-harness-mirror/proposal.md`. `WIN-007-harness-mirror` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #1288: WIN-007: setup-windows.ps1 never mirrors harness/ into ~/.dotfiles, so doctor fails on model-map and model-pins and its printed remedy can never clear -->
+
+Measured 2026-08-27 on the Windows work box: after a clean `.\setup-windows.ps1`, `dotf doctor` FAILs the routing registry and the model-pin check because `~/.dotfiles/harness/` does not exist, and both messages print *"re-run setup to mirror it"* — a remedy that cannot clear them, because `setup-windows.ps1` never mirrors `harness/`. Linux carries a 60-line bash+jq block for exactly this (with a zsh word-split hazard and a "jq not on PATH yet" race it documents itself); Windows has nothing; and the Go doctor records the false belief that Windows has no mirror at all and early-returns its orphan check on that belief. Two shell implementations of one mirror is the drift class ADR-020 exists to remove, and the first slice of the CLI-026/CLI-035 engine port that pays for itself today.
+
+## What
+
+- `dotf harness mirror` (Go, `cli/internal/harness/mirror.go`): copies the whole `harness/` tree and every file `harness/manifest.json` declares in `.targets[].file` from the checkout into `$DOTFILES_DIR`, preserving relative paths. Idempotent — a file whose bytes match is left untouched, mtime included — and it reports `N updated, M unchanged` so a setup run has its `changed=0` evidence (#1266). It never prunes (`dotf doctor --fix` owns orphans, #802). A declared target the checkout lacks is named on stderr and the command exits 1 **after** mirroring everything else.
+- Both setup scripts call it, at the position the bash block occupied on Linux (after `compile-harness.sh --refresh`) and beside the other `dotf` calls on Windows. The bash+jq block in `setup-linux.sh` is deleted, not duplicated.
+- `dotf doctor`: `checkHarnessMirrorOrphans` stops special-casing Windows (its stale comment goes with it), and the pi-packages count reads `ai/pi/packages.json` checkout-first like every other registry read (it reported "0 packages declared" as a PASS on Windows).
+
+## Out of scope
+
+- `dotf harness {refresh,deploy,check}` — the engine port is CLI-026 (#495) / CLI-035 (#909); this is the mirror slice only.
+- Pruning the mirror — `dotf doctor --fix` (#802 semantic).
+- The copilot catalog CRLF writer (WIN-008) and the non-recursive `sensitive/` copy (WIN-011): their PowerShell halves ship in the PowerShell hygiene PR.
+- Mirroring `ai/` wholesale: nothing reads it from the mirror once the pi-packages count is checkout-first.
+
+## Risks / open questions
+
+- On Linux `~/.local/bin` may not be on PATH in the setup process (the jq comment in the old block). Resolved: the call uses the same `command -v dotf` guard as `dotf tools install` two hundred lines earlier, degrades with a warning naming the consequence, and `tests/verify-setup.bats` ("every harness manifest target exists in the deploy dir") fails on the resulting gap in the integration job.
+- Windows CI never runs `dotf` today (TEST-003/#1298), so the Windows call site is exercised end-to-end only after that lands. Accepted: the behaviour is covered by the Go tests, which run on the `cli` workflow's Windows matrix, and by the `test-windows` bats source assertion on the call site.
+- Order on Linux matters: the mirror must run after `--refresh` so the snapshot matches the refreshed repo. Resolved: the call replaces the block in place.
+
+## Acceptance criteria
+
+- [ ] AC1 — `dotf harness mirror` copies `harness/` and every `.targets[].file` into the deploy dir; a re-run reports `0 updated` and rewrites nothing (mtime unchanged).
+- [ ] AC2 — a declared target the checkout lacks is named on stderr and the command exits 1, with everything else still mirrored.
+- [ ] AC3 — a file only the deploy dir has survives a mirror run (no pruning).
+- [ ] AC4 — both `setup-linux.sh` and `setup-windows.ps1` call `dotf harness mirror`, and `setup-linux.sh` no longer carries the bash+jq mirror block.
+- [ ] AC5 — `dotf doctor` reports harness mirror orphans on Windows as on Linux, and the pi-packages count reads the checkout first.
+
+## References
+
+- Bitácora: #1288 (WIN-007); parent port: #495 (CLI-026), #909 (CLI-035); Linux precedent: #1200 (the mirror evaluated a target setup never copied).
+- ADR-020 (strangler-fig on contact), ADR-030 (checkout-first precedence), #802 (doctor --fix prunes, setup only copies).
+- `00_meta/patterns/pattern-setup-script-idempotence.md`.

--- a/specs/WIN-007-harness-mirror/tasks.md
+++ b/specs/WIN-007-harness-mirror/tasks.md
@@ -1,0 +1,47 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-27"
+---
+
+# Tasks - WIN-007-harness-mirror
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers** (optional, additive — borrowed from `github/spec-kit`, adapt-not-adopt per #141):
+> - `[P]` — this task has **no dependency on another unchecked task**, so it is safe to run in parallel (fan out to a `Workflow`, or just batch). TDD chains (test → implement → refactor of the *same* behavior) are sequential and must NOT carry `[P]`; independent behaviors can.
+> - `[AC<n>]` — this task helps satisfy **acceptance criterion #`<n>`** from `proposal.md`. Lets `/spec check` map coverage deterministically; omit it and the check falls back to semantic judgment.
+
+## Setup
+
+- [x] Branch created from main: `feat/harness-mirror`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+- [x] [P] [AC1] Write failing tests: `TestMirror_CopiesTheTreeAndEveryDeclaredTarget`, `TestMirror_IsIdempotentAndDoesNotRewriteIdenticalFiles` (`cli/internal/harness/mirror_test.go`)
+- [x] [AC1] Implement `harness.Mirror` (tree walk + manifest `.targets[].file`, byte-compare before write, atomic temp+rename)
+- [x] [P] [AC2] Write failing test: `TestMirror_NamesADeclaredTargetTheCheckoutLacks`; implement `ErrMissingTargets` after mirroring the rest
+- [x] [P] [AC3] Write failing test: `TestMirror_DoesNotPrune`; confirm no delete path exists
+- [x] [AC1] [AC2] Write failing test: `TestHarnessMirrorCmd` (counts on stdout, gap on stderr, exit 1); implement `dotf harness mirror` and wire it into `newHarnessCmd`
+- [x] [P] [AC4] Replace the `setup-linux.sh` bash+jq block with `dotf harness mirror` at the same position (after `--refresh`); insert the call in `setup-windows.ps1` beside `dotf tools install`
+- [x] [AC4] Rewrite the `tests/setup-linux.bats` guards that asserted the bash block (mirror present, derivation in Go, ordering after `--refresh`); delete the jq-by-path guard (#1202) now that jq is not involved; add the Windows + parity guards in `tests/setup-windows.bats`
+- [x] [P] [AC5] Flip the Windows subtest in `checks_harness_mirror_test.go` (orphan reported, not silent); drop the `GOOS == "windows"` early return and its false comment
+- [x] [P] [AC5] Write failing test: `TestPiPackagesManifest_ReadsTheCheckoutBeforeTheMirror`; make `piPackagesManifest` checkout-first
+- [x] Refactor for clarity: none needed (single-purpose file, no duplication with `deploy.go`'s atomic write beyond the two-line temp+rename idiom)
+
+## Closing
+
+- [x] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [x] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
+- [x] Type checks pass (`go build ./... && go vet ./...`, Windows and `GOOS=linux`)
+- [x] Lint passes (`golangci-lint run ./...` pinned 2.12.2; `shellcheck setup-linux.sh`; PowerShell parser + ASCII-only on the `.ps1` insert)
+- [x] No unrelated changes in the diff (no scope creep)
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.

--- a/specs/WIN-007-harness-mirror/verification.md
+++ b/specs/WIN-007-harness-mirror/verification.md
@@ -1,0 +1,69 @@
+---
+tags: [spec, verification]
+created: "2026-08-27"
+---
+
+# Verification - WIN-007-harness-mirror
+
+## Evidence
+
+All produced 2026-08-27 on the Windows work box (the box where the defect was measured), from the `feat/harness-mirror` worktree.
+
+`features.json` verification commands (Git Bash, Go 1.26 on PATH):
+
+```
+WIN-007-harness-mirror-f1: exit=0  ok  github.com/mlorentedev/dotfiles/cli/internal/harness
+WIN-007-harness-mirror-f2: exit=0  ok  github.com/mlorentedev/dotfiles/cli/internal/cmd
+WIN-007-harness-mirror-f3: exit=0  ok  github.com/mlorentedev/dotfiles/cli/internal/harness
+WIN-007-harness-mirror-f4: exit=0
+WIN-007-harness-mirror-f5: exit=0  ok  github.com/mlorentedev/dotfiles/cli/internal/doctor
+```
+
+Whole tree: `go build ./... && go vet ./... && GOOS=linux go vet ./... && go test ./...` green; `golangci-lint run ./...` (pinned 2.12.2) 0 issues; `bash -n setup-linux.sh` + `shellcheck` (no new findings; pre-existing info-level notes only); `setup-windows.ps1` parses clean (PowerShell AST parser, 0 errors) and the inserted block is ASCII-only; `bats tests/setup-linux.bats tests/setup-windows.bats` — the rewritten and new guards pass (the one failing case, *valid zsh syntax*, is the pre-existing `zsh: command not found` on Windows).
+
+**Real-box run** with `dotf` built from this branch:
+
+```
+$ dotf harness mirror
+harness mirror: harness/ + 3 target(s) → C:\Users\<u>\.dotfiles (76 updated, 0 unchanged)
+$ dotf harness mirror
+harness mirror: harness/ + 3 target(s) → C:\Users\<u>\.dotfiles (0 updated, 76 unchanged)
+$ dotf doctor | grep -E 'FAIL|Results'
+  [FAIL] no DR escrow at ...                     ← WIN-011, fixed in #1304
+  [FAIL] $HOME/.pi/agent/settings.json pi-deployed-default-model: "deepseek-v4-flash-0731" resolves to nothing the routing registry declares
+  [FAIL] stale: .copilot/copilot-instructions.md ← WIN-008, comparator fixed in #1304
+Results: 124 passed, 3 failed, 2 warned, 26 skipped   (was 122 / 4 / 2 / 25 before the mirror)
+```
+
+The two registry FAILs this spec exists for (`harness/model-map.json not found`, `read harness/model-pins.json`) are gone. The pin check, which had never been able to run on this box, now reports a genuine drift in the live pi settings (the "dead dated id" `model-pins.json` itself anticipates) — a finding, not a regression.
+
+## Test status
+
+| AC | Test | Status |
+|---|---|---|
+| AC1 | `TestMirror_CopiesTheTreeAndEveryDeclaredTarget`, `TestMirror_IsIdempotentAndDoesNotRewriteIdenticalFiles`, `TestHarnessMirrorCmd` | pass |
+| AC2 | `TestMirror_NamesADeclaredTargetTheCheckoutLacks`, `TestHarnessMirrorCmd` (stderr + exit 1) | pass |
+| AC3 | `TestMirror_DoesNotPrune` | pass |
+| AC4 | `setup-linux.bats` (mirror via dotf; derivation in Go; ordering after `--refresh`), `setup-windows.bats` (call present; parity) | pass |
+| AC5 | `TestCheckHarnessMirrorOrphans` (Windows subtest flipped), `TestPiPackagesManifest_ReadsTheCheckoutBeforeTheMirror` | pass |
+
+Also: `TestMirror_RefusesWhenTheCheckoutIsTheDeployDir`, `TestMirror_FailsLoudWithoutAManifest`, `TestHarnessMirrorCmd_SaysSoWhenTheCheckoutIsTheDeployDir`.
+
+## Decisions made during implementation
+
+- **Narrow slice, not the engine.** `dotf harness mirror` only; `refresh/deploy/check` stay with CLI-026/CLI-035 (#495/#909). A second manifest-driven "deploy everything" design mid-drive was the rabbit hole named in review.
+- **Never prune.** Kept #802's semantic: setup copies, `dotf doctor --fix` prunes. The Windows early-return in the orphan check was removed instead of extended, because the premise behind it ("Windows has no mirror") was false.
+- **Missing target = exit 1 after mirroring the rest.** The bash block warned and continued; the Go command mirrors everything it can, names the gap on stderr and exits non-zero, and both setups keep the `|| log_warning` / `$LASTEXITCODE` degrade — loud, not fatal (C9 degrade-not-break).
+- **Deleted, not ported, the jq-by-path guard (#1202).** jq is no longer involved; the test asserting the workaround would have asserted a workaround for a problem that no longer exists.
+- **`env.RepoDir` prefers the cwd walk-up** (BUG-072), so the cmd test carries a `.git` marker and `t.Chdir`s into its fixture — the first draft resolved the real checkout and mirrored 76 files into a temp dir.
+
+## Promotion candidates
+
+- Lesson (repo `docs/lessons/`): *a mirror that is partial on one OS while the code believes it is absent* — the early-return and its comment were the reason nobody looked; the check that could have flagged the gap was the one switched off. Written with the DOCS-015 (#1303) batch.
+- No vault promotion: build/operate detail.
+
+## Archive checklist
+
+- [ ] `dotf spec review WIN-007-harness-mirror` — passing `review.md` from the reviewer pool (needs an unlocked Bitwarden vault on the box that runs it: the reviewer resolves its key through `dotf secrets run`)
+- [ ] PR merged; issue #1288 closed
+- [ ] `dotf spec archive WIN-007-harness-mirror`

--- a/tests/Dockerfile.integration
+++ b/tests/Dockerfile.integration
@@ -67,13 +67,14 @@ RUN mkdir -p /home/testuser/.config/age \
 # Copy repo to ~/dotfiles-repo (NOT ~/.dotfiles) to trigger the copy branch
 COPY --chown=testuser:testuser . /home/testuser/dotfiles-repo
 
-# dotf from this tree, where install_dotf places the release; DOTF_VERSION=dev
-# makes install_dotf treat the source build as already installed.
+# dotf from this tree, where install_dotf places the release. It reports
+# `dev`, and install_dotf leaves a dev build in place (a DOTF_VERSION env
+# override cannot express this: setup-linux.sh sources versions.conf, which
+# sets DOTF_VERSION back to the pin).
 RUN mkdir -p /home/testuser/.local/bin \
     && cd /home/testuser/dotfiles-repo/cli \
     && go build -o /home/testuser/.local/bin/dotf ./cmd/dotf \
     && /home/testuser/.local/bin/dotf version
-ENV DOTF_VERSION=dev
 
 # Marker for verify-setup.bats to detect it's running inside the container
 ENV DOTFILES_INTEGRATION_TEST=1

--- a/tests/Dockerfile.integration
+++ b/tests/Dockerfile.integration
@@ -11,6 +11,9 @@ FROM ubuntu:26.04
 
 ARG BATS_VERSION=1.13.0
 ARG AGE_VERSION=1.3.1
+# Go toolchain for building dotf from THIS tree (default mirrors cli/go.mod's
+# `go` directive; ci.yml passes the real value as a build-arg).
+ARG GO_VERSION=1.26.0
 
 # Minimal dependencies that setup-linux.sh actually needs. xz-utils is required
 # for the shellcheck install (a .tar.xz extracted with `tar xJf`); without it the
@@ -42,6 +45,16 @@ RUN curl -fsSL "https://github.com/bats-core/bats-core/archive/refs/tags/v${BATS
     && /tmp/bats-core-${BATS_VERSION}/install.sh /usr/local \
     && rm -rf /tmp/bats.tar.gz /tmp/bats-core-${BATS_VERSION}
 
+# Go, for building dotf from the tree under test. The released dotf lags the
+# tree: setup-linux.sh's install_dotf downloaded 0.51.0 here, which had no
+# `harness mirror`, so the integration job tested the last release and failed
+# on the PR that added the command (#1305). Same principle as the Windows job
+# (TEST-003, #1298): CI certifies the PR's binary, not the previous one's.
+RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tar.gz \
+    && tar -C /usr/local -xzf /tmp/go.tar.gz \
+    && rm -f /tmp/go.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
 # Non-root user (setup-linux.sh uses $HOME)
 RUN useradd -m -s /bin/bash testuser
 USER testuser
@@ -53,6 +66,14 @@ RUN mkdir -p /home/testuser/.config/age \
 
 # Copy repo to ~/dotfiles-repo (NOT ~/.dotfiles) to trigger the copy branch
 COPY --chown=testuser:testuser . /home/testuser/dotfiles-repo
+
+# dotf from this tree, where install_dotf places the release; DOTF_VERSION=dev
+# makes install_dotf treat the source build as already installed.
+RUN mkdir -p /home/testuser/.local/bin \
+    && cd /home/testuser/dotfiles-repo/cli \
+    && go build -o /home/testuser/.local/bin/dotf ./cmd/dotf \
+    && /home/testuser/.local/bin/dotf version
+ENV DOTF_VERSION=dev
 
 # Marker for verify-setup.bats to detect it's running inside the container
 ENV DOTFILES_INTEGRATION_TEST=1

--- a/tests/integration-builds-dotf.bats
+++ b/tests/integration-builds-dotf.bats
@@ -24,11 +24,10 @@ setup() {
     [ "$build_line" -gt "$copy_line" ]
 }
 
-@test "integration: DOTF_VERSION=dev keeps the source build through install_dotf" {
-    grep -qF 'ENV DOTF_VERSION=dev' "$DOCKERFILE"
+@test "integration: the source build is made before setup runs, so install_dotf sees it" {
     setup_line=$(grep -n 'bash setup-linux.sh' "$DOCKERFILE" | head -1 | cut -d: -f1)
-    env_line=$(grep -n '^ENV DOTF_VERSION=dev' "$DOCKERFILE" | head -1 | cut -d: -f1)
-    [ "$env_line" -lt "$setup_line" ]
+    build_line=$(grep -n 'go build -o /home/testuser/.local/bin/dotf' "$DOCKERFILE" | head -1 | cut -d: -f1)
+    [ "$build_line" -lt "$setup_line" ]
 }
 
 @test "integration: GO_VERSION reaches the container from cli/go.mod, not a second pin" {
@@ -37,7 +36,13 @@ setup() {
     grep -qF 'ARG GO_VERSION=' "$DOCKERFILE"
 }
 
-@test "both installers treat a 'dev' build as already installed when the pin is dev" {
+@test "both installers leave a 'dev' (source) build in place instead of replacing it with the release" {
+    # setup-linux.sh sources versions.conf, so a DOTF_VERSION=dev env override is
+    # clobbered back to the pin before install_dotf runs (measured on #1305's
+    # third run: "dotf dev drifted from pinned 0.51.0; converging"). The rule
+    # has to live in the installers themselves.
     grep -qF "grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+|dev'" "$REPO/scripts/install-dotf.sh"
+    grep -qF 'if [ "$_dotf_current" = "dev" ]; then' "$REPO/scripts/install-dotf.sh"
     grep -qF "(\\d+\\.\\d+\\.\\d+|dev)" "$REPO/scripts/install-dotf.ps1"
+    grep -qF "if (\$current -eq 'dev') {" "$REPO/scripts/install-dotf.ps1"
 }

--- a/tests/integration-builds-dotf.bats
+++ b/tests/integration-builds-dotf.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+# The integration container must test the dotf built from the tree under
+# test, not the last release. setup-linux.sh's install_dotf downloaded 0.51.0
+# into the container, which had no `harness mirror`, so the job failed on the
+# very PR that added the command (#1305) -- and would have kept certifying the
+# previous release's behaviour on every PR after it. Same principle as the
+# Windows job (TEST-003, #1298).
+#
+# Asserted on the Dockerfile / workflow / installer text, because nothing here
+# can run Docker or GitHub's runner.
+
+setup() {
+    export REPO="$BATS_TEST_DIRNAME/.."
+    export DOCKERFILE="$REPO/tests/Dockerfile.integration"
+    export CI="$REPO/.github/workflows/ci.yml"
+}
+
+@test "integration: the container builds dotf from this tree into ~/.local/bin" {
+    grep -qF 'go build -o /home/testuser/.local/bin/dotf ./cmd/dotf' "$DOCKERFILE"
+    # The build must follow the COPY of the repo (it compiles what was copied).
+    copy_line=$(grep -n '^COPY --chown=testuser:testuser \. /home/testuser/dotfiles-repo' "$DOCKERFILE" | head -1 | cut -d: -f1)
+    build_line=$(grep -n 'go build -o /home/testuser/.local/bin/dotf' "$DOCKERFILE" | head -1 | cut -d: -f1)
+    [ -n "$copy_line" ] && [ -n "$build_line" ]
+    [ "$build_line" -gt "$copy_line" ]
+}
+
+@test "integration: DOTF_VERSION=dev keeps the source build through install_dotf" {
+    grep -qF 'ENV DOTF_VERSION=dev' "$DOCKERFILE"
+    setup_line=$(grep -n 'bash setup-linux.sh' "$DOCKERFILE" | head -1 | cut -d: -f1)
+    env_line=$(grep -n '^ENV DOTF_VERSION=dev' "$DOCKERFILE" | head -1 | cut -d: -f1)
+    [ "$env_line" -lt "$setup_line" ]
+}
+
+@test "integration: GO_VERSION reaches the container from cli/go.mod, not a second pin" {
+    grep -qF "GO_VERSION=\$(sed -n 's/^go //p' cli/go.mod)" "$CI"
+    grep -qF -- '--build-arg GO_VERSION="$GO_VERSION"' "$CI"
+    grep -qF 'ARG GO_VERSION=' "$DOCKERFILE"
+}
+
+@test "both installers treat a 'dev' build as already installed when the pin is dev" {
+    grep -qF "grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+|dev'" "$REPO/scripts/install-dotf.sh"
+    grep -qF "(\\d+\\.\\d+\\.\\d+|dev)" "$REPO/scripts/install-dotf.ps1"
+}

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -431,39 +431,25 @@ setup() {
 # so the snapshot matches the refreshed repo state (else the repo<->deploy drift
 # sub-check would see drift).
 
-@test "setup-linux.sh mirrors harness/ into the deploy dir (drift fix)" {
-    grep -qF 'cp -rf "$CURRENT_DIR/harness/." "$DOTFILES_DIR/harness/"' "$DOTFILES_DIR/setup-linux.sh"
+@test "setup-linux.sh mirrors harness/ into the deploy dir through dotf harness mirror (WIN-007)" {
+    grep -qF 'dotf harness mirror' "$DOTFILES_DIR/setup-linux.sh"
+    # The bash+jq block is gone -- one implementation for both OSes. A `run` +
+    # status check, not a bare negation: a negated assertion is exempt from
+    # set -e and cannot fail a test (lesson 224).
+    run grep -qF 'cp -rf "$CURRENT_DIR/harness/." "$DOTFILES_DIR/harness/"' "$DOTFILES_DIR/setup-linux.sh"
+    [ "$status" -ne 0 ]
 }
 
-@test "setup-linux.sh derives the mirrored target list from harness/manifest.json" {
-    # This used to assert two literal `safe_copy` lines, one per target. That
-    # made the test a FOURTH restatement of the manifest's list -- alongside the
-    # manifest itself, the deploy block, and compile-harness-rootresolve.bats --
-    # and it could only ever assert that the targets someone remembered were
-    # copied, never that the list was complete. #1200: a third target was added
-    # to the manifest with no copy line, and this test stayed green while
-    # `dotf doctor` failed permanently.
-    #
-    # Assert the derivation instead. The OUTCOME -- every declared target
-    # actually present in $DOTFILES_DIR -- is asserted by verify-setup.bats
-    # against a real deploy, which is the half source-text grep cannot reach.
-    # Patterns must not start with `-`: grep reads a leading dash as an OPTION
-    # and exits 2 (usage error), which a boolean assertion cannot tell apart
-    # from 1 (not found) — the test would report "the derivation is missing"
-    # when grep never looked at the file.
-    grep -qF '.targets[].file' "$DOTFILES_DIR/setup-linux.sh"
-    grep -qF '"$CURRENT_DIR/harness/manifest.json"' "$DOTFILES_DIR/setup-linux.sh"
-    grep -qF 'safe_copy "$CURRENT_DIR/$_harness_target" "$_harness_target_dir/"' \
-        "$DOTFILES_DIR/setup-linux.sh"
-}
-
-@test "setup-linux.sh resolves jq by path, not only by name (#1202)" {
-    # The installer downloads jq to ~/.local/bin, which this process's PATH may
-    # not carry: the integration container logs "jq installed" and "jq not
-    # found" 22 seconds apart in one run. A `command -v jq` test alone silently
-    # skips the mirror right after a successful install, so the derivation
-    # no-ops and every manifest target goes missing without an error.
-    grep -qF '[ -x "$HOME/.local/bin/jq" ]' "$DOTFILES_DIR/setup-linux.sh"
+@test "setup-linux.sh derives the mirrored target list from harness/manifest.json (in Go, via dotf harness mirror)" {
+    # The derivation lives in cli/internal/harness/mirror.go (reads
+    # .targets[].file), so the script must not restate the list -- #1200: a
+    # third target was added to the manifest with no copy line, and the old
+    # per-target assertions stayed green while `dotf doctor` failed permanently.
+    # The OUTCOME -- every declared target present in $DOTFILES_DIR -- is
+    # asserted by verify-setup.bats against a real deploy.
+    grep -qF 'dotf harness mirror' "$DOTFILES_DIR/setup-linux.sh"
+    run grep -qF 'safe_copy "$CURRENT_DIR/$_harness_target"' "$DOTFILES_DIR/setup-linux.sh"
+    [ "$status" -ne 0 ]
 }
 
 @test "setup-linux.sh installs the GUARD memory-sink git-hooks (#418 deploy + wire)" {
@@ -473,7 +459,7 @@ setup() {
 
 @test "setup-linux.sh harness mirror runs AFTER compile-harness --refresh (ordering guard)" {
     refresh_line=$(grep -n 'compile-harness.sh" --refresh' "$DOTFILES_DIR/setup-linux.sh" | head -1 | cut -d: -f1)
-    mirror_line=$(grep -n 'cp -rf "\$CURRENT_DIR/harness/\.' "$DOTFILES_DIR/setup-linux.sh" | head -1 | cut -d: -f1)
+    mirror_line=$(grep -n 'dotf harness mirror' "$DOTFILES_DIR/setup-linux.sh" | head -1 | cut -d: -f1)
     [ -n "$refresh_line" ] && [ -n "$mirror_line" ]
     [ "$mirror_line" -gt "$refresh_line" ]
 }

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -452,6 +452,14 @@ setup() {
     [ "$status" -ne 0 ]
 }
 
+@test "setup-linux.sh resolves dotf by path for the harness mirror, not only by name (#1202 class)" {
+    # install_dotf places the binary in ~/.local/bin, which this process's PATH
+    # may not carry: the integration container installed dotf and then skipped
+    # the mirror in the same run, and verify-setup.bats caught the gap (#1305).
+    grep -qF '[ -x "$HOME/.local/bin/dotf" ]' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF '"$_dotf" harness mirror' "$DOTFILES_DIR/setup-linux.sh"
+}
+
 @test "setup-linux.sh installs the GUARD memory-sink git-hooks (#418 deploy + wire)" {
     grep -qF '. ./scripts/install-git-hooks.sh' "$DOTFILES_DIR/setup-linux.sh"
     grep -qF 'install_git_hooks' "$DOTFILES_DIR/setup-linux.sh"

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -798,3 +798,15 @@ setup() {
     grep -qF 'ai\opencode\tui.json' "$PS1_SCRIPT"
     grep -qF '.config\opencode\tui.json' "$PS1_SCRIPT"
 }
+
+@test "setup-windows.ps1 mirrors the harness inputs through dotf harness mirror (WIN-007)" {
+    # ~/.dotfiles/harness never existed on Windows, so `dotf doctor` failed the
+    # routing registry and the model-pin checks after every setup, with a
+    # remedy ("re-run setup") that could not clear them (#1288).
+    grep -qF 'dotf harness mirror' "$PS1_SCRIPT"
+}
+
+@test "parity: both setups mirror the harness through the same dotf command (WIN-007)" {
+    grep -qF 'dotf harness mirror' "$PS1_SCRIPT"
+    grep -qF 'dotf harness mirror' "$DOTFILES_DIR/setup-linux.sh"
+}


### PR DESCRIPTION
## Summary

`dotf harness mirror`: one Go implementation of the deploy-dir mirror, called by both setup scripts. Spec: `specs/WIN-007-harness-mirror/`. Part of #1288 (the issue closes with the spec archive, after the pooled adversarial review).

**Why.** Measured 2026-08-27 on the Windows work box: `~/.dotfiles/harness/` never existed, so `dotf doctor` failed `harness/model-map.json` and `harness/model-pins.json` after every setup and printed *re-run setup to mirror it* — a remedy that could not clear them, because `setup-windows.ps1` had no mirror block. Linux carried a 60-line bash+jq block (zsh word-split hazard, "jq not on PATH yet" race, both documented in-place). The Go doctor's orphan check early-returned on Windows on the stated belief that Windows has no repo/mirror split — false: `$DotfilesDest` is `~/.dotfiles`, the very dir `cfg.DotfilesDir` resolves to; it just never received `harness/`.

**What.**
- `cli/internal/harness/mirror.go` — copies `harness/` + every manifest `.targets[].file` from the checkout into the deploy dir; byte-compare before write (re-run: `0 updated`, mtimes untouched); never prunes (`dotf doctor --fix` owns orphans, #802); a declared target the checkout lacks is named on stderr and the command exits 1 **after** mirroring the rest.
- `setup-linux.sh`: the bash+jq block is replaced by the call at the same position (after `--refresh`). `setup-windows.ps1`: the call is added beside `dotf tools install`.
- doctor: `checkHarnessMirrorOrphans` applies on every OS (stale comment removed); `piPackagesManifest` reads the checkout first (it reported "0 packages declared" as a PASS on Windows).
- Guards: Go unit + cmd tests (idempotence, missing target, no-prune, same-dir, no-manifest); `setup-linux.bats` guards rewritten to the new call, the jq-by-path guard (#1202) deleted with the jq; `setup-windows.bats` call-site + parity guards.

## Evidence (this session, Windows work box)

- All five `features.json` verifications exit 0; `go build/vet/test ./...` green on Windows and `GOOS=linux go vet`; `golangci-lint` (2.12.2) 0 issues; PowerShell AST parse 0 errors, insert ASCII-only; bats guards pass.
- `dotf` built from this branch, run on the real box: `harness/ + 3 target(s) → C:\Users\<u>\.dotfiles (76 updated, 0 unchanged)`, then `(0 updated, 76 unchanged)`. `dotf doctor`: the two registry FAILs are gone (122/4/2/25 → 124/3/2/26). The model-pin check, which had never been able to run on this box, now reports a genuine drift in the live pi `settings.json` (`deepseek-v4-flash-0731`, the "dead dated id" `model-pins.json` anticipates) — a finding, not a regression; the two remaining FAILs are fixed in #1304.

## Not in this PR

`dotf harness {refresh,deploy,check}` (CLI-026 #495 / CLI-035 #909). The Windows CI job does not run `dotf` yet (TEST-003, #1298), so the Windows call site is exercised end-to-end there only after that lands; the behaviour is covered on the `cli` workflow's Windows matrix.
