### PR TITLE
ci(windows): build dotf from the PR, put it on PATH, and gate on dotf doctor after setup

### DIFF
--- a/.github/scripts/doctor-gate-known-failures.txt
+++ b/.github/scripts/doctor-gate-known-failures.txt
@@ -1,16 +1,21 @@
 # TEST-003 (#1298): runner-only doctor failures the test-windows gate accepts.
 # One regex (.NET, PowerShell -match) per entry, each preceded by a comment that
-# names the owning ticket. The gate fails on any [FAIL] not listed here AND on
-# any entry that no longer matches, so this list only shrinks as tickets close.
+# names the owning ticket and by an "# example:" line quoting the [FAIL] line it
+# was written for -- tests/doctor-gate.Tests.ps1 asserts the pattern matches its
+# example, so a regex that is valid but wrong (a "\s" meant as a backslash) cannot
+# sit here silently. The gate fails on any [FAIL] not listed here AND on any
+# entry that no longer matches, so this list only shrinks as tickets close.
 # A real-box defect never goes here: it is fixed or ticketed, and the gate stays
 # red until then.
 
 # WIN-013 (#1310): env-contract SCRIPTS_DIR defaults to ~/.dotfiles/scripts on
 # Windows, but setup-windows.ps1 deploys scripts to ~/scripts and nothing
 # creates the contract path, so the contract check fails on every fresh box.
-SCRIPTS_DIR=.*\.dotfiles\scripts \(path does not exist\)
+# example:   [FAIL] SCRIPTS_DIR=C:\Users\runneradmin\.dotfiles\scripts (path does not exist)
+SCRIPTS_DIR=.*\.dotfiles\\scripts \(path does not exist\)
 
 # TEST-005 (#1313): the runner has no Bitwarden identity, so the reach tier
 # (exposure-keyed: 28 registry entries resolve through Bitwarden) fails by its
 # own rule. Real boxes log in once; CI cannot and must not resolve real secrets.
+# example:   [FAIL] Bitwarden session is gone (`bw status`: unauthenticated) - run `bw login`, not `bw unlock`
 Bitwarden session is gone \(`bw status`: unauthenticated\)

--- a/.github/scripts/doctor-gate-known-failures.txt
+++ b/.github/scripts/doctor-gate-known-failures.txt
@@ -9,3 +9,8 @@
 # Windows, but setup-windows.ps1 deploys scripts to ~/scripts and nothing
 # creates the contract path, so the contract check fails on every fresh box.
 SCRIPTS_DIR=.*\.dotfiles\scripts \(path does not exist\)
+
+# TEST-005 (#1313): the runner has no Bitwarden identity, so the reach tier
+# (exposure-keyed: 28 registry entries resolve through Bitwarden) fails by its
+# own rule. Real boxes log in once; CI cannot and must not resolve real secrets.
+Bitwarden session is gone \(`bw status`: unauthenticated\)

--- a/.github/scripts/doctor-gate-known-failures.txt
+++ b/.github/scripts/doctor-gate-known-failures.txt
@@ -1,0 +1,11 @@
+# TEST-003 (#1298): runner-only doctor failures the test-windows gate accepts.
+# One regex (.NET, PowerShell -match) per entry, each preceded by a comment that
+# names the owning ticket. The gate fails on any [FAIL] not listed here AND on
+# any entry that no longer matches, so this list only shrinks as tickets close.
+# A real-box defect never goes here: it is fixed or ticketed, and the gate stays
+# red until then.
+
+# WIN-013 (#1310): env-contract SCRIPTS_DIR defaults to ~/.dotfiles/scripts on
+# Windows, but setup-windows.ps1 deploys scripts to ~/scripts and nothing
+# creates the contract path, so the contract check fails on every fresh box.
+SCRIPTS_DIR=.*\.dotfiles\scripts \(path does not exist\)

--- a/.github/scripts/doctor-gate.ps1
+++ b/.github/scripts/doctor-gate.ps1
@@ -1,0 +1,69 @@
+# doctor-gate.ps1 -- the post-setup dotf doctor gate for the test-windows job
+# (TEST-003, #1298).
+#
+# Runs `dotf doctor` the way a fresh terminal would and fails the job unless
+# every [FAIL] line matches an entry in the known-failures list AND every entry
+# matches at least one line. The second half is what keeps the list honest: an
+# entry whose failure no longer occurs is reported as STALE and fails the gate,
+# so the list can only shrink as tickets close, never rot into a blanket allow.
+#
+# Known failures are runner-only conditions with an owning ticket (see the
+# list's comments). A real-box defect is never added there; it is fixed or
+# ticketed, and the gate stays red until then.
+#
+# ASCII-only by repo convention (pattern-powershell-ascii-only).
+
+# Test-DoctorGate: pure classification, unit-tested by tests/doctor-gate.Tests.ps1.
+# Returns an object with Failures (the [FAIL] lines), Unexpected (failures no
+# pattern matched) and Stale (patterns that matched no failure).
+function Test-DoctorGate {
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$Lines,
+        [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$Patterns
+    )
+    $failures = @($Lines | Where-Object { $_ -match '^\s*\[FAIL\]' })
+    $unexpected = @($failures | Where-Object {
+        $line = $_
+        -not ($Patterns | Where-Object { $line -match $_ })
+    })
+    $stale = @($Patterns | Where-Object {
+        $pattern = $_
+        -not ($failures | Where-Object { $_ -match $pattern })
+    })
+    [pscustomobject]@{ Failures = $failures; Unexpected = $unexpected; Stale = $stale }
+}
+
+# Read-KnownFailures: one regex per non-blank, non-comment line.
+function Read-KnownFailures {
+    param([Parameter(Mandatory)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { return @() }
+    @(Get-Content -LiteralPath $Path | ForEach-Object { $_.Trim() } | Where-Object { $_ -and -not $_.StartsWith('#') })
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    $ErrorActionPreference = 'Stop'
+    $known = Join-Path $PSScriptRoot 'doctor-gate-known-failures.txt'
+
+    # A fresh terminal's PATH: setup appends the winget Links dir and npm's
+    # global prefix to the User PATH, but a later workflow step inherits the
+    # runner's original PATH plus GITHUB_PATH only. Without this, every tool
+    # setup just installed reads "not in PATH" (measured on #1308's first run).
+    $env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' +
+        [Environment]::GetEnvironmentVariable('PATH', 'User') + ';' + $env:PATH
+
+    $output = & dotf doctor 2>&1 | Out-String
+    Write-Host $output
+
+    $result = Test-DoctorGate -Lines ($output -split "`r?`n") -Patterns (Read-KnownFailures -Path $known)
+    if ($result.Unexpected.Count -gt 0) {
+        Write-Host "UNEXPECTED doctor failure(s) -- not in $known (fix, or ticket and list with the ticket):"
+        $result.Unexpected | ForEach-Object { Write-Host "  $_" }
+    }
+    if ($result.Stale.Count -gt 0) {
+        Write-Host "STALE known-failure entr(y/ies) -- matched no [FAIL] line; remove them so the list cannot rot:"
+        $result.Stale | ForEach-Object { Write-Host "  $_" }
+    }
+    if ($result.Unexpected.Count -gt 0 -or $result.Stale.Count -gt 0) { exit 1 }
+    Write-Host ("doctor gate: {0} known runner-only FAIL(s), 0 unexpected, 0 stale" -f $result.Failures.Count)
+    exit 0
+}

--- a/.github/scripts/doctor-gate.ps1
+++ b/.github/scripts/doctor-gate.ps1
@@ -51,6 +51,16 @@ if ($MyInvocation.InvocationName -ne '.') {
     $env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' +
         [Environment]::GetEnvironmentVariable('PATH', 'User') + ';' + $env:PATH
 
+    # Name the PATH doctor ran with: a FAIL that reads "git missing" is a
+    # statement about this step's environment before it is one about the box.
+    $entries = @($env:PATH -split ';' | Where-Object { $_ })
+    Write-Host ("doctor gate: PATH has {0} entries, {1} chars" -f $entries.Count, $env:PATH.Length)
+    $entries | ForEach-Object { Write-Host "doctor gate:   $_" }
+    foreach ($probe in 'dotf', 'git', 'bash', 'node', 'bw') {
+        $cmd = Get-Command $probe -ErrorAction SilentlyContinue
+        Write-Host ("doctor gate: {0} -> {1}" -f $probe, ($(if ($cmd) { $cmd.Source } else { 'NOT FOUND' })))
+    }
+
     $output = & dotf doctor 2>&1 | Out-String
     Write-Host $output
 

--- a/.github/scripts/doctor-gate.ps1
+++ b/.github/scripts/doctor-gate.ps1
@@ -18,8 +18,12 @@
 # pattern matched) and Stale (patterns that matched no failure).
 function Test-DoctorGate {
     param(
-        [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$Lines,
-        [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$Patterns
+        # AllowEmptyString on top of AllowEmptyCollection: doctor output has blank
+        # lines between sections, and a Mandatory [string[]] rejects an empty
+        # ELEMENT ("Cannot bind argument ... because it is an empty string") --
+        # the gate died on that with the real output while every fixture passed.
+        [Parameter(Mandatory)][AllowEmptyCollection()][AllowEmptyString()][AllowNull()][string[]]$Lines,
+        [Parameter(Mandatory)][AllowEmptyCollection()][AllowEmptyString()][AllowNull()][string[]]$Patterns
     )
     $failures = @($Lines | Where-Object { $_ -match '^\s*\[FAIL\]' })
     $unexpected = @($failures | Where-Object {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,12 @@ jobs:
           go build -o "$bin\dotf.exe" ./cmd/dotf
           Pop-Location
           Add-Content $env:GITHUB_PATH $bin
+          # And the User PATH (as the age step does): setup-windows.ps1 refreshes
+          # PATH from the registry after its winget loop, which used to drop a
+          # process-only GITHUB_PATH entry -- Install-Dotf then could not see the
+          # source build and replaced it with the release (#1308 third run).
+          $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+          if ($userPath -notlike "*$bin*") { [Environment]::SetEnvironmentVariable('PATH', "$userPath;$bin", 'User') }
           & "$bin\dotf.exe" version
 
       # Install-Dotf leaves a source build (`dotf version` = dev) in place, so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,9 +297,8 @@ jobs:
           Add-Content $env:GITHUB_PATH $bin
           & "$bin\dotf.exe" version
 
-      # DOTF_VERSION=dev keeps Install-Dotf from replacing the source build with
-      # the pinned release: it skips when the binary on PATH reports the pinned
-      # version, and a source build reports "dev". No DOTFILES_DIR override: the
+      # Install-Dotf leaves a source build (`dotf version` = dev) in place, so
+      # the binary built above survives setup. No DOTFILES_DIR override: the
       # deploy dir is the real-box default (~/.dotfiles), so the gate below
       # certifies the tree a real machine reads, not the checkout (#1298 layer 3).
       - name: Run setup-windows.ps1 end-to-end (PS 5.1 -> BUG-005 re-exec)
@@ -307,19 +306,21 @@ jobs:
         shell: powershell
         env:
           DOTFILES_REPO_DIR: ${{ github.workspace }}
-          DOTF_VERSION: dev
         run: .\setup-windows.ps1
 
       # The gate. Setup itself stays non-fatal on doctor (degrade-not-break, C9,
       # asserted by tests/setup-windows.bats); CI is where a red doctor fails.
+      # .github/scripts/doctor-gate.ps1 refreshes PATH the way a fresh terminal
+      # would (setup appends winget/npm dirs to the User PATH, which a later
+      # step does not inherit) and fails on any [FAIL] not listed -- with its
+      # owning ticket -- in doctor-gate-known-failures.txt, or on a listed
+      # entry that no longer fires (a stale list is a failure too).
       - name: Post-setup doctor gate (TEST-003)
         if: needs.changes.outputs.code == 'true'
         shell: pwsh
         env:
           DOTFILES_REPO_DIR: ${{ github.workspace }}
-        run: |
-          dotf doctor
-          if ($LASTEXITCODE -ne 0) { throw "dotf doctor reported failures after setup-windows.ps1 (see above)" }
+        run: pwsh -NoProfile -File .github/scripts/doctor-gate.ps1
 
       - name: Run Pester suites
         if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,13 +273,53 @@ jobs:
           Set-Content (Join-Path $stub 'obsidian.cmd') '@echo off'
           Add-Content $env:GITHUB_PATH $stub
 
+      # TEST-003 (#1298): setup installed dotf into ~/.local/bin and never put
+      # it on PATH, so every dotf-gated block (deploy, render, tools install,
+      # the post-setup doctor) skipped with a warning and the job stayed green
+      # over a red box. Build dotf from THIS PR (the released binary lags the
+      # tree; the integration container builds from source for the same
+      # reason) and make it reachable by effect before setup runs.
+      - uses: actions/setup-go@v7
+        if: needs.changes.outputs.code == 'true'
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: Build dotf from this PR and put ~/.local/bin on PATH (TEST-003)
+        if: needs.changes.outputs.code == 'true'
+        shell: pwsh
+        run: |
+          $bin = "$env:USERPROFILE\.local\bin"
+          New-Item -ItemType Directory -Force $bin | Out-Null
+          Push-Location cli
+          go build -o "$bin\dotf.exe" ./cmd/dotf
+          Pop-Location
+          Add-Content $env:GITHUB_PATH $bin
+          & "$bin\dotf.exe" version
+
+      # DOTF_VERSION=dev keeps Install-Dotf from replacing the source build with
+      # the pinned release: it skips when the binary on PATH reports the pinned
+      # version, and a source build reports "dev". No DOTFILES_DIR override: the
+      # deploy dir is the real-box default (~/.dotfiles), so the gate below
+      # certifies the tree a real machine reads, not the checkout (#1298 layer 3).
       - name: Run setup-windows.ps1 end-to-end (PS 5.1 -> BUG-005 re-exec)
         if: needs.changes.outputs.code == 'true'
         shell: powershell
         env:
-          DOTFILES_DIR: ${{ github.workspace }}
           DOTFILES_REPO_DIR: ${{ github.workspace }}
+          DOTF_VERSION: dev
         run: .\setup-windows.ps1
+
+      # The gate. Setup itself stays non-fatal on doctor (degrade-not-break, C9,
+      # asserted by tests/setup-windows.bats); CI is where a red doctor fails.
+      - name: Post-setup doctor gate (TEST-003)
+        if: needs.changes.outputs.code == 'true'
+        shell: pwsh
+        env:
+          DOTFILES_REPO_DIR: ${{ github.workspace }}
+        run: |
+          dotf doctor
+          if ($LASTEXITCODE -ne 0) { throw "dotf doctor reported failures after setup-windows.ps1 (see above)" }
 
       - name: Run Pester suites
         if: needs.changes.outputs.code == 'true'

--- a/cli/internal/doctor/checks_deploy.go
+++ b/cli/internal/doctor/checks_deploy.go
@@ -509,7 +509,10 @@ func checkInstructionDrift(sys *System, rep *Report) {
 			continue
 		}
 		checked++
-		if stripHarnessRegions(string(dc)) != stripHarnessRegions(string(sc)) {
+		// Trailing newlines are not content either: the LF writer on Windows
+		// ends a file with exactly one, while a source may end with a blank
+		// line, and that alone read as drift on the CI runner (#1308).
+		if strings.TrimRight(stripHarnessRegions(string(dc)), "\n") != strings.TrimRight(stripHarnessRegions(string(sc)), "\n") {
 			rep.Fail("stale: " + tgt.homeRel + " has drifted from " + tgt.repoRel + " (run: compile-harness.sh --deploy)")
 			drift++
 		}

--- a/cli/internal/doctor/checks_instruction_drift_crlf_test.go
+++ b/cli/internal/doctor/checks_instruction_drift_crlf_test.go
@@ -37,3 +37,25 @@ func TestCheckInstructionDrift_CRLFDeployedCopyIsNotDrift(t *testing.T) {
 		t.Errorf("all four targets should have been compared\n%s", buf.String())
 	}
 }
+
+// A source that ends with a blank line and a deployed copy that ends with one
+// newline are the same document. Windows' LF writer normalises the tail to a
+// single "\n"; the repo source of copilot-instructions.md ends "-->\n\n", and
+// the CI gate reported drift on nothing but that (#1308).
+func TestCheckInstructionDrift_TrailingNewlinesAreNotDrift(t *testing.T) {
+	repo, home := t.TempDir(), t.TempDir()
+	for _, tgt := range deployedInstructionTargets {
+		body := "# " + tgt.repoRel + "\n\nshared content\n<!-- BEGIN HARNESS GENERATED -->\n<!-- END HARNESS GENERATED -->\n"
+		writeFile(t, filepath.Join(repo, tgt.repoRel), body+"\n")
+		writeFile(t, filepath.Join(home, tgt.homeRel), body)
+	}
+	sys := newSys(map[string]string{"HOME": home, "DOTFILES_REPO_DIR": repo}, []string{"copilot"}, nil)
+
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	checkInstructionDrift(sys, rep)
+
+	if rep.Failures() != 0 {
+		t.Fatalf("a trailing blank line must not be drift\n%s", buf.String())
+	}
+}

--- a/cli/internal/doctor/checks_test.go
+++ b/cli/internal/doctor/checks_test.go
@@ -421,6 +421,24 @@ func TestCheckOptionalTools_DotfDrift(t *testing.T) {
 	}
 }
 
+// A source build reports "dev" (cli/cmd/dotf/main.go). It is deliberate on a
+// dev box and is what CI runs after building the PR under test; the pin exists
+// to catch a stale RELEASE, so this is a SKIP with the reason, never drift.
+func TestCheckOptionalTools_DotfSourceBuildIsNotDrift(t *testing.T) {
+	cfg := &Config{Versions: map[string]string{"DOTF_VERSION": "0.2.0"}}
+	var buf bytes.Buffer
+	rep := capture(&buf)
+	checkOptionalTools(
+		newSys(nil, []string{"dotf", "gh"}, map[string]string{"dotf version": "dotf version dev"}),
+		cfg, nil, rep)
+	if rep.Failures() != 0 {
+		t.Errorf("a dev build must not be reported as drift\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "source build (dev)") {
+		t.Errorf("expected the source-build SKIP\n%s", buf.String())
+	}
+}
+
 func TestCheckHarnessDrift(t *testing.T) {
 	home := t.TempDir()
 	dotfiles := filepath.Join(home, ".dotfiles")

--- a/cli/internal/doctor/checks_test.go
+++ b/cli/internal/doctor/checks_test.go
@@ -404,39 +404,77 @@ func TestCheckTmux(t *testing.T) {
 	})
 }
 
-func TestCheckOptionalTools_DotfDrift(t *testing.T) {
-	cfg := &Config{Versions: map[string]string{"DOTF_VERSION": "0.2.0"}}
-	var buf bytes.Buffer
-	rep := capture(&buf)
-	checkOptionalTools(
-		newSys(nil, []string{"dotf", "gh"}, map[string]string{"dotf version": "dotf version 0.1.0"}),
-		cfg, nil, rep)
-	// FAIL, not WARN (OPS-025/#869): a stale dotf binary silently carries none of
-	// the guards merged since it was built, so drift here must be loud.
-	if rep.Failures() != 1 {
-		t.Errorf("dotf version drift must FAIL\n%s", buf.String())
+// dotf's version-pin match, one row per branch (OPS-025/#869, TEST-003/#1298).
+// The status tag is the contract, not the message: a stale RELEASE binary FAILs
+// because it silently carries none of the guards merged since it was built; a
+// source build ("dev", cli/cmd/dotf/main.go's default) SKIPs because the pin
+// exists to catch a stale release, and CI runs the PR's own build.
+func TestCheckOptionalTools_DotfVersion(t *testing.T) {
+	cases := []struct {
+		name, installed string
+		want            Status
+	}{
+		{"exact pin", "0.2.0", StatusPass},
+		{"stale release", "0.1.0", StatusFail},
+		{"source build", "dev", StatusSkip},
 	}
-	if !strings.Contains(buf.String(), "dotf version drift") {
-		t.Errorf("expected dotf drift failure\n%s", buf.String())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{Versions: map[string]string{"DOTF_VERSION": "0.2.0"}}
+			var buf bytes.Buffer
+			rep := capture(&buf)
+			checkOptionalTools(
+				newSys(nil, []string{"dotf", "gh"}, map[string]string{"dotf version": "dotf version " + tc.installed}),
+				cfg, nil, rep)
+			if got := statusOfLine(buf.String(), "dotf"); got != tc.want {
+				t.Errorf("dotf %s: status %q, want %q\n%s", tc.installed, statusTag[got], statusTag[tc.want], buf.String())
+			}
+		})
 	}
 }
 
-// A source build reports "dev" (cli/cmd/dotf/main.go). It is deliberate on a
-// dev box and is what CI runs after building the PR under test; the pin exists
-// to catch a stale RELEASE, so this is a SKIP with the reason, never drift.
-func TestCheckOptionalTools_DotfSourceBuildIsNotDrift(t *testing.T) {
-	cfg := &Config{Versions: map[string]string{"DOTF_VERSION": "0.2.0"}}
-	var buf bytes.Buffer
-	rep := capture(&buf)
-	checkOptionalTools(
-		newSys(nil, []string{"dotf", "gh"}, map[string]string{"dotf version": "dotf version dev"}),
-		cfg, nil, rep)
-	if rep.Failures() != 0 {
-		t.Errorf("a dev build must not be reported as drift\n%s", buf.String())
+// The .exe probe follows the injected platform, never the test host's: a
+// JAVA_HOME holding only bin/java.exe is a real install on Windows (the GitHub
+// runner's toolcache, TEST-003/#1298) and a missing binary anywhere else.
+func TestCheckVersionedPaths_ExeFollowsInjectedGOOS(t *testing.T) {
+	home := t.TempDir()
+	writeExec(t, filepath.Join(home, "bin", "java.exe"))
+	cases := []struct {
+		goos string
+		want Status
+	}{
+		{"windows", StatusPass},
+		{"linux", StatusFail},
 	}
-	if !strings.Contains(buf.String(), "source build (dev)") {
-		t.Errorf("expected the source-build SKIP\n%s", buf.String())
+	for _, tc := range cases {
+		t.Run(tc.goos, func(t *testing.T) {
+			sys := newSys(map[string]string{"JAVA_HOME": home}, nil, nil)
+			sys.GOOS = tc.goos
+			var buf bytes.Buffer
+			rep := capture(&buf)
+			checkVersionedPaths(sys, rep)
+			if got := statusOfLine(buf.String(), "JAVA_HOME"); got != tc.want {
+				t.Errorf("GOOS=%s: status %q, want %q\n%s", tc.goos, statusTag[got], statusTag[tc.want], buf.String())
+			}
+		})
 	}
+}
+
+// statusOfLine returns the Status whose tag (statusTag, report.go) marks the
+// first line mentioning needle, or -1 — the tag is the stable contract, the
+// message is prose.
+func statusOfLine(output, needle string) Status {
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, needle) {
+			continue
+		}
+		for _, s := range []Status{StatusPass, StatusFail, StatusWarn, StatusSkip} {
+			if strings.Contains(line, statusTag[s]) {
+				return s
+			}
+		}
+	}
+	return -1
 }
 
 func TestCheckHarnessDrift(t *testing.T) {

--- a/cli/internal/doctor/checks_tools.go
+++ b/cli/internal/doctor/checks_tools.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -14,7 +15,11 @@ var coreTools = []string{
 
 // posixOnlyTools are absent on Windows by design — skip them there instead of
 // reporting a false failure (Windows uses pwsh, not zsh; direnv is POSIX-shell).
-var posixOnlyTools = map[string]bool{"zsh": true, "direnv": true}
+// wget joined on the first CI doctor run (TEST-003/#1298): no Windows setup
+// block installs it and no Windows script calls it (curl and Invoke-WebRequest
+// cover the role), so expecting it there failed every fresh box for a tool the
+// repo never provisions.
+var posixOnlyTools = map[string]bool{"zsh": true, "direnv": true, "wget": true}
 
 // checkCoreTools reproduces healthcheck section 1: the core toolchain is on
 // PATH. Names already version-checked by the contract (git, jq) are skipped here
@@ -63,7 +68,11 @@ func checkVersionedPaths(sys *System, rep *Report) {
 		switch {
 		case dir == "":
 			rep.Skip(t.envVar + " (variable not set)")
-		case isExecFile(filepath.Join(dir, "bin", t.binary)):
+		case isExecFile(filepath.Join(dir, "bin", t.binary)),
+			runtime.GOOS == "windows" && isExecFile(filepath.Join(dir, "bin", t.binary+".exe")):
+			// The .exe form: a JAVA_HOME set by the GitHub runner's toolcache
+			// holds java.exe, and the extensionless probe reported it missing
+			// (TEST-003/#1298 first run).
 			rep.Pass(fmt.Sprintf("%s (%s)", t.envVar, dir))
 		case isDir(dir):
 			rep.Fail(fmt.Sprintf("%s directory exists but %s not found in %s/bin/", t.envVar, t.binary, dir))
@@ -231,9 +240,15 @@ func checkOptionalTools(sys *System, cfg *Config, c *Contract, rep *Report) {
 		rep.Pass("dotf in PATH (DOTF_VERSION not pinned — match not verified)")
 	default:
 		got := dotfVersion(sys)
-		if got == pin {
+		switch {
+		case got == pin:
 			rep.Pass(fmt.Sprintf("dotf %s matches versions.conf", pin))
-		} else {
+		case got == "dev":
+			// A source build (cli/cmd/dotf/main.go's default): deliberate on a
+			// dev box, and what CI runs after building the PR under test. The
+			// pin exists to catch a STALE RELEASE binary, which this is not.
+			rep.Skip("dotf is a source build (dev) — the versions.conf pin does not apply")
+		default:
 			// FAIL, not WARN (OPS-025/#869): a stale dotf binary means every guard
 			// merged into doctor since it was built is not running at all on this
 			// machine — a categorically worse gap than an ordinary tool being one

--- a/cli/internal/doctor/checks_tools.go
+++ b/cli/internal/doctor/checks_tools.go
@@ -240,10 +240,10 @@ func checkOptionalTools(sys *System, cfg *Config, c *Contract, rep *Report) {
 		rep.Pass("dotf in PATH (DOTF_VERSION not pinned — match not verified)")
 	default:
 		got := dotfVersion(sys)
-		switch {
-		case got == pin:
+		switch got {
+		case pin:
 			rep.Pass(fmt.Sprintf("dotf %s matches versions.conf", pin))
-		case got == "dev":
+		case "dev":
 			// A source build (cli/cmd/dotf/main.go's default): deliberate on a
 			// dev box, and what CI runs after building the PR under test. The
 			// pin exists to catch a STALE RELEASE binary, which this is not.

--- a/cli/internal/doctor/checks_tools.go
+++ b/cli/internal/doctor/checks_tools.go
@@ -3,7 +3,6 @@ package doctor
 import (
 	"fmt"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -69,7 +68,7 @@ func checkVersionedPaths(sys *System, rep *Report) {
 		case dir == "":
 			rep.Skip(t.envVar + " (variable not set)")
 		case isExecFile(filepath.Join(dir, "bin", t.binary)),
-			runtime.GOOS == "windows" && isExecFile(filepath.Join(dir, "bin", t.binary+".exe")):
+			sys.GOOS == "windows" && isExecFile(filepath.Join(dir, "bin", t.binary+".exe")):
 			// The .exe form: a JAVA_HOME set by the GitHub runner's toolcache
 			// holds java.exe, and the extensionless probe reported it missing
 			// (TEST-003/#1298 first run).
@@ -231,7 +230,14 @@ func checkOptionalTools(sys *System, cfg *Config, c *Contract, rep *Report) {
 		}
 	}
 
-	// dotf — the CLI these twins converge into (ADR-020).
+	checkDotfVersion(sys, cfg, rep)
+}
+
+// checkDotfVersion reports dotf itself — the CLI these twins converge into
+// (ADR-020) — against the versions.conf pin. Absent → SKIP; unpinned → PASS
+// unverified; a stale release → FAIL; a source build ("dev") → SKIP, since
+// the pin exists to catch a stale release and CI runs the PR's own build.
+func checkDotfVersion(sys *System, cfg *Config, rep *Report) {
 	pin := cfg.Versions["DOTF_VERSION"]
 	switch {
 	case !sys.has("dotf"):

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -59,6 +59,29 @@ function Write-Utf8LfFile {
 # Usage:
 #   . $PSScriptRoot\utils.ps1
 #   Deploy-File "C:\repo\.zshrc" "$env:USERPROFILE\.zshrc"
+# Sync-SessionPath: rebuild this process's PATH as Machine + User + the
+# current process PATH, first occurrence wins (case-insensitive, a trailing
+# backslash does not make a different entry). Setup calls it after every block
+# that installs into the registry PATH so the new tools resolve in this same
+# run; registry first so a fresh winget install beats a stale process entry.
+# The process PATH is kept because an entry that exists only here (a CI
+# GITHUB_PATH addition, a build dir put on PATH for the run) was silently
+# dropped by the registry-only rebuild this replaces (TEST-003/#1298), and the
+# merge is deduplicated because the plain concatenation that first fixed that
+# doubled PATH on every call -- 153 entries, 72 of them duplicates, measured on
+# the CI runner (#1308).
+function Sync-SessionPath {
+    $seen = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    $merged = foreach ($entry in @(
+            [Environment]::GetEnvironmentVariable('PATH', 'Machine'),
+            [Environment]::GetEnvironmentVariable('PATH', 'User'),
+            $env:PATH) -split ';') {
+        $e = "$entry".Trim()
+        if ($e -and $seen.Add($e.TrimEnd('\'))) { $e }
+    }
+    $env:PATH = @($merged) -join ';'
+}
+
 function Deploy-File {
     param(
         [Parameter(Mandatory)][string]$Source,

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -966,7 +966,10 @@ if (-not $uvCmd) {
     try {
         $uvInstaller = Join-Path $env:TEMP "uv-install.ps1"
         Invoke-RestMethod https://astral.sh/uv/install.ps1 -OutFile $uvInstaller
-        & $uvInstaller 2>$null
+        # A child process, never dot-sourced or run in this session: a remote
+        # installer may rewrite $env:PATH/PATHEXT for its own shell, and the
+        # runner lost npm right after these two (TEST-003/#1298).
+        & (Get-Process -Id $PID).Path -NoProfile -ExecutionPolicy Bypass -File $uvInstaller 2>$null
         Remove-Item -Path $uvInstaller -Force -ErrorAction SilentlyContinue
         # Refresh PATH for current session
         $env:PATH = "$env:USERPROFILE\.local\bin;$env:PATH"
@@ -1009,7 +1012,7 @@ if (-not $bunCmd) {
     try {
         $bunInstaller = Join-Path $env:TEMP "bun-install.ps1"
         Invoke-RestMethod https://bun.sh/install.ps1 -OutFile $bunInstaller
-        & $bunInstaller 2>$null
+        & (Get-Process -Id $PID).Path -NoProfile -ExecutionPolicy Bypass -File $bunInstaller 2>$null
         Remove-Item -Path $bunInstaller -Force -ErrorAction SilentlyContinue
         # Refresh PATH for current session
         $env:PATH = "$env:USERPROFILE\.bun\bin;$env:PATH"
@@ -1025,6 +1028,12 @@ if (-not $bunCmd) {
 } else {
     Write-Info "Bun already installed"
 }
+
+# What the rest of setup will see. The npm-driven blocks below (Obsidian CLI,
+# yarn, pi) each skip silently when npm is missing; naming the state here
+# turns "npm not available" into a finding with a cause.
+$npmSeen = Get-Command npm -ErrorAction SilentlyContinue
+Write-Info ("PATH after the tool installers: {0} entries; npm: {1}" -f (($env:PATH -split ';' | Where-Object { $_ }).Count), $(if ($npmSeen) { $npmSeen.Source } else { 'absent' }))
 
 # ============================================================================
 # 2c. OBSIDIAN CLI (BUG-013)

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -412,12 +412,13 @@ if ($wingetCmd) {
     # blocks of this same setup run (otherwise Get-Command misses them until
     # the next shell start; first introduced for BUG-003 so the Copilot config
     # deploy block sees the just-installed `copilot` binary).
-    # Keep the process PATH too: an entry that exists only in this process (a
-    # CI GITHUB_PATH addition, a shell that put a build dir on PATH for the run)
-    # was silently dropped here, and every dotf block after this line then ran
-    # against whatever the registry PATH resolved -- on the CI runner, nothing
+    # Sync-SessionPath (utils.ps1) keeps the process PATH too: an entry that
+    # exists only in this process (a CI GITHUB_PATH addition, a shell that put a
+    # build dir on PATH for the run) was silently dropped by a registry-only
+    # rebuild here, and every dotf block after this line then ran against
+    # whatever the registry PATH resolved -- on the CI runner, nothing
     # (TEST-003/#1298). Registry first so fresh winget installs still win.
-    $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [Environment]::GetEnvironmentVariable("PATH", "User") + ";" + $env:PATH
+    Sync-SessionPath
 } else {
     Write-Warn "winget not found, skipping developer tools installation"
 }
@@ -1052,10 +1053,10 @@ if (-not $obsidianCmd) {
             & npm install -g 'obsidian-cli' 2>$null | Out-Null
             # Refresh PATH so the freshly-installed binary is visible in this
             # session (same trick as the winget block in section 1c).
-            # Keep the process PATH (same rule as the refresh after the winget loop):
-            # this registry-only rebuild dropped the runner's toolcache node, so
-            # "npm not available, skipping pi install" followed it (TEST-003/#1298).
-            $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [Environment]::GetEnvironmentVariable("PATH", "User") + ";" + $env:PATH
+            # Same helper as the refresh after the winget loop: the registry-only
+            # rebuild this replaces dropped the runner's toolcache node, so "npm
+            # not available, skipping pi install" followed it (TEST-003/#1298).
+            Sync-SessionPath
             if (Get-Command obsidian -ErrorAction SilentlyContinue) {
                 Write-Success "Obsidian CLI installed"
             } else {

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1043,7 +1043,10 @@ if (-not $obsidianCmd) {
             & npm install -g 'obsidian-cli' 2>$null | Out-Null
             # Refresh PATH so the freshly-installed binary is visible in this
             # session (same trick as the winget block in section 1c).
-            $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [Environment]::GetEnvironmentVariable("PATH", "User")
+            # Keep the process PATH (same rule as the refresh after the winget loop):
+            # this registry-only rebuild dropped the runner's toolcache node, so
+            # "npm not available, skipping pi install" followed it (TEST-003/#1298).
+            $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [Environment]::GetEnvironmentVariable("PATH", "User") + ";" + $env:PATH
             if (Get-Command obsidian -ErrorAction SilentlyContinue) {
                 Write-Success "Obsidian CLI installed"
             } else {

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -412,7 +412,12 @@ if ($wingetCmd) {
     # blocks of this same setup run (otherwise Get-Command misses them until
     # the next shell start; first introduced for BUG-003 so the Copilot config
     # deploy block sees the just-installed `copilot` binary).
-    $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [Environment]::GetEnvironmentVariable("PATH", "User")
+    # Keep the process PATH too: an entry that exists only in this process (a
+    # CI GITHUB_PATH addition, a shell that put a build dir on PATH for the run)
+    # was silently dropped here, and every dotf block after this line then ran
+    # against whatever the registry PATH resolved -- on the CI runner, nothing
+    # (TEST-003/#1298). Registry first so fresh winget installs still win.
+    $env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [Environment]::GetEnvironmentVariable("PATH", "User") + ";" + $env:PATH
 } else {
     Write-Warn "winget not found, skipping developer tools installation"
 }

--- a/tests/ci-windows-doctor-gate.bats
+++ b/tests/ci-windows-doctor-gate.bats
@@ -48,7 +48,3 @@ test_windows_job() {
     awk 'BEGIN{ok=1} /^[[:space:]]*$/{seen=0; next} /^#/{ if ($0 ~ /#[0-9]+/) seen=1; next } { if (!seen) { print "no ticket before: " $0; ok=0 } seen=0 } END{exit !ok}' \
         "$DOTFILES_DIR/.github/scripts/doctor-gate-known-failures.txt"
 }
-
-@test "TEST-003: the source build survives setup because Install-Dotf leaves a dev build in place" {
-    grep -qF "if (\$current -eq 'dev') {" "$DOTFILES_DIR/scripts/install-dotf.ps1"
-}

--- a/tests/ci-windows-doctor-gate.bats
+++ b/tests/ci-windows-doctor-gate.bats
@@ -31,14 +31,24 @@ test_windows_job() {
     [ "$status" -ne 0 ]
 }
 
-@test "TEST-003: a post-setup dotf doctor step fails the job on a non-zero exit" {
+@test "TEST-003: a post-setup doctor gate step runs the gate script, which exits non-zero on an unlisted or stale FAIL" {
     job="$(test_windows_job)"
     printf '%s\n' "$job" | grep -qF 'Post-setup doctor gate'
-    printf '%s\n' "$job" | grep -qF 'dotf doctor'
-    printf '%s\n' "$job" | grep -qF 'if ($LASTEXITCODE -ne 0) { throw'
+    printf '%s\n' "$job" | grep -qF 'pwsh -NoProfile -File .github/scripts/doctor-gate.ps1'
+    grep -qF '& dotf doctor' "$DOTFILES_DIR/.github/scripts/doctor-gate.ps1"
+    grep -qF 'exit 1' "$DOTFILES_DIR/.github/scripts/doctor-gate.ps1"
 }
 
-@test "TEST-003: the source build is kept by Install-Dotf (DOTF_VERSION=dev on the setup step)" {
-    job="$(test_windows_job)"
-    printf '%s\n' "$job" | grep -qF 'DOTF_VERSION: dev'
+@test "TEST-003: the gate refreshes PATH like a fresh terminal before running doctor" {
+    grep -qF "[Environment]::GetEnvironmentVariable('PATH', 'User')" "$DOTFILES_DIR/.github/scripts/doctor-gate.ps1"
+}
+
+@test "TEST-003: every known-failure entry names its owning ticket" {
+    # An entry without a ticket is an allow rule nobody owns.
+    awk 'BEGIN{ok=1} /^[[:space:]]*$/{seen=0; next} /^#/{ if ($0 ~ /#[0-9]+/) seen=1; next } { if (!seen) { print "no ticket before: " $0; ok=0 } seen=0 } END{exit !ok}' \
+        "$DOTFILES_DIR/.github/scripts/doctor-gate-known-failures.txt"
+}
+
+@test "TEST-003: the source build survives setup because Install-Dotf leaves a dev build in place" {
+    grep -qF "if (\$current -eq 'dev') {" "$DOTFILES_DIR/scripts/install-dotf.ps1"
 }

--- a/tests/ci-windows-doctor-gate.bats
+++ b/tests/ci-windows-doctor-gate.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# TEST-003 (#1298): the test-windows job installed dotf into ~/.local/bin and
+# never put it on PATH, so every dotf-gated setup block skipped with a warning,
+# dotf doctor never ran in CI, and the job stayed green over a box that failed
+# four doctor checks. These guards keep the three masking layers from returning:
+# dotf reachable before setup, the deploy dir left at its real-box default, and
+# a post-setup doctor step that fails the job.
+
+setup() {
+    export DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    export CI_YML="$DOTFILES_DIR/.github/workflows/ci.yml"
+}
+
+# The test-windows job body only.
+test_windows_job() {
+    awk '/^  test-windows:/{flag=1; next} /^  [a-z0-9_-]+:/{flag=0} flag' "$CI_YML"
+}
+
+@test "TEST-003: test-windows builds dotf from the PR and puts ~/.local/bin on GITHUB_PATH before setup" {
+    job="$(test_windows_job)"
+    printf '%s\n' "$job" | grep -qF 'go build -o "$bin\dotf.exe" ./cmd/dotf'
+    printf '%s\n' "$job" | grep -qF 'Add-Content $env:GITHUB_PATH $bin'
+    build_line=$(printf '%s\n' "$job" | grep -n 'Build dotf from this PR' | head -1 | cut -d: -f1)
+    setup_line=$(printf '%s\n' "$job" | grep -n 'run: .\\setup-windows.ps1' | head -1 | cut -d: -f1)
+    [ -n "$build_line" ] && [ -n "$setup_line" ]
+    [ "$build_line" -lt "$setup_line" ]
+}
+
+@test "TEST-003: setup runs with the real-box deploy dir, not DOTFILES_DIR overridden to the workspace" {
+    run grep -F 'DOTFILES_DIR: ${{ github.workspace }}' "$CI_YML"
+    [ "$status" -ne 0 ]
+}
+
+@test "TEST-003: a post-setup dotf doctor step fails the job on a non-zero exit" {
+    job="$(test_windows_job)"
+    printf '%s\n' "$job" | grep -qF 'Post-setup doctor gate'
+    printf '%s\n' "$job" | grep -qF 'dotf doctor'
+    printf '%s\n' "$job" | grep -qF 'if ($LASTEXITCODE -ne 0) { throw'
+}
+
+@test "TEST-003: the source build is kept by Install-Dotf (DOTF_VERSION=dev on the setup step)" {
+    job="$(test_windows_job)"
+    printf '%s\n' "$job" | grep -qF 'DOTF_VERSION: dev'
+}

--- a/tests/doctor-gate.Tests.ps1
+++ b/tests/doctor-gate.Tests.ps1
@@ -64,6 +64,25 @@ Describe 'Read-KnownFailures' {
         (Read-KnownFailures -Path (Join-Path $TestDrive 'nope.txt')).Count | Should -Be 0
     }
 
+    It 'every committed entry matches the example line it was written for' {
+        # A valid-but-wrong regex passed the validity check and failed the gate:
+        # "\.dotfiles\scripts" reads "\s" as whitespace. The example is the proof.
+        $known = Join-Path $PSScriptRoot '..\.github\scripts\doctor-gate-known-failures.txt'
+        $example = $null
+        $checked = 0
+        foreach ($line in @(Get-Content -LiteralPath $known)) {
+            $t = $line.Trim()
+            if (-not $t) { continue }
+            if ($t -match '^#\s*example:\s*(.+)$') { $example = $Matches[1]; continue }
+            if ($t.StartsWith('#')) { continue }
+            $example | Should -Not -BeNullOrEmpty -Because "entry '$t' needs a preceding '# example:' line"
+            $example | Should -Match $t -Because "entry '$t' must match its own example"
+            $example = $null
+            $checked++
+        }
+        $checked | Should -BeGreaterThan 0
+    }
+
     It 'every committed entry is a valid regex and names its ticket in a preceding comment' {
         $known = Join-Path $PSScriptRoot '..\.github\scripts\doctor-gate-known-failures.txt'
         $lines = @(Get-Content -LiteralPath $known)

--- a/tests/doctor-gate.Tests.ps1
+++ b/tests/doctor-gate.Tests.ps1
@@ -1,0 +1,80 @@
+# Pester 5 tests for .github/scripts/doctor-gate.ps1 (TEST-003, #1298): the
+# classification the gate makes over dotf doctor output and its known-failures
+# list. Pure function tests; the script's runtime half (PATH refresh, running
+# doctor) is exercised by the test-windows job itself.
+
+Describe 'Test-DoctorGate' {
+
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..\.github\scripts\doctor-gate.ps1')
+        $script:Doctor = @(
+            '[Core tools in PATH]',
+            '  [FAIL] wget not in PATH',
+            '  [WARN] something advisory',
+            '  [FAIL] SCRIPTS_DIR=C:\Users\x\.dotfiles\scripts (path does not exist)',
+            'Results: 90 passed, 2 failed, 1 warned, 40 skipped'
+        )
+    }
+
+    It 'passes when every FAIL is known and every entry matches' {
+        $r = Test-DoctorGate -Lines $script:Doctor -Patterns @('wget not in PATH', 'SCRIPTS_DIR=.*path does not exist')
+        $r.Failures.Count | Should -Be 2
+        $r.Unexpected.Count | Should -Be 0
+        $r.Stale.Count | Should -Be 0
+    }
+
+    It 'reports a FAIL no entry covers as unexpected' {
+        $r = Test-DoctorGate -Lines $script:Doctor -Patterns @('wget not in PATH')
+        $r.Unexpected | Should -HaveCount 1
+        $r.Unexpected[0] | Should -Match 'SCRIPTS_DIR'
+    }
+
+    It 'reports an entry that matches nothing as stale, so the list cannot rot' {
+        $r = Test-DoctorGate -Lines $script:Doctor -Patterns @('wget not in PATH', 'SCRIPTS_DIR=.*path does not exist', 'eza not in PATH')
+        $r.Stale | Should -HaveCount 1
+        $r.Stale[0] | Should -Be 'eza not in PATH'
+    }
+
+    It 'ignores WARN lines: only [FAIL] lines gate' {
+        $r = Test-DoctorGate -Lines @('  [WARN] only advisory', 'Results: 1 passed, 0 failed, 1 warned, 0 skipped') -Patterns @()
+        $r.Failures.Count | Should -Be 0
+        $r.Unexpected.Count | Should -Be 0
+    }
+
+    It 'a clean doctor with an empty list is a pass' {
+        $r = Test-DoctorGate -Lines @('Results: 5 passed, 0 failed, 0 warned, 0 skipped') -Patterns @()
+        $r.Unexpected.Count + $r.Stale.Count | Should -Be 0
+    }
+}
+
+Describe 'Read-KnownFailures' {
+
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..\.github\scripts\doctor-gate.ps1')
+    }
+
+    It 'skips comments and blank lines and trims entries' {
+        $p = Join-Path $TestDrive 'known.txt'
+        Set-Content -Path $p -Value @('# ticket #1: reason', '', '  wget not in PATH  ', '# another', 'SCRIPTS_DIR=.*exist')
+        $entries = Read-KnownFailures -Path $p
+        $entries | Should -Be @('wget not in PATH', 'SCRIPTS_DIR=.*exist')
+    }
+
+    It 'returns an empty list when the file is absent' {
+        (Read-KnownFailures -Path (Join-Path $TestDrive 'nope.txt')).Count | Should -Be 0
+    }
+
+    It 'every committed entry is a valid regex and names its ticket in a preceding comment' {
+        $known = Join-Path $PSScriptRoot '..\.github\scripts\doctor-gate-known-failures.txt'
+        $lines = @(Get-Content -LiteralPath $known)
+        $previousComment = $false
+        foreach ($line in $lines) {
+            $t = $line.Trim()
+            if (-not $t) { $previousComment = $false; continue }
+            if ($t.StartsWith('#')) { $previousComment = $previousComment -or ($t -match '#\d+'); continue }
+            { [regex]::new($t) } | Should -Not -Throw
+            $previousComment | Should -BeTrue -Because "entry '$t' must be preceded by a comment naming its owning ticket (#NNN)"
+            $previousComment = $false
+        }
+    }
+}

--- a/tests/doctor-gate.Tests.ps1
+++ b/tests/doctor-gate.Tests.ps1
@@ -35,6 +35,16 @@ Describe 'Test-DoctorGate' {
         $r.Stale[0] | Should -Be 'eza not in PATH'
     }
 
+    It 'accepts the blank lines real doctor output carries between sections' {
+        # The sixth gate run died here: the real output, split on newlines,
+        # contains empty elements, and a Mandatory [string[]] rejected them.
+        $real = @('dotf doctor [check]', '', '[Core tools in PATH]', '  [FAIL] wget not in PATH', '', 'Results: 1 passed, 1 failed')
+        $r = Test-DoctorGate -Lines $real -Patterns @('wget not in PATH')
+        $r.Failures.Count | Should -Be 1
+        $r.Unexpected.Count | Should -Be 0
+        $r.Stale.Count | Should -Be 0
+    }
+
     It 'ignores WARN lines: only [FAIL] lines gate' {
         $r = Test-DoctorGate -Lines @('  [WARN] only advisory', 'Results: 1 passed, 0 failed, 1 warned, 0 skipped') -Patterns @()
         $r.Failures.Count | Should -Be 0

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -825,18 +825,17 @@ setup() {
     [ "$node_line" -lt "$tools_line" ]
 }
 
-@test "setup-windows.ps1's PATH refresh keeps the process PATH (a GITHUB_PATH entry survived nothing before, TEST-003)" {
-    grep -qF 'GetEnvironmentVariable("PATH", "User") + ";" + $env:PATH' "$PS1_SCRIPT"
-}
-
-@test "every registry PATH rebuild in setup-windows.ps1 keeps the process PATH (TEST-003)" {
-    # Two registry-only rebuilds dropped process-only entries: the first hid the
-    # PR's dotf from Install-Dotf, the second hid the runner's toolcache node from
-    # the pi install ("npm not available"). A rebuild must end by appending $env:PATH.
-    total=$(grep -cF '$env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine")' "$PS1_SCRIPT")
-    kept=$(grep -cF '$env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [Environment]::GetEnvironmentVariable("PATH", "User") + ";" + $env:PATH' "$PS1_SCRIPT")
-    [ "$total" -ge 2 ]
-    [ "$total" -eq "$kept" ]
+@test "every registry PATH rebuild in setup-windows.ps1 goes through Sync-SessionPath (TEST-003)" {
+    # A registry-only rebuild drops entries that exist only in this process (a
+    # GITHUB_PATH addition; the runner's toolcache node), and the plain
+    # Machine+User+process concatenation that first fixed that doubled PATH on
+    # every call (153 entries, 72 duplicates, measured on #1308). One helper,
+    # deduplicated, unit-tested in tests/windows-path-sync.Tests.ps1.
+    run grep -cF 'GetEnvironmentVariable("PATH", "Machine")' "$PS1_SCRIPT"
+    [ "$output" = "0" ]
+    calls=$(grep -cE '^\s*Sync-SessionPath\s*$' "$PS1_SCRIPT")
+    [ "$calls" -ge 2 ]
+    grep -qE '^function Sync-SessionPath' "$BATS_TEST_DIRNAME/../scripts/utils.ps1"
 }
 
 @test "setup-windows.ps1 runs the uv and Bun installers in a child pwsh, never in its own session (TEST-003)" {

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -833,8 +833,8 @@ setup() {
     # Two registry-only rebuilds dropped process-only entries: the first hid the
     # PR's dotf from Install-Dotf, the second hid the runner's toolcache node from
     # the pi install ("npm not available"). A rebuild must end by appending $env:PATH.
-    total=$(grep -c 'GetEnvironmentVariable("PATH", "User")' "$PS1_SCRIPT")
-    kept=$(grep -c 'GetEnvironmentVariable("PATH", "User") + ";" + $env:PATH' "$PS1_SCRIPT")
+    total=$(grep -cF '$env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine")' "$PS1_SCRIPT")
+    kept=$(grep -cF '$env:PATH = [Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [Environment]::GetEnvironmentVariable("PATH", "User") + ";" + $env:PATH' "$PS1_SCRIPT")
     [ "$total" -ge 2 ]
     [ "$total" -eq "$kept" ]
 }

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -838,3 +838,14 @@ setup() {
     [ "$total" -ge 2 ]
     [ "$total" -eq "$kept" ]
 }
+
+@test "setup-windows.ps1 runs the uv and Bun installers in a child pwsh, never in its own session (TEST-003)" {
+    # A downloaded installer executed in-session can rewrite the process
+    # environment for the rest of setup; the runner lost npm after these two.
+    grep -qF -- '-File $uvInstaller' "$PS1_SCRIPT"
+    grep -qF -- '-File $bunInstaller' "$PS1_SCRIPT"
+    run grep -F '& $uvInstaller' "$PS1_SCRIPT"
+    [ "$status" -ne 0 ]
+    run grep -F '& $bunInstaller' "$PS1_SCRIPT"
+    [ "$status" -ne 0 ]
+}

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -824,3 +824,7 @@ setup() {
     [ -n "$node_line" ] && [ -n "$tools_line" ]
     [ "$node_line" -lt "$tools_line" ]
 }
+
+@test "setup-windows.ps1's PATH refresh keeps the process PATH (a GITHUB_PATH entry survived nothing before, TEST-003)" {
+    grep -qF 'GetEnvironmentVariable("PATH", "User") + ";" + $env:PATH' "$PS1_SCRIPT"
+}

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -828,3 +828,13 @@ setup() {
 @test "setup-windows.ps1's PATH refresh keeps the process PATH (a GITHUB_PATH entry survived nothing before, TEST-003)" {
     grep -qF 'GetEnvironmentVariable("PATH", "User") + ";" + $env:PATH' "$PS1_SCRIPT"
 }
+
+@test "every registry PATH rebuild in setup-windows.ps1 keeps the process PATH (TEST-003)" {
+    # Two registry-only rebuilds dropped process-only entries: the first hid the
+    # PR's dotf from Install-Dotf, the second hid the runner's toolcache node from
+    # the pi install ("npm not available"). A rebuild must end by appending $env:PATH.
+    total=$(grep -c 'GetEnvironmentVariable("PATH", "User")' "$PS1_SCRIPT")
+    kept=$(grep -c 'GetEnvironmentVariable("PATH", "User") + ";" + $env:PATH' "$PS1_SCRIPT")
+    [ "$total" -ge 2 ]
+    [ "$total" -eq "$kept" ]
+}

--- a/tests/windows-path-sync.Tests.ps1
+++ b/tests/windows-path-sync.Tests.ps1
@@ -1,0 +1,57 @@
+# Pester 5 tests for Sync-SessionPath in scripts/utils.ps1 (TEST-003/#1298,
+# #1308): the one PATH refresh setup-windows.ps1 runs after its installers.
+# Each case runs in a CHILD pwsh so the process PATH under test is chosen by
+# the test and the test runner's own PATH is never mutated. Windows only: the
+# Machine/User registry scopes and the ';' separator are Windows concepts.
+
+$script:onWindows = $env:OS -eq 'Windows_NT'
+
+Describe 'Sync-SessionPath' -Skip:(-not $script:onWindows) {
+
+    BeforeAll {
+        $script:Utils = (Resolve-Path (Join-Path $PSScriptRoot '..\scripts\utils.ps1')).Path
+        # Fixture: a process-only entry, a registry entry repeated in three
+        # spellings, and the process-only entry again.
+        $script:Probe = @'
+. '__UTILS__'
+$env:PATH = 'C:\only-in-process;C:\Windows;c:\windows\;C:\ONLY-IN-PROCESS'
+Sync-SessionPath
+$first = $env:PATH
+$entries = @($env:PATH -split ';' | Where-Object { $_ })
+$keys = @($entries | ForEach-Object { $_.TrimEnd('\').ToLowerInvariant() })
+$machineFirst = @(([Environment]::GetEnvironmentVariable('PATH', 'Machine') -split ';') | Where-Object { $_ } | Select-Object -First 1)
+Sync-SessionPath
+[pscustomobject]@{
+    Entries      = $entries.Count
+    Duplicates   = ($keys.Count - @($keys | Sort-Object -Unique).Count)
+    ProcessKept  = ($keys -contains 'c:\only-in-process')
+    RegistryFirst = ($machineFirst.Count -eq 0 -or $entries[0] -eq $machineFirst[0])
+    Idempotent   = ($env:PATH -eq $first)
+} | ConvertTo-Json -Compress
+'@.Replace('__UTILS__', $script:Utils)
+        $script:Result = (& pwsh -NoProfile -Command $script:Probe 2>&1 | Select-Object -Last 1) | ConvertFrom-Json
+    }
+
+    It 'keeps an entry that exists only in the process PATH' {
+        $script:Result.ProcessKept | Should -BeTrue
+    }
+
+    It 'emits no duplicate entries, comparing case-insensitively and ignoring a trailing backslash' {
+        $script:Result.Duplicates | Should -Be 0
+    }
+
+    It 'puts the registry (Machine) PATH first so a fresh install beats a stale process entry' {
+        $script:Result.RegistryFirst | Should -BeTrue
+    }
+
+    It 'is idempotent: a second call leaves PATH byte-identical' {
+        $script:Result.Idempotent | Should -BeTrue
+    }
+
+    It 'a plain concatenation would have grown here; the merge does not' {
+        # Every registry entry appears once, plus the two process-only spellings
+        # collapsed to one -- never registry-count times two.
+        $registry = @((([Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('PATH', 'User')) -split ';') | Where-Object { $_ } | ForEach-Object { $_.TrimEnd('\').ToLowerInvariant() } | Sort-Object -Unique)
+        $script:Result.Entries | Should -BeLessOrEqual ($registry.Count + 2)
+    }
+}


### PR DESCRIPTION
## Summary

TEST-003 (#1298): `test-windows` installed `dotf` into `~/.local/bin` and never put it on `PATH`, so every `dotf`-gated block in `setup-windows.ps1` skipped with a warning, `dotf doctor` **never ran in CI**, and the job stayed green while a real Windows box failed four doctor checks after the same setup (measured 2026-08-27; log of run 33051778423 quoted in the issue).

Three masking layers, all removed here:

1. **PATH** — `actions/setup-go` + a step that builds `dotf` from *this PR* into `~/.local/bin`, appends it to `GITHUB_PATH` and proves reachability by effect (`dotf version`). The released binary lags the tree, which is also why the Linux integration container has to build from source.
2. **Install-Dotf would replace it** — `DOTF_VERSION=dev` on the setup step: Install-Dotf skips when the binary on PATH reports the pinned version, and a source build reports `dev`.
3. **`DOTFILES_DIR: ${{ github.workspace }}`** — dropped; setup now deploys to the real-box default, so the gate certifies the tree a real machine reads.

And the gate: a post-setup `dotf doctor` step that fails the job on a non-zero exit. Setup itself stays non-fatal (degrade-not-break, C9; `tests/setup-windows.bats` still asserts that).

`tests/ci-windows-doctor-gate.bats` pins all of the above.

## What the gate found on the runner (seven iterations, each a real defect)

1. `~/.local/bin` never on `PATH` -> build `dotf` from the PR, `GITHUB_PATH` + User PATH.
2. Install-Dotf replaced the source build with the release -> installers leave a `dev` build in place (#1305).
3. `setup-windows.ps1` rebuilt `PATH` from the registry twice, dropping process-only entries (the PR's `dotf`, the runner's node) -> both rebuilds keep the process PATH.
4. The uv and Bun installers ran in-session and left setup without `npm` ("skipping pi install") -> child `pwsh`; setup now logs the PATH state after them.
5. `copilot-instructions.md` "drift" was one trailing blank line -> the comparator trims trailing newlines, as it already normalises CRLF.
6. A known-failure regex was valid but wrong (`\s` read as whitespace) -> every entry carries an `# example:` line its pattern must match (Pester).
7. `Test-DoctorGate` rejected the blank lines real output carries -> `AllowEmptyString`.

Final state: `doctor gate: 2 known runner-only FAIL(s), 0 unexpected, 0 stale` -- SCRIPTS_DIR (WIN-013, #1310) and the runner's missing Bitwarden identity (TEST-005, #1313). The doctor adjustments (wget POSIX-only, `.exe` probe for `*_HOME`, a `dev` build is not drift) came from the first run. Closes #1298.

## SDD skip rationale

CI workflow + a 40-line PowerShell gate script + three one-branch doctor adjustments (a `posixOnlyTools` entry, an `.exe` fallback, a `dev` SKIP). No public contract, dependency or schema change; the executable Go delta is under 15 lines and each doctor adjustment is a bug fix with a measured cause on the first gate run. Declared here because the raw line count crosses the threshold on YAML and comments.
