### PR TITLE
docs: lessons 236-240 from the Windows deploy audit, and the stale Windows sections

### DIFF
--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -254,3 +254,8 @@ tags: [lessons, index, dotfiles]
 | [233 - Piping a single-element array into ConvertTo-Json unwraps it](lesson-233-piping-a-single-element-array-into-convertto-json-un.md) | 2026-08-26 |  |
 | [234 - Orchestrating Orca ADE declarative configuration and bidirectional settings capture](lesson-234-orchestrating-orca-ade-declarative-configuration-and-bi.md) | 2026-08-26 |  |
 | [235 - Reproducing a bug from an environment that already works measures the environment, not the bug](lesson-235-reproducing-a-bug-from-an-environment-that-alread.md) | 2026-08-27 |  |
+| [236 - A CI job that installs a tool and never puts it on PATH certifies nothing it was built to check](lesson-236-a-ci-job-that-installs-a-tool-and-never-puts-it-on-p.md) | 2026-08-27 |  |
+| [237 - CREATE_NEW_PROCESS_GROUP is not detachment: a console child dies with its terminal](lesson-237-create-new-process-group-is-not-detachment-a-console.md) | 2026-08-27 |  |
+| [238 - Two independent defects, each sufficient for a permanent red, hide behind one symptom](lesson-238-two-independent-defects-each-sufficient-for-a-perman.md) | 2026-08-27 |  |
+| [239 - Re-measure a filed bug on the current toolchain before implementing its fix](lesson-239-re-measure-a-filed-bug-on-the-current-toolchain-before.md) | 2026-08-27 |  |
+| [240 - A partial mirror the code believes absent: the check that could have flagged the gap was the one switched off](lesson-240-a-partial-mirror-the-code-believes-absent-the-check.md) | 2026-08-27 |  |

--- a/docs/lessons/lesson-236-a-ci-job-that-installs-a-tool-and-never-puts-it-on-p.md
+++ b/docs/lessons/lesson-236-a-ci-job-that-installs-a-tool-and-never-puts-it-on-p.md
@@ -1,0 +1,54 @@
+# Lesson 236 — A CI job that installs a tool and never puts it on PATH certifies nothing it was built to check
+
+**Date:** 2026-08-27
+**Context:** TEST-003 (#1298) — `test-windows` green on every PR while a real Windows box failed four `dotf doctor` checks after the same setup.
+**Category:** ci, windows, guards, false negatives
+
+## What happened
+
+The `test-windows` job runs `setup-windows.ps1` end to end. Setup installs
+`dotf` into `~/.local/bin`, and nothing ever added that directory to
+`$GITHUB_PATH`. The real log of a green run (33051778423) reads, in order:
+
+```
+dotf 0.51.0 installed to C:\Users\runneradmin\.local\bin\dotf.exe
+... dotf secrets render unavailable/failed
+... dotf not on PATH -- skipping pi config deploy
+[WARNING] dotf not found on PATH, skipping post-setup diagnostics
+Setup Complete!
+```
+
+Every `dotf`-gated block degraded exactly as designed — with a warning — and
+the job passed. `dotf doctor` had **never run in CI**. The same day, on the
+Windows work box, doctor reported four FAILs after a clean setup (WIN-007,
+WIN-008, WIN-011 and a false DR FAIL), all of which the job would have shown
+had the tool been reachable.
+
+Three independent layers had to be removed before the job could see any of it:
+
+| Layer | What it hid |
+|---|---|
+| `~/.local/bin` never on `GITHUB_PATH` | every `dotf` call, including the doctor |
+| doctor's exit code swallowed by setup (by design, C9) and a bats test asserting the swallow | a red doctor, had it run |
+| `DOTFILES_DIR: ${{ github.workspace }}` on the setup step | the mirror gap (WIN-007): doctor would have read `harness/` from the checkout and passed |
+
+## The lesson
+
+"Installed" is a statement about a directory. The property the job needs is
+"reachable from the process that has to call it", and that is only established
+by effect — run the tool from the same step and check its exit status.
+
+A verifier that degrades gracefully in production must be a **gate** in CI, and
+it must run in the environment a real machine has (the default deploy dir, not
+the convenient one). Otherwise CI certifies the tree nobody reads.
+
+The fix builds `dotf` from the PR under test (the released binary lags the
+tree, as the integration container already knew), puts it on `GITHUB_PATH`
+before setup, drops the `DOTFILES_DIR` override, and adds a post-setup
+`dotf doctor` step that fails the job. Setup itself stays non-fatal.
+
+## Guard
+
+`tests/ci-windows-doctor-gate.bats` asserts the build step precedes setup, the
+override is gone, and the gate step exists. The gate is the guard for
+everything downstream.

--- a/docs/lessons/lesson-236-a-ci-job-that-installs-a-tool-and-never-puts-it-on-p.md
+++ b/docs/lessons/lesson-236-a-ci-job-that-installs-a-tool-and-never-puts-it-on-p.md
@@ -10,7 +10,7 @@ The `test-windows` job runs `setup-windows.ps1` end to end. Setup installs
 `dotf` into `~/.local/bin`, and nothing ever added that directory to
 `$GITHUB_PATH`. The real log of a green run (33051778423) reads, in order:
 
-```
+```text
 dotf 0.51.0 installed to C:\Users\runneradmin\.local\bin\dotf.exe
 ... dotf secrets render unavailable/failed
 ... dotf not on PATH -- skipping pi config deploy
@@ -42,7 +42,7 @@ A verifier that degrades gracefully in production must be a **gate** in CI, and
 it must run in the environment a real machine has (the default deploy dir, not
 the convenient one). Otherwise CI certifies the tree nobody reads.
 
-The fix builds `dotf` from the PR under test (the released binary lags the
+The fix (#1308, in review as this lesson is written) builds `dotf` from the PR under test (the released binary lags the
 tree, as the integration container already knew), puts it on `GITHUB_PATH`
 before setup, drops the `DOTFILES_DIR` override, and adds a post-setup
 `dotf doctor` step that fails the job. Setup itself stays non-fatal.

--- a/docs/lessons/lesson-237-create-new-process-group-is-not-detachment-a-console.md
+++ b/docs/lessons/lesson-237-create-new-process-group-is-not-detachment-a-console.md
@@ -1,0 +1,52 @@
+# Lesson 237 — CREATE_NEW_PROCESS_GROUP is not detachment: a console child dies with its terminal
+
+**Date:** 2026-08-27
+**Context:** WIN-012 (#1293) — `pi` and `opencode` "do not work" on the Windows work box; they work on the Linux one.
+**Category:** windows, processes, secrets, daemons
+
+## What happened
+
+Both agent wrappers run `dotf secrets run --only NAN_API_KEY,... -- <agent>`,
+which resolves the keys through the `bw serve` daemon before exec'ing the
+binary. `dotf secrets unlock` starts that daemon. On Windows it was spawned with
+`CREATE_NEW_PROCESS_GROUP` only, and the file's own comment recorded the
+lifecycle as *"explicitly deferred to empirical validation on Windows"*.
+
+The validation happened by accident: unlock in one terminal, close it, and every
+wrapper in every other terminal failed at once with *"no bw serve daemon is
+running"*. Nothing announced the change.
+
+## The actual defect
+
+Two different properties were being conflated:
+
+- `CREATE_NEW_PROCESS_GROUP` re-routes `CTRL_C_EVENT` so a Ctrl+C to the CLI
+  does not also hit the child. It does **not** detach the child from the
+  console.
+- A console-subsystem child created without `DETACHED_PROCESS` (or
+  `CREATE_NO_WINDOW`) stays attached to its parent's console. When that console
+  closes, Windows delivers `CTRL_CLOSE_EVENT` to every attached process and
+  terminates it after the handler timeout.
+
+The CLI exiting was never the problem — stdio was already NUL and Windows has no
+parent→child kill. The terminal closing was. Linux never showed it because
+`bwserve_unix.go` uses `Setsid`, which does detach.
+
+## The lesson
+
+On Windows, "survives the parent" and "survives the console" are separate
+guarantees with separate flags. Test the one you actually need, by effect: a
+child spawned with the attribute reports `GetConsoleWindow() == NULL`; a control
+child without it reports a handle; where the test process itself has no console
+(Git Bash pty, some runners) both read NULL and the test says so instead of
+passing vacuously.
+
+A deferral written in a comment is a decision nobody made. It needs a ticket or
+a test that fails until the validation happens.
+
+## Guard
+
+`cli/internal/secrets/bwserve_windows_test.go` (`//go:build windows`), plus a
+doctor WARN naming `dotf secrets unlock` when the wrappers' keys are bw-backed
+and no unlocked daemon is reachable — the precondition every green file/PATH
+predicate in that section had been standing in for.

--- a/docs/lessons/lesson-238-two-independent-defects-each-sufficient-for-a-perman.md
+++ b/docs/lessons/lesson-238-two-independent-defects-each-sufficient-for-a-perman.md
@@ -1,0 +1,47 @@
+# Lesson 238 — Two independent defects, each sufficient for a permanent red, hide behind one symptom
+
+**Date:** 2026-08-27
+**Context:** WIN-008 (#1289) — `[FAIL] stale: .copilot/copilot-instructions.md has drifted` on every Windows setup, with a remedy (`compile-harness.sh --deploy`) that does not exist on Windows.
+**Category:** guards, line endings, windows, diagnosis
+
+## What happened
+
+The deployed file measured 5708 bytes with 67 CR / 67 LF; the repo source 1902
+bytes with 0 CR. After stripping the harness regions the two differed only by
+the carriage returns. So the cause looked like one thing: a writer emitting CRLF.
+
+It was two things, and either alone guaranteed the FAIL:
+
+1. **Writer.** `Set-Content -Value $list -Encoding UTF8` joins a list with the
+   platform newline and rewrote the *whole* file CRLF, not just the injected
+   region. The same call shape wrote every rendered `SKILL.md` and command file.
+2. **Comparator.** `stripHarnessRegions` split on `"\n"` and closed a skipped
+   region with `l == endMarker`. A `\r`-suffixed END marker never matched, so
+   the strip swallowed the rest of the file — the comparison was not "off by 67
+   carriage returns", it was comparing a truncated document. And independently,
+   every remaining line kept its trailing `\r`.
+
+Fixing the writer alone would have cleared the FAIL and left the comparator
+one stray `\r` away from the same runaway skip. Fixing the comparator alone
+would have cleared it and left every deployed `.md` violating the
+`.gitattributes` contract the repo declares (`*.md eol=lf`).
+
+## The lesson
+
+When a guard is permanently red with a remedy that cannot clear it, keep
+looking after the first cause. A symptom that survives a correct fix is the
+second defect announcing itself — cheaper to find now, with the measurement
+already in hand, than after the first fix ships and the FAIL "comes back".
+
+Normalise what is not content at the comparator (line endings), and fix the
+writer to honour the declared contract; guard both halves separately, because
+they fail separately.
+
+## Guard
+
+Go: `TestStripHarnessRegions/CRLF_input…` and
+`TestCheckInstructionDrift_CRLFDeployedCopyIsNotDrift` (mutation-checked: both
+fail without the normalisation). PowerShell: `Write-Utf8LfFile` pinned by
+`tests/console-encoding.Tests.ps1`, and the copilot native-skills smoke — which
+was invoked nowhere before — now asserts 0 CR bytes and no BOM on the deployed
+copy after a real `Deploy-SkillRecord` run.

--- a/docs/lessons/lesson-239-re-measure-a-filed-bug-on-the-current-toolchain-before.md
+++ b/docs/lessons/lesson-239-re-measure-a-filed-bug-on-the-current-toolchain-before.md
@@ -1,0 +1,44 @@
+# Lesson 239 — Re-measure a filed bug on the current toolchain before implementing its fix
+
+**Date:** 2026-08-27
+**Context:** #912 (BUG-069, `core.hooksPath` in `C:/` form breaks hook execution) and #914 (WIN-006, hooks resolve WSL's bash) — both open, both claiming `git commit` fails on Windows.
+**Category:** git, windows, diagnosis, tickets
+
+## What happened
+
+Both issues were filed with care. #912 carried a 2×2 evidence table (EOL ×
+path form) measured on git-for-windows 2.53.0, isolating the `C:/` hooksPath
+value as the cause: MSYS bash could not open the hook at a drive path. #914
+proposed a different mechanism — `#!/usr/bin/env bash` resolving to WSL's
+`bash.exe` because `C:\Windows\System32` precedes Git on PATH.
+
+On the work box today, git is 2.55.0.windows.5, and `git commit` from
+PowerShell exits 0 with the same `C:/…/git-hooks` value, System32 still first on
+PATH. `GIT_TRACE=1` shows git starting all three hooks by their `C:/` path with
+its bundled bash, ignoring the shebang; a repo-local `commit-msg` exiting 1
+blocks the commit through the global→local chain. An isolated probe shows MSYS
+bash on 2.55 opening a `C:/` path with rc=0 — the exact call that returned rc=1
+on 2.53.
+
+So #912's diagnosis was correct and its fix was shipped upstream, by
+git-for-windows, between the two measurements. #914's mechanism never applied:
+git does not consult the shebang when it invokes a hook.
+
+## The lesson
+
+A correct diagnosis has a toolchain version attached to it, whether or not the
+ticket says so. Before implementing a filed bug's fix, reproduce it on what is
+installed *now*; an upstream fix invalidates a correct ticket silently, and the
+workaround it would have earned (`/c/` MSYS-form rewriting) becomes a
+maintenance liability with no remaining cause.
+
+What survives such a bug is not the workaround but the **floor**: the minimum
+toolchain version that carries the upstream fix, declared where the repo
+declares versions, and a guard that asserts the behaviour by effect rather than
+by string-comparing a config value.
+
+## Disposition
+
+#914 closed as a misdiagnosed duplicate. #912 re-scoped to its acceptance
+criterion 3 — a declared git-for-windows version floor plus the by-effect guard
+— and explicitly not to the `/c/` rewrite.

--- a/docs/lessons/lesson-240-a-partial-mirror-the-code-believes-absent-the-check.md
+++ b/docs/lessons/lesson-240-a-partial-mirror-the-code-believes-absent-the-check.md
@@ -1,0 +1,56 @@
+# Lesson 240 — A partial mirror the code believes absent: the check that could have flagged the gap was the one switched off
+
+**Date:** 2026-08-27
+**Context:** WIN-007 (#1288) — `dotf doctor` FAILs `harness/model-map.json` and `harness/model-pins.json` after every Windows setup, remedy "re-run setup to mirror it".
+**Category:** windows, deploy mirror, doctor, false beliefs
+
+## What happened
+
+`~/.dotfiles` on the Windows box held exactly seven artifacts — `versions.conf`,
+`packages.json`, `git-hooks/`, `sensitive/`, `secrets/registry.yaml`,
+`env-contract.json`, `paths.ps1` — and no `harness/`. `setup-linux.sh` mirrors
+`harness/` with a 60-line bash+jq block; `setup-windows.ps1` had no such block,
+so the doctor's remedy could never clear.
+
+The Go doctor made it worse by believing it could not happen:
+
+```go
+// Windows has no repo/mirror split — setup-windows.ps1 sets
+// `$DotfilesDir = $PSScriptRoot`, i.e. the deploy dir IS the checkout
+func checkHarnessMirrorOrphans(...) {
+    if sys.GOOS == "windows" { return }
+```
+
+The comment was true of a *variable name*: on Windows `$DotfilesDir` is the
+checkout — Linux uses `DOTFILES_DIR` for the deploy dir, the two scripts invert
+the name. The deploy dir on Windows is `$DotfilesDest = ~\.dotfiles`, the very
+path `cfg.DotfilesDir` resolves to. A partial mirror, believed absent, with the
+one check that walks the mirror switched off for that OS — and a test locking
+the switch-off in ("windows has no separate mirror -> no-op").
+
+The pi-packages count read the same missing mirror and reported "0 packages
+declared" as a PASS. Green tag, wrong number.
+
+## The lesson
+
+Never encode a belief about an environment as an early return without a test
+that fails when the belief is false. The `GOOS == "windows"` branch had a test —
+asserting the belief, not the world.
+
+Two shell implementations of one mirror will diverge, and the divergence will
+be discovered by the check that reads the result, printing a remedy the
+divergent side cannot execute. One implementation (`dotf harness mirror`,
+called by both setups) removes the class; a remedy a check prints must be one
+the check can verify clears.
+
+The gap had a cost beyond the two FAILs: with the mirror in place the model-pin
+check ran on Windows for the first time and found a real drift in the live pi
+settings — a finding the switched-off path had been hiding along with the
+false ones.
+
+## Guard
+
+`TestCheckHarnessMirrorOrphans` now asserts Windows reports an orphan like any
+OS; `TestPiPackagesManifest_ReadsTheCheckoutBeforeTheMirror`; the mirror's own
+tests (idempotent, no prune, missing target named); and the CI doctor gate
+(lesson 236) that finally runs the check where it can fail.

--- a/docs/runbooks/_index.md
+++ b/docs/runbooks/_index.md
@@ -6,6 +6,8 @@ Operational guides and procedures for managing the dotfiles environment.
 |---|---|---|
 | [guide-secrets-governance.md](guide-secrets-governance.md) | Secrets lifecycle, `dotf secrets`, Age encryption & Bitwarden sync | Active |
 | [guide-opencode-go-setup.md](guide-opencode-go-setup.md) | OpenCode setup, NaN provider, models & coexistence rules | Active |
+| [ai-tools-setup.md](ai-tools-setup.md) | AI tools setup: what each setup script deploys per agent, `dotf init`, MCP registration | Active |
+| [guide-cross-agent-memory.md](guide-cross-agent-memory.md) | Cross-agent session memory bridge (handoff threads, vault-linked auto-memory) | Active |
 | [guide-antigravity-cli-migration.md](guide-antigravity-cli-migration.md) | Antigravity CLI (`agy`) setup, permissions & model configuration | Active |
 | [guide-pr-agent-reviewer.md](guide-pr-agent-reviewer.md) | PR-Agent automated code review workflow | Active |
 | [guide-knowledge-distillation.md](guide-knowledge-distillation.md) | Knowledge crystallization, observation promotion & vault syncing | Active |

--- a/docs/runbooks/ai-tools-setup.md
+++ b/docs/runbooks/ai-tools-setup.md
@@ -89,10 +89,9 @@ dotf init my-project --stack python
 dotf init . --stack go         # Initialize current directory
 ```
 
-On Windows (PowerShell), until a Windows `dotf` install path exists (#380):
-```powershell
-project-init my-project python
-```
+The same commands work on Windows (PowerShell): `setup-windows.ps1` installs
+`dotf` into `~/.local/bin` (WIN-006, #380 closed 2026-06-21). `project-init`
+remains as a thin wrapper that calls `dotf init` (CLI-020).
 
 ### Option B: Manual Setup
 

--- a/docs/troubleshooting/hive-mcp-orphaned-trampoline.md
+++ b/docs/troubleshooting/hive-mcp-orphaned-trampoline.md
@@ -133,6 +133,18 @@ anything (dotfiles#796 / AI-028 PR1):
 Get-ScheduledTaskInfo -TaskName DotfilesHiveUpgrade   # LastTaskResult != 0 => broken install
 ```
 
+**Caveat (measured 2026-08-27, work box).** That signal reads `uv tool list`,
+and so does `setup-windows.ps1`'s version gate for `hive service`. Since hive
+moved to its own installer (`%LOCALAPPDATA%\hive\runtime\current\Scripts\hive.exe`
+behind a `hive.cmd` shim), `uv tool list` shows **no** hive-vault entry on a
+healthy box either: `hive --version` printed `hive-vault 3.0.0` while setup
+reported `hive <unknown> predates 'hive service'` and skipped daemon
+supervision, and the timer's "no install" exit fires for a working install. The
+instrument is wrong, not the box. Probe the binary (`hive --version`) until
+AI-028 (#791) lands; a stray `~/.local/bin/hive.exe` trampoline printing
+*uv trampoline failed to canonicalize script path* is the leftover of the old
+channel and is safe to delete once `hive --version` resolves elsewhere.
+
 That is detection, not repair — the recipe above is still the fix until #574 lands.
 
 The durable, cross-machine version of this check + repair is **#574** — `dotf doctor`

--- a/docs/troubleshooting/opencode.md
+++ b/docs/troubleshooting/opencode.md
@@ -139,3 +139,36 @@ DeepSeek V4 Pro on Go infrastructure: ~1–3s first-token latency from Europe, 4
 - [`guide-opencode-go-setup.md`](../runbooks/guide-opencode-go-setup.md) — one-time setup + guardrail (predates the NaN provider switch; see its own banner)
 - SSOT for current provider/model facts: `ai/opencode/opencode.jsonc`
 - Upstream docs: <https://opencode.ai/docs/>
+
+## Windows
+
+Measured 2026-08-27 on the Windows work box; each item names the ticket that
+carries the fix.
+
+### `OpenCode locked. below pinned minimum …` on setup, then "another install shadows it"
+
+Two installs coexist: npm-global `opencode-ai` (scoop's node `bin`, first on
+PATH) and winget `SST.opencode` (what `setup-windows.ps1` pinned). The version
+parse took the last token of the first output line and accepted `locked.` as a
+version. Check with `Get-Command opencode -All`.
+
+Decision (2026-08-27, AI-034 #1294): **npm is the channel for node-distributed
+agents on every OS** — opencode joins `packages.json` beside pi and bw, `dotf
+tools install` converges it, and both the winget and the Linux curl-script
+installs are retired. Until it lands, remove the copy you do not want (`npm rm
+-g opencode-ai` or `winget uninstall SST.opencode`) so one binary owns PATH.
+
+### `opencode` / `pi` exit immediately: *bitwarden vault is locked … run `dotf secrets unlock`*
+
+The shell wrappers run the agents under `dotf secrets run`, which resolves the
+NaN key through Bitwarden **before** exec'ing the binary; while the vault is
+locked the agent never starts. Run `dotf secrets unlock` once per boot — the
+daemon then serves every terminal. Before #1304 the Windows daemon died with
+the terminal that unlocked it (WIN-012); `dotf doctor` now WARNs with this exact
+remedy when the keys are bw-backed and no unlocked daemon is reachable.
+
+### `ΓÇö` and similar glyphs in captured output
+
+The console decoded native output with OEM code page 437. `scripts/utils.ps1`
+and the deployed profile set UTF-8 console I/O (WIN-009, #1290); re-run setup
+and open a fresh terminal.

--- a/docs/troubleshooting/secrets.md
+++ b/docs/troubleshooting/secrets.md
@@ -97,6 +97,25 @@ echo $KUBECONFIG  # Should show dest path
 - Destination directory doesn't exist (e.g., `~/.kube/` not created)
 - Dest file is newer than `.age` source (caching) — use `secrets_refresh`
 
+## Agent wrapper refuses to launch (vault locked)
+
+**Symptom.** `pi` or `opencode` exits at once with
+*Error: bw resolve nan-api-key/api-key: bitwarden vault is locked: no bw serve
+daemon is running — run `dotf secrets unlock`*.
+
+**Cause.** The wrappers (`.zshrc`, `.bashrc`, `powershell/profile.ps1`) are
+`dotf secrets run --only NAN_API_KEY,… -- <agent>`: the keys are resolved
+through the `bw serve` daemon before the agent process exists, and a locked
+vault fails the resolution (ADR-028 "not always exposed": nothing is in the
+ambient shell).
+
+**Fix.** `dotf secrets unlock` once per boot. The daemon is detached from the
+terminal that started it on every OS (Linux `Setsid`; Windows `DETACHED_PROCESS`
+since #1304 — before that, closing the unlocking terminal killed it and every
+wrapper in every other terminal failed together, WIN-012). `dotf doctor` WARNs
+with this remedy under `[OpenCode + pi]` while the keys are bw-backed and no
+unlocked daemon answers.
+
 ## Related
 
 - [Runbook: Secrets Management](../runbooks/secrets-management.md)


### PR DESCRIPTION
## Summary

Knowledge from the 2026-08-27 Windows deploy audit, written the day it was learned (Standing Order 3).

**Lessons 236–240** (`docs/lessons/`, indexed — 240 files, 240 rows):
- 236 — a CI job that installs a tool and never puts it on PATH certifies nothing it was built to check (TEST-003, #1298)
- 237 — `CREATE_NEW_PROCESS_GROUP` is not detachment: a console child dies with its terminal (WIN-012, #1293)
- 238 — two independent defects, each sufficient for a permanent red, hide behind one symptom (WIN-008, #1289)
- 239 — re-measure a filed bug on the current toolchain before implementing its fix (#912 / #914 on git 2.55)
- 240 — a partial mirror the code believes absent: the check that could have flagged the gap was the one switched off (WIN-007, #1288)

**Stale Windows sections** (DOCS-015, #1303):
- `runbooks/ai-tools-setup.md` — still pointed Windows at #380 (closed 2026-06-21); `dotf` is installed by `setup-windows.ps1`.
- `runbooks/_index.md` — `ai-tools-setup.md` and `guide-cross-agent-memory.md` were on disk and absent from the index (#1286 class).
- `troubleshooting/hive-mcp-orphaned-trampoline.md` — "the auto-upgrade timer detects it for you" reads `uv tool list`, which no longer sees a healthy install once hive moved to its own installer (#791); measured caveat added.
- `troubleshooting/opencode.md` — a Windows section: dual installs + the `locked.` parse (AI-034 decision: npm on every OS), wrapper refusing while the vault is locked, OEM mojibake.
- `troubleshooting/secrets.md` — the locked-vault wrapper refusal and the daemon lifecycle per OS.

Closes #1303. Docs-only.
