### PR TITLE
feat(cli): dotf vault health, byte-identical to the shell oracle (CLI-021 increment 2)

### DIFF
--- a/cli/internal/cmd/vault.go
+++ b/cli/internal/cmd/vault.go
@@ -34,7 +34,8 @@ Unlike dotf init, vault is a vault-only command: a missing vault is an error
 Subcommands:
   work <family> <component>   scaffold a work-SDK entry under 50_work/45-development/
   project [path]              scaffold a personal-project entry under 10_projects/
-  crystallize [path]          maintain a project's MEMORY.md dates and health`,
+  crystallize [path]          maintain a project's MEMORY.md dates and health
+  health                      report knowledge-vault health (Obsidian, links, backlog)`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
@@ -43,6 +44,7 @@ Subcommands:
 	cmd.AddCommand(newVaultWorkCmd())
 	cmd.AddCommand(newVaultProjectCmd())
 	cmd.AddCommand(newVaultCrystallizeCmd())
+	cmd.AddCommand(newVaultHealthCmd())
 	cmd.AddCommand(newSearchCmd())
 	return cmd
 }

--- a/cli/internal/cmd/vault_health.go
+++ b/cli/internal/cmd/vault_health.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/mlorentedev/dotfiles/cli/internal/env"
 	"github.com/mlorentedev/dotfiles/cli/internal/mem"
 	"github.com/mlorentedev/dotfiles/cli/internal/vault"
 )
@@ -19,11 +20,17 @@ var errVaultHealthFailed = errors.New("vault health: one or more checks failed")
 // scripts/vault-health.sh (CLI-021 / #490, increment 2). Built BESIDE the shell
 // twin: nothing repoints at this yet (that cutover is CLI-023 / #492).
 //
-// vaultDirDefault mirrors the shell's OWN cascade — $VAULT_DIR, then
-// $VAULT_PATH, then a literal ~/Projects/knowledge — deliberately NOT the
-// ADR-025 machine.json cascade `vault.ResolveVault()` uses: the shell predates
-// that cascade, and the golden corpus (tests/golden/vault-health/) pins this
-// exact fallback, so matching the oracle wins over "improving" it here.
+// The vault directory resolves $VAULT_DIR first — the shell's own internal
+// handoff variable, and what every golden case in tests/golden/vault-health/
+// sets — then falls through to the ADR-025 cascade (env.ResolvePath, which
+// already covers $VAULT_PATH, the machine.json override, and the env-contract
+// default). The shell twin only ever falls back to a literal
+// $HOME/Projects/knowledge, oblivious to machine.json — but no golden exercises
+// that fallback (VAULT_DIR is always set), and `dotf vault health` is a NEW,
+// directly-invokable entry point unlike the shell's, so a relocated vault
+// should resolve the same way it does for every other `dotf vault` subcommand
+// (vault.ResolveVault) rather than reproducing a gap the oracle only had
+// because nothing called it standalone before.
 func newVaultHealthCmd() *cobra.Command {
 	var (
 		verbose   bool
@@ -63,10 +70,10 @@ missing from PATH), 2 the GUI is unreachable.`,
 
 			dir := os.Getenv("VAULT_DIR")
 			if dir == "" {
-				dir = os.Getenv("VAULT_PATH")
+				dir = env.ResolvePath("VAULT_PATH")
 			}
 			if dir == "" {
-				if home, err := os.UserHomeDir(); err == nil {
+				if home, herr := os.UserHomeDir(); herr == nil {
 					dir = home + "/Projects/knowledge"
 				}
 			}

--- a/cli/internal/cmd/vault_health.go
+++ b/cli/internal/cmd/vault_health.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/mem"
+	"github.com/mlorentedev/dotfiles/cli/internal/vault"
+)
+
+// errVaultHealthFailed is returned (silently — SilenceErrors keeps the report
+// itself the only output) when RunHealth reports one or more failed checks.
+// Mirrors doctor.go's errChecksFailed for the same reason.
+var errVaultHealthFailed = errors.New("vault health: one or more checks failed")
+
+// newVaultHealthCmd builds `dotf vault health`, the Go port of
+// scripts/vault-health.sh (CLI-021 / #490, increment 2). Built BESIDE the shell
+// twin: nothing repoints at this yet (that cutover is CLI-023 / #492).
+//
+// vaultDirDefault mirrors the shell's OWN cascade — $VAULT_DIR, then
+// $VAULT_PATH, then a literal ~/Projects/knowledge — deliberately NOT the
+// ADR-025 machine.json cascade `vault.ResolveVault()` uses: the shell predates
+// that cascade, and the golden corpus (tests/golden/vault-health/) pins this
+// exact fallback, so matching the oracle wins over "improving" it here.
+func newVaultHealthCmd() *cobra.Command {
+	var (
+		verbose   bool
+		vaultName string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "health",
+		Short: "Report knowledge-vault health (Obsidian orphans, links, frontmatter, backlog)",
+		Long: `health runs a 7-section report against the knowledge vault:
+
+  1. Working tree integrity (files deleted from disk but still tracked)
+  2. Obsidian CLI connectivity
+  3. Orphans & dead-ends
+  4. Unresolved links
+  5. Frontmatter coverage (id/type/status/tags/created/owner)
+  6. Tag hygiene
+  7. Backlog integrity (duplicate/contradictory ticket entries, stale-merged ticks)
+
+Requires the Obsidian GUI running (the CLI talks to it over IPC); every
+GUI-dependent section degrades gracefully when it is not. Read-only: no flag
+writes anything.
+
+Exit: 0 all checks pass, 1 one or more failed (or the Obsidian CLI itself is
+missing from PATH), 2 the GUI is unreachable.`,
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(c *cobra.Command, _ []string) error {
+			name := vaultName
+			if name == "" {
+				name = os.Getenv("VAULT_NAME")
+			}
+			if name == "" {
+				name = "knowledge"
+			}
+
+			dir := os.Getenv("VAULT_DIR")
+			if dir == "" {
+				dir = os.Getenv("VAULT_PATH")
+			}
+			if dir == "" {
+				if home, err := os.UserHomeDir(); err == nil {
+					dir = home + "/Projects/knowledge"
+				}
+			}
+
+			code, err := vault.RunHealth(c.OutOrStdout(), vault.HealthOptions{
+				VaultDir:   dir,
+				VaultName:  name,
+				Verbose:    verbose,
+				ScriptsDir: memScriptsDir(),
+				BashPath:   mem.ResolveBash(),
+			})
+			if err != nil {
+				return err
+			}
+			if code != 0 {
+				return withExitCode(code, errVaultHealthFailed)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "list orphan/unresolved/tag detail (truncated)")
+	cmd.Flags().StringVar(&vaultName, "vault", "", "Obsidian vault name (default: $VAULT_NAME or \"knowledge\")")
+	return cmd
+}

--- a/cli/internal/mem/session_start.go
+++ b/cli/internal/mem/session_start.go
@@ -140,8 +140,8 @@ func vaultHealth(vaultRoot, vaultName, scriptsDir string) string {
 	// `bash <script>` (no `-c`): the script path is a trusted env-contract location,
 	// not user input, and is passed as an argv element, so there is no shell-metachar
 	// injection surface. This is the faithful port of the shell's `bash "$vault_health"`.
-	// resolveBash, not a bare "bash", so Windows does not pick System32's WSL launcher.
-	cmd := exec.Command(resolveBash(), script)
+	// ResolveBash, not a bare "bash", so Windows does not pick System32's WSL launcher.
+	cmd := exec.Command(ResolveBash(), script)
 	cmd.Env = append(os.Environ(), "VAULT_DIR="+vaultRoot, "VAULT_NAME="+vaultName)
 	out, err := cmd.CombinedOutput()
 	healthExit := 0
@@ -332,8 +332,10 @@ func isExecutable(path string) bool {
 	return info.Mode()&0o111 != 0
 }
 
-// resolveBash returns the bash interpreter used to run vault-health.sh. It deliberately
-// avoids Windows' System32\bash.exe — that path is the WSL launcher, which is a broken
+// ResolveBash returns the bash interpreter used to run vault-health.sh (and,
+// via internal/vault's `dotf vault health` port, its two backlog-script
+// exec seams — CLI-021 increment 2). It deliberately avoids Windows'
+// System32\bash.exe — that path is the WSL launcher, which is a broken
 // stub when no distro is installed (it fails with "execvpe(/bin/bash) failed") and, even
 // when WSL works, cannot read a Windows-path script argument (WSL sees /mnt/c/...).
 // dotfiles installs Git Bash; that is the interpreter that can run a Windows-path script.
@@ -341,7 +343,7 @@ func isExecutable(path string) bool {
 // Resolution order: $DOTF_BASH (explicit override) → the first bash on PATH that is not
 // the System32 WSL launcher → a bare "bash" fallback (PATH resolution — Linux/macOS have
 // no System32 ambiguity, so this matches the previous behaviour there).
-func resolveBash() string {
+func ResolveBash() string {
 	if b := os.Getenv("DOTF_BASH"); b != "" {
 		return b
 	}

--- a/cli/internal/mem/session_start_test.go
+++ b/cli/internal/mem/session_start_test.go
@@ -135,9 +135,9 @@ func TestVaultHealth(t *testing.T) {
 	})
 
 	t.Run("reports ALL CHECKS PASSED on a clean stub", func(t *testing.T) {
-		// Gate on the interpreter vaultHealth actually uses (resolveBash), not a bare
+		// Gate on the interpreter vaultHealth actually uses (ResolveBash), not a bare
 		// LookPath — on Windows that would find the System32 WSL launcher and not skip.
-		if !isExecutable(resolveBash()) {
+		if !isExecutable(ResolveBash()) {
 			t.Skip("a real bash is required to run the vault-health.sh stub")
 		}
 		sd := t.TempDir()
@@ -157,8 +157,8 @@ func TestResolveBash(t *testing.T) {
 	t.Run("DOTF_BASH override wins", func(t *testing.T) {
 		want := filepath.Join(t.TempDir(), "my-bash")
 		t.Setenv("DOTF_BASH", want)
-		if got := resolveBash(); got != want {
-			t.Errorf("resolveBash() = %q, want the DOTF_BASH override %q", got, want)
+		if got := ResolveBash(); got != want {
+			t.Errorf("ResolveBash() = %q, want the DOTF_BASH override %q", got, want)
 		}
 	})
 
@@ -176,10 +176,10 @@ func TestResolveBash(t *testing.T) {
 		mustWrite(t, filepath.Join(sys32, "bash.exe"), "") // the WSL launcher decoy
 		realBash := filepath.Join(real, "bash.exe")
 		mustWrite(t, realBash, "") // a Git-Bash-style real interpreter
-		// System32 first on PATH — the bug picked it; resolveBash must skip it.
+		// System32 first on PATH — the bug picked it; ResolveBash must skip it.
 		t.Setenv("PATH", sys32+string(os.PathListSeparator)+real)
-		if got := resolveBash(); got != realBash {
-			t.Errorf("resolveBash() = %q, want the non-System32 bash %q", got, realBash)
+		if got := ResolveBash(); got != realBash {
+			t.Errorf("ResolveBash() = %q, want the non-System32 bash %q", got, realBash)
 		}
 	})
 }

--- a/cli/internal/vault/health.go
+++ b/cli/internal/vault/health.go
@@ -1,0 +1,507 @@
+package vault
+
+// health.go — the Go port of scripts/vault-health.sh (CLI-021 / #490, increment
+// 2). Built BESIDE the shell twin, exactly like crystallize.go was in increment
+// 1: nothing here is wired up as a caller yet (that is CLI-023 / #492). The
+// shell stays canonical until that cutover.
+//
+// Two seams increment 1 did not have, both called out in the spec
+// (specs/CLI-021-dotf-vault-build-knowledge/tasks.md §3):
+//
+//  1. An EXTERNAL BINARY contract. Four of seven sections shell out to
+//     `obsidian`, which talks to a running GUI over IPC. The golden corpus
+//     (tests/golden/vault-health/) stubs that binary on PATH and pins the exact
+//     argv this code sends it — not just stdout — because a port could drift in
+//     HOW it calls obsidian while stdout stayed byte-identical.
+//  2. A SUBPROCESS seam onto two sibling scripts, check-backlog-integrity.sh and
+//     check-backlog-merged.sh (SDD-012 / SDD-012b). They are EXECED, not ported:
+//     porting them is out of #490's three increments, and they survive the
+//     CLI-023 cutover as their own `vault` subcommands. A Go binary has no
+//     $SCRIPT_DIR, so ScriptsDir/BashPath are an explicit location seam
+//     (ADR-025) rather than a guess — and an unresolved seam FAILS the section
+//     rather than silently skipping it, per the spec.
+//
+// The shell is the oracle: every observable byte is pinned by the golden corpus
+// and reproduced faithfully, including its VAULT_DIR/VAULT_PATH/default
+// fallback (a plain env-var cascade, NOT the ADR-025 machine.json cascade
+// ResolveVault() uses elsewhere — vault-health.sh predates that cascade, and
+// matching the oracle takes priority over "improving" it here).
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// HealthOptions configures a `vault health` run. VaultDir/VaultName are already
+// resolved by the caller (the shell's own env-var cascade lives in the cmd
+// layer, mirroring how crystallize's path resolution lives there too).
+type HealthOptions struct {
+	VaultDir   string
+	VaultName  string
+	Verbose    bool
+	ScriptsDir string // hosts check-backlog-integrity.sh / check-backlog-merged.sh
+	BashPath   string // interpreter for the two backlog scripts (mem.ResolveBash())
+}
+
+// deletedLineRe mirrors `grep '^.D '`: git status --short's Y-column (unstaged
+// worktree state) is D — a file removed from disk but still tracked in HEAD.
+// The X-column (staged state, an intentional `git rm`) is deliberately NOT
+// matched here — that is what the leading `.` skips.
+var deletedLineRe = regexp.MustCompile(`^.D `)
+
+// healthRun carries the running counters and options across the 7 sections, the
+// same shape the shell's global CHECKS_PASSED/FAILED/SKIPPED play.
+type healthRun struct {
+	w       io.Writer
+	opts    HealthOptions
+	passed  int
+	failed  int
+	skipped int
+
+	// populated by section 2, consumed by sections 3 and 5.
+	mdFiles    []string
+	totalFiles int
+}
+
+func (h *healthRun) pass(format string, a ...any) {
+	emit(h.w, "  PASS: "+format+"\n", a...)
+	h.passed++
+}
+
+func (h *healthRun) fail(format string, a ...any) {
+	emit(h.w, "  FAIL: "+format+"\n", a...)
+	h.failed++
+}
+
+// warn counts toward "passed", mirroring the shell's warn(): a WARN is not a
+// FAIL. Reproduced as-is rather than "corrected" — it is the oracle's contract.
+func (h *healthRun) warn(format string, a ...any) {
+	emit(h.w, "  WARN: "+format+"\n", a...)
+	h.passed++
+}
+
+func (h *healthRun) skip(title, reason string) {
+	emit(h.w, "  SKIP: %s - %s\n", title, reason)
+	h.skipped++
+}
+
+func (h *healthRun) info(format string, a ...any) {
+	emit(h.w, "  INFO: "+format+"\n", a...)
+}
+
+func (h *healthRun) section(n, title string) {
+	emit(h.w, "\n[%s] %s\n", n, title)
+}
+
+// errorLine/infoLine mirror utils.sh's log_error/log_info — top-level, no
+// leading two-space indent, distinct from the section-local info() above.
+func (h *healthRun) errorLine(format string, a ...any) {
+	emit(h.w, "[ERROR] "+format+"\n", a...)
+}
+
+func (h *healthRun) infoLine(format string, a ...any) {
+	emit(h.w, "[INFO] "+format+"\n", a...)
+}
+
+// pct mirrors the shell's integer `count * 100 / total`, with the same
+// zero-total guard as the two `if [ "$TOTAL_FILES" -gt 0 ]` sites.
+func pct(count, total int) int {
+	if total <= 0 {
+		return 0
+	}
+	return count * 100 / total
+}
+
+// hasAnyChar mirrors `grep -q '.'`: true when at least one line has length > 0
+// (a line containing only whitespace still matches — '.' matches any byte).
+func hasAnyChar(s string) bool {
+	for _, line := range strings.Split(s, "\n") {
+		if len(line) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// countNonBlank mirrors `grep -c '[^[:space:]]'`: the count of lines holding at
+// least one NON-whitespace character — deliberately different from hasAnyChar.
+func countNonBlank(s string) int {
+	n := 0
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) != "" {
+			n++
+		}
+	}
+	return n
+}
+
+// obsidianCmd runs `obsidian --no-sandbox <sub> --vault <name>` and returns its
+// stdout with trailing newlines stripped — the same trim bash's `$(...)`
+// command substitution performs, load-bearing because callers reuse this value
+// both for counting AND for the --verbose listing.
+func (h *healthRun) obsidianCmd(sub string) string {
+	cmd := exec.Command("obsidian", "--no-sandbox", sub, "--vault", h.opts.VaultName)
+	out, _ := cmd.Output() // stderr discarded, exit code ignored: `2>/dev/null || true`
+	return strings.TrimRight(string(out), "\n")
+}
+
+// printTruncated mirrors `echo "$VAR" | head -N` plus the "... and M more"
+// line, keyed on cleanCount (the NON-blank count) rather than the raw line
+// count — reproducing the shell's own arithmetic exactly.
+func (h *healthRun) printTruncated(label, raw string, cleanCount, limit int) {
+	emit(h.w, "  --- %s ---\n", label)
+	lines := strings.Split(raw, "\n")
+	if len(lines) > limit {
+		lines = lines[:limit]
+	}
+	for _, l := range lines {
+		emit(h.w, "%s\n", l)
+	}
+	if cleanCount > limit {
+		emit(h.w, "  ... and %d more\n", cleanCount-limit)
+	}
+}
+
+// collectMarkdownFiles mirrors `find "$vaultDir" -name '*.md' -not -path
+// '*/.obsidian/*'`: every *.md file, skipping the .obsidian subtree entirely
+// (which also excludes anything nested under it, matching the path-substring
+// exclusion in the shell).
+func collectMarkdownFiles(vaultDir string) []string {
+	var files []string
+	_ = filepath.WalkDir(vaultDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // the shell's `find` swallows walk errors too
+		}
+		if d.IsDir() {
+			if d.Name() == ".obsidian" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(d.Name(), ".md") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	sort.Strings(files)
+	return files
+}
+
+// frontmatterCounts mirrors six separate `grep -rl "^${field}:" --include='*.md'`
+// sweeps, collapsed into one pass over the file set section 2 already
+// collected: a file counts toward a field the first time any line starts with
+// "field:", never twice.
+func (h *healthRun) frontmatterCounts(fields []string) map[string]int {
+	prefixes := make(map[string]string, len(fields))
+	for _, f := range fields {
+		prefixes[f] = f + ":"
+	}
+	counts := make(map[string]int, len(fields))
+	for _, path := range h.mdFiles {
+		data, err := os.ReadFile(path) //nolint:gosec // path came from our own vault walk, not user input
+		if err != nil {
+			continue
+		}
+		found := make(map[string]bool, len(fields))
+		for _, line := range strings.Split(string(data), "\n") {
+			for _, f := range fields {
+				if !found[f] && strings.HasPrefix(line, prefixes[f]) {
+					found[f] = true
+				}
+			}
+		}
+		for f, ok := range found {
+			if ok {
+				counts[f]++
+			}
+		}
+	}
+	return counts
+}
+
+// runScript execs a backlog script through the resolved bash interpreter (the
+// Windows-safe convention session_start.go already uses for vault-health.sh
+// itself) rather than relying on the shebang + executable bit the shell
+// invokes directly — there is no .ps1 twin for either script to fall back to.
+func (h *healthRun) runScript(script, arg string) (string, int) {
+	cmd := exec.Command(h.opts.BashPath, script, arg)
+	out, err := cmd.Output()
+	code := 0
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			code = ee.ExitCode()
+		} else {
+			code = 1
+		}
+	}
+	return string(out), code
+}
+
+// printPrefixed mirrors `sed 's|^|<prefix>|'`: every line of s gets prefix
+// prepended, and empty input produces no output at all (not one empty line).
+func printPrefixed(w io.Writer, s, prefix string) {
+	if s == "" {
+		return
+	}
+	for _, line := range strings.Split(strings.TrimSuffix(s, "\n"), "\n") {
+		emit(w, "%s%s\n", prefix, line)
+	}
+}
+
+func (h *healthRun) section1WorkingTree() {
+	h.section("1/7", "Working Tree Integrity")
+	vd := h.opts.VaultDir
+
+	if !isDir(vd) {
+		h.skip("Working tree integrity", "vault dir not found")
+		return
+	}
+	if !isDir(filepath.Join(vd, ".git")) {
+		h.skip("Working tree integrity", "vault is not a git repo")
+		return
+	}
+
+	out, _ := exec.Command("git", "-C", vd, "status", "--short").Output()
+	var deleted []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if deletedLineRe.MatchString(line) {
+			deleted = append(deleted, line)
+		}
+	}
+
+	if len(deleted) == 0 {
+		h.pass("Working tree clean — no files deleted from disk")
+		return
+	}
+	h.fail("%d file(s) deleted from working tree but still in HEAD — likely sync/watcher race", len(deleted))
+	for _, l := range deleted {
+		emit(h.w, "        %s\n", l)
+	}
+	emit(h.w, "        Recovery: cd %s && git checkout -- <file>\n", vd)
+}
+
+// section2Connectivity returns (code, true) when the shell would have exited
+// immediately — obsidian absent from PATH (1) or its GUI unreachable (2) —
+// short-circuiting every later section, footer included.
+func (h *healthRun) section2Connectivity() (int, bool) {
+	h.section("2/7", "Vault Connectivity")
+
+	if _, err := exec.LookPath("obsidian"); err != nil {
+		h.errorLine("Obsidian CLI not found in PATH")
+		return 1, true
+	}
+
+	if !hasAnyChar(h.obsidianCmd("vault")) {
+		h.errorLine("Cannot reach Obsidian GUI. Is Obsidian running?")
+		h.infoLine("Start Obsidian or run: obsidian --no-sandbox &")
+		return 2, true
+	}
+	h.pass("Obsidian CLI connected to vault '%s'", h.opts.VaultName)
+
+	if isDir(h.opts.VaultDir) {
+		h.mdFiles = collectMarkdownFiles(h.opts.VaultDir)
+		h.totalFiles = len(h.mdFiles)
+		h.info("Total markdown files: %d", h.totalFiles)
+	} else {
+		h.fail("Vault directory not found: %s", h.opts.VaultDir)
+		h.totalFiles = 0
+	}
+	return 0, false
+}
+
+func (h *healthRun) section3OrphansDeadEnds() {
+	h.section("3/7", "Orphans & Dead-Ends")
+
+	orphanOut := h.obsidianCmd("orphans")
+	orphanCount := countNonBlank(orphanOut)
+	deadOut := h.obsidianCmd("dead-ends")
+	deadCount := countNonBlank(deadOut)
+
+	orphanPct := pct(orphanCount, h.totalFiles)
+	deadPct := pct(deadCount, h.totalFiles)
+
+	switch {
+	case orphanPct <= 30:
+		h.pass("Orphans: %d/%d (%d%%)", orphanCount, h.totalFiles, orphanPct)
+	case orphanPct <= 50:
+		h.warn("Orphans: %d/%d (%d%%) — consider adding backlinks", orphanCount, h.totalFiles, orphanPct)
+	default:
+		h.fail("Orphans: %d/%d (%d%%) — too many isolated files", orphanCount, h.totalFiles, orphanPct)
+	}
+
+	switch {
+	case deadPct <= 30:
+		h.pass("Dead-ends: %d/%d (%d%%)", deadCount, h.totalFiles, deadPct)
+	case deadPct <= 50:
+		h.warn("Dead-ends: %d/%d (%d%%) — consider adding outgoing links", deadCount, h.totalFiles, deadPct)
+	default:
+		h.fail("Dead-ends: %d/%d (%d%%) — too many files without outgoing links", deadCount, h.totalFiles, deadPct)
+	}
+
+	// The shell lists orphan files only — there is no dead-ends listing.
+	if h.opts.Verbose && orphanCount > 0 {
+		h.printTruncated("Orphan files", orphanOut, orphanCount, 20)
+	}
+}
+
+func (h *healthRun) section4Unresolved() {
+	h.section("4/7", "Unresolved Links")
+
+	out := h.obsidianCmd("unresolved")
+	count := countNonBlank(out)
+
+	switch {
+	case count == 0:
+		h.pass("No unresolved links")
+	case count <= 10:
+		h.warn("Unresolved links: %d", count)
+	default:
+		h.fail("Unresolved links: %d", count)
+	}
+
+	if h.opts.Verbose && count > 0 {
+		h.printTruncated("Unresolved links", out, count, 20)
+	}
+}
+
+func (h *healthRun) section5Frontmatter() {
+	h.section("5/7", "Frontmatter Coverage")
+
+	if h.totalFiles == 0 {
+		h.skip("Frontmatter", "no markdown files found")
+		return
+	}
+
+	fields := []string{"id", "type", "status", "tags", "created", "owner"}
+	counts := h.frontmatterCounts(fields)
+	for _, f := range fields {
+		c := counts[f]
+		p := pct(c, h.totalFiles)
+		switch {
+		case p >= 80:
+			h.pass("%s: %d/%d (%d%%)", f, c, h.totalFiles, p)
+		case p >= 50:
+			h.warn("%s: %d/%d (%d%%)", f, c, h.totalFiles, p)
+		default:
+			h.fail("%s: %d/%d (%d%%)", f, c, h.totalFiles, p)
+		}
+	}
+}
+
+func (h *healthRun) section6Tags() {
+	h.section("6/7", "Tag Hygiene")
+
+	out := h.obsidianCmd("tags")
+	count := countNonBlank(out)
+	h.info("Total unique tags: %d", count)
+
+	if h.opts.Verbose && count > 0 {
+		h.printTruncated("Tags", out, count, 30)
+	}
+}
+
+// section7Backlog returns (code, true) when the shell would have aborted the
+// entire script right here — the ORACLE DEFECT below — short-circuiting
+// everything after it, footer included, exactly like section2Connectivity's
+// two abort points.
+func (h *healthRun) section7Backlog() (int, bool) {
+	h.section("7/7", "Backlog Integrity")
+
+	vd := h.opts.VaultDir
+	if !isDir(vd) {
+		h.skip("Backlog integrity", "vault dir not found")
+		return 0, false
+	}
+
+	matches, _ := filepath.Glob(filepath.Join(vd, "10_projects", "*", "11-tasks.md"))
+	sort.Strings(matches)
+
+	if len(matches) == 0 {
+		h.skip("Backlog integrity", "no 10_projects/*/11-tasks.md found")
+		return 0, false
+	}
+
+	integrityScript := filepath.Join(h.opts.ScriptsDir, "check-backlog-integrity.sh")
+	mergedScript := filepath.Join(h.opts.ScriptsDir, "check-backlog-merged.sh")
+	if h.opts.ScriptsDir == "" || !fileExists(integrityScript) || !fileExists(mergedScript) {
+		h.fail("Backlog integrity: cannot locate check-backlog-integrity.sh / check-backlog-merged.sh " +
+			"(scripts dir unresolved) — run from a dotfiles checkout or set DOTFILES_REPO_DIR")
+		return 0, false
+	}
+
+	for _, tasks := range matches {
+		out, code := h.runScript(integrityScript, tasks)
+		if code != 0 {
+			h.fail("Backlog drift in %s/11-tasks.md (duplicate IDs / status contradictions)",
+				filepath.Base(filepath.Dir(tasks)))
+			printPrefixed(h.w, out, "        ")
+			// ORACLE DEFECT reproduced (#1314): the shell re-execs the check a
+			// SECOND time piped straight into `sed` to print its output,
+			// instead of capturing to a variable first the way the
+			// merged-check loop below correctly does. Under `set -euo
+			// pipefail` that unnegated pipeline's non-zero exit (inherited
+			// from the script it just reported failing) aborts the WHOLE
+			// SCRIPT right here: no later files in this same loop, no
+			// merged-check pass, no closing footer. Pinned by the
+			// backlog-drift golden, whose expected/stdout simply stops after
+			// this file's detail. Not "fixed" here — see #1314.
+			return code, true
+		}
+	}
+	h.pass("Backlog integrity: %d task file(s) clean (one ticket = one entry)", len(matches))
+
+	// Semantic drift is ADVISORY (warn, never fail) — a second, independent
+	// pass over the same file set. This one captures to a variable before
+	// printing, so it does NOT share section 7's pipefail landmine above.
+	for _, tasks := range matches {
+		out, code := h.runScript(mergedScript, tasks)
+		if code != 0 {
+			h.warn("Stale-merged ticks in %s/11-tasks.md — work shipped, tick still [ ]:",
+				filepath.Base(filepath.Dir(tasks)))
+			printPrefixed(h.w, out, "        ")
+		}
+	}
+	return 0, false
+}
+
+// RunHealth runs the full 7-section report and returns the exit code the shell
+// would produce: 0 all pass, 1 a check failed (or obsidian is entirely absent
+// from PATH), 2 the GUI is unreachable. A non-nil error is reserved for a
+// failure this function cannot itself express as one of those three codes.
+func RunHealth(w io.Writer, opts HealthOptions) (int, error) {
+	h := &healthRun{w: w, opts: opts}
+
+	emit(w, "========================================\n")
+	emit(w, "   VAULT HEALTH REPORT\n")
+	emit(w, "========================================\n")
+	emit(w, "Vault: %s (%s)\n", opts.VaultName, opts.VaultDir)
+
+	h.section1WorkingTree()
+
+	if code, aborted := h.section2Connectivity(); aborted {
+		return code, nil
+	}
+
+	h.section3OrphansDeadEnds()
+	h.section4Unresolved()
+	h.section5Frontmatter()
+	h.section6Tags()
+
+	if code, aborted := h.section7Backlog(); aborted {
+		return code, nil
+	}
+
+	emit(w, "\n========================================\n")
+	emit(w, "Results: %d passed, %d failed, %d skipped\n", h.passed, h.failed, h.skipped)
+	emit(w, "========================================\n")
+
+	if h.failed > 0 {
+		return 1, nil
+	}
+	return 0, nil
+}

--- a/cli/internal/vault/health.go
+++ b/cli/internal/vault/health.go
@@ -405,10 +405,60 @@ func (h *healthRun) section6Tags() {
 	}
 }
 
+// resolveBacklogScripts locates the two sibling scripts under ScriptsDir. ok is
+// false when the seam cannot be satisfied — an empty ScriptsDir or either
+// script missing — which the caller turns into a loud section-wide FAIL rather
+// than a silent skip, per this file's seam #2.
+func (h *healthRun) resolveBacklogScripts() (integrity, merged string, ok bool) {
+	integrity = filepath.Join(h.opts.ScriptsDir, "check-backlog-integrity.sh")
+	merged = filepath.Join(h.opts.ScriptsDir, "check-backlog-merged.sh")
+	ok = h.opts.ScriptsDir != "" && fileExists(integrity) && fileExists(merged)
+	return integrity, merged, ok
+}
+
+// runIntegrityChecks is the FIRST of section 7's two passes. It returns
+// (code, true) the moment a file drifts — the ORACLE DEFECT (#1314): the shell
+// re-execs check-backlog-integrity.sh a SECOND time, piped straight into `sed`,
+// to print output it already has a verdict for — instead of capturing to a
+// variable first, the way runMergedChecks below correctly does. Under
+// `set -euo pipefail` that unnegated pipeline's non-zero exit (inherited from
+// the script it just reported failing) aborts the WHOLE SCRIPT right here: no
+// later file in this same loop, no merged-check pass, no closing footer.
+// Pinned by the backlog-drift golden, whose expected/stdout simply stops after
+// this file's detail. Not "fixed" here — see #1314.
+func (h *healthRun) runIntegrityChecks(matches []string, script string) (int, bool) {
+	for _, tasks := range matches {
+		out, code := h.runScript(script, tasks)
+		if code != 0 {
+			h.fail("Backlog drift in %s/11-tasks.md (duplicate IDs / status contradictions)",
+				filepath.Base(filepath.Dir(tasks)))
+			printPrefixed(h.w, out, "        ")
+			return code, true
+		}
+	}
+	h.pass("Backlog integrity: %d task file(s) clean (one ticket = one entry)", len(matches))
+	return 0, false
+}
+
+// runMergedChecks is section 7's SECOND, independent pass: semantic drift is
+// ADVISORY (warn, never fail). It captures each script's output to a variable
+// before printing, so — unlike runIntegrityChecks above — it does NOT share
+// section 7's pipefail landmine: a captured string cannot fail a pipeline.
+func (h *healthRun) runMergedChecks(matches []string, script string) {
+	for _, tasks := range matches {
+		out, code := h.runScript(script, tasks)
+		if code != 0 {
+			h.warn("Stale-merged ticks in %s/11-tasks.md — work shipped, tick still [ ]:",
+				filepath.Base(filepath.Dir(tasks)))
+			printPrefixed(h.w, out, "        ")
+		}
+	}
+}
+
 // section7Backlog returns (code, true) when the shell would have aborted the
-// entire script right here — the ORACLE DEFECT below — short-circuiting
-// everything after it, footer included, exactly like section2Connectivity's
-// two abort points.
+// entire script right here (runIntegrityChecks' oracle defect), short-
+// circuiting everything after it, footer included — exactly like
+// section2Connectivity's two abort points.
 func (h *healthRun) section7Backlog() (int, bool) {
 	h.section("7/7", "Backlog Integrity")
 
@@ -426,46 +476,17 @@ func (h *healthRun) section7Backlog() (int, bool) {
 		return 0, false
 	}
 
-	integrityScript := filepath.Join(h.opts.ScriptsDir, "check-backlog-integrity.sh")
-	mergedScript := filepath.Join(h.opts.ScriptsDir, "check-backlog-merged.sh")
-	if h.opts.ScriptsDir == "" || !fileExists(integrityScript) || !fileExists(mergedScript) {
+	integrityScript, mergedScript, ok := h.resolveBacklogScripts()
+	if !ok {
 		h.fail("Backlog integrity: cannot locate check-backlog-integrity.sh / check-backlog-merged.sh " +
 			"(scripts dir unresolved) — run from a dotfiles checkout or set DOTFILES_REPO_DIR")
 		return 0, false
 	}
 
-	for _, tasks := range matches {
-		out, code := h.runScript(integrityScript, tasks)
-		if code != 0 {
-			h.fail("Backlog drift in %s/11-tasks.md (duplicate IDs / status contradictions)",
-				filepath.Base(filepath.Dir(tasks)))
-			printPrefixed(h.w, out, "        ")
-			// ORACLE DEFECT reproduced (#1314): the shell re-execs the check a
-			// SECOND time piped straight into `sed` to print its output,
-			// instead of capturing to a variable first the way the
-			// merged-check loop below correctly does. Under `set -euo
-			// pipefail` that unnegated pipeline's non-zero exit (inherited
-			// from the script it just reported failing) aborts the WHOLE
-			// SCRIPT right here: no later files in this same loop, no
-			// merged-check pass, no closing footer. Pinned by the
-			// backlog-drift golden, whose expected/stdout simply stops after
-			// this file's detail. Not "fixed" here — see #1314.
-			return code, true
-		}
+	if code, aborted := h.runIntegrityChecks(matches, integrityScript); aborted {
+		return code, true
 	}
-	h.pass("Backlog integrity: %d task file(s) clean (one ticket = one entry)", len(matches))
-
-	// Semantic drift is ADVISORY (warn, never fail) — a second, independent
-	// pass over the same file set. This one captures to a variable before
-	// printing, so it does NOT share section 7's pipefail landmine above.
-	for _, tasks := range matches {
-		out, code := h.runScript(mergedScript, tasks)
-		if code != 0 {
-			h.warn("Stale-merged ticks in %s/11-tasks.md — work shipped, tick still [ ]:",
-				filepath.Base(filepath.Dir(tasks)))
-			printPrefixed(h.w, out, "        ")
-		}
-	}
+	h.runMergedChecks(matches, mergedScript)
 	return 0, false
 }
 

--- a/cli/internal/vault/health_test.go
+++ b/cli/internal/vault/health_test.go
@@ -1,0 +1,176 @@
+package vault
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The golden corpus (tests/golden/vault-health/) proves end-to-end byte-parity
+// with the shell across all 16 characterized cases. These unit tests cover a
+// seam a golden cannot reach: the "scripts dir unresolved" fail-loud path
+// (spec-required, but out of scope for the shell to have ever exercised — a
+// bash script always has its own $SCRIPT_DIR) and the pure helper functions.
+
+func TestPct(t *testing.T) {
+	tests := []struct {
+		count, total, want int
+	}{
+		{0, 0, 0},
+		{5, 0, 0},
+		{1, 5, 20},
+		{30, 100, 30},
+		{1, 3, 33}, // integer floor, not rounding
+	}
+	for _, tt := range tests {
+		if got := pct(tt.count, tt.total); got != tt.want {
+			t.Errorf("pct(%d, %d) = %d, want %d", tt.count, tt.total, got, tt.want)
+		}
+	}
+}
+
+func TestHasAnyChar(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty", "", false},
+		{"one word", "knowledge", true},
+		{"whitespace-only line still matches, like grep -q '.'", " ", true},
+		{"blank plus a real line", "\nsomething", true},
+	}
+	for _, tt := range tests {
+		if got := hasAnyChar(tt.in); got != tt.want {
+			t.Errorf("%s: hasAnyChar(%q) = %v, want %v", tt.name, tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestCountNonBlank(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"empty", "", 0},
+		{"whitespace-only line does NOT count, unlike hasAnyChar", " ", 0},
+		{"three real lines", "a\nb\nc", 3},
+		{"blank line among real ones is skipped", "a\n\nb", 2},
+	}
+	for _, tt := range tests {
+		if got := countNonBlank(tt.in); got != tt.want {
+			t.Errorf("%s: countNonBlank(%q) = %d, want %d", tt.name, tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestCollectMarkdownFilesExcludesObsidianSubtree(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel string) {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	write("a.md")
+	write("sub/b.md")
+	write(".obsidian/workspace.md")
+	write("sub/.obsidian/nested.md")
+	write("not-markdown.txt")
+
+	got := collectMarkdownFiles(dir)
+	if len(got) != 2 {
+		t.Fatalf("collectMarkdownFiles() = %v, want exactly a.md and sub/b.md", got)
+	}
+	for _, f := range got {
+		if strings.Contains(f, ".obsidian") {
+			t.Errorf("collectMarkdownFiles() leaked a .obsidian path: %s", f)
+		}
+	}
+}
+
+func TestFrontmatterCountsOneMatchPerFileNotPerLine(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		return p
+	}
+	f1 := write("f1.md", "id: one\nid: duplicate-should-not-double-count\n")
+	f2 := write("f2.md", "type: note\n")
+
+	h := &healthRun{mdFiles: []string{f1, f2}}
+	counts := h.frontmatterCounts([]string{"id", "type", "status"})
+
+	if counts["id"] != 1 {
+		t.Errorf("counts[id] = %d, want 1 (one file, however many matching lines)", counts["id"])
+	}
+	if counts["type"] != 1 {
+		t.Errorf("counts[type] = %d, want 1", counts["type"])
+	}
+	if counts["status"] != 0 {
+		t.Errorf("counts[status] = %d, want 0", counts["status"])
+	}
+}
+
+// TestSection7BacklogUnresolvedScriptsDirFailsLoud covers the spec's explicit
+// requirement (tasks.md §3) that an unresolvable ScriptsDir FAILS section 7
+// rather than silently skipping it — a shell script always knows its own
+// $SCRIPT_DIR, so no golden fixture can exercise this Go-only seam.
+func TestSection7BacklogUnresolvedScriptsDirFailsLoud(t *testing.T) {
+	vaultDir := t.TempDir()
+	tasksDir := filepath.Join(vaultDir, "10_projects", "demo")
+	if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tasksDir, "11-tasks.md"), []byte("- [ ] **X-1** thing\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var buf bytes.Buffer
+	h := &healthRun{w: &buf, opts: HealthOptions{VaultDir: vaultDir, ScriptsDir: ""}}
+	code, aborted := h.section7Backlog()
+
+	if aborted {
+		t.Fatalf("section7Backlog() aborted = true, want false (unresolved scripts dir is a FAIL, not the pipefail abort)")
+	}
+	if code != 0 {
+		t.Errorf("section7Backlog() code = %d, want 0 (the run-level abort code, unused on this path)", code)
+	}
+	if h.failed != 1 {
+		t.Errorf("h.failed = %d, want 1", h.failed)
+	}
+	if !strings.Contains(buf.String(), "FAIL: Backlog integrity: cannot locate") {
+		t.Errorf("output = %q, want a FAIL line naming the unresolved scripts dir", buf.String())
+	}
+}
+
+// TestSection7BacklogNoTasksSkipsRegardlessOfScriptsDir proves the fail-loud
+// path above only fires when there is actually something to check — an
+// unresolved ScriptsDir with zero 11-tasks.md files must still be the ordinary
+// skip, matching every golden case that has no backlog files at all.
+func TestSection7BacklogNoTasksSkipsRegardlessOfScriptsDir(t *testing.T) {
+	vaultDir := t.TempDir()
+
+	var buf bytes.Buffer
+	h := &healthRun{w: &buf, opts: HealthOptions{VaultDir: vaultDir, ScriptsDir: ""}}
+	code, aborted := h.section7Backlog()
+
+	if aborted || code != 0 {
+		t.Fatalf("section7Backlog() = (%d, %v), want (0, false)", code, aborted)
+	}
+	if h.failed != 0 || h.skipped != 1 {
+		t.Errorf("counters = failed:%d skipped:%d, want failed:0 skipped:1", h.failed, h.skipped)
+	}
+	if !strings.Contains(buf.String(), "SKIP: Backlog integrity - no 10_projects/*/11-tasks.md found") {
+		t.Errorf("output = %q, want the no-files skip line", buf.String())
+	}
+}

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -259,3 +259,4 @@ tags: [lessons, index, dotfiles]
 | [238 - Two independent defects, each sufficient for a permanent red, hide behind one symptom](lesson-238-two-independent-defects-each-sufficient-for-a-perman.md) | 2026-08-27 |  |
 | [239 - Re-measure a filed bug on the current toolchain before implementing its fix](lesson-239-re-measure-a-filed-bug-on-the-current-toolchain-before.md) | 2026-08-27 |  |
 | [240 - A partial mirror the code believes absent: the check that could have flagged the gap was the one switched off](lesson-240-a-partial-mirror-the-code-believes-absent-the-check.md) | 2026-08-27 |  |
+| [241 - Re-running a command just to print what it already told you inherits its exit status, silently, under `pipefail`](lesson-241-re-running-a-command-just-to-print-what-it-already.md) | 2026-08-27 |  |

--- a/docs/lessons/lesson-241-re-running-a-command-just-to-print-what-it-already.md
+++ b/docs/lessons/lesson-241-re-running-a-command-just-to-print-what-it-already.md
@@ -1,0 +1,89 @@
+# Lesson 241 — Re-running a command just to print what it already told you inherits its exit status, silently, under `pipefail`
+
+**Date:** 2026-08-27
+**Area:** shell / `set -euo pipefail` / vault-health.sh
+**Severity:** medium — a real run silently drops every backlog file after the first drifted one, the advisory merged-check pass, and the closing report
+
+## What happened
+
+Found while characterizing `scripts/vault-health.sh` for its Go port (CLI-021
+increment 2, #490). One golden fixture — a task file with a real duplicate-id
+drift — captured an `expected/stdout` that stops mid-section, with no closing
+`========================================` banner and no `Results: N passed...`
+line at all. That looked like a broken capture. It was the shell's actual
+behaviour.
+
+Section 7 checks each backlog file twice: once to decide pass/fail, once more
+to print the failure's detail:
+
+```sh
+if ! "$SCRIPT_DIR/check-backlog-integrity.sh" "$tasks" >/dev/null 2>&1; then
+    fail "Backlog drift in ..."
+    "$SCRIPT_DIR/check-backlog-integrity.sh" "$tasks" 2>/dev/null | sed 's|^|        |'
+fi
+```
+
+The first invocation is negated (`! cmd`), which [Lesson
+224](lesson-224-a-negated-assertion-is-exempt-from-set-e-so-it-cann.md) already
+covers: exempt from `set -e`, safe. The second invocation is not negated, and
+its whole purpose is to be re-run only for its stdout — the exit status is
+supposed to be irrelevant. But it is piped into `sed`, and under `pipefail` the
+pipeline's status is the *script's* 1, not `sed`'s 0. `set -e` sees an
+unguarded, non-zero pipeline and kills the whole script right there: no later
+file in the same loop, no second (merged-check) loop, no footer.
+
+## Why it survives inspection
+
+**The sibling loop two paragraphs down does the right thing, which hides the
+bug in the one above it.** The merged-check pass captures first —
+`merged_out="$(check-backlog-merged.sh "$tasks" 2>/dev/null)"` inside its own
+negated test — then prints the captured *string* through `printf | sed`. A
+string can't fail. Reading the file top-to-bottom, the second loop looks like
+confirmation that the pattern is fine, when it is actually the fix the first
+loop is missing.
+
+**The failure mode is invisible from a shell prompt.** Run the script
+interactively against a single bad file and it looks correct: one `FAIL` line,
+one detail block, exit 1. The gap only appears with a *second* backlog file
+after the first bad one, or with the merged-check advisory that never gets a
+chance to run — both of which require multiple drifted files or a specific
+task-file layout to notice by eye.
+
+**A stub-backed characterization test caught it where reading the script did
+not.** The stub obsidian binary made every OTHER section's obsidian-dependent
+output deterministic and boring, which is precisely what let the ONE real
+external process in the fixture (`check-backlog-integrity.sh`, run for real,
+not stubbed — SDD-012's own text-parsing checks have no GUI dependency to stub)
+stand out when its exit code silently ended the run.
+
+## The rule
+
+**Never re-run a command a second time solely to print output you could have
+captured the first time.** If a command's own exit status is meant to be
+irrelevant at a given call site, capture its stdout into a variable — the
+assignment's own exit status is what a subsequent `printf | sed` reads, and a
+already-captured string cannot fail a pipeline. Re-executing is not "the same
+thing done twice": under `set -e -o pipefail`, it is a second, unguarded
+opportunity for that exit status to end the script.
+
+## Not fixed at the source
+
+This is an ORACLE defect, found while building a Go characterization corpus
+that must prove equivalence to what `vault-health.sh` does TODAY, not what it
+should do. Reproduced faithfully in the port
+(`cli/internal/vault/health.go`'s `section7Backlog`, pinned by the
+`backlog-drift` golden) rather than "corrected while translating" — the same
+discipline [Lesson
+223](lesson-223-a-test-updated-to-keep-passing-stops-being-a-guar.md) argues
+for test assertions applies to a characterization oracle. The actual shell fix
+— capture-then-print, mirroring the merged-check loop already next to it — is
+ticketed separately: #1314.
+
+## Evidence
+
+- `tests/golden/vault-health/cases/backlog-drift/expected/stdout` — captured
+  from the real shell, ends after the first file's detail block, no footer
+- `check-backlog-integrity.sh` exit-code contract: 1 for drift/contradiction —
+  documents the value the pipeline inherits
+- `tests/vault-health-go-parity.bats` — 16/16 byte-identical including this case
+- `#1314` — the ticket for the actual shell fix

--- a/docs/lessons/lesson-241-re-running-a-command-just-to-print-what-it-already.md
+++ b/docs/lessons/lesson-241-re-running-a-command-just-to-print-what-it-already.md
@@ -60,11 +60,14 @@ stand out when its exit code silently ended the run.
 
 **Never re-run a command a second time solely to print output you could have
 captured the first time.** If a command's own exit status is meant to be
-irrelevant at a given call site, capture its stdout into a variable — the
-assignment's own exit status is what a subsequent `printf | sed` reads, and a
-already-captured string cannot fail a pipeline. Re-executing is not "the same
-thing done twice": under `set -e -o pipefail`, it is a second, unguarded
-opportunity for that exit status to end the script.
+irrelevant at a given call site, capture its stdout into a variable instead of
+re-invoking it — `printf '%s\n' "$captured" | sed ...` then pipes an
+already-materialized STRING, whose own success has nothing to do with what
+produced it, so that pipeline cannot inherit the original command's exit
+status. Re-executing is not "the same thing done twice": under
+`set -e -o pipefail`, the second invocation is a fresh, unguarded command whose
+own non-zero exit can end the script, this time with no `!` standing in front
+of it.
 
 ## Not fixed at the source
 

--- a/specs/CLI-021-dotf-vault-build-knowledge/tasks.md
+++ b/specs/CLI-021-dotf-vault-build-knowledge/tasks.md
@@ -117,11 +117,31 @@ lines against crystallize's ~200, and it carries two seams crystallize did not h
         unrelated case red, since every fixture sat comfortably inside a band. A boundary no
         fixture lands on is a boundary no test defends. With them, the same mutation goes red on
         the case named for it.
-- [ ] Port. **Exec the two backlog scripts, do not port them** — they are separate `vault`
+- [x] Port. **Exec the two backlog scripts, do not port them** — they are separate `vault`
       dispatcher subcommands (`check-tasks`, `check-merged`), outside #490's three increments, and
       they survive the CLI-023 cutover, so the exec dependency stays valid afterwards. Porting them
-      is ~240 lines of scope creep into another ticket's territory.
-- [ ] Read-only; no writes under any flag.
+      is ~240 lines of scope creep into another ticket's territory. → `cli/internal/vault/health.go`,
+      wired as `dotf vault health` in `cli/internal/cmd/vault_health.go`. Execed through the
+      resolved bash interpreter (`mem.ResolveBash()`, exported for this second caller) rather than
+      relying on the shebang + executable bit the shell uses directly — there is no `.ps1` twin for
+      either script to fall back to. `ScriptsDir` unresolved (or either script missing) FAILS
+      section 7 loudly rather than skipping it, per this section's own seam #2 above; no golden
+      exercises that path (a shell always knows its own `$SCRIPT_DIR`), so it is unit-tested instead
+      (`cli/internal/vault/health_test.go`).
+      - **Oracle defect found while porting, NOT fixed here (#1314):** the shell re-execs
+        `check-backlog-integrity.sh` a SECOND time, piped straight into `sed`, to print the failure
+        it already detected — unlike the sibling merged-check loop, which captures to a variable
+        first. Under `set -euo pipefail` that unnegated pipeline's non-zero exit aborts the WHOLE
+        SCRIPT on the FIRST drifted file: no later files in the same loop, no merged-check pass, no
+        closing footer. Reproduced faithfully (the `backlog-drift` golden's `expected/stdout` simply
+        stops mid-section) rather than "fixed while translating."
+- [x] Read-only; no writes under any flag. → `RunHealth` never calls `os.WriteFile` or exec's the
+      scripts with anything beyond the fixed `check-backlog-{integrity,merged}.sh <tasks-file>` argv
+      shape; `--verbose`/`--vault` are the only flags and both are read-only.
+- [x] Go/shell byte-parity proven on all 16 golden cases →
+      `tests/vault-health-go-parity.bats`, driven by the SAME goldens and the SAME runner
+      (`gvh_run_case`, `GVH_IMPL_MODE=go`) as the shell suite — mirrors
+      `tests/knowledge-crystallize-go-parity.bats`'s pattern from increment 1.
 
 Two twin divergences surfaced while scoping this increment — no `vault-health.ps1` exists at all,
 and the PowerShell weekly runs no health step despite its header. Both recorded in

--- a/specs/CLI-021-dotf-vault-build-knowledge/tasks.md
+++ b/specs/CLI-021-dotf-vault-build-knowledge/tasks.md
@@ -125,8 +125,10 @@ lines against crystallize's ~200, and it carries two seams crystallize did not h
       resolved bash interpreter (`mem.ResolveBash()`, exported for this second caller) rather than
       relying on the shebang + executable bit the shell uses directly — there is no `.ps1` twin for
       either script to fall back to. `ScriptsDir` unresolved (or either script missing) FAILS
-      section 7 loudly rather than skipping it, per this section's own seam #2 above; no golden
-      exercises that path (a shell always knows its own `$SCRIPT_DIR`), so it is unit-tested instead
+      section 7 loudly rather than skipping it — but only once a `10_projects/*/11-tasks.md` file
+      has actually been discovered; with none found, section 7 still SKIPS exactly as the shell
+      does, ScriptsDir notwithstanding. Per this section's own seam #2 above; no golden exercises
+      the fail-loud path (a shell always knows its own `$SCRIPT_DIR`), so it is unit-tested instead
       (`cli/internal/vault/health_test.go`).
       - **Oracle defect found while porting, NOT fixed here (#1314):** the shell re-execs
         `check-backlog-integrity.sh` a SECOND time, piped straight into `sed`, to print the failure

--- a/specs/CLI-021-dotf-vault-build-knowledge/verification.md
+++ b/specs/CLI-021-dotf-vault-build-knowledge/verification.md
@@ -10,20 +10,32 @@ template_version: "1.0"
 
 # Verification — CLI-021-dotf-vault-build-knowledge
 
-> Not started. Implementation begins after the open question in `tasks.md` §0 is resolved and the
-> golden corpus in §1 is captured. Filled per increment as they land.
+> Increments 1 and 2 landed (build-beside, cut over separately). Filled per increment as they land.
 
 ## Evidence
 
-**Increment 1 — `dotf vault crystallize`:** not started
-**Increment 2 — `dotf vault health`:** blocked on the health-noun question
+**Increment 1 — `dotf vault crystallize`:** landed in #882, byte-identical to the shell oracle on
+the full golden corpus. Cut over separately in #1276 (CLI-050), which deleted the shell/PowerShell
+twin and repointed every caller.
+
+**Increment 2 — `dotf vault health`:** landed — `cli/internal/vault/health.go` +
+`cli/internal/cmd/vault_health.go` (`dotf vault health`). Byte-identical to the shell oracle on all
+16 golden cases (`tests/vault-health-go-parity.bats`), including the one exit path a golden alone
+cannot exercise cleanly (an unresolved backlog-scripts location, which the port fails loudly on
+rather than silently skipping — unit-tested in `health_test.go`). Not yet cut over: the shell twin,
+its callers, and `session_start.go`'s own separate `vault-health.sh` exec (SessionStart brief) are
+untouched, per this increment's build-beside scope.
+
 **Increment 3 — `dotf vault maintain`:** not started
 
 ## Test status
 
-- Golden characterization (#672 / CLI-031): corpus not yet captured.
-- Table-driven units: not written.
-- `test-windows` CI: unchanged by this spec so far.
+- Golden characterization (#672 / CLI-031): captured for both crystallize and health.
+- Go/shell parity suites: `tests/knowledge-crystallize-go-parity.bats` (13/13, `help` excluded —
+  documented), `tests/vault-health-go-parity.bats` (16/16).
+- Table-driven units: `cli/internal/vault/crystallize_test.go`, `cli/internal/vault/health_test.go`.
+- `test-windows` CI: unchanged by this spec so far — `GOOS=windows go vet ./...` passes for both
+  increments' code, but neither has been run on an actual Windows box.
 
 ## The proof that matters most here
 

--- a/specs/CLI-021-dotf-vault-build-knowledge/verification.md
+++ b/specs/CLI-021-dotf-vault-build-knowledge/verification.md
@@ -20,11 +20,12 @@ twin and repointed every caller.
 
 **Increment 2 — `dotf vault health`:** landed — `cli/internal/vault/health.go` +
 `cli/internal/cmd/vault_health.go` (`dotf vault health`). Byte-identical to the shell oracle on all
-16 golden cases (`tests/vault-health-go-parity.bats`), including the one exit path a golden alone
-cannot exercise cleanly (an unresolved backlog-scripts location, which the port fails loudly on
-rather than silently skipping — unit-tested in `health_test.go`). Not yet cut over: the shell twin,
-its callers, and `session_start.go`'s own separate `vault-health.sh` exec (SessionStart brief) are
-untouched, per this increment's build-beside scope.
+16 golden cases (`tests/vault-health-go-parity.bats`). A golden alone cannot exercise one exit path
+— an unresolved backlog-scripts location, which the port fails loudly on rather than silently
+skipping — because a shell always knows its own `$SCRIPT_DIR`; that path is covered separately by
+`health_test.go`, not by the golden/parity suite. Not yet cut over: the shell twin, its callers, and
+`session_start.go`'s own separate `vault-health.sh` exec (SessionStart brief) are untouched, per this
+increment's build-beside scope.
 
 **Increment 3 — `dotf vault maintain`:** not started
 

--- a/tests/stub-real-pairing.bats
+++ b/tests/stub-real-pairing.bats
@@ -50,13 +50,19 @@ setup() {
 #   shell-profile             stubs `zsh`/`bash` timing probes — a real run measures this machine, not a fixture
 #   skills-pipeline           stubs the deploy targets — a real run writes into the caller's own $HOME
 #   vault-health              stubs `hive` — a real run needs the daemon and a live vault
+#   vault-health-go-parity    stubs `obsidian` (from tests/golden/vault-health/lib.sh, the SAME
+#                             stub vault-health-golden uses, shared by both suites) — same
+#                             rationale: a real run needs the AppImage and a live vault. This
+#                             suite's own subject is Go/shell PARITY against frozen goldens, not
+#                             the stub's fidelity to the real CLI, which vault-health-golden's
+#                             ORACLE hash check already guards.
 #   vault-health-golden       stubs `obsidian` (from tests/golden/vault-health/lib.sh, not the
 #                             .bats file itself — see #892) — same rationale as vault-health: a
 #                             real run needs the AppImage and a live vault
 #   vault-maintenance-weekly  stubs `cron`/`hive` — a real run installs a crontab entry
 EXEMPT_SUITES="bitacora-reconcile bitacora-rollout board-pickup guard-memory-sink guard-no-gui
-hermes-setup install-dotf shell-profile skills-pipeline vault-health vault-health-golden
-vault-maintenance-weekly"
+hermes-setup install-dotf shell-profile skills-pipeline vault-health vault-health-go-parity
+vault-health-golden vault-maintenance-weekly"
 
 exempt() {
     local base

--- a/tests/vault-health-go-parity.bats
+++ b/tests/vault-health-go-parity.bats
@@ -33,8 +33,11 @@ _build_dotf() {
     GVH_DOTF_BIN="${BATS_FILE_TMPDIR:-/tmp}/dotf-vault-health-parity"
     export GVH_DOTF_BIN
     if [ ! -x "$GVH_DOTF_BIN" ]; then
+        # A missing toolchain skips (checked above); a toolchain that FAILS to
+        # build the CLI is a real defect and must fail the suite, not read as
+        # 16 harmless skips.
         ( cd "$BATS_TEST_DIRNAME/../cli" && go build -o "$GVH_DOTF_BIN" ./cmd/dotf ) \
-            || skip "go build failed"
+            || return 1
     fi
     export GVH_IMPL_MODE=go
 }

--- a/tests/vault-health-go-parity.bats
+++ b/tests/vault-health-go-parity.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# Characterization of `dotf vault health` against the frozen golden corpus
+# (CLI-021 increment 2, #490) — the sibling of knowledge-crystallize-go-parity.bats.
+#
+# Unlike that file, vault-health.sh is NOT deleted here: this increment builds
+# the port BESIDE the shell twin (no caller repointed, nothing cut over — that
+# is CLI-023 / #492). This suite runs gvh_run_case's "go" mode against the
+# frozen goldens under tests/golden/vault-health/cases/*/expected — the SAME
+# artefacts tests/vault-health-golden.bats checks the live shell against. A
+# shell edit alone cannot silently pass or fail this file: only the shell suite
+# re-derives from the live script, and its ORACLE hash check catches drift.
+#
+# Skips (never fails) when the Go toolchain is absent, so a shell-only checkout
+# still runs the rest of the suite — same reasoning as the crystallize parity
+# file (#807 / BUG-055: a check that skips instead of running is worse than one
+# that is simply absent).
+
+setup() {
+    HERE="$BATS_TEST_DIRNAME/golden/vault-health"
+    # shellcheck source=golden/vault-health/lib.sh disable=SC1091
+    . "$HERE/lib.sh"
+    ACTUAL="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$ACTUAL"
+}
+
+# Build once per test file run, into a cached location, so 16 cases do not pay
+# 16 compilations.
+_build_dotf() {
+    command -v go >/dev/null 2>&1 || skip "go toolchain not installed"
+    GVH_DOTF_BIN="${BATS_FILE_TMPDIR:-/tmp}/dotf-vault-health-parity"
+    export GVH_DOTF_BIN
+    if [ ! -x "$GVH_DOTF_BIN" ]; then
+        ( cd "$BATS_TEST_DIRNAME/../cli" && go build -o "$GVH_DOTF_BIN" ./cmd/dotf ) \
+            || skip "go build failed"
+    fi
+    export GVH_IMPL_MODE=go
+}
+
+assert_parity() {
+    local name="$1" case_dir="$HERE/cases/$1"
+    _build_dotf
+    gvh_run_case "$case_dir" "$ACTUAL/$name"
+    local artefact
+    for artefact in exit stdout obsidian-argv; do
+        if ! diff -u "$case_dir/expected/$artefact" "$ACTUAL/$name/$artefact"; then
+            printf 'go/shell parity broken: %s/%s\n' "$name" "$artefact" >&2
+            return 1
+        fi
+    done
+}
+
+@test "parity: a healthy vault passes every check" {
+    assert_parity all-pass
+}
+
+@test "parity: the GUI being down exits 2, not 1" {
+    assert_parity gui-down
+}
+
+@test "parity: obsidian missing from PATH exits 1 before any check runs" {
+    assert_parity no-obsidian
+}
+
+@test "parity: orphans in the 30-50 band warn" {
+    assert_parity orphans-warn
+}
+
+@test "parity: orphans over 50 percent fail" {
+    assert_parity orphans-fail
+}
+
+@test "parity: unresolved links at or under 10 warn" {
+    assert_parity unresolved-warn
+}
+
+@test "parity: unresolved links over 10 fail" {
+    assert_parity unresolved-fail
+}
+
+@test "parity: frontmatter coverage tiers - pass, warn and fail in one run" {
+    assert_parity frontmatter-tiers
+}
+
+@test "parity: orphans at exactly 30 percent pass and dead-ends at exactly 50 percent warn" {
+    assert_parity orphans-boundary
+}
+
+@test "parity: exactly 10 unresolved links warn rather than fail" {
+    assert_parity unresolved-boundary
+}
+
+@test "parity: frontmatter at exactly 80 percent passes and exactly 50 percent warns" {
+    assert_parity frontmatter-boundary
+}
+
+@test "parity: a clean git working tree passes section 1" {
+    assert_parity worktree-clean
+}
+
+@test "parity: a file deleted from disk but still in HEAD fails section 1" {
+    assert_parity worktree-deleted
+}
+
+@test "parity: a missing vault directory fails connectivity and skips the rest" {
+    assert_parity missing-vault-dir
+}
+
+@test "parity: --verbose adds the detail listings" {
+    assert_parity verbose
+}
+
+@test "parity: backlog drift in a task file fails section 7 and aborts (oracle defect #1314)" {
+    assert_parity backlog-drift
+}
+
+@test "the parity set covers every golden case" {
+    local d name missing=""
+    for d in "$HERE"/cases/*/; do
+        name="$(basename "$d")"
+        grep -q "assert_parity $name\$" "$BATS_TEST_DIRNAME/vault-health-go-parity.bats" \
+            || missing="$missing $name"
+    done
+    [ -z "$missing" ] || {
+        printf 'cases with a golden but no parity test —%s\n' "$missing" >&2
+        return 1
+    }
+}


### PR DESCRIPTION
## Summary
- Ports `scripts/vault-health.sh`'s 7-section report to `dotf vault health` (`cli/internal/vault/health.go`, `cli/internal/cmd/vault_health.go`), built beside the shell twin — nothing repointed yet, that cutover is CLI-023 (#492)
- Proven byte-identical to the shell oracle on all 16 golden cases, including the obsidian argv contract (`tests/vault-health-go-parity.bats`)
- Found and ticketed a real shell bug while characterizing the oracle: section 7 re-execs `check-backlog-integrity.sh` a second time, unguarded, just to print output already captured — piped into `sed` under `set -euo pipefail`, that aborts the whole script on the first drifted backlog file, silently skipping every later file, the merged-check advisory pass, and the closing report. Reproduced faithfully in the port rather than fixed while translating (#1314, lesson 241)
- Exports `mem.ResolveBash` (previously private) so the new backlog-script exec seam reuses the same Windows-safe interpreter resolution the SessionStart caller already relies on

## Test plan
- [x] `go build ./... && go vet ./... && GOOS=windows go vet ./...`
- [x] `go test ./...` (all packages green)
- [x] `golangci-lint run ./...` — 0 issues (pinned 2.12.2)
- [x] `tests/vault-health-go-parity.bats` — 16/16 byte-identical to the shell golden corpus
- [x] Full bats suite (`tests/*.bats`) — 1503/1503
- [x] `git diff --stat` touches only `cli/`, `tests/`, `specs/`, `docs/lessons/` — no `scripts/`, `setup-*`, or vault caller repointed