### PR TITLE
fix(harness): read both skills: frontmatter forms when rendering presence

### DIFF
--- a/cli/internal/cmd/harness.go
+++ b/cli/internal/cmd/harness.go
@@ -26,6 +26,7 @@ pattern triggers, and workflow integrations.`,
 	cmd.AddCommand(newHarnessSuggestCmd())
 	cmd.AddCommand(newHarnessResolveTierCmd())
 	cmd.AddCommand(newHarnessResolveCapabilitiesCmd())
+	cmd.AddCommand(newHarnessResolveSkillsCmd())
 	cmd.AddCommand(newHarnessGateCmd())
 	cmd.AddCommand(newHarnessMirrorCmd())
 	return cmd

--- a/cli/internal/cmd/harness_resolve_skills.go
+++ b/cli/internal/cmd/harness_resolve_skills.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/harness"
+)
+
+// newHarnessResolveSkillsCmd is the third member of the resolve-* family, and it
+// exists for the same reason as the other two: the shell renderer must not grow
+// a parser of its own.
+//
+// `compile-harness.sh`'s skill_field reads the INLINE frontmatter form only. Once
+// a record declares `skills:` as a block list it returns empty, and the presence
+// block renders "MUST consume: none" — enforcement removed, silently, on every
+// harness at once. Measured 2026-08-27. `LoadPersona` already reads both forms on
+// a real YAML parser, so delegating is strictly cheaper than teaching awk YAML.
+//
+// TWO CONTRACT DIFFERENCES FROM resolve-capabilities, both deliberate:
+//
+//   - No `--harness` flag. resolve-capabilities prints a whole frontmatter line
+//     because the native field name differs per harness (`tools:` vs
+//     `permission:`). A persona's skills reach the harness as PROSE inside a
+//     markdown bullet the caller composes, so there is no per-harness field name
+//     to hide and no reason to demand one.
+//
+//   - IDs only, never severity. `enforce:` is what `dotf harness gate` acts on,
+//     not what the presence text says — presence asks, bind enforces. Annotating
+//     each id would also breach a hard platform limit: the doctrine payload this
+//     block lands in is capped at 12000 characters for .gemini/GEMINI.md, and it
+//     has been breached twice already, most recently by the roster itself.
+//
+// The output is byte-identical to skill_field's for every record still in the
+// legacy form, which is what makes this substitution provably behaviour-preserving
+// rather than merely argued to be.
+func newHarnessResolveSkillsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "resolve-skills <record>",
+		Short: "Print the forced-skill ids one agent record declares, in either frontmatter form",
+		Long: `resolve-skills reads one agent record's ` + "`skills:`" + ` frontmatter and prints the
+declared skill ids as a YAML flow sequence, accepting both the legacy inline form
+and the mapping form that carries per-skill severity:
+
+    skills: [audit, adversarial-review]        # legacy, no severity
+    skills:                                    # mapping form
+      - id: audit
+        enforce: block
+
+Both print the same thing — ` + "`[audit, adversarial-review]`" + ` — because severity is
+consumed by ` + "`dotf harness gate`" + `, not by the presence text that names the skills.
+
+A record declaring no skills prints nothing and exits 0; the caller decides what
+an empty roster reads as. A ` + "`skills:`" + ` key that is PRESENT but unparseable exits
+non-zero and writes nothing to stdout. It never degrades to an empty list: an
+unreadable skill list and an empty one produce the same downstream behaviour — a
+gate that enforces nothing — and mean opposite things.`,
+		Example: `  dotf harness resolve-skills harness/agents/reviewer/AGENT.md
+  # [audit, verification-before-completion, adversarial-review, cyclomatic-complexity]`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p, err := harness.LoadPersona(args[0])
+			if err != nil {
+				return err
+			}
+			if len(p.Skills) == 0 {
+				return nil
+			}
+			ids := make([]string, 0, len(p.Skills))
+			for _, s := range p.Skills {
+				ids = append(ids, s.ID)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "[%s]\n", strings.Join(ids, ", "))
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cli/internal/cmd/harness_resolve_skills_test.go
+++ b/cli/internal/cmd/harness_resolve_skills_test.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/harness"
+)
+
+// writeRecord drops one agent record into a temp dir and returns its path.
+func writeRecord(t *testing.T, frontmatter string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENT.md")
+	body := "---\n" + frontmatter + "\n---\n\n# Persona\n\nbody\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write record: %v", err)
+	}
+	return path
+}
+
+// TestHarnessResolveSkills pins the stdout contract.
+//
+// captureRealStreams rather than execute(), for the same reason resolve-tier
+// gives: the sole consumer is `compile-harness.sh` reading through a shell
+// `$(...)`, where a value written to stderr arrives as an empty string. An empty
+// string is precisely the failure this subcommand exists to prevent, so a test
+// that could not tell stdout from stderr would be blind to it (BUG-070 #915).
+func TestHarnessResolveSkills(t *testing.T) {
+	tests := []struct {
+		name        string
+		frontmatter string
+		wantStdout  string
+		wantErrSubs []string
+	}{
+		{
+			name:        "the legacy inline form",
+			frontmatter: "name: x\nkind: invocable\nskills: [audit, cyclomatic-complexity]",
+			wantStdout:  "[audit, cyclomatic-complexity]",
+		},
+		{
+			// The whole point of the subcommand. skill_field returns EMPTY here,
+			// which renders "MUST consume: none" -- enforcement removed silently.
+			name:        "the mapping form carrying severity",
+			frontmatter: "name: x\nkind: invocable\nskills:\n  - id: audit\n    enforce: block\n  - id: insights\n    enforce: warn",
+			wantStdout:  "[audit, insights]",
+		},
+		{
+			// Severity is the gate's input, never the presence text's. Emitting
+			// it here would also push the doctrine payload past .gemini's hard
+			// 12000-character cap, which the roster has already breached twice.
+			name:        "severity never reaches stdout",
+			frontmatter: "name: x\nkind: invocable\nskills:\n  - id: audit\n    enforce: block",
+			wantStdout:  "[audit]",
+		},
+		{
+			// Distinct from an unreadable one, and the caller renders "none".
+			name:        "a record declaring no skills prints nothing and succeeds",
+			frontmatter: "name: x\nkind: invocable",
+			wantStdout:  "",
+		},
+		{
+			name:        "the mapping form with no severity is refused, not defaulted",
+			frontmatter: "name: x\nkind: invocable\nskills:\n  - id: audit",
+			wantErrSubs: []string{"enforce", "audit"},
+		},
+		{
+			name:        "an unknown severity is refused",
+			frontmatter: "name: x\nkind: invocable\nskills:\n  - id: audit\n    enforce: nag",
+			wantErrSubs: []string{"nag", "block"},
+		},
+		{
+			name:        "a scalar skills value is refused rather than coerced",
+			frontmatter: "name: x\nkind: invocable\nskills: audit",
+			wantErrSubs: []string{"want a list"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := writeRecord(t, tc.frontmatter)
+			stdout, _, err := captureRealStreams(t, "harness", "resolve-skills", rec)
+
+			if len(tc.wantErrSubs) > 0 {
+				if err == nil {
+					t.Fatalf("want an error, got stdout %q", stdout)
+				}
+				// C15: a refusal must write NOTHING to stdout. A message there
+				// would be captured by the shell's $(...) and rendered into the
+				// presence block as if it were a skill list.
+				if strings.TrimSpace(stdout) != "" {
+					t.Errorf("a refusal wrote to stdout: %q", stdout)
+				}
+				for _, sub := range tc.wantErrSubs {
+					if !strings.Contains(err.Error(), sub) {
+						t.Errorf("error %q does not mention %q", err, sub)
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := strings.TrimSpace(stdout); got != tc.wantStdout {
+				t.Errorf("stdout = %q, want %q", got, tc.wantStdout)
+			}
+		})
+	}
+}
+
+// TestResolveSkillsMatchesShippedRecords is the equivalence proof, run against
+// the records the repository actually ships rather than a fixture.
+//
+// `compile-harness.sh` previously read this field with an awk one-liner that
+// takes the text after `skills:` verbatim. Go's strings.Join NORMALISES the
+// separator to ", ", so a record written `[a,b]` would render differently
+// through the two paths and silently change every deployed instructions file.
+// Byte-equality across all shipped records is what makes the substitution
+// behaviour-preserving in fact rather than by argument.
+func TestResolveSkillsMatchesShippedRecords(t *testing.T) {
+	root := repoRootForTest(t)
+	dir := filepath.Join(root, "harness", "agents")
+
+	personas, err := harness.LoadPersonas(dir)
+	if err != nil {
+		t.Fatalf("load personas: %v", err)
+	}
+
+	for _, p := range personas {
+		t.Run(p.Name, func(t *testing.T) {
+			raw, err := os.ReadFile(p.Path)
+			if err != nil {
+				t.Fatalf("read %s: %v", p.Path, err)
+			}
+			awkLike := legacySkillField(string(raw))
+			if awkLike == "" {
+				t.Skipf("%s declares no inline skills line", p.Name)
+			}
+			stdout, _, err := captureRealStreams(t, "harness", "resolve-skills", p.Path)
+			if err != nil {
+				t.Fatalf("resolve-skills: %v", err)
+			}
+			if got := strings.TrimSpace(stdout); got != awkLike {
+				t.Errorf("delegation changes the rendered line for %s:\n  awk: %q\n  go : %q",
+					p.Name, awkLike, got)
+			}
+		})
+	}
+}
+
+// legacySkillField reproduces the awk skill_field read that compile-harness.sh
+// used before the delegation: the verbatim text after `skills:` in frontmatter.
+func legacySkillField(raw string) string {
+	fences := 0
+	for _, line := range strings.Split(raw, "\n") {
+		if strings.TrimSpace(line) == "---" {
+			fences++
+			if fences >= 2 {
+				return ""
+			}
+			continue
+		}
+		if fences != 1 {
+			continue
+		}
+		if after, ok := strings.CutPrefix(line, "skills:"); ok {
+			return strings.TrimSpace(after)
+		}
+	}
+	return ""
+}

--- a/cli/internal/cmd/harness_resolve_tier_test.go
+++ b/cli/internal/cmd/harness_resolve_tier_test.go
@@ -217,7 +217,7 @@ func TestHarnessHelpListsSubcommands(t *testing.T) {
 		t.Fatalf("harness --help failed: %v (stderr=%q)", err, stderr)
 	}
 	out := stdout + stderr
-	for _, sub := range []string{"resolve-tier", "resolve-capabilities"} {
+	for _, sub := range []string{"resolve-tier", "resolve-capabilities", "resolve-skills"} {
 		// Same shape the shell greps for: the name at the start of its line in
 		// the command list, followed by whitespace before its summary.
 		if !regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(sub) + `\s`).MatchString(out) {

--- a/harness/agent-frontmatter.schema.json
+++ b/harness/agent-frontmatter.schema.json
@@ -11,7 +11,29 @@
     "kind": { "type": "string", "enum": ["invocable", "autonomous"], "description": "invocable = no 80_agents/ state; autonomous = persona cataloged here, live state in 80_agents/<name>/." },
     "model": { "type": "string", "description": "Neutral tier (top|mid|low); resolved to this harness's model id at deploy via harness/model-map.json, and emitted into the rendered frontmatter (#1161). A tier the map cannot answer fails the render rather than dropping the field — a definition naming no model is the degrade the routing registry exists to prevent (ADR-035). Absent = rendered with no model line." },
     "capabilities": { "description": "Neutral capability vocab (e.g. [read, search, edit, shell, web]); mapped to provider tools via capability-map at compile (H-044)." },
-    "skills": { "description": "Forced-consumption skills; compiled to the harness determinism hook (presence/action/dispatch)." },
+    "skills": {
+      "description": "Forced-consumption skills; compiled to the harness determinism hook (presence/action/dispatch). TWO FORMS, both accepted during the HARNESS-045 migration: the legacy flat list carries no severity and the gate refuses to act on it, while the mapping form declares per-skill `enforce` and is what makes a persona binding rather than merely present. NOTE, measured 2026-08-27: compile-harness.sh's validate_skill_frontmatter evaluates `required` keys ONLY and does not read the constraints below, so this subschema is the SSOT for the SHAPE (cli/internal/harness.parseSkills implements it, dotf harness resolve-skills serves it) and is NOT itself an enforced guard here.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Legacy: skills: [audit, cyclomatic-complexity]. No severity, so the gate will not act on these; `dotf harness gate` reports them as unmigrated rather than defaulting, because a default of `warn` would render every gate silently inert and a default of `block` would turn every existing skill into a hard gate at once."
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "enforce"],
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "enforce": { "type": "string", "enum": ["block", "warn"], "description": "block stops the tool call; warn emits and allows. Required: an entry declaring no severity is refused, never defaulted." }
+            },
+            "additionalProperties": false
+          },
+          "description": "Mapping form: a list of {id, enforce}. Severity is consumed by `dotf harness gate` and deliberately never reaches the presence text, which is character-capped."
+        }
+      ]
+    },
     "targets": { "description": "Optional per-agent harness allowlist (e.g. [claude]); absent = all harnesses." },
     "id": { "type": "string" },
     "type": { "type": "string" },

--- a/scripts/compile-harness.sh
+++ b/scripts/compile-harness.sh
@@ -587,6 +587,54 @@ skill_field() {
         n>=2 { exit }' "$1"
 }
 
+# Print the forced-skill list one agent record declares, or nothing.
+#
+# Same three-outcome shape as agent_model_line and agent_capability_line, and
+# delegated to `dotf` for the same reason: skill_field reads the INLINE
+# frontmatter form only, so a record declaring `skills:` as a block list returns
+# EMPTY here and the presence block renders "MUST consume: none". That is not a
+# degraded render, it is enforcement removed — on every harness at once, silently.
+# `dotf harness resolve-skills` reads both forms through the persona loader's real
+# YAML parser, so the shape lives in Go once instead of being re-hand-rolled in
+# awk. Verified byte-identical to skill_field across all 7 records, 2026-08-27.
+#
+# The degrade is where this differs from its two siblings, and the difference is
+# the whole point. A stale or absent dotf falls back to the awk read, which is
+# correct for a legacy record and CATASTROPHIC for a migrated one — it is exactly
+# the silent disarm above. So the fallback carries the block-form guard that
+# agent_capability_line established for `capabilities:`, on the identical
+# reasoning one field over: an empty skill list is not "no opinion", it is
+# "nothing enforced".
+agent_skills_line() {
+    local record="$1" rc=0 line
+    type -P dotf >/dev/null 2>&1 || rc=2
+    if [ "$rc" -eq 0 ] && ! dotf_knows_subcommand resolve-skills; then rc=2; fi
+    if [ "$rc" -eq 0 ]; then
+        line="$(dotf harness resolve-skills "$record")" || rc=1
+    fi
+    case "$rc" in
+        0) printf '%s\n' "$line" ;;
+        1) printf '[ERROR] %s declares a `skills:` list that cannot be resolved\n' "$record" >&2
+           return 1 ;;
+        2) line="$(skill_field "$record" skills)"
+           if [ -z "$line" ] && record_has_block_skills "$record"; then
+               printf '[ERROR] %s declares `skills:` in YAML block style, and dotf is absent or\n' "$record" >&2
+               printf '        predates resolve-skills, so this renderer cannot read it. Rendering\n' >&2
+               printf '        "MUST consume: none" would DISARM the persona rather than describe it\n' >&2
+               printf '        -- rebuild dotf and re-run --deploy\n' >&2
+               return 1
+           fi
+           printf '%s\n' "$line" ;;
+    esac
+}
+
+# True when a record declares `skills:` with nothing after the colon -- the YAML
+# block form. Shared by the guard above and its test; a bare `skills:` key with an
+# empty value is the one case skill_field cannot distinguish from "no key at all".
+record_has_block_skills() {
+    awk '/^---[[:space:]]*$/{n++; next} n==1 && /^skills:[[:space:]]*$/{found=1} n>=2{exit} END{exit !found}' "$1"
+}
+
 # Build a markdown skill catalog (one bullet per skill targeting <agent>), for
 # agents with no per-skill mechanism (e.g. copilot's single instructions file).
 # Deterministic order (glob sorts). Args: <record_dir> <agent>
@@ -1013,7 +1061,7 @@ build_agent_presence() {
             printf 'When acting as one, you MUST consume its skills.\n\n'
             first=0
         fi
-        skills_line="$(skill_field "$ag_dir/AGENT.md" skills)"
+        skills_line="$(agent_skills_line "$ag_dir/AGENT.md")" || return 1
         printf -- '- **%s** — MUST consume: %s\n' "$name" "${skills_line:-none}"
     done
 }

--- a/specs/HARNESS-045-hook-emission/tasks.md
+++ b/specs/HARNESS-045-hook-emission/tasks.md
@@ -28,21 +28,63 @@ created: "2026-08-27"
       `emit: false` so the gap is visible rather than remembered. They need two
       generated-code templates plus their deploy, which is a sitting of its own —
       splitting it was a decision, not an omission.
-- [ ] [AC7] The block-style guards. **Four parsers read `skills:` and three
-      break silently on the mapping form** (the fourth is this spec's loader):
-      - `specs/HARNESS-046/check-roster-consistency.py:62` — regex on the inline
-        form, falls back to `[]`
+- [x] [AC7] The block-style guards. **Corrected against measurement, 2026-08-27:
+      THREE parsers read `skills:` and TWO break silently**, not four and three.
+      The count carried forward was reconstruction; each line below was executed
+      against a record in the mapping form rather than read.
+      - `scripts/compile-harness.sh:1016` — `skill_field` returns EMPTY, so the
+        presence block renders `MUST consume: none`. The worst of the three: it
+        is the presence mechanism itself, and it disarms every harness at once.
+        **MEASURED.**
+      - `specs/HARNESS-046/check-roster-consistency.py:64` — falls back to `[]`
+        and compares "no skills" against the roster. It is that spec's declared
+        verification (`features.json:26`), so it runs. **MEASURED.**
       - `cli/internal/doctor/checks_agent_tiers.go` `readAgentFrontmatter` —
-        skips indented lines by design
-      - `scripts/compile-harness.sh:1016` — `skill_field` reads inline only, so
-        `skills_line` renders empty
-      **The fix already exists in that same file.** `agent_capability_line()`
-      detects the block form for `capabilities:` and refuses, on the reasoning
-      that an empty allow-list is not "no opinion" but "full default access".
-      The identical argument applies to `skills:`, where empty means "nothing
-      enforced". Copy that guard.
-- [ ] Migrate the 35 skills across 7 personas to declared severity. Blocked on
-      the guards above, or the migration silently disarms three readers.
+        **NOT a breakage.** It does skip indented lines, but its only consumers
+        are `fm["model"]` and `fm["targets"]`; it never reads `skills`. A latent
+        trap with no live effect, so no guard was built for it. Building one
+        would be a guard over a non-consumer.
+
+      **Shape decided this sitting: delegate, do not copy.** Copying
+      `agent_capability_line`'s refuse would have made the migration a flag-day —
+      the renderer would reject every migrated record permanently, and that
+      renderer feeds the presence block on all four harnesses. Instead
+      `build_agent_presence` calls the new `dotf harness resolve-skills`, which
+      reads both forms through `LoadPersona`'s real YAML parser. The copied
+      refuse survives where it is still needed: **inside the degrade path**, for
+      a dotf that is absent or predates the subcommand, where the awk fallback
+      would otherwise render `none`.
+
+      Contract: ids only, no `--harness` flag. Severity is `dotf harness gate`'s
+      input, not the presence text's — and the doctrine payload has no room for
+      it, being capped at 12000 characters for `.gemini/GEMINI.md` (breached
+      twice already, most recently by the roster going from one persona to seven).
+
+      Verified byte-identical to the awk read across all 7 shipped records, and
+      the stub now advertises `resolve-skills`, so **every pre-existing presence
+      test in `compile-harness.bats` exercises the delegated path** — their
+      unchanged expectations are the equivalence proof.
+
+- [ ] [AC7] **Not met, and it cannot be met by writing the schema.** AC7 asks for
+      a loud failure "in the schema validation". Measured: `compile-harness.sh`'s
+      `validate_skill_frontmatter` evaluates `jq -r '.required[]'` and nothing
+      else — its own comment says "do not read a passing --check as type
+      validation" — and `skills` is not in `required`. So no type constraint in
+      `agent-frontmatter.schema.json` is enforced by anything. The subschema was
+      written anyway, as the SSOT for the shape that `parseSkills` implements,
+      and it is labelled unenforced in its own description. **Ticketed as
+      HARNESS-089 (#1318)** rather than absorbed here — the hole is wider than
+      this field and wider than this schema, so fixing it inside an AC7 sitting
+      would have been the wrong size. Enforcement today lives in `parseSkills`
+      plus the two guards above.
+
+- [ ] Migrate the 35 skills across 7 personas to declared severity. Unblocked by
+      the guards above. **The records under `harness/agents/` are GENERATED**
+      (`generated_from: 00_meta/agents/definitions/...`): the migration edits the
+      vault definitions and re-runs `compile-harness.sh --refresh`, vault
+      committed direct to master. Editing the records in place is clobbered by
+      the next refresh. Per-skill severity is a design decision for the owner,
+      not 35 silent judgement calls.
 
 ## Closing
 

--- a/specs/HARNESS-046/check-roster-consistency.py
+++ b/specs/HARNESS-046/check-roster-consistency.py
@@ -57,11 +57,42 @@ def roster_rows(path: str) -> dict:
     return rows
 
 
+class UnreadableSkills(Exception):
+    """A `skills:` key this guard can see but cannot parse."""
+
+
 def definition_skills(path: str):
-    """Frontmatter only; a regex on the skills line avoids a yaml dependency."""
+    """Frontmatter only; a regex on the skills line avoids a yaml dependency.
+
+    A `skills:` key that is PRESENT but not in the inline form raises rather than
+    returning []. The two are indistinguishable downstream -- both compare an
+    empty list against the roster and both satisfy the >= SKILLS_MIN check by
+    failing it for the wrong reason -- and they mean opposite things. HARNESS-045
+    introduces a block form carrying per-skill severity:
+
+        skills:
+          - id: audit
+            enforce: block
+
+    Under the old `... if skills else []` this guard read that as "declares no
+    skills" and kept reporting exit 0, so the drift check HARNESS-046 exists to
+    provide would have been disarmed by a schema change it never noticed.
+    Measured 2026-08-27. Parsing the block form here would make this the THIRD
+    hand-rolled frontmatter reader in the repository; refusing loudly instead
+    means whoever migrates the definitions has to come back and do it once, in
+    `dotf harness resolve-skills`, where the parser already lives.
+    """
     head = open(path, encoding="utf-8").read().split("---")[1]
     kind = re.search(r"^kind:\s*(\S+)", head, re.M)
     skills = re.search(r"^skills:\s*\[(.*?)\]", head, re.M | re.S)
+    if skills is None and re.search(r"^skills:", head, re.M):
+        raise UnreadableSkills(
+            f"{path}: declares `skills:` in a form this guard cannot read "
+            "(expected the inline `skills: [a, b]`). Refusing to report it as an "
+            "empty skill list -- that would compare 'no skills' against the roster "
+            "and pass. Teach this guard the new form, or use "
+            "`dotf harness resolve-skills`."
+        )
     return (
         kind.group(1) if kind else "",
         [s.strip() for s in skills.group(1).split(",") if s.strip()] if skills else [],
@@ -78,7 +109,11 @@ def main() -> int:
         agent_md = os.path.join(defs_dir, name, "AGENT.md")
         if not os.path.isfile(agent_md):
             continue
-        kind, skills = definition_skills(agent_md)
+        try:
+            kind, skills = definition_skills(agent_md)
+        except UnreadableSkills as exc:
+            errors.append(str(exc))
+            continue
         if kind != "invocable":
             continue  # autonomous entries are cataloged separately, not in the phase table
 

--- a/tests/compile-harness.bats
+++ b/tests/compile-harness.bats
@@ -70,7 +70,23 @@ seed_dotf_stub() {
 # The capability probe: the render greps this for the subcommand name to decide
 # whether the binary is new enough. cli/internal/cmd pins the real help's shape.
 if [ "$1 $2" = "harness --help" ]; then
-    printf 'Available Commands:\n  resolve-tier          Resolve a neutral model tier\n  resolve-capabilities  Resolve neutral capabilities\n  triggers              x\n'
+    printf 'Available Commands:\n  resolve-tier          Resolve a neutral model tier\n  resolve-capabilities  Resolve neutral capabilities\n  resolve-skills        Print the forced-skill ids a record declares\n  triggers              x\n'
+    exit 0
+fi
+# Simulates the real subcommand's CONTRACT: both frontmatter forms in, one flow
+# sequence of ids out. Listing it in --help above means every presence test in
+# this file now exercises the delegated path rather than the awk fallback, which
+# is what makes their unchanged expectations an equivalence proof.
+if [ "$1 $2" = "harness resolve-skills" ]; then
+    inline="$(awk '/^---[[:space:]]*$/{n++; next}
+                   n==1 && /^skills:[[:space:]]*\[/ { sub(/^[^:]*:[[:space:]]*/,""); print; exit }
+                   n>=2 { exit }' "$3")"
+    if [ -n "$inline" ]; then printf '%s\n' "$inline"; exit 0; fi
+    ids="$(awk '/^---[[:space:]]*$/{n++; next}
+                n==1 && /^[[:space:]]+-[[:space:]]+id:[[:space:]]*[^[:space:]]/ {
+                    sub(/^[^:]*:[[:space:]]*/,""); printf "%s%s", sep, $0; sep=", " }
+                n>=2 { exit }' "$3")"
+    [ -n "$ids" ] && printf '[%s]\n' "$ids"
     exit 0
 fi
 if [ "$1 $2" = "harness resolve-capabilities" ]; then
@@ -1179,6 +1195,62 @@ PY
     [[ "$output" == *"block style"* ]]
     [[ "$output" == *GRANT* || "$output" == *"would GRANT"* ]]
     [ ! -f "$FAKEHOME/.claude/agents/curator.md" ]
+}
+
+@test "agents: a block-style skills list renders the real skills, not \"none\"" {
+    seed_agents_fixture
+    seed_instructions_file "$FAKEHOME/.claude/CLAUDE.md"
+    # HARNESS-045 AC7. skill_field reads the inline form only, so before the
+    # delegation this rendered "MUST consume: none" -- enforcement removed with
+    # no error anywhere. The presence text carries ids only: `enforce:` is what
+    # `dotf harness gate` acts on, and the doctrine payload is character-capped.
+    python3 - "$VAULT/00_meta/agents/definitions/curator/AGENT.md" <<'PY'
+import re, sys, pathlib
+p = pathlib.Path(sys.argv[1])
+p.write_text(re.sub(
+    r"^skills:.*$",
+    "skills:\n  - id: crystallize\n    enforce: block\n  - id: insights\n    enforce: warn",
+    p.read_text(), count=1, flags=re.M))
+PY
+    run_refresh; [ "$status" -eq 0 ]
+    run_deploy; [ "$status" -eq 0 ]
+    grep -q 'MUST consume: \[crystallize, insights\]' "$FAKEHOME/.claude/CLAUDE.md"
+    refute_grep_fixed 'MUST consume: none' "$FAKEHOME/.claude/CLAUDE.md"
+    # severity stays out of the prose; it belongs to the gate
+    refute_grep_fixed 'enforce' "$FAKEHOME/.claude/CLAUDE.md"
+}
+
+@test "agents: a block-style skills list fails loudly when dotf cannot read it" {
+    seed_agents_fixture
+    seed_instructions_file "$FAKEHOME/.claude/CLAUDE.md"
+    python3 - "$VAULT/00_meta/agents/definitions/curator/AGENT.md" <<'PY'
+import re, sys, pathlib
+p = pathlib.Path(sys.argv[1])
+p.write_text(re.sub(
+    r"^skills:.*$",
+    "skills:\n  - id: crystallize\n    enforce: block",
+    p.read_text(), count=1, flags=re.M))
+PY
+    run_refresh; [ "$status" -eq 0 ]
+    # a dotf predating resolve-skills: the fallback is the awk read, which returns
+    # EMPTY for this record. Degrading to "none" here is the silent disarm the
+    # whole acceptance criterion exists to prevent, so the fallback must refuse.
+    cat > "$STUB_BIN/dotf" <<'NOSKILLS'
+#!/usr/bin/env bash
+if [ "$1 $2" = "harness --help" ]; then
+    printf 'Available Commands:\n  resolve-tier          x\n  resolve-capabilities  x\n'
+    exit 0
+fi
+if [ "$1 $2" = "harness resolve-capabilities" ]; then printf 'tools: Read\n'; exit 0; fi
+[ "$1 $2" = "harness resolve-tier" ] || { printf 'stub: unexpected: %s\n' "$*" >&2; exit 127; }
+printf 'opus\n'
+NOSKILLS
+    chmod +x "$STUB_BIN/dotf"
+    run_deploy
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"block style"* ]]
+    [[ "$output" == *DISARM* ]]
+    refute_grep_fixed 'MUST consume: none' "$FAKEHOME/.claude/CLAUDE.md"
 }
 
 @test "agents: the unavailable-resolver warning states that it GRANTS, not denies" {


### PR DESCRIPTION
Closes the AC7 half of `specs/HARNESS-045-hook-emission/`. No persona migrates here — this is the gate that has to land first.

## The defect

`build_agent_presence` read `skills:` with an awk one-liner matching the inline form only. A record declaring the mapping form that carries per-skill severity returned **empty**, and the presence block rendered:

```
- **reviewer** — MUST consume: none
```

Enforcement removed, no error, on every harness at once. Measured against a real record in that form, not inferred:

| parser | on the mapping form | consequence |
|---|---|---|
| `compile-harness.sh:1016` | empty | `MUST consume: none` — the presence mechanism disarms itself |
| `check-roster-consistency.py:64` | `[]` | compares "no skills" against the roster and passes. It is HARNESS-046's declared verification (`features.json:26`), so it runs |

## Two corrections to the spec, both measured

**THREE parsers read `skills:` and TWO break — not four and three.** `doctor.readAgentFrontmatter` does skip indented lines, but its only consumers are `fm["model"]` and `fm["targets"]`; it never reads `skills`. A latent trap with no live effect, so no guard was built for it — a guard over a non-consumer is the kind of meta-work this repo caps.

**AC7's "loud failure in the schema validation" cannot be met by writing the schema.** `validate_skill_frontmatter` evaluates `jq -r '.required[]'` and nothing else (its own comment says so), and `skills` is not required. The `oneOf` is added as the SSOT for the shape `parseSkills` implements and says in its own `description` that nothing enforces it. Wider hole ticketed as **#1318**.

## Shape: delegate, don't copy

The spec said to copy `agent_capability_line`'s block-form refuse. That would have made the migration a **flag-day** — the renderer would reject every migrated record permanently, and that renderer feeds the presence block on all four harnesses.

So `build_agent_presence` calls a new `dotf harness resolve-skills`, which reads both forms through `LoadPersona`'s real YAML parser. Same seam as `resolve-tier` and `resolve-capabilities`; the shape lives in Go once instead of being hand-rolled in awk a third time.

**The copied refuse survives where it is still needed: inside the degrade path.** A dotf that is absent or predates the subcommand falls back to the awk read, which is correct for a legacy record and catastrophic for a migrated one — the same silent disarm. So the fallback carries the guard.

Contract: **ids only, no `--harness` flag.** `enforce:` is the gate's input, not the presence text's — and there is no room for it: the doctrine payload has **44 characters of headroom** against `.gemini/GEMINI.md`'s hard 12000-character cap (11956 measured), which the roster has already breached twice.

## On the live box

Installed `dotf` is 0.51.0 and predates `resolve-skills`, so real deploys take the **degrade path** (WARN + awk) until a rebuilt dotf lands. That is correct for today's all-legacy records, and the refuse only arms against migrated ones. Stated so it is not discovered as a surprise.

## Verification

- `resolve-skills` is **byte-identical to the awk read across all 7 shipped records**, asserted per record. Go's `strings.Join` normalises separators that the awk read passed verbatim, so this is the thing that could have silently changed every deployed instructions file.
- The bats stub now advertises the subcommand, so **every pre-existing presence test exercises the delegated path** — their unchanged expectations are the equivalence proof.
- The `--help` contract test now pins `resolve-skills` (lesson 219: a renamed `Use:` makes the shell probe answer "too old" forever and route every deploy through the fallback, silently).

**Mutation-checked in four places**, each turning a test red before restore: removing the degrade refuse, reverting the delegation, changing the join separator, renaming the subcommand.

`go build` / `go vet` / `GOOS=windows go vet` clean · `go test -count=1` 19/19 packages · `golangci-lint` 2.12.2 (the pin) 0 issues · `bats tests/*.bats` **1488/1488, exit 0**.

Local shellcheck is 0.10.0 against the 0.11.0 pin (#1265 open), so CI arbitrates the shell lint. The four SC2016 hits are info-level, pre-existing in this file, and CI runs `severity: error`.

## Also fixed, found along the way

HARNESS-046's declared verification was **red on `main`** before this branch: `cyclomatic-complexity` was in the builder and reviewer definitions and not in `ROSTER.md`. Fixed vault-side (`2e2155b7`, direct to master per convention); the guard now reports `6 invocable roles, all >= 3 skills`, exit 0.

## Next, deliberately not here

Migrating the 35 skills to declared severity. The records under `harness/agents/` are **generated** — that migration edits the vault definitions and re-runs `--refresh`, and per-skill severity is a design decision for the owner rather than 35 silent judgement calls.

Refs #561.