### PR TITLE
feat(tools): one install channel per tool class, opencode through packages.json, dotf tools version

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -220,9 +220,6 @@ if [[ -n "${DOTFILES_PROFILE:-}" ]]; then
     echo "bashrc profile written to /tmp/bashrc-profile.$$.log"
 fi
 
-# opencode CLI
-export PATH="$HOME/.opencode/bin:$PATH"
-
 # Dotfiles scripts on PATH
 export PATH="$HOME/.dotfiles/scripts:$PATH"
 

--- a/.zshrc
+++ b/.zshrc
@@ -178,9 +178,6 @@ complete -o nospace -C /usr/bin/terraform terraform
 # Dump zprof results at end of startup if profiling is enabled
 [[ -n "${DOTFILES_PROFILE:-}" ]] && zprof | head -25
 
-# opencode CLI
-export PATH="$HOME/.opencode/bin:$PATH"
-
 # Dotfiles scripts on PATH
 export PATH="$HOME/.dotfiles/scripts:$PATH"
 

--- a/cli/internal/cmd/tools.go
+++ b/cli/internal/cmd/tools.go
@@ -32,6 +32,7 @@ func newToolsCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newToolsListCmd())
 	cmd.AddCommand(newToolsInstallCmd())
+	cmd.AddCommand(newToolsVersionCmd())
 	return cmd
 }
 
@@ -143,6 +144,32 @@ func newToolsListCmd() *cobra.Command {
 				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", t.Name, t.Version, t.Profile, asset)
 			}
 			return w.Flush()
+		},
+	}
+}
+
+// toolsVersionRunner is the exec seam for `dotf tools version`; tests inject a fake.
+var toolsVersionRunner tools.Runner = tools.ExecRunner
+
+func newToolsVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version <name>",
+		Short: "Print the semver a tool on PATH reports, or exit 1",
+		Long: "version runs `<name> --version` and prints the first semver in its output —\n" +
+			"the one extraction every caller shares (ADR-036). The setup scripts used to\n" +
+			"parse \"last token of the first line\" in seven places, and on the Windows\n" +
+			"work box that accepted `locked.` as opencode's version (AI-034, #1294).\n" +
+			"Exits 1 with nothing on stdout when the tool is absent or prints no version,\n" +
+			"so a shell caller can test either.",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := tools.ProbeVersion(args[0], toolsVersionRunner)
+			if v == "" {
+				return fmt.Errorf("%s: no version found on PATH", args[0])
+			}
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), v)
+			return nil
 		},
 	}
 }

--- a/cli/internal/cmd/tools_version_test.go
+++ b/cli/internal/cmd/tools_version_test.go
@@ -21,23 +21,31 @@ func TestToolsVersionCmd(t *testing.T) {
 		}
 		return nil, errors.New("not found")
 	}
-	run := func(name string) (string, error) {
-		c := newToolsVersionCmd()
-		var out bytes.Buffer
-		c.SetOut(&out)
-		c.SetErr(&bytes.Buffer{})
-		c.SetArgs([]string{name})
-		err := c.Execute()
-		return strings.TrimSpace(out.String()), err
-	}
 
-	if got, err := run("hive"); err != nil || got != "3.0.0" {
-		t.Errorf("hive: want 3.0.0, got %q (%v)", got, err)
+	cases := []struct {
+		name    string
+		tool    string
+		want    string
+		wantErr bool
+	}{
+		{name: "prefixed banner", tool: "hive", want: "3.0.0"},
+		{name: "banner line before the number", tool: "opencode", want: "1.16.2"},
+		{name: "absent tool: empty stdout, exit error", tool: "nope", want: "", wantErr: true},
 	}
-	if got, err := run("opencode"); err != nil || got != "1.16.2" {
-		t.Errorf("opencode: the banner line must not be taken as the version, got %q (%v)", got, err)
-	}
-	if got, err := run("nope"); err == nil || got != "" {
-		t.Errorf("absent tool: want exit error and empty stdout, got %q (%v)", got, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newToolsVersionCmd()
+			var out bytes.Buffer
+			c.SetOut(&out)
+			c.SetErr(&bytes.Buffer{})
+			c.SetArgs([]string{tc.tool})
+			err := c.Execute()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got := strings.TrimSpace(out.String()); got != tc.want {
+				t.Errorf("stdout = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/cli/internal/cmd/tools_version_test.go
+++ b/cli/internal/cmd/tools_version_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The two banners that broke the setup scripts' token parse, plus the absent
+// case: a shell caller tests stdout and the exit status, both must be right.
+func TestToolsVersionCmd(t *testing.T) {
+	orig := toolsVersionRunner
+	t.Cleanup(func() { toolsVersionRunner = orig })
+	toolsVersionRunner = func(name string, _ ...string) ([]byte, error) {
+		switch name {
+		case "hive":
+			return []byte("hive-vault 3.0.0\n"), nil
+		case "opencode":
+			return []byte("OpenCode locked.\n1.16.2\n"), nil
+		}
+		return nil, errors.New("not found")
+	}
+	run := func(name string) (string, error) {
+		c := newToolsVersionCmd()
+		var out bytes.Buffer
+		c.SetOut(&out)
+		c.SetErr(&bytes.Buffer{})
+		c.SetArgs([]string{name})
+		err := c.Execute()
+		return strings.TrimSpace(out.String()), err
+	}
+
+	if got, err := run("hive"); err != nil || got != "3.0.0" {
+		t.Errorf("hive: want 3.0.0, got %q (%v)", got, err)
+	}
+	if got, err := run("opencode"); err != nil || got != "1.16.2" {
+		t.Errorf("opencode: the banner line must not be taken as the version, got %q (%v)", got, err)
+	}
+	if got, err := run("nope"); err == nil || got != "" {
+		t.Errorf("absent tool: want exit error and empty stdout, got %q (%v)", got, err)
+	}
+}

--- a/cli/internal/doctor/checks_catalog.go
+++ b/cli/internal/doctor/checks_catalog.go
@@ -1,0 +1,90 @@
+package doctor
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/tools"
+)
+
+// loadCatalog reads packages.json checkout-first (ADR-030 precedence), then
+// the deploy mirror. An empty catalog means neither copy was readable.
+func loadCatalog(sys *System, cfg *Config) tools.Catalog {
+	var paths []string
+	if repo := resolveRepoDir(sys); repo != "" {
+		paths = append(paths, filepath.Join(repo, "packages.json"))
+	}
+	if cfg != nil && cfg.DotfilesDir != "" {
+		paths = append(paths, filepath.Join(cfg.DotfilesDir, "packages.json"))
+	}
+	for _, p := range paths {
+		if cat, err := tools.Load(p); err == nil {
+			return cat
+		}
+	}
+	return tools.Catalog{}
+}
+
+// catalogPin returns the packages.json pin for name, or "" when the catalog or
+// the tool is absent. packages.json is the pin SSOT for every catalog tool
+// (bw, sops, and since AI-034/#1294 opencode); versions.conf keeps only the
+// pins the shell layer still consumes.
+func catalogPin(sys *System, cfg *Config, name string) string {
+	for _, t := range loadCatalog(sys, cfg).Tools {
+		if t.Name == name {
+			return t.Version
+		}
+	}
+	return ""
+}
+
+// checkShadowedCatalogTools reports an npm-distributed catalog tool that
+// resolves from more than one PATH directory (AI-034/#1294). The copy that
+// wins is not necessarily the one `dotf tools install` converges: the Windows
+// work box carried an npm-global opencode (first on PATH) and a winget one,
+// and setup reported "still locked. after winget install 1.16.2" forever. The
+// catalog cannot converge a binary it does not own, so the extra channel is
+// named for the operator to remove. WARN, not FAIL: the tool does run.
+func checkShadowedCatalogTools(sys *System, cfg *Config, rep *Report) {
+	for _, t := range loadCatalog(sys, cfg).Tools {
+		if t.Source.Type != "npm" {
+			continue
+		}
+		dirs := sys.dirsProviding(t.Name)
+		if len(dirs) > 1 {
+			rep.Warn(fmt.Sprintf("%s resolves from %d PATH directories (%s) — `dotf tools install` converges the npm copy only; remove the other channel's copy",
+				t.Name, len(dirs), strings.Join(dirs, ", ")))
+		}
+	}
+}
+
+// dirsProviding lists the PATH directories that carry an executable named
+// name (on Windows also name.exe / .cmd / .ps1, the shapes npm, scoop and
+// winget each leave), in PATH order, without duplicates.
+func (s *System) dirsProviding(name string) []string {
+	candidates := []string{name}
+	if runtime.GOOS == "windows" || s.GOOS == "windows" {
+		candidates = append(candidates, name+".exe", name+".cmd", name+".ps1")
+	}
+	seen := map[string]bool{}
+	var dirs []string
+	for _, dir := range s.pathEntries() {
+		if dir == "" {
+			continue
+		}
+		clean := filepath.Clean(dir)
+		if seen[clean] {
+			continue
+		}
+		for _, c := range candidates {
+			if isExecFile(filepath.Join(clean, c)) {
+				seen[clean] = true
+				dirs = append(dirs, clean)
+				break
+			}
+		}
+	}
+	return dirs
+}

--- a/cli/internal/doctor/checks_catalog_test.go
+++ b/cli/internal/doctor/checks_catalog_test.go
@@ -1,0 +1,71 @@
+package doctor
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const catalogWithOpencode = `{"tools":[{"name":"opencode","version":"1.16.2","profile":"full","source":{"type":"npm","package":"opencode-ai"}},{"name":"sops","version":"3.13.1","profile":"full","source":{"type":"github-release","repo":"getsops/sops","asset":{"linux":"x"},"checksums":"c"}}]}`
+
+func TestCatalogPin_ReadsTheCheckoutBeforeTheMirror(t *testing.T) {
+	repo, mirror := t.TempDir(), t.TempDir()
+	writeFile(t, filepath.Join(repo, "packages.json"), catalogWithOpencode)
+	writeFile(t, filepath.Join(mirror, "packages.json"), strings.ReplaceAll(catalogWithOpencode, "1.16.2", "1.0.0"))
+	sys := newSys(map[string]string{"DOTFILES_REPO_DIR": repo}, nil, nil)
+	cfg := &Config{DotfilesDir: mirror}
+
+	if got := catalogPin(sys, cfg, "opencode"); got != "1.16.2" {
+		t.Errorf("checkout pin must win, got %q", got)
+	}
+	if got := catalogPin(sys, cfg, "nope"); got != "" {
+		t.Errorf("an unknown tool has no pin, got %q", got)
+	}
+}
+
+// Two opencode copies on PATH — the Windows work box's npm-global + winget
+// pair — must be named; one copy must stay quiet.
+func TestCheckShadowedCatalogTools_NamesEveryDirectoryProvidingTheTool(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "packages.json"), catalogWithOpencode)
+	a, b := filepath.Join(t.TempDir(), "npm"), filepath.Join(t.TempDir(), "winget")
+	writeExec(t, filepath.Join(a, "opencode"))
+	writeExec(t, filepath.Join(b, "opencode"))
+	pathSep := string(os.PathListSeparator)
+
+	t.Run("two directories -> WARN naming both", func(t *testing.T) {
+		sys := newSys(map[string]string{"DOTFILES_REPO_DIR": repo, "PATH": a + pathSep + b}, nil, nil)
+		var buf bytes.Buffer
+		rep := capture(&buf)
+		checkShadowedCatalogTools(sys, &Config{DotfilesDir: t.TempDir()}, rep)
+		out := buf.String()
+		if !strings.Contains(out, "[WARN]") || !strings.Contains(out, "opencode resolves from 2 PATH directories") {
+			t.Fatalf("expected a WARN naming the count\n%s", out)
+		}
+		if !strings.Contains(out, a) || !strings.Contains(out, b) {
+			t.Errorf("both directories must be named\n%s", out)
+		}
+	})
+
+	t.Run("one directory -> quiet", func(t *testing.T) {
+		sys := newSys(map[string]string{"DOTFILES_REPO_DIR": repo, "PATH": a}, nil, nil)
+		var buf bytes.Buffer
+		rep := capture(&buf)
+		checkShadowedCatalogTools(sys, &Config{DotfilesDir: t.TempDir()}, rep)
+		if strings.Contains(buf.String(), "opencode") {
+			t.Errorf("a single copy is not shadowed\n%s", buf.String())
+		}
+	})
+
+	t.Run("a duplicated PATH entry is one directory", func(t *testing.T) {
+		sys := newSys(map[string]string{"DOTFILES_REPO_DIR": repo, "PATH": a + pathSep + a}, nil, nil)
+		var buf bytes.Buffer
+		rep := capture(&buf)
+		checkShadowedCatalogTools(sys, &Config{DotfilesDir: t.TempDir()}, rep)
+		if strings.Contains(buf.String(), "opencode") {
+			t.Errorf("the same directory twice on PATH is not two copies\n%s", buf.String())
+		}
+	})
+}

--- a/cli/internal/doctor/checks_deploy.go
+++ b/cli/internal/doctor/checks_deploy.go
@@ -10,6 +10,7 @@ import (
 
 	envpkg "github.com/mlorentedev/dotfiles/cli/internal/env"
 	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
+	"github.com/mlorentedev/dotfiles/cli/internal/tools"
 )
 
 // checkSymlinks reproduces healthcheck section 4: the dotfiles symlinks resolve.
@@ -273,7 +274,7 @@ func checkOpenCode(sys *System, cfg *Config, rep *Report) {
 	opencodeBin := filepath.Join(home, ".opencode", "bin", "opencode")
 	switch {
 	case sys.has("opencode"):
-		ver := trailingVersion(sys, "opencode", "--version")
+		ver := semverOf(sys, "opencode")
 		rep.Pass("opencode in PATH: " + ver)
 		matchPinFrom(rep, "opencode", ver, catalogPin(sys, cfg, "opencode"), "packages.json")
 	case isExecFile(opencodeBin):
@@ -304,7 +305,7 @@ func checkOpenCode(sys *System, cfg *Config, rep *Report) {
 	piConfigured := pathExists(filepath.Join(home, ".pi", "agent", "models.json"))
 	switch {
 	case sys.has("pi"):
-		ver := trailingVersion(sys, "pi", "--version")
+		ver := semverOf(sys, "pi")
 		rep.Pass("pi in PATH: " + ver)
 		matchPin(rep, "pi", ver, cfg.Versions["PI_VERSION"])
 	case isExecFile(piLocalBin):
@@ -831,27 +832,25 @@ func checkAntigravity(sys *System, rep *Report) {
 	}
 }
 
-// trailingVersion returns the last whitespace field of the first line of
-// `name <arg>` output (the awk '{print $NF}' idiom), or "unknown" on error.
-func trailingVersion(sys *System, name, arg string) string {
-	out, err := sys.CommandOutput(name, arg)
-	if err != nil {
-		return "unknown"
-	}
-	first := out
-	if i := strings.IndexByte(out, '\n'); i >= 0 {
-		first = out[:i]
-	}
-	fields := strings.Fields(first)
-	if len(fields) == 0 {
-		return "unknown"
-	}
-	return fields[len(fields)-1]
-}
-
 // matchPin compares an installed version against a versions.conf pin: empty pin
 // → SKIP, equal → PASS, drift → WARN (never a FAIL — a pinned-tool drift is
 // advisory, exactly as healthcheck treated it).
+// semverOf is the doctor-side face of tools.ProbeVersion: the first semver in
+// `<name> --version`, through the System seam so tests inject the banner.
+// trailingVersion (last token of the first line) is what reported "locked."
+// for opencode on the Windows work box (AI-034/#1294); "unknown" when the
+// tool prints no version at all, so the report line stays readable.
+func semverOf(sys *System, name string) string {
+	v := tools.ProbeVersion(name, func(n string, args ...string) ([]byte, error) {
+		out, err := sys.CommandOutput(n, args...)
+		return []byte(out), err
+	})
+	if v == "" {
+		return "unknown"
+	}
+	return v
+}
+
 func matchPin(rep *Report, tool, installed, pin string) {
 	matchPinFrom(rep, tool, installed, pin, "versions.conf")
 }

--- a/cli/internal/doctor/checks_deploy.go
+++ b/cli/internal/doctor/checks_deploy.go
@@ -275,11 +275,13 @@ func checkOpenCode(sys *System, cfg *Config, rep *Report) {
 	case sys.has("opencode"):
 		ver := trailingVersion(sys, "opencode", "--version")
 		rep.Pass("opencode in PATH: " + ver)
-		matchPin(rep, "opencode", ver, cfg.Versions["OPENCODE_VERSION"])
+		matchPinFrom(rep, "opencode", ver, catalogPin(sys, cfg, "opencode"), "packages.json")
 	case isExecFile(opencodeBin):
-		rep.Fail("opencode binary exists at " + opencodeBin + " but not in PATH (reload shell)")
+		// The retired curl-script channel (ADR-036) left a copy behind and
+		// nothing on PATH resolves: the rc files no longer add ~/.opencode/bin.
+		rep.Fail("opencode not on PATH; a legacy curl-script copy sits at " + opencodeBin + " — run `dotf tools install opencode` and delete the legacy copy (ADR-036)")
 	default:
-		rep.Fail("opencode binary missing (run setup)")
+		rep.Fail("opencode missing (run `dotf tools install opencode`)")
 	}
 
 	// opencode config + $schema.
@@ -328,6 +330,8 @@ func checkOpenCode(sys *System, cfg *Config, rep *Report) {
 			rep.Skip("pi models.json substitution — age identity absent ({env:} resolves at runtime)")
 		}
 	}
+
+	checkShadowedCatalogTools(sys, cfg, rep)
 
 	// Launchability. Everything above is a static predicate — files and PATH —
 	// and every one of them was green on a box where `pi` could not start
@@ -849,13 +853,19 @@ func trailingVersion(sys *System, name, arg string) string {
 // → SKIP, equal → PASS, drift → WARN (never a FAIL — a pinned-tool drift is
 // advisory, exactly as healthcheck treated it).
 func matchPin(rep *Report, tool, installed, pin string) {
+	matchPinFrom(rep, tool, installed, pin, "versions.conf")
+}
+
+// matchPinFrom is matchPin with the pin's source named: packages.json is the
+// SSOT for catalog tools (ADR-036), versions.conf for the rest.
+func matchPinFrom(rep *Report, tool, installed, pin, source string) {
 	switch {
 	case pin == "":
-		rep.Skip(tool + " version not pinned in versions.conf — match not verified")
+		rep.Skip(tool + " version not pinned in " + source + " — match not verified")
 	case installed == pin:
-		rep.Pass(fmt.Sprintf("%s version matches versions.conf (%s)", tool, pin))
+		rep.Pass(fmt.Sprintf("%s version matches %s (%s)", tool, source, pin))
 	default:
-		rep.Warn(fmt.Sprintf("%s version drift: installed=%s pinned=%s", tool, installed, pin))
+		rep.Warn(fmt.Sprintf("%s version drift: installed=%s pinned=%s (%s)", tool, installed, pin, source))
 	}
 }
 

--- a/cli/internal/doctor/checks_opencode_version_test.go
+++ b/cli/internal/doctor/checks_opencode_version_test.go
@@ -1,0 +1,38 @@
+package doctor
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The opencode banner that setup-windows.ps1 parsed as the version "locked."
+// (AI-034/#1294) must not become a false drift report in doctor: the version
+// is the first semver anywhere in the output, matched against the catalog pin.
+func TestCheckOpenCode_VersionIsTheSemverNotTheBannerToken(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "packages.json"), catalogWithOpencode)
+	cases := []struct {
+		name, banner, wantLine string
+	}{
+		{"banner line before the number", "OpenCode locked.\n1.16.2\n", "opencode version matches packages.json (1.16.2)"},
+		{"plain version", "1.16.2\n", "opencode version matches packages.json (1.16.2)"},
+		{"older version", "1.15.0\n", "opencode version drift: installed=1.15.0 pinned=1.16.2 (packages.json)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			sys := newSys(map[string]string{"HOME": home, "DOTFILES_REPO_DIR": repo}, []string{"opencode"},
+				map[string]string{"opencode --version": tc.banner})
+			var buf bytes.Buffer
+			checkOpenCode(sys, &Config{DotfilesDir: t.TempDir(), Versions: map[string]string{}}, capture(&buf))
+			if !strings.Contains(buf.String(), tc.wantLine) {
+				t.Errorf("want %q in\n%s", tc.wantLine, buf.String())
+			}
+			if strings.Contains(buf.String(), "locked.") {
+				t.Errorf("the banner token must never be reported as a version\n%s", buf.String())
+			}
+		})
+	}
+}

--- a/cli/internal/tools/version.go
+++ b/cli/internal/tools/version.go
@@ -1,0 +1,37 @@
+package tools
+
+import "os/exec"
+
+// Runner executes name with args and returns its combined output. The seam
+// ProbeVersion takes, so the extraction is unit-tested against captured banners
+// without the tools installed.
+type Runner func(name string, args ...string) ([]byte, error)
+
+// ExecRunner is the production Runner: `<name> <args>` on PATH, stdout and
+// stderr merged, because tools disagree about which stream a version goes to.
+func ExecRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput() //nolint:gosec // name is an operator-chosen tool
+}
+
+// ProbeVersion runs `<name> --version` through run and returns the first
+// semver anywhere in its output, or "" when the tool is absent or prints none.
+//
+// One extraction for every caller. The setup scripts each parsed the version
+// as "last whitespace token of the first line" — seven sites across both OSes —
+// and on the Windows work box that accepted `locked.` as opencode's version
+// from a banner line printed before the number (AI-034, #1294). Output is
+// still used when the command exits non-zero: several tools print the version
+// and then complain about something unrelated.
+func ProbeVersion(name string, run Runner) string {
+	if run == nil {
+		run = ExecRunner
+	}
+	out, err := run(name, "--version")
+	if err != nil && len(out) == 0 {
+		return ""
+	}
+	if m := semverRE.Find(out); m != nil {
+		return string(m)
+	}
+	return ""
+}

--- a/cli/internal/tools/version_test.go
+++ b/cli/internal/tools/version_test.go
@@ -5,42 +5,33 @@ import (
 	"testing"
 )
 
-// Banners captured from real tools. The first two are the ones that broke the
-// "last token of the first line" parse in the setup scripts.
-func TestProbeVersion_ExtractsTheSemverFromRealBanners(t *testing.T) {
+// One table for every branch of ProbeVersion: real banners (the first two are
+// the ones that broke the setup scripts' "last token of the first line"
+// parse), a version printed before an unrelated non-zero exit, and an absent
+// tool.
+func TestProbeVersion(t *testing.T) {
 	cases := []struct {
-		name, out, want string
+		name string
+		out  string
+		err  error
+		want string
 	}{
-		{"opencode banner line first", "OpenCode locked.\n1.16.2\n", "1.16.2"},
-		{"hive prefixed name", "hive-vault 3.0.0\n", "3.0.0"},
-		{"pi bare", "0.84.3\n", "0.84.3"},
-		{"dotf prefixed", "dotf version 0.51.0\n", "0.51.0"},
-		{"jq with a suffix", "jq-1.7.1\n", "1.7.1"},
-		{"no version at all", "usage: thing [options]\n", ""},
-		{"empty", "", ""},
+		{name: "opencode banner line first", out: "OpenCode locked.\n1.16.2\n", want: "1.16.2"},
+		{name: "hive prefixed name", out: "hive-vault 3.0.0\n", want: "3.0.0"},
+		{name: "pi bare", out: "0.84.3\n", want: "0.84.3"},
+		{name: "dotf prefixed", out: "dotf version 0.51.0\n", want: "0.51.0"},
+		{name: "jq with a suffix", out: "jq-1.7.1\n", want: "1.7.1"},
+		{name: "no version at all", out: "usage: thing [options]\n", want: ""},
+		{name: "empty output", out: "", want: ""},
+		{name: "version printed before an unrelated non-zero exit", out: "tool 2.3.4\nerror: telemetry endpoint unreachable\n", err: errors.New("exit status 1"), want: "2.3.4"},
+		{name: "absent tool", err: errors.New("not found"), want: ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ProbeVersion("x", func(string, ...string) ([]byte, error) { return []byte(tc.out), nil })
+			got := ProbeVersion("x", func(string, ...string) ([]byte, error) { return []byte(tc.out), tc.err })
 			if got != tc.want {
-				t.Errorf("ProbeVersion(%q) = %q, want %q", tc.out, got, tc.want)
+				t.Errorf("ProbeVersion(%q, err=%v) = %q, want %q", tc.out, tc.err, got, tc.want)
 			}
 		})
-	}
-}
-
-func TestProbeVersion_UsesOutputEvenWhenTheToolExitsNonZero(t *testing.T) {
-	got := ProbeVersion("x", func(string, ...string) ([]byte, error) {
-		return []byte("tool 2.3.4\nerror: telemetry endpoint unreachable\n"), errors.New("exit status 1")
-	})
-	if got != "2.3.4" {
-		t.Errorf("a version printed before an unrelated error must still count, got %q", got)
-	}
-}
-
-func TestProbeVersion_AbsentToolIsEmpty(t *testing.T) {
-	got := ProbeVersion("x", func(string, ...string) ([]byte, error) { return nil, errors.New("not found") })
-	if got != "" {
-		t.Errorf("absent tool must probe as empty, got %q", got)
 	}
 }

--- a/cli/internal/tools/version_test.go
+++ b/cli/internal/tools/version_test.go
@@ -1,0 +1,46 @@
+package tools
+
+import (
+	"errors"
+	"testing"
+)
+
+// Banners captured from real tools. The first two are the ones that broke the
+// "last token of the first line" parse in the setup scripts.
+func TestProbeVersion_ExtractsTheSemverFromRealBanners(t *testing.T) {
+	cases := []struct {
+		name, out, want string
+	}{
+		{"opencode banner line first", "OpenCode locked.\n1.16.2\n", "1.16.2"},
+		{"hive prefixed name", "hive-vault 3.0.0\n", "3.0.0"},
+		{"pi bare", "0.84.3\n", "0.84.3"},
+		{"dotf prefixed", "dotf version 0.51.0\n", "0.51.0"},
+		{"jq with a suffix", "jq-1.7.1\n", "1.7.1"},
+		{"no version at all", "usage: thing [options]\n", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ProbeVersion("x", func(string, ...string) ([]byte, error) { return []byte(tc.out), nil })
+			if got != tc.want {
+				t.Errorf("ProbeVersion(%q) = %q, want %q", tc.out, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProbeVersion_UsesOutputEvenWhenTheToolExitsNonZero(t *testing.T) {
+	got := ProbeVersion("x", func(string, ...string) ([]byte, error) {
+		return []byte("tool 2.3.4\nerror: telemetry endpoint unreachable\n"), errors.New("exit status 1")
+	})
+	if got != "2.3.4" {
+		t.Errorf("a version printed before an unrelated error must still count, got %q", got)
+	}
+}
+
+func TestProbeVersion_AbsentToolIsEmpty(t *testing.T) {
+	got := ProbeVersion("x", func(string, ...string) ([]byte, error) { return nil, errors.New("not found") })
+	if got != "" {
+		t.Errorf("absent tool must probe as empty, got %q", got)
+	}
+}

--- a/docs/adr/adr-036-install-channels.md
+++ b/docs/adr/adr-036-install-channels.md
@@ -1,0 +1,50 @@
+---
+id: "ADR-036-install-channels"
+type: adr
+status: accepted
+owner: manu
+date: "2026-08-27"
+supersedes: []
+extends: [adr-020-tooling-cli-go-convergence, adr-025-cross-machine-paths]
+issue: mlorentedev/dotfiles#1294
+tags: [architecture, decision, tooling, install, packages, windows, linux]
+created: "2026-08-27"
+---
+
+# ADR-036: Install channels — one channel per tool class, on every OS, pinned in `packages.json`
+
+## Context
+
+Measured 2026-08-27 on the Windows work box: `opencode` was installed three ways across the two machines — npm-global `opencode-ai` (scoop's node `bin`, first on PATH), winget `SST.opencode` (what `setup-windows.ps1` pinned), and the curl install script into `~/.opencode/bin` on Linux. Setup parsed the version as "last token of the first output line", accepted `locked.` as a version, "upgraded" the winget copy, and printed *"another install shadows it in PATH; converge that install instead"* — a manual instruction — on every run. Seven such parse sites existed across both setup scripts (`opencode`, `pi`, `hive`, `yarn`), and no document anywhere recorded which channel a tool was supposed to come from. `specs/archive/AI-014-opencode-windows-bootstrap` had considered npm as a fallback and never decided.
+
+The repository already carried the right primitive: `packages.json` + `dotf tools install` (CLI-029) implements pin-as-floor reconciliation with a semver-regex probe for two source types, `github-release` (sha256-verified into `~/.local/bin`) and `npm` (`npm install -g <pkg>@<version>`), used by `sops` and `bw`. Nothing said when a tool belongs there.
+
+## Decision
+
+1. **Every tool this repository provisions has exactly one install channel, the same on every OS**, chosen by the tool's own distribution shape:
+
+   | Tool class | Channel | Source type |
+   |---|---|---|
+   | node-distributed agents and CLIs (`pi`, `opencode`, `bw`) | npm global | `npm` |
+   | static single-binary releases (`sops`, `age`, `eza`, `zoxide`, `dotf`) | GitHub release, sha256-verified | `github-release` |
+   | tools with no cross-OS channel (`git`, `gh`, `jq`, `copilot`, `uv`) | the OS package manager (`winget` / apt / official installer) | setup script |
+
+   A tool in the first two classes is declared in `packages.json` and converged by `dotf tools install` on both OSes; the setup scripts stop carrying per-OS install blocks for it.
+
+2. **`packages.json` is the pin SSOT for every catalog tool.** A catalog tool's version appears nowhere else; `versions.conf` keeps only the pins the shell layer still consumes directly. `dotf doctor` reads the catalog pin for those tools.
+
+3. **Version detection happens once, in Go.** `dotf tools version <name>` returns the first semver in `<name> --version`'s output; setup scripts call it instead of parsing. `dotf tools install` already probes the same way.
+
+4. **A second copy on PATH is a finding, not a state to converge silently.** `dotf doctor` WARNs when an npm catalog tool resolves from more than one PATH directory and names them; the catalog converges the copy it owns and the operator removes the other channel's. Setup never prints a manual instruction for it.
+
+5. **Migration is by the same mechanism.** Retiring a channel (winget `SST.opencode`, the opencode curl script, the `~/.opencode/bin` PATH line in the rc files) leaves the old copy where it is; the next `dotf tools install` converges the declared channel and doctor reports the leftover.
+
+## Consequences
+
+- `setup-linux.sh` and `setup-windows.ps1` lose their opencode install blocks and the winget loop's version-pin machinery (no winget tool carries a pin any more). The hive `hive service` gate probes `hive --version` through `dotf tools version` instead of `uv tool list`, which stopped seeing a healthy install when hive moved to its own installer (AI-028, #791).
+- `pi` is not moved in the same change: its Linux block installs with `--prefix ~/.local --ignore-scripts` for the Orca per-node-version PATH trap (#426), a behaviour `installNpm` does not yet carry. It follows once `packages.json` can express those flags (tracked on #1294's follow-up).
+- The Linux box will report the orphaned `~/.opencode/bin` copy the first time doctor runs after this lands; removing it is the migration.
+
+## References
+
+- AI-034 (#1294), CLI-029 (`packages.json`, `dotf tools`), AI-028 (#791), #1265 / #1262 / #1267 (convergence and pin semantics), `pattern-setup-script-idempotence`.

--- a/docs/adr/adr-036-install-channels.md
+++ b/docs/adr/adr-036-install-channels.md
@@ -21,7 +21,7 @@ The repository already carried the right primitive: `packages.json` + `dotf tool
 
 ## Decision
 
-1. **Every tool this repository provisions has exactly one install channel, the same on every OS**, chosen by the tool's own distribution shape:
+1. **Every tool this repository provisions has exactly one install channel**, chosen by the tool's own distribution shape. For the first two classes below that channel is the same on every OS and lives in `packages.json`; the third class has no cross-OS channel by definition and takes the OS package manager or the official installer, one per OS, in the setup script:
 
    | Tool class | Channel | Source type |
    |---|---|---|

--- a/packages.json
+++ b/packages.json
@@ -16,6 +16,15 @@
       }
     },
     {
+      "name": "opencode",
+      "version": "1.16.2",
+      "profile": "full",
+      "source": {
+        "type": "npm",
+        "package": "opencode-ai"
+      }
+    },
+    {
       "name": "bw",
       "version": "2026.5.0",
       "profile": "full",

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -995,9 +995,16 @@ fi
 # now expresses what was the hard-coded Claude-only skip-list.
 
 # Post-deploy assertion: binary reachable + version reports. Placement is
-# `dotf tools install`'s (packages.json, AI-034/#1294); this only verifies it.
+# `dotf tools install`'s (packages.json, AI-034/#1294); this only verifies it,
+# through the one version probe (ADR-036) rather than a local parse.
 if command -v opencode >/dev/null 2>&1; then
-    opencode_ready_version=$(opencode --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+    _dotf=""
+    if command -v dotf >/dev/null 2>&1; then _dotf="dotf"; elif [ -x "$HOME/.local/bin/dotf" ]; then _dotf="$HOME/.local/bin/dotf"; fi
+    opencode_ready_version=""
+    if [ -n "$_dotf" ]; then
+        opencode_ready_version=$("$_dotf" tools version opencode 2>/dev/null) || opencode_ready_version=""
+    fi
+    unset _dotf
     log_success "opencode ready: ${opencode_ready_version:-unknown}"
 else
     log_warning "opencode not reachable on PATH after 'dotf tools install' — agent unavailable (re-run 'dotf tools install opencode')"

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -40,7 +40,7 @@ if [ "$CURRENT_DIR" = "$DOTFILES_DIR" ]; then
 fi
 
 # Single source of truth for tool versions (REFACTOR-011): source the manifest
-# from the checkout so $OPENCODE_VERSION / etc. are reliable
+# from the checkout so $PI_VERSION / etc. are reliable
 # regardless of the parent shell. Read from $CURRENT_DIR: the copy under
 # $DOTFILES_DIR does not exist yet on a first run (it is created below).
 [ -f "$CURRENT_DIR/versions.conf" ] && . "$CURRENT_DIR/versions.conf"
@@ -688,58 +688,16 @@ fi
 # OpenCode (secondary AI coding agent — see ADR-009 and specs/AI-011-opencode-bootstrap)
 
 # Idempotent per pattern-setup-script-idempotence:
-#   - install only if absent (no forced re-install on every run)
+#   - the binary is a packages.json catalog tool (npm on every OS, AI-034/#1294,
+#     ADR-036): `dotf tools install` above converges it; nothing installs here
 #   - reconcile config (not skip-if-exists) so source-of-truth wins on drift
 #   - no silenced errors; failures surface as log_warning
 log_info "Setting up OpenCode configuration..."
-OPENCODE_BIN_DIR="$HOME/.opencode/bin"
-OPENCODE_BINARY="$OPENCODE_BIN_DIR/opencode"
-
-if ! command -v opencode >/dev/null 2>&1 && [ ! -x "$OPENCODE_BINARY" ]; then
-    # Pin to $OPENCODE_VERSION from versions.conf (REFACTOR-011). The official
-    # installer honors `--version`. If the manifest is missing (broken checkout)
-    # OPENCODE_VERSION is empty -- fall back to latest rather than passing an
-    # empty --version, and let healthcheck surface the drift.
-    opencode_install_status=0
-    if [ -n "$OPENCODE_VERSION" ]; then
-        log_info "Installing opencode v$OPENCODE_VERSION via official install script..."
-        curl -fsSL https://opencode.ai/install | bash -s -- --version "$OPENCODE_VERSION" || opencode_install_status=$?
-    else
-        log_info "Installing opencode (latest; OPENCODE_VERSION unset) via official install script..."
-        curl -fsSL https://opencode.ai/install | bash || opencode_install_status=$?
-    fi
-    if [ "$opencode_install_status" -eq 0 ]; then
-        log_success "opencode installed to $OPENCODE_BIN_DIR"
-    else
-        log_warning "opencode install failed — re-run setup or install manually (https://opencode.ai/docs/)"
-    fi
-elif [ -n "$OPENCODE_VERSION" ]; then
-    # REFACTOR-011/013: presence is not convergence, and the pin is a MINIMUM.
-    # An opencode OLDER than the pin was previously skipped as "already
-    # installed"; an exact-match reconcile would conversely DOWNGRADE a newer
-    # install. Upgrade only when installed < pin (version_gte), never downgrade.
-    opencode_cmd="opencode"
-    command -v opencode >/dev/null 2>&1 || opencode_cmd="$OPENCODE_BINARY"
-    installed_opencode=$("$opencode_cmd" --version 2>/dev/null | head -1 | awk '{print $NF}')
-    if ! version_gte "$installed_opencode" "$OPENCODE_VERSION"; then
-        log_info "opencode ${installed_opencode:-unknown} below pinned minimum $OPENCODE_VERSION, upgrading..."
-        curl -fsSL https://opencode.ai/install | bash -s -- --version "$OPENCODE_VERSION" || true
-        # Re-query instead of trusting the installer exit code: when the
-        # PATH-resolved binary comes from another package manager (npm
-        # global), the installer converges its own copy but the shadowing
-        # install keeps winning -- that is not convergence.
-        converged_opencode=$("$opencode_cmd" --version 2>/dev/null | head -1 | awk '{print $NF}')
-        if version_gte "$converged_opencode" "$OPENCODE_VERSION"; then
-            log_success "opencode upgraded to ${converged_opencode:-$OPENCODE_VERSION} (>= $OPENCODE_VERSION)"
-        else
-            log_warning "opencode still ${converged_opencode:-unknown} after install of $OPENCODE_VERSION: another install shadows it in PATH (e.g. npm global); converge that install instead"
-        fi
-    else
-        log_info "opencode already installed (${installed_opencode:-unknown} >= $OPENCODE_VERSION)"
-    fi
-else
-    log_info "opencode already installed"
-fi
+# The curl-script install into ~/.opencode/bin and its "last token of the
+# first line" version parse lived here until AI-034. A leftover copy from that
+# channel is reported by `dotf doctor` (a catalog tool resolving from two PATH
+# directories) and is safe to delete once `command -v opencode` resolves the
+# npm one; the rc files no longer put ~/.opencode/bin on PATH.
 
 # Deploy opencode.jsonc with deploy-time {env:VAR} substitution (SDD-009).
 # Source ships placeholders like {env:NAN_API_KEY}; we substitute the literal
@@ -1036,13 +994,13 @@ fi
 # ai/opencode/commands/ + skills-to-opencode.sh path; the per-skill targets[]
 # now expresses what was the hard-coded Claude-only skip-list.
 
-# Post-deploy assertion — binary reachable + version reports
-if [ -x "$OPENCODE_BINARY" ] || command -v opencode >/dev/null 2>&1; then
-    OPENCODE_VERSION=$("$OPENCODE_BINARY" --version 2>&1 | head -1 || echo "unknown")
-    log_success "opencode ready: $OPENCODE_VERSION"
-    log_info "First-time use: launch \`opencode\` and run /connect to authenticate (Go subscription)"
+# Post-deploy assertion: binary reachable + version reports. Placement is
+# `dotf tools install`'s (packages.json, AI-034/#1294); this only verifies it.
+if command -v opencode >/dev/null 2>&1; then
+    opencode_ready_version=$(opencode --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+    log_success "opencode ready: ${opencode_ready_version:-unknown}"
 else
-    log_warning "opencode binary not reachable at $OPENCODE_BINARY after install — agent unavailable"
+    log_warning "opencode not reachable on PATH after 'dotf tools install' — agent unavailable (re-run 'dotf tools install opencode')"
 fi
 
 # GitHub Copilot CLI (BUG-003: standalone agentic CLI, drops legacy gh-copilot
@@ -1203,7 +1161,18 @@ fi
 # `hive service`, which an older hive routes to the blocking stdio server). The MCP
 # entry itself is already `hive client` (re-added from mcp-servers.json above).
 # Non-fatal: a missing systemd --user or any failure leaves the in-process fallback.
-hive_ver=$(uv tool list 2>/dev/null | sed -n 's/^hive-vault v\?\([0-9][0-9.]*\).*/\1/p' | head -1)
+# Probe the BINARY, not the installer registry: hive moved to its own installer
+# and `uv tool list` stopped seeing a healthy install (AI-028/#791), so this
+# gate skipped daemon supervision with "hive <unknown> predates 'hive service'"
+# while `hive --version` answered 3.0.0. `dotf tools version` is the one semver
+# extraction both OSes share (ADR-036); resolved by path as well as by name
+# because ~/.local/bin may not be on this process's PATH (#1202 class).
+hive_ver=""
+if command -v dotf >/dev/null 2>&1; then
+    hive_ver=$(dotf tools version hive 2>/dev/null || true)
+elif [ -x "$HOME/.local/bin/dotf" ]; then
+    hive_ver=$("$HOME/.local/bin/dotf" tools version hive 2>/dev/null || true)
+fi
 if command -v hive >/dev/null 2>&1 && [ -n "$hive_ver" ] \
     && [ "$(printf '1.32.0\n%s\n' "$hive_ver" | sort -V | head -1)" = "1.32.0" ]; then
     if hive service install >/dev/null 2>&1; then

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -384,7 +384,12 @@ if ($wingetCmd) {
         @{ Name = "jq"; Cmd = "jq"; Id = "jqlang.jq" },
         @{ Name = "GitHub CLI"; Cmd = "gh"; Id = "GitHub.cli" },
         @{ Name = "zoxide"; Cmd = "zoxide"; Id = "ajeetdsouza.zoxide" },
-        @{ Name = "GitHub Copilot CLI"; Cmd = "copilot"; Id = "GitHub.Copilot" }
+        @{ Name = "GitHub Copilot CLI"; Cmd = "copilot"; Id = "GitHub.Copilot" },
+        # Node.js is the prerequisite of the npm channel (ADR-036 class 3: no
+        # cross-OS channel, so winget here, nvm on Linux). It must exist before
+        # `dotf tools install` runs below, or bw and opencode cannot install on
+        # a clean box. A scoop/nvm node already on PATH is left alone.
+        @{ Name = "Node.js LTS"; Cmd = "node"; Id = "OpenJS.NodeJS.LTS" }
         # opencode left this list for packages.json (npm on every OS, AI-034/#1294,
         # ADR-036): `dotf tools install` below converges it. No winget tool carries
         # a version pin any more, so the loop only installs what is absent.

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -375,18 +375,6 @@ if (Test-Path -LiteralPath $installHooksPs1) {
 
 Write-Info "Installing developer tools..."
 
-# Pin OpenCode to OPENCODE_VERSION from versions.conf (REFACTOR-011), mirroring
-# the Linux installer. winget honors --version. If the manifest is missing or
-# the key is absent, $opencodeVersion stays $null and OpenCode installs latest.
-$opencodeVersion = $null
-if (Test-Path -LiteralPath $versionsSource) {
-    foreach ($line in Get-Content -LiteralPath $versionsSource) {
-        if ($line -match '^\s*OPENCODE_VERSION\s*=\s*(.+?)\s*$') {
-            $opencodeVersion = $Matches[1].Trim().Trim('"').Trim("'")
-            break
-        }
-    }
-}
 
 $wingetCmd = Get-Command winget -ErrorAction SilentlyContinue
 if ($wingetCmd) {
@@ -396,47 +384,20 @@ if ($wingetCmd) {
         @{ Name = "jq"; Cmd = "jq"; Id = "jqlang.jq" },
         @{ Name = "GitHub CLI"; Cmd = "gh"; Id = "GitHub.cli" },
         @{ Name = "zoxide"; Cmd = "zoxide"; Id = "ajeetdsouza.zoxide" },
-        @{ Name = "GitHub Copilot CLI"; Cmd = "copilot"; Id = "GitHub.Copilot" },
-        # AI-014: OpenCode (secondary AI agent, ADR-009). User-scope winget
-        # package, no admin. Cleaner than the Linux curl-bash equivalent.
-        @{ Name = "OpenCode"; Cmd = "opencode"; Id = "SST.opencode"; Version = $opencodeVersion }
+        @{ Name = "GitHub Copilot CLI"; Cmd = "copilot"; Id = "GitHub.Copilot" }
+        # opencode left this list for packages.json (npm on every OS, AI-034/#1294,
+        # ADR-036): `dotf tools install` below converges it. No winget tool carries
+        # a version pin any more, so the loop only installs what is absent.
     )
     foreach ($tool in $tools) {
         if (-not (Get-Command $tool.Cmd -ErrorAction SilentlyContinue)) {
             Write-Info "Installing $($tool.Name)..."
             try {
                 $wingetArgs = @($tool.Id, '--accept-package-agreements', '--accept-source-agreements')
-                # ContainsKey guard: utils.ps1 sets Set-StrictMode Latest, so
-                # $tool.Version on a hashtable WITHOUT that key throws instead
-                # of returning $null -- latent until a box actually needs the
-                # install branch (first caught by the WIN-004 CI runner).
-                if ($tool.ContainsKey('Version') -and $tool.Version) { $wingetArgs += @('--version', $tool.Version) }
                 & winget install @wingetArgs 2>$null | Out-Null
                 Write-Success "$($tool.Name) installed"
             } catch {
                 Write-Warn "Failed to install $($tool.Name): $_"
-            }
-        } elseif ($tool.ContainsKey('Version') -and $tool.Version) {
-            # REFACTOR-011/013: presence is not convergence, and the pin is a
-            # MINIMUM. A tool OLDER than the pin was skipped as "already
-            # installed"; an exact-match `-ne` reconcile would conversely
-            # DOWNGRADE a newer install. Upgrade only when installed < pin.
-            $installedVer = ((& $tool.Cmd --version 2>&1 | Select-Object -First 1) -split '\s+')[-1]
-            if (-not (Test-VersionAtLeast $installedVer $tool.Version)) {
-                Write-Info "$($tool.Name) $installedVer below pinned minimum $($tool.Version), upgrading..."
-                & winget install $tool.Id --version $tool.Version --accept-package-agreements --accept-source-agreements --force 2>$null | Out-Null
-                # Re-query instead of trusting winget's exit code: when the
-                # PATH-resolved binary comes from another package manager (npm
-                # global, scoop), winget converges its own copy but the
-                # shadowing install keeps winning -- that is not convergence.
-                $postVer = ((& $tool.Cmd --version 2>&1 | Select-Object -First 1) -split '\s+')[-1]
-                if (Test-VersionAtLeast $postVer $tool.Version) {
-                    Write-Success "$($tool.Name) upgraded to $postVer (>= $($tool.Version))"
-                } else {
-                    Write-Warn "$($tool.Name) still $postVer after winget install $($tool.Version): another install shadows it in PATH (e.g. npm global, scoop); converge that install instead"
-                }
-            } else {
-                Write-Info "$($tool.Name) already installed ($installedVer >= $($tool.Version))"
             }
         } else {
             Write-Info "$($tool.Name) already installed"
@@ -680,8 +641,16 @@ if (Get-Command dotf -ErrorAction SilentlyContinue) {
 # `hive service`, which an older hive routes to the blocking stdio server). The MCP
 # entry itself is already `hive client` (re-added from mcp-servers.json above).
 # Non-fatal: any failure leaves the in-process `hive client` fallback.
-$hiveVerMatch = (& uv tool list 2>$null | Select-String -Pattern '^hive-vault\s+v?([\d.]+)')
-$hiveVer = if ($hiveVerMatch) { $hiveVerMatch.Matches[0].Groups[1].Value } else { $null }
+# Probe the BINARY, not the installer registry: hive moved to its own installer
+# and `uv tool list` stopped seeing a healthy install (AI-028/#791), so this gate
+# skipped daemon supervision with "hive <unknown> predates 'hive service'" while
+# `hive --version` answered 3.0.0 on the work box. `dotf tools version` is the one
+# semver extraction both OSes share (ADR-036).
+$hiveVer = $null
+if (Get-Command dotf -ErrorAction SilentlyContinue) {
+    $hiveVer = (& dotf tools version hive 2>$null | Select-Object -First 1)
+    if ($LASTEXITCODE -ne 0 -or -not $hiveVer) { $hiveVer = $null }
+}
 if ((Get-Command hive -ErrorAction SilentlyContinue) -and $hiveVer -and ([version]$hiveVer -ge [version]'1.32.0')) {
     & hive service install *> $null
     $hiveSvcRc = $LASTEXITCODE
@@ -1083,7 +1052,7 @@ if (-not $obsidianCmd) {
 # ============================================================================
 # 2d. OPENCODE CONFIG + COMMANDS (AI-014)
 # ============================================================================
-# Binary install is handled in section 1c via winget SST.opencode. This block
+# Binary install: packages.json (npm) via dotf tools install (AI-034, ADR-036). This block
 # deploys the canonical config + skill-derived commands using the same
 # reconcile-not-skip pattern as setup-linux.sh (AI-011, lines 415-465).
 # Both files: SHA256 byte-equality test before overwrite so user-side edits

--- a/specs/AI-034-opencode-npm-channel/features.json
+++ b/specs/AI-034-opencode-npm-channel/features.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "AI-034-opencode-npm-channel-f1",
+    "behavior": "packages.json declares opencode as an npm catalog tool and versions.conf no longer pins it.",
+    "verification": "jq -e '.tools[] | select(.name==\"opencode\" and .source.type==\"npm\" and .source.package==\"opencode-ai\" and (.version|test(\"^[0-9]+\\\\.[0-9]+\\\\.[0-9]+$\")))' packages.json >/dev/null && ! grep -q '^OPENCODE_VERSION=' versions.conf",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-034-opencode-npm-channel-f2",
+    "behavior": "Neither setup script carries an opencode install block, a winget SST.opencode entry, the winget version-pin machinery, or the ~/.opencode/bin PATH export.",
+    "verification": "bats tests/opencode.bats tests/setup-windows.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-034-opencode-npm-channel-f3",
+    "behavior": "dotf tools version <name> prints the first semver of <name> --version and exits 1 when none; both setups gate hive service on it.",
+    "verification": "cd cli && go test ./internal/tools/ ./internal/cmd/ -run 'TestProbeVersion|TestToolsVersionCmd' && cd .. && bats tests/hive-upgrade-timer.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-034-opencode-npm-channel-f4",
+    "behavior": "dotf doctor reads opencode's pin from packages.json and WARNs, naming the directories, when an npm catalog tool resolves from more than one PATH entry.",
+    "verification": "cd cli && go test ./internal/doctor/ -run 'TestCatalogPin|TestCheckShadowedCatalogTools|TestCheckOpenCode'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "AI-034-opencode-npm-channel-f5",
+    "behavior": "ADR-036 records the channel policy and the Linux migration consequence.",
+    "verification": "grep -q '^# ADR-036' docs/adr/adr-036-install-channels.md && grep -q 'opencode/bin' docs/adr/adr-036-install-channels.md",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/AI-034-opencode-npm-channel/proposal.md
+++ b/specs/AI-034-opencode-npm-channel/proposal.md
@@ -1,0 +1,51 @@
+---
+id: "AI-034-opencode-npm-channel"
+type: spec
+status: verifying # draft | implementing | verifying | archived
+created: "2026-08-27"
+issue: "mlorentedev/dotfiles#1294"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# AI-034-opencode-npm-channel
+
+> **Naming**: file lives at `<repo>/specs/AI-034-opencode-npm-channel/proposal.md`. `AI-034-opencode-npm-channel` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #1294: AI-034: opencode is installed through three channels and its version parse accepted 'locked.', so setup never converges the binary on PATH -->
+
+Measured 2026-08-27 on the Windows work box: `setup-windows.ps1` printed *"OpenCode locked. below pinned minimum 1.16.2, upgrading..."* and then *"still locked. after winget install 1.16.2: another install shadows it in PATH; converge that install instead"* — a version parse that accepted a banner word as a version, and a manual instruction as the remedy. opencode reached the two machines through three channels (npm-global, winget, the curl script), seven fragile `--version` parse sites lived across both setup scripts, and no document anywhere said which channel a tool should come from. The repo already had the right primitive — `packages.json` + `dotf tools install`, with pin-as-floor and a semver-regex probe — used for `bw` and `sops` and nothing else.
+
+## What
+
+- **Decision recorded as ADR-036:** one install channel per tool class on every OS; npm for node-distributed agents; `packages.json` is the pin SSOT for catalog tools; version detection happens once in Go; a second copy on PATH is a doctor finding, not a thing setup converges silently.
+- `packages.json` gains `opencode` (`npm`, `opencode-ai`, 1.16.2); `OPENCODE_VERSION` leaves `versions.conf`. Both setup scripts already call `dotf tools install`; their opencode install blocks and the winget loop's version-pin machinery are deleted, as is the `~/.opencode/bin` PATH line in the rc files.
+- `dotf tools version <name>`: prints the first semver in `<name> --version` output, exit 1 when none. Both setup scripts use it for the hive `hive service` gate instead of `uv tool list`, which stopped seeing a healthy install once hive moved to its own installer (AI-028/#791).
+- `dotf doctor`: reads opencode's pin from the catalog, and WARNs when an npm catalog tool resolves from more than one PATH directory, naming them.
+
+## Out of scope
+
+- Moving `pi` to the catalog: its Linux block installs with `--prefix ~/.local --ignore-scripts` (#426) and `installNpm` cannot express that yet. Follow-up on #1294.
+- Pruning the leftover channel copies (`~/.opencode/bin`, winget `SST.opencode`): doctor names them; removal is the operator's, per ADR-036 §5.
+- The remaining `yarn` version parse in both setups (display only, not a gate).
+
+## Risks / open questions
+
+- On the Linux box the curl copy in `~/.opencode/bin` stays first on PATH until removed — with the rc PATH line gone it drops off PATH at the next shell, `dotf tools install` provisions the npm copy, and doctor reports the leftover. Accepted and documented in the ADR.
+- `npm install -g opencode-ai` needs node on PATH in the setup process; both setups install node before `dotf tools install` runs (as `bw` already relies on).
+- `hive --version` prints `hive-vault X.Y.Z`; `ProbeVersion` takes the first semver anywhere in the output, so the prefix is fine (tested with the real banner).
+
+## Acceptance criteria
+
+- [ ] AC1 — `packages.json` declares `opencode` as an npm catalog tool and `versions.conf` no longer pins it; `dotf tools install` converges it on both OSes (on the work box: "opencode 1.16.2 already installed; skipping").
+- [ ] AC2 — neither setup script carries an opencode install block, a winget `SST.opencode` entry, the winget version-pin machinery, or the `~/.opencode/bin` PATH export.
+- [ ] AC3 — `dotf tools version <name>` prints the first semver of `<name> --version` (incl. the `OpenCode locked.` and `hive-vault 3.0.0` banners) and exits 1 when none; both setups gate `hive service` on it.
+- [ ] AC4 — `dotf doctor` reads opencode's pin from `packages.json` and WARNs, naming the directories, when an npm catalog tool resolves from more than one PATH entry.
+- [ ] AC5 — ADR-036 records the channel policy, with the migration consequence for the Linux box.
+
+## References
+
+- Bitácora: #1294 (AI-034); #145 (AI-021 umbrella), #791 (AI-028), #1265 / #1262 / #1267 (convergence + pin semantics).
+- ADR-036 (this change), ADR-020, CLI-029 (`packages.json`), `pattern-setup-script-idempotence`.

--- a/specs/AI-034-opencode-npm-channel/tasks.md
+++ b/specs/AI-034-opencode-npm-channel/tasks.md
@@ -1,0 +1,48 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-27"
+---
+
+# Tasks - AI-034-opencode-npm-channel
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers** (optional, additive — borrowed from `github/spec-kit`, adapt-not-adopt per #141):
+> - `[P]` — this task has **no dependency on another unchecked task**, so it is safe to run in parallel (fan out to a `Workflow`, or just batch). TDD chains (test → implement → refactor of the *same* behavior) are sequential and must NOT carry `[P]`; independent behaviors can.
+> - `[AC<n>]` — this task helps satisfy **acceptance criterion #`<n>`** from `proposal.md`. Lets `/spec check` map coverage deterministically; omit it and the check falls back to semantic judgment.
+
+## Setup
+
+- [x] Branch created from main: `feat/opencode-npm-channel`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+- [x] [P] [AC5] Write ADR-036 (channel per tool class, `packages.json` pin SSOT, version probe in Go, shadowed copy is a finding, migration by the same mechanism)
+- [x] [P] [AC3] Write failing tests `TestProbeVersion_*` (real banners: `OpenCode locked.`, `hive-vault 3.0.0`); implement `tools.ProbeVersion` + `ExecRunner`
+- [x] [AC3] Write failing test `TestToolsVersionCmd`; implement `dotf tools version <name>` (exit 1, empty stdout when none)
+- [x] [P] [AC4] Write failing tests `TestCatalogPin_*`, `TestCheckShadowedCatalogTools_*`; implement `loadCatalog`, `catalogPin`, `checkShadowedCatalogTools`, `System.dirsProviding`
+- [x] [AC4] `checkOpenCode` reads the catalog pin (`matchPinFrom`), names the legacy curl copy, calls the shadowed check
+- [x] [P] [AC1] `packages.json` gains opencode (npm, `opencode-ai`); `OPENCODE_VERSION` leaves `versions.conf`
+- [x] [P] [AC2] `setup-linux.sh`: delete the curl block + `~/.opencode/bin` variables; post-deploy assertion on PATH only; hive gate via `dotf tools version hive` (by path too)
+- [x] [P] [AC2] `setup-windows.ps1`: delete the `$opencodeVersion` block, the winget entry and the loop's version-pin machinery; hive gate via `dotf tools version hive`
+- [x] [P] [AC2] `.zshrc` / `.bashrc`: drop the `~/.opencode/bin` PATH export
+- [x] [AC1] [AC2] [AC3] Rewrite the bats guards: `opencode.bats`, `setup-windows.bats`, `versions-conf.bats`, `hive-upgrade-timer.bats`
+- [x] Refactor for clarity: `matchPin` delegates to `matchPinFrom` (source named in every message)
+
+## Closing
+
+- [x] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [x] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
+- [x] Type checks pass (`go build ./... && go vet ./...`, Windows and `GOOS=linux`)
+- [x] Lint passes (`golangci-lint run ./...` pinned 2.12.2; `shellcheck setup-linux.sh`; PowerShell parser + ASCII-only on the `.ps1` edits)
+- [x] No unrelated changes in the diff (no scope creep)
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.

--- a/specs/AI-034-opencode-npm-channel/verification.md
+++ b/specs/AI-034-opencode-npm-channel/verification.md
@@ -11,7 +11,7 @@ All produced 2026-08-27 on the Windows work box (where the defect was measured),
 
 `features.json` verification commands (Git Bash, Go 1.26, jq, bats 1.13):
 
-```
+```text
 AI-034-opencode-npm-channel-f1: exit=0
 AI-034-opencode-npm-channel-f2: exit=0
 AI-034-opencode-npm-channel-f3: exit=0
@@ -23,7 +23,7 @@ Whole tree: `go build ./... && go vet ./... && GOOS=linux go vet ./...` clean; `
 
 **Real-box run** with `dotf` built from this branch:
 
-```
+```text
 $ dotf tools version hive
 3.0.0                      ← setup used to report "hive <unknown> predates 'hive service'"
 $ dotf tools version opencode

--- a/specs/AI-034-opencode-npm-channel/verification.md
+++ b/specs/AI-034-opencode-npm-channel/verification.md
@@ -1,0 +1,67 @@
+---
+tags: [spec, verification]
+created: "2026-08-27"
+---
+
+# Verification - AI-034-opencode-npm-channel
+
+## Evidence
+
+All produced 2026-08-27 on the Windows work box (where the defect was measured), from the `feat/opencode-npm-channel` worktree.
+
+`features.json` verification commands (Git Bash, Go 1.26, jq, bats 1.13):
+
+```
+AI-034-opencode-npm-channel-f1: exit=0
+AI-034-opencode-npm-channel-f2: exit=0
+AI-034-opencode-npm-channel-f3: exit=0
+AI-034-opencode-npm-channel-f4: exit=0
+AI-034-opencode-npm-channel-f5: exit=0
+```
+
+Whole tree: `go build ./... && go vet ./... && GOOS=linux go vet ./...` clean; `go test ./internal/tools/ ./internal/cmd/ ./internal/doctor/` green; `golangci-lint run ./...` (2.12.2) 0 issues; `bash -n` + `shellcheck -S warning setup-linux.sh` clean; `setup-windows.ps1` parses (0 errors) with the non-ASCII byte count unchanged from `main` (32); `bats tests/opencode.bats tests/setup-windows.bats tests/versions-conf.bats tests/hive-upgrade-timer.bats tests/setup-linux.bats` — no failures beyond the pre-existing `zsh: command not found` cases on Windows.
+
+**Real-box run** with `dotf` built from this branch:
+
+```
+$ dotf tools version hive
+3.0.0                      ← setup used to report "hive <unknown> predates 'hive service'"
+$ dotf tools version opencode
+1.16.2                     ← setup used to accept "locked." here
+$ dotf tools version nope
+Error: nope: no version found on PATH   (exit 1)
+$ DOTFILES_DIR=<checkout> dotf tools install opencode
+opencode 1.16.2 already installed; skipping
+$ DOTFILES_REPO_DIR=<checkout> dotf doctor        # [OpenCode + pi]
+  [WARN] opencode resolves from 3 PATH directories (…\scoop\apps\nodejs-lts\current\bin, …\scoop\shims, …\WinGet\Packages\SST.opencode_…) — `dotf tools install` converges the npm copy only; remove the other channel's copy
+```
+
+The last line is the finding this spec makes visible: three copies on the box, which setup had summarised as *"converge that install instead"*.
+
+## Test status
+
+| AC | Test | Status |
+|---|---|---|
+| AC1 | f1 (jq over `packages.json`, `versions.conf` refute); `opencode.bats` "packages.json is the only opencode pin" | pass |
+| AC2 | `opencode.bats` (no install block, retired PATH line, post-deploy assertion), `setup-windows.bats` (no winget entry / pin machinery), `versions-conf.bats` | pass |
+| AC3 | `TestProbeVersion_*` (7 banners), `TestToolsVersionCmd`, `hive-upgrade-timer.bats` parity guard | pass |
+| AC4 | `TestCatalogPin_ReadsTheCheckoutBeforeTheMirror`, `TestCheckShadowedCatalogTools_*` (two dirs, one dir, duplicated entry) | pass |
+| AC5 | f5 (ADR-036 present, migration consequence recorded) | pass |
+
+## Decisions made during implementation
+
+- **`pi` stays out of the catalog for now.** Its Linux install uses `--prefix ~/.local --ignore-scripts` (#426); `installNpm` cannot express that yet. Recorded in ADR-036 and on #1294 as the follow-up.
+- **`versions.conf` loses `OPENCODE_VERSION` instead of mirroring it.** Two pins for one tool is the #693 drift class; the catalog is the SSOT for catalog tools, and doctor reads it there (`matchPinFrom`, source named in every message).
+- **The winget loop lost its version-pin machinery entirely** rather than gaining a better parser: with opencode gone, no winget tool carried a pin, so the code path — and the StrictMode guard test written for it — was dead.
+- **`ProbeVersion` uses output even on a non-zero exit.** Several tools print the version and then complain about something unrelated; an absent tool is distinguished by having no output at all.
+- **Shadowed copies are a WARN, not a FAIL.** The tool runs; what is wrong is which copy `dotf tools install` can converge, and that is the operator's removal to make (ADR-036 §4).
+
+## Promotion candidates
+
+- None beyond the ADR: the channel policy is a build/operate decision and lives in `docs/adr/`.
+
+## Archive checklist
+
+- [ ] `dotf spec review AI-034-opencode-npm-channel` — passing `review.md` from the reviewer pool (needs an unlocked Bitwarden vault on the box that runs it)
+- [ ] PR merged; issue #1294 closed
+- [ ] `dotf spec archive AI-034-opencode-npm-channel`

--- a/tests/hive-upgrade-timer.bats
+++ b/tests/hive-upgrade-timer.bats
@@ -229,3 +229,15 @@ setup() {
     grep -qF '1.32.0' "$DOTFILES_DIR/setup-linux.sh"
     grep -qF '1.32.0' "$DOTFILES_DIR/setup-windows.ps1"
 }
+
+@test "parity: both setups probe hive's version through dotf tools version, not uv tool list (AI-034, #791)" {
+    # hive moved to its own installer, so `uv tool list` shows no hive-vault on a
+    # healthy box; both gates reported "hive <unknown> predates 'hive service'"
+    # while `hive --version` answered 3.0.0 (work box, 2026-08-27).
+    grep -qF 'dotf tools version hive' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF 'dotf tools version hive' "$DOTFILES_DIR/setup-windows.ps1"
+    run grep -F "hive_ver=\$(uv tool list" "$DOTFILES_DIR/setup-linux.sh"
+    [ "$status" -ne 0 ]
+    run grep -F "uv tool list 2>\$null | Select-String -Pattern '^hive-vault" "$DOTFILES_DIR/setup-windows.ps1"
+    [ "$status" -ne 0 ]
+}

--- a/tests/opencode.bats
+++ b/tests/opencode.bats
@@ -39,8 +39,11 @@ setup() {
     grep -q 'dotf secrets render "\$OPENCODE_CONFIG_TMP"' "$SETUP_SCRIPT"
 }
 
-@test "setup-linux.sh opencode block has post-deploy assertion" {
+@test "setup-linux.sh opencode block has post-deploy assertion, probed through dotf tools version (ADR-036)" {
     grep -q "opencode not reachable on PATH" "$SETUP_SCRIPT"
+    grep -qF 'tools version opencode' "$SETUP_SCRIPT"
+    # No second version-detection contract beside the shared probe.
+    refute_grep_fixed 'opencode --version 2>&1 | grep' "$SETUP_SCRIPT"
 }
 
 @test "the retired ~/.opencode/bin channel is off PATH in .zshrc and .bashrc (AI-034, ADR-036)" {

--- a/tests/opencode.bats
+++ b/tests/opencode.bats
@@ -19,8 +19,11 @@ setup() {
     grep -q "OpenCode (secondary AI coding agent" "$SETUP_SCRIPT"
 }
 
-@test "setup-linux.sh opencode install is idempotent (command -v gate before install)" {
-    grep -q 'if ! command -v opencode' "$SETUP_SCRIPT"
+@test "opencode is a packages.json catalog tool (npm) and setup-linux.sh carries no install block (AI-034, ADR-036)" {
+    jq -e '.tools[] | select(.name=="opencode" and .source.type=="npm" and .source.package=="opencode-ai")' "$DOTFILES_DIR/packages.json" >/dev/null
+    refute_grep_fixed 'opencode.ai/install' "$SETUP_SCRIPT"
+    refute_grep_fixed 'OPENCODE_BIN_DIR=' "$SETUP_SCRIPT"
+    refute_grep_fixed 'OPENCODE_VERSION' "$SETUP_SCRIPT"
 }
 
 @test "setup-linux.sh opencode config deploy is declarative always-overwrite (no cmp -s skip)" {
@@ -37,35 +40,24 @@ setup() {
 }
 
 @test "setup-linux.sh opencode block has post-deploy assertion" {
-    grep -q "opencode binary not reachable" "$SETUP_SCRIPT"
+    grep -q "opencode not reachable on PATH" "$SETUP_SCRIPT"
 }
 
-@test "opencode PATH is baked into repo .zshrc and .bashrc (SSOT, no setup-time mutation)" {
-    grep -q 'export PATH="\$HOME/.opencode/bin:\$PATH"' "$DOTFILES_DIR/.zshrc"
-    grep -q 'export PATH="\$HOME/.opencode/bin:\$PATH"' "$DOTFILES_DIR/.bashrc"
-    refute_grep 'ensure_line_in_file.*OPENCODE_PATH_LINE' "$SETUP_SCRIPT"
+@test "the retired ~/.opencode/bin channel is off PATH in .zshrc and .bashrc (AI-034, ADR-036)" {
+    # The curl-script copy would otherwise keep shadowing the npm one on the
+    # Linux box; doctor names the leftover, the rc files stop reaching for it.
+    refute_grep_fixed '.opencode/bin' "$DOTFILES_DIR/.zshrc"
+    refute_grep_fixed '.opencode/bin' "$DOTFILES_DIR/.bashrc"
 }
 
-@test "setup-linux.sh upgrades a below-minimum opencode to the versions.conf pin (REFACTOR-011/013)" {
-    # Presence is not convergence, and the pin is a MINIMUM: an opencode older
-    # than OPENCODE_VERSION was skipped as "already installed", while an exact
-    # != reconcile would downgrade a newer install. Gate on version_gte so only
-    # an older opencode triggers an upgrade.
-    grep -q 'version_gte "$installed_opencode" "$OPENCODE_VERSION"' "$SETUP_SCRIPT"
-    refute_grep_fixed 'installed_opencode" != "$OPENCODE_VERSION' "$SETUP_SCRIPT"
-    # Convergence is verified by re-query, not by installer exit code: a
-    # shadowing install (npm global) would otherwise produce a false SUCCESS.
-    grep -q 'shadows it in PATH' "$SETUP_SCRIPT"
+@test "packages.json is the only opencode pin (versions.conf carries none, ADR-036)" {
+    refute_grep '^OPENCODE_VERSION=' "$DOTFILES_DIR/versions.conf"
+    [ "$(jq -r '.tools[] | select(.name=="opencode") | .version' "$DOTFILES_DIR/packages.json")" != "" ]
 }
 
 # CLI-018: version-drift-is-WARN (yarn/opencode/pi) was asserted against
 # healthcheck.ps1; it now lives in go test (TestCheckOptionalTools_DotfDrift,
 # TestCheckVersionMatch) after the .ps1 was retired.
-
-@test "setup-linux.sh opencode install URL uses opencode.ai (not anomalyco fork)" {
-    grep -q 'curl -fsSL https://opencode.ai/install' "$SETUP_SCRIPT"
-    refute_grep 'curl.*anomalyco' "$SETUP_SCRIPT"
-}
 
 @test "setup-linux.sh opencode block has no new silenced errors (2>/dev/null || true)" {
     # Count silenced errors in opencode block specifically (between OPENCODE marker and next blank-line section)

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -317,29 +317,14 @@ setup() {
 # reconcile-not-skip, and sync ai/opencode/commands/*.md to the user's
 # OpenCode commands directory.
 
-@test "setup-windows.ps1 installs OpenCode via winget SST.opencode (AI-014)" {
-    grep -qF 'SST.opencode' "$PS1_SCRIPT"
-}
-
-@test "setup-windows.ps1 upgrades a below-minimum opencode to the versions.conf pin (REFACTOR-011/013)" {
-    # Presence is not convergence, and the pin is a MINIMUM: an opencode older
-    # than OPENCODE_VERSION was skipped as "already installed", while an exact
-    # -ne reconcile would downgrade a newer install. Gate on Test-VersionAtLeast
-    # so only a below-minimum opencode triggers an upgrade.
-    grep -qF 'Test-VersionAtLeast $installedVer $tool.Version' "$PS1_SCRIPT"
-    refute_grep_fixed '$installedVer -ne $tool.Version' "$PS1_SCRIPT"
-    grep -qE 'winget install \$tool\.Id --version \$tool\.Version' "$PS1_SCRIPT"
-    # Convergence is verified by re-query, not by winget's exit code: a
-    # shadowing install (npm global, scoop) would otherwise produce a false
-    # SUCCESS -- the same lie class this branch eliminates for S4U tasks.
-    grep -qF 'shadows it in PATH' "$PS1_SCRIPT"
-}
-
-# utils.ps1 sets Set-StrictMode Latest, so accessing a missing hashtable key
-# as a property throws. Latent until a box actually needs the install branch
-# (all tools present locally) -- first caught by the WIN-004 CI runner.
-@test "setup-windows.ps1 guards the optional Version key under StrictMode (WIN-004)" {
-    grep -qF "ContainsKey('Version')" "$PS1_SCRIPT"
+@test "setup-windows.ps1 installs OpenCode through packages.json (npm), not winget (AI-034, ADR-036)" {
+    # Two channels coexisted on the work box (npm-global first on PATH + winget),
+    # and the winget loop's version parse accepted "locked." as a version.
+    refute_grep_fixed 'SST.opencode' "$PS1_SCRIPT"
+    refute_grep_fixed 'OPENCODE_VERSION' "$PS1_SCRIPT"
+    refute_grep_fixed "ContainsKey('Version')" "$PS1_SCRIPT"
+    jq -e '.tools[] | select(.name=="opencode" and .source.type=="npm")' "$DOTFILES_DIR/packages.json" >/dev/null
+    grep -qF 'dotf tools install' "$PS1_SCRIPT"
 }
 
 @test "setup-windows.ps1 deploys opencode.jsonc via Deploy-File helper (SDD-007)" {

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -817,10 +817,10 @@ setup() {
 
 @test "setup-windows.ps1 provisions Node.js before dotf tools install, the npm channel's prerequisite (ADR-036)" {
     grep -qF 'Id = "OpenJS.NodeJS.LTS"' "$PS1_SCRIPT"
-    # The .ps1 is CRLF (.gitattributes) and GNU grep does not read a CR escape,
-    # so strip the CRs before anchoring on the line end (line numbers survive).
-    node_line=$(tr -d '' < "$PS1_SCRIPT" | grep -n 'Id = "OpenJS.NodeJS.LTS"' | head -1 | cut -d: -f1)
-    tools_line=$(tr -d '' < "$PS1_SCRIPT" | grep -n '^    dotf tools install$' | head -1 | cut -d: -f1)
+    # The .ps1 is CRLF (.gitattributes): [[:space:]]* absorbs the CR before the
+    # end anchor on every OS, and GNU grep reads no CR escape anyway.
+    node_line=$(grep -n 'Id = "OpenJS.NodeJS.LTS"' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
+    tools_line=$(grep -nE '^    dotf tools install[[:space:]]*$' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
     [ -n "$node_line" ] && [ -n "$tools_line" ]
     [ "$node_line" -lt "$tools_line" ]
 }

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -814,3 +814,11 @@ setup() {
     grep -qF '[Console]::OutputEncoding = ' "$DOTFILES_DIR/scripts/utils.ps1"
     grep -qF '[Console]::OutputEncoding = ' "$DOTFILES_DIR/powershell/profile.ps1"
 }
+
+@test "setup-windows.ps1 provisions Node.js before dotf tools install, the npm channel's prerequisite (ADR-036)" {
+    grep -qF 'Id = "OpenJS.NodeJS.LTS"' "$PS1_SCRIPT"
+    node_line=$(grep -n 'Id = "OpenJS.NodeJS.LTS"' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
+    tools_line=$(grep -n '^    dotf tools install$' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
+    [ -n "$node_line" ] && [ -n "$tools_line" ]
+    [ "$node_line" -lt "$tools_line" ]
+}

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -818,7 +818,8 @@ setup() {
 @test "setup-windows.ps1 provisions Node.js before dotf tools install, the npm channel's prerequisite (ADR-036)" {
     grep -qF 'Id = "OpenJS.NodeJS.LTS"' "$PS1_SCRIPT"
     node_line=$(grep -n 'Id = "OpenJS.NodeJS.LTS"' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
-    tools_line=$(grep -n '^    dotf tools install$' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
+    # The .ps1 is CRLF (.gitattributes), so an end anchor must tolerate the CR on Linux.
+    tools_line=$(grep -nE '^    dotf tools install?$' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
     [ -n "$node_line" ] && [ -n "$tools_line" ]
     [ "$node_line" -lt "$tools_line" ]
 }

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -817,9 +817,10 @@ setup() {
 
 @test "setup-windows.ps1 provisions Node.js before dotf tools install, the npm channel's prerequisite (ADR-036)" {
     grep -qF 'Id = "OpenJS.NodeJS.LTS"' "$PS1_SCRIPT"
-    node_line=$(grep -n 'Id = "OpenJS.NodeJS.LTS"' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
-    # The .ps1 is CRLF (.gitattributes), so an end anchor must tolerate the CR on Linux.
-    tools_line=$(grep -nE '^    dotf tools install?$' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
+    # The .ps1 is CRLF (.gitattributes) and GNU grep does not read a CR escape,
+    # so strip the CRs before anchoring on the line end (line numbers survive).
+    node_line=$(tr -d '' < "$PS1_SCRIPT" | grep -n 'Id = "OpenJS.NodeJS.LTS"' | head -1 | cut -d: -f1)
+    tools_line=$(tr -d '' < "$PS1_SCRIPT" | grep -n '^    dotf tools install$' | head -1 | cut -d: -f1)
     [ -n "$node_line" ] && [ -n "$tools_line" ]
     [ "$node_line" -lt "$tools_line" ]
 }

--- a/tests/versions-conf.bats
+++ b/tests/versions-conf.bats
@@ -54,9 +54,9 @@ setup() {
     [[ -n "$BATS_VERSION" ]]
 }
 
-@test "versions.conf sets OPENCODE_VERSION" {
+@test "versions.conf does not pin opencode (packages.json is the catalog pin SSOT, ADR-036)" {
     . "$VERSIONS_CONF"
-    [[ -n "$OPENCODE_VERSION" ]]
+    [[ -z "${OPENCODE_VERSION:-}" ]]
 }
 
 @test "versions.conf sets PI_VERSION" {

--- a/versions.conf
+++ b/versions.conf
@@ -14,7 +14,6 @@ AGE_VERSION=1.3.1
 EZA_VERSION=0.23.4
 ZOXIDE_VERSION=0.9.9
 OBSIDIAN_VERSION=1.12.4
-OPENCODE_VERSION=1.16.2
 YARN_VERSION=1.22.22
 PI_VERSION=0.84.3
 # ShellCheck release assets are versioned (the `-stable` alias was retired after


### PR DESCRIPTION
## Summary

**ADR-036** — one install channel per tool class, on every OS; `packages.json` is the pin SSOT for catalog tools; version detection happens once, in Go; a second copy on PATH is a doctor finding. Spec: `specs/AI-034-opencode-npm-channel/`. Part of #1294 (closes with the spec archive after the pooled adversarial review).

**Why.** Measured 2026-08-27 on the Windows work box: `opencode` reached the two machines through three channels (npm-global first on PATH, winget `SST.opencode`, the curl script on Linux). Setup parsed the version as *last token of the first line*, accepted `locked.` as a version, "upgraded" the winget copy and printed *converge that install instead* — a manual instruction — on every run. Seven such parse sites existed across both setup scripts; no document said which channel a tool should come from. The right primitive already existed (`packages.json` + `dotf tools install`, pin-as-floor, semver probe) and served two tools.

**What.**
- `packages.json` gains `opencode` (npm); `OPENCODE_VERSION` leaves `versions.conf`. Both setups already call `dotf tools install`.
- `setup-linux.sh`: curl block + `~/.opencode/bin` variables gone; post-deploy assertion on PATH only. `setup-windows.ps1`: winget entry + pin-parse block + the loop's version-pin machinery gone (no winget tool carries a pin any more). `.zshrc`/`.bashrc`: no `~/.opencode/bin` PATH line.
- `dotf tools version <name>` — first semver in `<name> --version`, exit 1 when none. Both setups gate `hive service` on it instead of `uv tool list`, which stopped seeing a healthy install when hive moved to its own installer (#791): the work box reported `hive <unknown> predates 'hive service'` for a 3.0.0.
- `dotf doctor`: opencode's pin from the catalog (`matchPinFrom` names the source); **WARN when an npm catalog tool resolves from more than one PATH directory**, naming them.
- Guards: `TestProbeVersion_*` over the real banners (`OpenCode locked.`, `hive-vault 3.0.0`), `TestToolsVersionCmd`, `TestCatalogPin_*`, `TestCheckShadowedCatalogTools_*`; bats over both setups, the rc files, `versions.conf` and the hive gate parity.

## Evidence (this session, Windows work box, `dotf` built from this branch)

```
$ dotf tools version hive        → 3.0.0
$ dotf tools version opencode    → 1.16.2
$ dotf tools version nope        → exit 1, "no version found on PATH"
$ dotf tools install opencode    → opencode 1.16.2 already installed; skipping
$ dotf doctor                    → [WARN] opencode resolves from 3 PATH directories (…\nodejs-lts\current\bin, …\scoop\shims, …\WinGet\Packages\SST.opencode_…) — `dotf tools install` converges the npm copy only; remove the other channel's copy
```

All five `features.json` verifications exit 0; `go build/vet` (Windows + `GOOS=linux`), `go test`, `golangci-lint` 0 issues, `shellcheck`, PowerShell parse + unchanged non-ASCII count; bats green (pre-existing `zsh: command not found` cases aside).

## Not in this PR

- `pi` stays out of the catalog: its Linux install uses `--prefix ~/.local --ignore-scripts` (#426), which `installNpm` cannot express yet — follow-up on #1294.
- Leftover channel copies are not deleted: doctor names them, the operator removes them (ADR-036 §5). On the Linux box the `~/.opencode/bin` copy will be reported after the next setup.
