### PR TITLE
fix(copilot): config keys the CLI reads, Co-authored-by off, dead exports removed

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -67,7 +67,6 @@ else
     export AGY_HOME="${AGY_HOME:-$HOME/.gemini/antigravity-cli}"
     export COPILOT_HOME="${COPILOT_HOME:-$HOME/.copilot}"
     export OPENCODE_HOME="${OPENCODE_HOME:-$HOME/.config/opencode}"
-    export COPILOT_MODEL="${COPILOT_MODEL:-gpt-5.6}"
 fi
 
 # Telemetry suppression (prevents agent prompts and unnecessary analytics network calls)
@@ -168,6 +167,11 @@ fi
 # AI Tool Aliases
 alias g='agy'
 alias c='claude'
+# GitHub Copilot CLI: cop -> interactive agent; cops -> single-shot prompt with
+# --allow-all-tools (required by the CLI for -p mode). Same pair as aliases.zsh
+# and profile.ps1 -- bash had neither (AI-036/#1296).
+alias cop='copilot'
+cops() { copilot -p "$*" --allow-all-tools -s; }
 alias obsidian='obsidian --no-sandbox'
 
 # Gemini saved-prompt helper `agyp` lives in .zsh/functions.sh (shared bash/zsh,

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,7 @@
 
 ## Model Tier (per AGENTS.md "Model Selection")
 
-- **Top:** `gpt-5.6-terra` / `gpt-5.6` / `claude-3.7-sonnet` (deep reasoning / architecture) | **Mid:** `gpt-5.6-sol` / `gpt-5` (default / implementation / tests) | **Low:** `gpt-5.6-luna` / `o3-mini` (syntax / quick transforms).
+- **Top:** `gpt-5.6-terra` / `claude-opus-5` (deep reasoning / architecture) | **Mid:** `gpt-5.6-sol` / `claude-sonnet-5` (default / implementation / tests) | **Low:** `gpt-5.6-luna` / `claude-haiku-4.5` (syntax / quick transforms). Ids as listed by `copilot help config` on the seat; the cross-agent routing SSOT is `harness/model-map.json`.
 
 ## Skills
 

--- a/.zshrc
+++ b/.zshrc
@@ -37,7 +37,6 @@ else
     export AGY_HOME="${AGY_HOME:-$HOME/.gemini/antigravity-cli}"
     export COPILOT_HOME="${COPILOT_HOME:-$HOME/.copilot}"
     export OPENCODE_HOME="${OPENCODE_HOME:-$HOME/.config/opencode}"
-    export COPILOT_MODEL="${COPILOT_MODEL:-gpt-5.6}"
 fi
 export AGY_APP_DATA="$AGY_HOME"
 export ANTIGRAVITY_ENDPOINT="https://cloudcode-pa.googleapis.com"

--- a/ai/copilot/config.json
+++ b/ai/copilot/config.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://raw.githubusercontent.com/github/copilot-cli/main/schemas/config.json",
-  "defaultModel": "gpt-5.6",
+  "model": "gpt-5.6-sol",
+  "includeCoAuthoredBy": false,
   "trustedFolders": [
     "/home/manu/Projects",
     "/home/manu/Projects/*",

--- a/ai/copilot/copilot-instructions.md
+++ b/ai/copilot/copilot-instructions.md
@@ -19,7 +19,7 @@
 
 ## Model Tier (per AGENTS.md "Model Selection")
 
-- **Top:** `gpt-5.6-terra` / `gpt-5.6` / `claude-3.7-sonnet` (deep reasoning / architecture) | **Mid:** `gpt-5.6-sol` / `gpt-5` (default / implementation / tests) | **Low:** `gpt-5.6-luna` / `o3-mini` (syntax / quick transforms).
+- **Top:** `gpt-5.6-terra` / `claude-opus-5` (deep reasoning / architecture) | **Mid:** `gpt-5.6-sol` / `claude-sonnet-5` (default / implementation / tests) | **Low:** `gpt-5.6-luna` / `claude-haiku-4.5` (syntax / quick transforms). Ids as listed by `copilot help config` on the seat; the cross-agent routing SSOT is `harness/model-map.json`.
 
 ## Skills
 

--- a/tests/aliases.bats
+++ b/tests/aliases.bats
@@ -163,11 +163,14 @@ setup() {
     grep -q 'function gp' "$ps_file"
 }
 
-@test "parity: cop and cops exist in both aliases.zsh and profile.ps1" {
+@test "parity: cop and cops exist in aliases.zsh, .bashrc and profile.ps1" {
     ps_file="$DOTFILES_DIR/powershell/profile.ps1"
+    bashrc_file="$DOTFILES_DIR/.bashrc"
     grep -qE '^alias cop="copilot"' "$ALIASES_FILE"
+    grep -qE "^alias cop='copilot'" "$bashrc_file"
     grep -qE 'Set-Alias -Name cop -Value copilot' "$ps_file"
     grep -qE '^cops\(\)' "$ALIASES_FILE"
+    grep -qE '^cops\(\)' "$bashrc_file"
     grep -qE 'function cops' "$ps_file"
 }
 

--- a/tests/copilot-config.bats
+++ b/tests/copilot-config.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+# ai/copilot/config.json is deployed verbatim to ~/.copilot/config.json. Audited
+# against GitHub Copilot CLI 1.0.80 on 2026-08-27 (AI-036/#1296): the file
+# declared a key the CLI does not read (`defaultModel`; the key is `model`), an
+# id the seat does not list, a `$schema` URL that 404s, and left
+# `includeCoAuthoredBy` at its default of TRUE -- so every commit Copilot made
+# carried a Co-authored-by trailer, against the no-attribution doctrine.
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    export CFG="$DOTFILES_DIR/ai/copilot/config.json"
+}
+
+@test "config.json is valid JSON" {
+    jq -e . "$CFG" >/dev/null
+}
+
+@test "config.json turns Co-authored-by trailers off (no AI attribution doctrine)" {
+    [ "$(jq -r '.includeCoAuthoredBy' "$CFG")" = "false" ]
+}
+
+@test "config.json pins the model under the key the CLI reads, not defaultModel" {
+    [ "$(jq -r '.defaultModel // "absent"' "$CFG")" = "absent" ]
+    model="$(jq -r '.model // ""' "$CFG")"
+    [ -n "$model" ]
+}
+
+@test "config.json carries no \$schema URL (the published one 404s)" {
+    [ "$(jq -r '.["$schema"] // "absent"' "$CFG")" = "absent" ]
+}

--- a/tests/env-contract.bats
+++ b/tests/env-contract.bats
@@ -173,3 +173,13 @@ setup() {
     [[ "$window" == *"\$env:COPILOT_HOME"* ]]
     [[ "$window" == *"\$env:OPENCODE_HOME"* ]]
 }
+
+@test "no rc file exports COPILOT_MODEL (retired: invalid id, fallback-only, absent on Windows) [AI-036]" {
+    # Copilot's model lives in ai/copilot/config.json (`model`) and --model; the
+    # export named a model the seat does not have and ran only in the
+    # paths.sh-missing fallback branch, so it was never set on a converged box.
+    for f in .bashrc .zshrc powershell/profile.ps1; do
+        run grep -F 'COPILOT_MODEL' "$DOTFILES_DIR/$f"
+        [ "$status" -ne 0 ]
+    done
+}


### PR DESCRIPTION
## Summary

Copilot CLI 1.0.80 audit on the Windows work box (AI-036, #1296): what the repo deploys for Copilot vs what the CLI reads.

| Deployed | Reality | Change |
|---|---|---|
| `includeCoAuthoredBy` unset | CLI default is **true**: every commit Copilot makes carries a `Co-authored-by` trailer, against the no-attribution doctrine in `AGENTS.md` | `false` |
| `"defaultModel": "gpt-5.6"` | the key is `model` (`copilot help config`); `gpt-5.6` is not a seat id — a double no-op | `"model": "gpt-5.6-sol"` |
| `$schema` → `raw.githubusercontent.com/github/copilot-cli/main/schemas/config.json` | 404 | removed |
| `export COPILOT_MODEL=gpt-5.6` in `.zshrc`/`.bashrc` | only inside the `paths.sh`-missing fallback branch (never set on a converged box), never on Windows, invalid value | deleted (deletion over correction) |
| `cop`/`cops` in `aliases.zsh` + `profile.ps1` | `.bashrc` had neither; the parity test did not cover bash | added, test widened |
| Model Tier line names `claude-3.7-sonnet`, `gpt-5`, `o3-mini` | none on the seat | seat ids, pointer to `harness/model-map.json` as the routing SSOT (#902). Applied to both copies per the `docs-drift` parity rule |

Verified working on the box (not changed): `copilot skill list` sees all 38 deployed skills; `copilot mcp list` loads the four servers from the deployed `mcp-config.json`; `trustedFolders` honoured.

Closes #1296. Out of scope: harness-emitted Copilot hooks (#803) — a feature with its own spec; the CLI supports `~/.copilot/hooks/*.json` carrying `bash` and `powershell` keys in one file, i.e. an OS-agnostic artifact.

## Evidence

`bats tests/copilot-config.bats tests/aliases.bats tests/env-contract.bats tests/docs-drift.bats` — green (the one failing case on this box is the pre-existing `zsh: command not found`). `bash -n .bashrc` clean.
