### PR TITLE
fix(setup): UTF-8 console, LF deployed .md files, recursive sensitive/ mirror on Windows

### DIFF
--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -200,6 +200,24 @@ function prompt {
 }
 
 # ============================================================================
+# CONSOLE ENCODING
+# ============================================================================
+
+# UTF-8 console I/O (WIN-009/#1290). PowerShell decodes captured native output
+# with [Console]::OutputEncoding, which defaults to the system OEM code page, so
+# `dotf` output carrying an em dash rendered as OEM glyphs and any function
+# parsing it read corrupted bytes. Mirrors the block scripts/utils.ps1 applies
+# to setup itself.
+try {
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [Console]::OutputEncoding = $utf8NoBom
+    [Console]::InputEncoding = $utf8NoBom
+    $OutputEncoding = $utf8NoBom
+} catch {
+    Write-Verbose "console encoding not set: $_"
+}
+
+# ============================================================================
 # ENVIRONMENT VARIABLES
 # ============================================================================
 

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -10,6 +10,42 @@
 
 Set-StrictMode -Version Latest
 
+# Console I/O is UTF-8 for this process (WIN-009/#1290). PowerShell decodes
+# captured native output with [Console]::OutputEncoding, which defaults to the
+# system OEM code page (437 on the work box), so a `dotf` message carrying an
+# em dash arrived as three OEM glyphs -- and every block that PARSES captured
+# output was reading corrupted bytes, not merely printing them. Process state,
+# not logic: one of the few things that legitimately stays in shell. Guarded:
+# a host without a console (a transcript-only CI step) throws on the setter.
+try {
+    $script:Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [Console]::OutputEncoding = $script:Utf8NoBom
+    [Console]::InputEncoding = $script:Utf8NoBom
+    $global:OutputEncoding = $script:Utf8NoBom
+} catch {
+    Write-Verbose "console encoding not set: $_"
+}
+
+# Write-Utf8LfFile: write CONTENT to PATH as UTF-8 without BOM and with LF line
+# endings, whatever the platform newline is. Set-Content joins with the platform
+# newline (CRLF here) and Windows PowerShell 5.1 adds a BOM, so a deployed .md
+# drifted from its LF repo source on every run and the doctor's drift check
+# could never clear (WIN-008/#1289). .gitattributes declares *.md eol=lf; the
+# deployed copy honours the same contract.
+function Write-Utf8LfFile {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Content
+    )
+    $text = $Content -replace "`r`n", "`n"
+    if (-not $text.EndsWith("`n")) { $text += "`n" }
+    $dir = Split-Path -Path $Path -Parent
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    [System.IO.File]::WriteAllText($Path, $text, (New-Object System.Text.UTF8Encoding($false)))
+}
+
 # Deploy-File: copy SRC to DST atomically + idempotently.
 # Parity with bash scripts/utils.sh deploy_file().
 #

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -609,14 +609,13 @@ $sensitiveDest = "$DotfilesDest\sensitive"
 if (Test-Path $sensitiveSource) {
     Ensure-Directory $sensitiveDest
     # The var->file mapping moved to secrets/registry.yaml (deployed below); sensitive/
-    # now holds only the encrypted .age blobs.
-    $ageFiles = Get-ChildItem -Path $sensitiveSource -Filter '*.secret.age' -ErrorAction SilentlyContinue
-    if ($ageFiles) {
-        foreach ($ageFile in $ageFiles) {
-            Copy-Item $ageFile.FullName "$sensitiveDest\" -Force
-        }
-        Write-Success "Deployed $($ageFiles.Count) encrypted secret files"
-    }
+    # holds the encrypted .age blobs and, under dr/, the Bitwarden DR escrow.
+    # Recursive, like setup-linux.sh's `cp -rf sensitive/*`: the top-level-only
+    # copy this used to be never mirrored dr/, and doctor reported total-loss risk
+    # over an escrow sitting in the checkout (WIN-011/#1292).
+    Copy-Item -Path (Join-Path $sensitiveSource '*') -Destination $sensitiveDest -Recurse -Force
+    $ageCount = (Get-ChildItem -Path $sensitiveDest -Filter '*.age' -File -Recurse -ErrorAction SilentlyContinue | Measure-Object).Count
+    Write-Success "Deployed $ageCount encrypted secret files (sensitive/ mirrored recursively)"
 } else {
     Write-Warn "Sensitive directory not found at $sensitiveSource"
 }
@@ -2005,7 +2004,7 @@ function Deploy-SkillRecord {
                 if ((Test-Path -LiteralPath $target) -and ((Get-Item -LiteralPath $target -Force).Attributes -band [IO.FileAttributes]::ReparsePoint)) {
                     Remove-Item -LiteralPath $target -Force -ErrorAction SilentlyContinue
                 }
-                Set-Content -LiteralPath $target -Value (Convert-SkillRecord -Kind $d.render -RecordMd $recMd -SrcPath $src) -Encoding UTF8
+                Write-Utf8LfFile -Path $target -Content (Convert-SkillRecord -Kind $d.render -RecordMd $recMd -SrcPath $src)
             } else {
                 $destDir = Join-Path $destBase $rec.Name
                 if (Test-Path -LiteralPath $destDir) {
@@ -2014,7 +2013,7 @@ function Deploy-SkillRecord {
                 }
                 Ensure-Directory $destDir
                 Copy-Item -Path (Join-Path $rec.FullName '*') -Destination $destDir -Recurse -Force -ErrorAction SilentlyContinue
-                Set-Content -LiteralPath (Join-Path $destDir 'SKILL.md') -Value (Convert-SkillRecord -Kind $d.render -RecordMd $recMd -SrcPath $src) -Encoding UTF8
+                Write-Utf8LfFile -Path (Join-Path $destDir 'SKILL.md') -Content (Convert-SkillRecord -Kind $d.render -RecordMd $recMd -SrcPath $src)
             }
         }
         # Prune our own stale outputs (skill removed, or targets[] dropped this agent).
@@ -2073,7 +2072,10 @@ function Deploy-SkillRecord {
                 }
                 $result.Add($line)
             }
-            Set-Content -LiteralPath $catFile -Value $result -Encoding UTF8
+            # LF + no BOM (WIN-008/#1289): Set-Content joined this list with CRLF and
+            # rewrote the whole file, so the deployed copy drifted from its LF source
+            # on every run and the doctor's drift FAIL could never clear.
+            Write-Utf8LfFile -Path $catFile -Content ($result -join "`n")
             Write-Success "Injected skill catalog into $catFile"
         }
     }

--- a/tests/console-encoding.Tests.ps1
+++ b/tests/console-encoding.Tests.ps1
@@ -1,0 +1,77 @@
+# Pester 5 tests for the console-encoding block and the LF writer in
+# scripts/utils.ps1 (WIN-009/#1290, WIN-008/#1289).
+#
+# The encoding cases run in a CHILD pwsh so the code page under test is chosen
+# by the test, never inherited from the runner (a runner already on UTF-8 would
+# pass vacuously). Windows only: code pages are a Windows console concept.
+
+$script:onWindows = $env:OS -eq 'Windows_NT'
+
+Describe 'scripts/utils.ps1 console encoding' -Skip:(-not $script:onWindows) {
+
+    BeforeAll {
+        $script:Utils = (Resolve-Path (Join-Path $PSScriptRoot '..\scripts\utils.ps1')).Path
+        $script:Profile = (Resolve-Path (Join-Path $PSScriptRoot '..\powershell\profile.ps1')).Path
+    }
+
+    It 'flips a child pwsh that starts on code page 437 to UTF-8 when dot-sourced' {
+        $probe = "[Console]::OutputEncoding = [Text.Encoding]::GetEncoding(437); . '$script:Utils'; [Console]::OutputEncoding.CodePage; `$OutputEncoding.CodePage"
+        $out = @(& pwsh -NoProfile -Command $probe 2>&1 | Select-Object -Last 2)
+        $out | Should -Be @('65001', '65001')
+    }
+
+    It 'lets a captured native em dash survive that used to arrive as OEM glyphs' {
+        # The native child prints U+2014 as UTF-8; the parent captures it once on
+        # code page 437 (mojibake) and once after sourcing utils.ps1 (intact).
+        $inner = '[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false); [Console]::Out.Write([string][char]0x2014)'
+        $probe = @"
+[Console]::OutputEncoding = [Text.Encoding]::GetEncoding(437)
+`$before = (& pwsh -NoProfile -Command '$inner' | Out-String).Trim()
+. '$script:Utils'
+`$after = (& pwsh -NoProfile -Command '$inner' | Out-String).Trim()
+"`$(`$before -eq [string][char]0x2014)|`$(`$after -eq [string][char]0x2014)"
+"@
+        $out = (& pwsh -NoProfile -Command $probe 2>&1 | Select-Object -Last 1)
+        $out | Should -Be 'False|True'
+    }
+
+    It 'is mirrored by the deployed profile' {
+        Get-Content -LiteralPath $script:Profile -Raw | Should -Match '\[Console\]::OutputEncoding\s*='
+    }
+}
+
+Describe 'Write-Utf8LfFile' -Skip:(-not $script:onWindows) {
+
+    BeforeAll {
+        . (Resolve-Path (Join-Path $PSScriptRoot '..\scripts\utils.ps1')).Path
+    }
+
+    It 'writes LF line endings and no BOM from CRLF input' {
+        $p = Join-Path $TestDrive 'a.md'
+        Write-Utf8LfFile -Path $p -Content "one`r`ntwo`r`n"
+        $bytes = [IO.File]::ReadAllBytes($p)
+        ($bytes -contains 13) | Should -BeFalse
+        $bytes[0] | Should -Not -Be 0xEF
+        [Text.Encoding]::UTF8.GetString($bytes) | Should -Be "one`ntwo`n"
+    }
+
+    It 'ends the file with exactly one LF' {
+        $p = Join-Path $TestDrive 'b.md'
+        Write-Utf8LfFile -Path $p -Content 'x'
+        [IO.File]::ReadAllText($p) | Should -Be "x`n"
+        Write-Utf8LfFile -Path $p -Content "x`n"
+        [IO.File]::ReadAllText($p) | Should -Be "x`n"
+    }
+
+    It 'creates the parent directory' {
+        $p = Join-Path $TestDrive 'nested\deeper\c.md'
+        Write-Utf8LfFile -Path $p -Content 'y'
+        Test-Path -LiteralPath $p | Should -BeTrue
+    }
+
+    It 'is what setup uses for every rendered .md it writes' {
+        $setup = Get-Content -LiteralPath (Join-Path $PSScriptRoot '..\setup-windows.ps1') -Raw
+        ([regex]::Matches($setup, 'Write-Utf8LfFile -Path')).Count | Should -BeGreaterOrEqual 3
+        $setup | Should -Not -Match 'Set-Content -LiteralPath \$catFile'
+    }
+}

--- a/tests/copilot-native-skills-smoke.ps1
+++ b/tests/copilot-native-skills-smoke.ps1
@@ -47,6 +47,9 @@ try {
     if ($parseErrors.Count -gt 0) {
         throw "setup-windows.ps1 failed to parse: $($parseErrors[0].Message)"
     }
+    # Write-Utf8LfFile (and the console encoding block) live in utils.ps1, which
+    # setup-windows.ps1 dot-sources before Deploy-SkillRecord runs.
+    . (Join-Path $repoRoot 'scripts\utils.ps1')
     foreach ($functionName in @(
         'Test-SkillTargetsAgent',
         'Get-SkillField',
@@ -58,7 +61,29 @@ try {
 
     $env:USERPROFILE = $scratch
     $env:COPILOT_HOME = $copilotHome
+    # The catalog is injected into an EXISTING deployed instructions file (the
+    # base file is copied verbatim earlier in setup). Seed it from the repo
+    # source so the injector runs, then assert the LF/no-BOM contract the
+    # doctor's drift check depends on (WIN-008/#1289).
+    Ensure-Directory $copilotHome
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'ai\copilot\copilot-instructions.md') -Destination (Join-Path $copilotHome 'copilot-instructions.md') -Force
     Deploy-SkillRecord -DotfilesDir $repoRoot
+
+    $instructions = Join-Path $copilotHome 'copilot-instructions.md'
+    $bytes = [System.IO.File]::ReadAllBytes($instructions)
+    if (-not ([System.Text.Encoding]::UTF8.GetString($bytes) -match 'skill catalog')) {
+        throw "catalog was not injected into $instructions"
+    }
+    if ($bytes -contains 13) {
+        throw "$instructions carries CR bytes; the deployed copy must stay LF like its repo source"
+    }
+    if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+        throw "$instructions starts with a UTF-8 BOM"
+    }
+    $skillBytes = [System.IO.File]::ReadAllBytes((Join-Path $copilotHome 'skills\handoff\SKILL.md'))
+    if ($skillBytes -contains 13) {
+        throw "rendered SKILL.md carries CR bytes"
+    }
 
     $handoff = Join-Path $copilotHome 'skills\handoff\SKILL.md'
     $auxiliary = Join-Path $copilotHome 'skills\systematic-debugging\root-cause-tracing.md'
@@ -75,13 +100,18 @@ try {
 
     $output = & $copilot.Source skill list 2>&1
     if ($LASTEXITCODE -ne 0) {
-        throw "copilot skill list failed:`n$($output -join "`n")"
+        # The deploy half above is the deterministic guard. Discovery needs the
+        # CLI itself to run, which on a runner without a Copilot login may not;
+        # say so loudly rather than fail the deploy assertions with it.
+        Write-Warn "copilot skill list failed (discovery not verified):`n$($output -join "`n")"
+        Write-Output 'Windows setup deployed handoff (LF, no BOM); Copilot discovery not verified on this host.'
+        return
     }
     if (($output -join "`n") -notmatch '(?m)^\s*handoff\s+-') {
-        throw "Copilot did not discover handoff in $skillTarget`n$($output -join "`n")"
+        throw "Copilot did not discover handoff in $copilotHome`n$($output -join "`n")"
     }
 
-    Write-Output 'Windows setup deployed handoff and Copilot discovered it.'
+    Write-Output 'Windows setup deployed handoff (LF, no BOM) and Copilot discovered it.'
 }
 finally {
     $env:COPILOT_HOME = $previousCopilotHome

--- a/tests/copilot-native-skills.Tests.ps1
+++ b/tests/copilot-native-skills.Tests.ps1
@@ -1,0 +1,21 @@
+# Pester 5 wrapper for tests/copilot-native-skills-smoke.ps1: Deploy-SkillRecord
+# end to end into a scratch COPILOT_HOME (handoff rendered, auxiliary file kept,
+# claude-only skill filtered out, instructions file LF and BOM-free with the
+# catalog injected) plus `copilot skill list` discovery where the CLI can run.
+#
+# The smoke script was invoked nowhere before this file existed: Pester
+# discovers *.Tests.ps1 only, so the one test exercising the injector never ran
+# in CI while the injector wrote CRLF for months (WIN-008/#1289, TEST-003/#1298).
+# Skipped where copilot is not installed; the skip is computed at discovery
+# time, not in BeforeAll (WIN-004 lesson).
+
+$script:hasCopilot = [bool](Get-Command copilot -ErrorAction SilentlyContinue)
+
+Describe 'copilot native skills (Deploy-SkillRecord end to end)' -Skip:(-not $script:hasCopilot) {
+
+    It 'deploys handoff with LF, no BOM, and the catalog injected' {
+        $smoke = Join-Path $PSScriptRoot 'copilot-native-skills-smoke.ps1'
+        $out = & $smoke 2>&1 | Out-String
+        $out | Should -Match 'deployed handoff \(LF, no BOM\)'
+    }
+}

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -810,3 +810,22 @@ setup() {
     grep -qF 'dotf harness mirror' "$PS1_SCRIPT"
     grep -qF 'dotf harness mirror' "$DOTFILES_DIR/setup-linux.sh"
 }
+
+@test "setup-windows.ps1 writes rendered skill files and the copilot catalog through Write-Utf8LfFile, never Set-Content (WIN-008)" {
+    # Set-Content joins with CRLF and rewrites the whole file, so the deployed
+    # copilot-instructions.md drifted from its LF source on every run (#1289).
+    grep -qF 'Write-Utf8LfFile -Path $catFile' "$PS1_SCRIPT"
+    run grep -qF 'Set-Content -LiteralPath $catFile' "$PS1_SCRIPT"
+    [ "$status" -ne 0 ]
+    run grep -cF 'Write-Utf8LfFile -Path' "$PS1_SCRIPT"
+    [ "$output" -ge 3 ]
+}
+
+@test "setup-windows.ps1 mirrors sensitive/ recursively so dr/ reaches the deploy dir (WIN-011)" {
+    grep -qF "Copy-Item -Path (Join-Path \$sensitiveSource '*') -Destination \$sensitiveDest -Recurse -Force" "$PS1_SCRIPT"
+}
+
+@test "utils.ps1 and profile.ps1 set a UTF-8 console encoding (WIN-009)" {
+    grep -qF '[Console]::OutputEncoding = ' "$DOTFILES_DIR/scripts/utils.ps1"
+    grep -qF '[Console]::OutputEncoding = ' "$DOTFILES_DIR/powershell/profile.ps1"
+}


### PR DESCRIPTION
## Summary

Three Windows setup defects measured 2026-08-27 on the work box, all in the PowerShell layer where the fix genuinely belongs (process state, a file writer, a copy flag). Each has a guard that fails without it.

| Defect | Root cause | Fix |
|---|---|---|
| `ΓÇö` mojibake in captured `dotf` output (WIN-009, #1290) | PowerShell decodes captured native output with `[Console]::OutputEncoding`, which defaults to the OEM code page (437 here). Any block *parsing* captured output read corrupted bytes. | `scripts/utils.ps1` (sourced by setup) and `powershell/profile.ps1` set console I/O to UTF-8 without BOM, guarded for hosts without a console. |
| `.copilot/copilot-instructions.md` deployed CRLF → permanent drift FAIL (WIN-008, #1289; comparator half merged in #1304) | `Set-Content` joins with the platform newline and rewrote the whole file; the same call shape wrote every rendered `SKILL.md` / command file CRLF. | `Write-Utf8LfFile` in `utils.ps1` (LF, no BOM, one trailing LF) replaces the three writers in `Deploy-SkillRecord`. |
| DR escrow never reaches the deploy dir (WIN-011, #1292; doctor half merged in #1304) | `sensitive/` was copied top-level only (`-Filter '*.secret.age'`), so `sensitive/dr/` was never mirrored. | Recursive copy, like `setup-linux.sh`'s `cp -rf sensitive/*`; the success line counts `.age` files recursively. |

Also: `tests/copilot-native-skills-smoke.ps1` was invoked nowhere (Pester discovers `*.Tests.ps1` only) — the one test exercising the injector never ran while the injector wrote CRLF. `tests/copilot-native-skills.Tests.ps1` now runs it; the smoke seeds the instructions file so the injector executes and asserts LF + no BOM on the deployed copy and on a rendered `SKILL.md`. `copilot skill list` discovery stays asserted where the CLI runs and is reported (not failed) where it cannot, since the deploy half is the deterministic guard. Part of TEST-003 (#1298).

Closes #1289, #1290, #1292.

## Evidence (this session, Windows work box)

- Pester `console-encoding.Tests.ps1`: 7/7 — including a child `pwsh` started on code page 437 whose captured native U+2014 reads `False` before and `True` after sourcing `utils.ps1`.
- Pester `copilot-native-skills.Tests.ps1`: 1/1 — `Deploy-SkillRecord` end to end into a scratch `COPILOT_HOME`, catalog injected, 0 CR bytes, no BOM, Copilot discovers `handoff`.
- `bats tests/setup-windows.bats`: 115/115 (three new guards).
- PowerShell AST parse: 0 errors on every touched `.ps1`; non-ASCII byte counts unchanged from `main` (the inserts are ASCII-only); PSScriptAnalyzer: 0 findings on the new files, pre-existing findings unchanged.

## SDD skip rationale

Raw production diff ≈ 76 lines across `utils.ps1`, `setup-windows.ps1`, `profile.ps1`; **executable** lines ≈ 24 (a 6-line try block ×2, an 8-line writer, three one-line call swaps, a two-line copy). Three independent bug fixes with measured causes, each under the 20-line exemption; the rest is the explanatory comment this codebase keeps beside every non-obvious fix. No contract, dependency or schema change.
