### PR TITLE
feat(secrets): the bw serve daemon leaves a log and a pid file, and doctor reads them when it dies

### DIFF
--- a/cli/internal/cmd/secrets_unlock.go
+++ b/cli/internal/cmd/secrets_unlock.go
@@ -4,15 +4,21 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/mlorentedev/dotfiles/cli/internal/env"
 	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
 	"github.com/spf13/cobra"
 )
 
 // bwDaemonAddr is the bw serve lifecycle seam unlock/lock/doctor share,
 // overridable so their tests never spawn a real bw process or touch a real
-// terminal — the daemon analog of bwReader/bwWriter.
+// terminal — the daemon analog of bwReader/bwWriter. The daemon's trace (log
+// + pid, #1315) lands under the deploy dir resolved the same way doctor
+// resolves cfg.DotfilesDir, so the writer here and the reader there agree.
 var bwDaemonAddr = func() *secrets.BWServeDaemon {
-	return &secrets.BWServeDaemon{Client: secrets.BWServeClient{}}
+	return &secrets.BWServeDaemon{
+		Client: secrets.BWServeClient{},
+		State:  secrets.NewBWServeState(env.DotfilesDir(env.Home())),
+	}
 }
 
 // newSecretsUnlockCmd is CLI-024-secrets-bw-serve's AC1/AC6: unlock Bitwarden
@@ -43,7 +49,7 @@ func newSecretsUnlockCmd() *cobra.Command {
 				return err
 			}
 			if st == "unlocked" {
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "already unlocked")
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "already unlocked (%s)\n", d.Trace())
 				return nil
 			}
 			_, _ = fmt.Fprint(cmd.ErrOrStderr(), "Bitwarden master password: ")
@@ -56,7 +62,7 @@ func newSecretsUnlockCmd() *cobra.Command {
 			if err := d.Unlock(string(pw)); err != nil {
 				return err
 			}
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "unlocked")
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "unlocked (%s)\n", d.Trace())
 			return nil
 		},
 	}
@@ -82,7 +88,7 @@ func newSecretsLockCmd() *cobra.Command {
 			if err := d.Lock(); err != nil {
 				return err
 			}
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "locked")
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "locked (%s)\n", d.Trace())
 			return nil
 		},
 	}

--- a/cli/internal/cmd/secrets_unlock_test.go
+++ b/cli/internal/cmd/secrets_unlock_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -45,17 +46,39 @@ func fakeBWServeHandler(t *testing.T, status *string, unlockPassword string) htt
 	}
 }
 
-func withFakeDaemon(t *testing.T, status *string, unlockPassword string) {
+// fakeDaemonPID is the pid the fake daemon's trace records, so a test can
+// assert unlock/lock print it (#1315) without a process behind it.
+const fakeDaemonPID = 4242
+
+// withFakeDaemon points the lifecycle seam at an httptest bw serve and gives
+// it a state dir carrying a pid file, the trace a daemon started by dotf
+// leaves behind. It returns the state so tests can assert on its paths.
+func withFakeDaemon(t *testing.T, status *string, unlockPassword string) secrets.BWServeState {
 	t.Helper()
 	srv := httptest.NewServer(fakeBWServeHandler(t, status, unlockPassword))
 	t.Cleanup(srv.Close)
+	state := secrets.NewBWServeState(t.TempDir())
+	if err := state.WritePID(fakeDaemonPID); err != nil {
+		t.Fatal(err)
+	}
 	old := bwDaemonAddr
 	bwDaemonAddr = func() *secrets.BWServeDaemon {
 		return &secrets.BWServeDaemon{
 			Client: secrets.BWServeClient{BaseURL: srv.URL, HTTPClient: &http.Client{Timeout: 2 * time.Second}},
+			State:  state,
 		}
 	}
 	t.Cleanup(func() { bwDaemonAddr = old })
+	return state
+}
+
+// assertTrace is AC3 of CLI-057: a confirmation line names the daemon's pid
+// and its log path, so the operator learns where to look before it is gone.
+func assertTrace(t *testing.T, out string, state secrets.BWServeState) {
+	t.Helper()
+	if !strings.Contains(out, "pid 4242") || !strings.Contains(out, state.LogPath()) {
+		t.Fatalf("expected the pid and the log path in the confirmation, got: %q", out)
+	}
 }
 
 func withFakePassword(t *testing.T, pw string, err error) {
@@ -89,7 +112,7 @@ func runLock(t *testing.T) (string, error) {
 // succeeds, and the password never appears in stdout or stderr.
 func TestSecretsUnlock_Succeeds_PasswordNeverInOutput(t *testing.T) {
 	status := "locked"
-	withFakeDaemon(t, &status, "correct-horse-battery-staple")
+	state := withFakeDaemon(t, &status, "correct-horse-battery-staple")
 	withFakePassword(t, "correct-horse-battery-staple", nil)
 
 	out, errOut, err := runUnlock(t)
@@ -99,6 +122,7 @@ func TestSecretsUnlock_Succeeds_PasswordNeverInOutput(t *testing.T) {
 	if !strings.Contains(out, "unlocked") {
 		t.Fatalf("expected confirmation in stdout, got: %q", out)
 	}
+	assertTrace(t, out, state)
 	if strings.Contains(out, "correct-horse-battery-staple") || strings.Contains(errOut, "correct-horse-battery-staple") {
 		t.Fatal("password must never appear in command output")
 	}
@@ -144,7 +168,7 @@ func TestSecretsUnlock_Idempotent(t *testing.T) {
 // TestSecretsLock is AC6: lock re-locks a running, unlocked daemon.
 func TestSecretsLock(t *testing.T) {
 	status := "unlocked"
-	withFakeDaemon(t, &status, "")
+	state := withFakeDaemon(t, &status, "")
 
 	out, err := runLock(t)
 	if err != nil {
@@ -153,6 +177,7 @@ func TestSecretsLock(t *testing.T) {
 	if !strings.Contains(out, "locked") {
 		t.Fatalf("expected confirmation, got: %q", out)
 	}
+	assertTrace(t, out, state)
 	if status != "locked" {
 		t.Fatalf("expected the daemon to report locked, got %q", status)
 	}
@@ -174,5 +199,28 @@ func TestSecretsLock_NoDaemon(t *testing.T) {
 	}
 	if !strings.Contains(out, "no daemon running") {
 		t.Fatalf("expected a no-op message, got: %q", out)
+	}
+}
+
+// TestSecretsUnlock_NoPIDFileIsSaidNotGuessed is AC3's honest branch: a daemon
+// dotf did not start (a hand-run `bw serve`, or one started before #1315) has
+// no pid file, and the confirmation says "pid unknown" rather than inventing
+// one — while still naming the log path, which is where a future start writes.
+func TestSecretsUnlock_NoPIDFileIsSaidNotGuessed(t *testing.T) {
+	status := "unlocked"
+	state := withFakeDaemon(t, &status, "")
+	if err := os.Remove(state.PIDPath()); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runUnlock(t)
+	if err != nil {
+		t.Fatalf("unlock: %v", err)
+	}
+	if !strings.Contains(out, "pid unknown") || !strings.Contains(out, state.LogPath()) {
+		t.Fatalf("expected 'pid unknown' and the log path, got: %q", out)
+	}
+	if strings.Contains(out, "pid 4242") {
+		t.Fatalf("a removed pid file must not be reported as a pid, got: %q", out)
 	}
 }

--- a/cli/internal/doctor/checks_bw_serve.go
+++ b/cli/internal/doctor/checks_bw_serve.go
@@ -1,6 +1,18 @@
 package doctor
 
-import "strconv"
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
+)
+
+// bwServeTailLines is how many trailing log lines the "daemon exited" line
+// carries: enough for the last Node error and its cause, not a stack dump.
+const bwServeTailLines = 3
 
 // checkBWServeDaemon reports the dotf-managed bw serve daemon's lock state —
 // absent / locked / unlocked — as its own section, distinct from
@@ -8,7 +20,11 @@ import "strconv"
 // AC4). The daemon is optional: `dotf secrets` falls back to the CLI
 // shellout when none is running, so no state this check observes is ever a
 // FAIL — only checkBitwardenReach's tiers can fail doctor over Bitwarden.
-func checkBWServeDaemon(sys *System, rep *Report) {
+//
+// "Absent" is two different facts, and since #1315 the pid file under the
+// deploy dir's state area tells them apart: never started here, or started
+// and gone. The second is the one that used to leave no trace.
+func checkBWServeDaemon(sys *System, cfg *Config, rep *Report) {
 	rep.Section("bw serve daemon (optional local unlock cache)")
 	st, err := sys.BWServeStatus()
 	if err != nil {
@@ -17,7 +33,7 @@ func checkBWServeDaemon(sys *System, rep *Report) {
 	}
 	switch st {
 	case "absent":
-		rep.Info("no daemon running — dotf secrets uses the CLI shellout (run `dotf secrets unlock` to start one)")
+		reportAbsentBWServe(sys, secrets.NewBWServeState(cfg.DotfilesDir), rep)
 	case "locked":
 		rep.Info("daemon running, locked — run `dotf secrets unlock` to use it")
 	case "unlocked":
@@ -25,4 +41,41 @@ func checkBWServeDaemon(sys *System, rep *Report) {
 	default:
 		rep.Warn("unrecognised bw serve status " + strconv.Quote(st))
 	}
+}
+
+// reportAbsentBWServe renders "nothing answers" at the precision the trace
+// allows. No pid file: nothing was started from this deploy dir, the resting
+// state of a fresh box. A pid file whose pid is gone: the daemon exited, and
+// its last log lines are the evidence nobody was there to read. A pid file
+// whose pid is alive: it is still starting, or the pid now belongs to another
+// process — said as the ambiguity it is, never as "the daemon is up".
+//
+// WARN, not FAIL, for the reason the section's doc gives: the shellout
+// fallback still works, and reportAgentLaunchability already says what an
+// absent daemon costs the wrappers.
+func reportAbsentBWServe(sys *System, state secrets.BWServeState, rep *Report) {
+	pid, err := state.ReadPID()
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		rep.Info("no daemon running — dotf secrets uses the CLI shellout (run `dotf secrets unlock` to start one)")
+		return
+	case err != nil:
+		rep.Warn("no daemon running, and its pid file is unreadable (" + err.Error() + ") — run `dotf secrets unlock` to start one")
+		return
+	}
+	if sys.ProcessAlive != nil && sys.ProcessAlive(pid) {
+		rep.Warn(fmt.Sprintf("daemon pid %d (%s) is alive but nothing answers on its port — still starting, or another process reusing the pid; log: %s",
+			pid, state.PIDPath(), state.LogPath()))
+		return
+	}
+	lines, readErr := state.LastLogLines(bwServeTailLines)
+	tail := "log is empty"
+	switch {
+	case readErr != nil:
+		tail = "log unreadable (" + readErr.Error() + ")"
+	case len(lines) > 0:
+		tail = strings.Join(lines, " | ")
+	}
+	rep.Warn(fmt.Sprintf("daemon exited — pid %d recorded in %s is gone; last lines: %s — run `dotf secrets unlock` to restart it (full log: %s)",
+		pid, state.PIDPath(), tail, state.LogPath()))
 }

--- a/cli/internal/doctor/checks_bw_serve_test.go
+++ b/cli/internal/doctor/checks_bw_serve_test.go
@@ -3,43 +3,155 @@ package doctor
 import (
 	"bytes"
 	"errors"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
 )
 
-func TestCheckBWServeDaemon_Absent(t *testing.T) {
+// bwServeSys is a System whose daemon reports status and whose recorded pid is
+// alive or not, on top of newSys's safe defaults.
+func bwServeSys(status string, alive bool) *System {
+	sys := newSys(nil, nil, nil)
+	sys.BWServeStatus = func() (string, error) { return status, nil }
+	sys.ProcessAlive = func(int) bool { return alive }
+	return sys
+}
+
+// writeBWServeTrace lays down the trace a started daemon leaves under the
+// deploy dir: its pid file and, when log is non-empty, its log.
+func writeBWServeTrace(t *testing.T, dotfilesDir string, pid int, log string) secrets.BWServeState {
+	t.Helper()
+	state := secrets.NewBWServeState(dotfilesDir)
+	if err := state.WritePID(pid); err != nil {
+		t.Fatal(err)
+	}
+	if log != "" {
+		if err := os.WriteFile(state.LogPath(), []byte(log), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return state
+}
+
+// TestCheckBWServeDaemon_States is AC5 of CLI-057: one row per observable
+// state, asserted by status tag (statusOfLine) rather than prose. The rows
+// that matter are the two "absent" ones with a pid file — before #1315 both
+// rendered as the same "no daemon running" Info, and a daemon that had died
+// was indistinguishable from one never started.
+func TestCheckBWServeDaemon_States(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     string
+		pid        int // 0 ⇒ no pid file
+		alive      bool
+		log        string
+		wantStatus Status
+		needle     string
+		wantSubstr []string
+	}{
+		{
+			name: "absent, never started → Info as before", status: "absent",
+			wantStatus: StatusInfo, needle: "no daemon running",
+		},
+		{
+			name: "absent, pid recorded and gone → WARN daemon exited with last lines", status: "absent",
+			pid: 4242, alive: false, log: "Listening on 127.0.0.1:8087\nTypeError: cannot read properties of undefined\n    at Object.<anonymous>\n",
+			wantStatus: StatusWarn, needle: "daemon exited",
+			wantSubstr: []string{"pid 4242", "TypeError: cannot read properties of undefined", "bw-serve.log", "dotf secrets unlock"},
+		},
+		{
+			name: "absent, pid recorded and gone, empty log → WARN says the log is empty", status: "absent",
+			pid: 4242, alive: false,
+			wantStatus: StatusWarn, needle: "daemon exited",
+			wantSubstr: []string{"log is empty"},
+		},
+		{
+			name: "absent, pid recorded and alive → WARN alive but not answering", status: "absent",
+			pid: 4242, alive: true,
+			wantStatus: StatusWarn, needle: "alive but nothing answers",
+			wantSubstr: []string{"pid 4242", "reusing the pid"},
+		},
+		{
+			name: "locked → Info", status: "locked",
+			pid: 4242, alive: true,
+			wantStatus: StatusInfo, needle: "locked",
+		},
+		{
+			name: "unlocked → PASS", status: "unlocked",
+			pid: 4242, alive: true,
+			wantStatus: StatusPass, needle: "unlocked",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dotfiles := t.TempDir()
+			if tc.pid != 0 {
+				writeBWServeTrace(t, dotfiles, tc.pid, tc.log)
+			}
+			var buf bytes.Buffer
+			rep := capture(&buf)
+
+			checkBWServeDaemon(bwServeSys(tc.status, tc.alive), &Config{DotfilesDir: dotfiles}, rep)
+
+			out := buf.String()
+			if got := statusOfLine(out, tc.needle); got != tc.wantStatus {
+				t.Fatalf("line mentioning %q: status %q, want %q\n%s", tc.needle, tagOf(got), tagOf(tc.wantStatus), out)
+			}
+			for _, want := range tc.wantSubstr {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected %q in:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+// tagOf renders a Status for a failure message; -1 (statusOfLine's "no such
+// line") has no tag.
+func tagOf(s Status) string {
+	if tag, ok := statusTag[s]; ok {
+		return tag
+	}
+	return "<no line>"
+}
+
+// A pid file that cannot be parsed is its own WARN, not silently "never
+// started": the trace exists and something wrote garbage into it.
+func TestCheckBWServeDaemon_UnreadablePIDFileIsAWarn(t *testing.T) {
+	dotfiles := t.TempDir()
+	state := secrets.NewBWServeState(dotfiles)
+	if err := os.MkdirAll(state.Dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(state.PIDPath(), []byte("garbage\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	rep := capture(&buf)
+
+	checkBWServeDaemon(bwServeSys("absent", false), &Config{DotfilesDir: dotfiles}, rep)
+
+	if got := statusOfLine(buf.String(), "pid file is unreadable"); got != StatusWarn {
+		t.Fatalf("want a WARN naming the unreadable pid file, got:\n%s", buf.String())
+	}
+}
+
+// The absent branch must survive a System with no ProcessAlive seam (older
+// callers, hand-built test Systems): an unknown liveness reads as gone, which
+// is the honest direction — the port is not answering.
+func TestCheckBWServeDaemon_NilProcessAliveReadsAsGone(t *testing.T) {
+	dotfiles := t.TempDir()
+	writeBWServeTrace(t, dotfiles, 4242, "")
 	var buf bytes.Buffer
 	rep := capture(&buf)
 	sys := &System{BWServeStatus: func() (string, error) { return "absent", nil }}
 
-	checkBWServeDaemon(sys, rep)
+	checkBWServeDaemon(sys, &Config{DotfilesDir: dotfiles}, rep)
 
-	if got := buf.String(); !strings.Contains(got, "no daemon running") {
-		t.Fatalf("expected an absent-daemon info line, got: %s", got)
-	}
-}
-
-func TestCheckBWServeDaemon_Locked(t *testing.T) {
-	var buf bytes.Buffer
-	rep := capture(&buf)
-	sys := &System{BWServeStatus: func() (string, error) { return "locked", nil }}
-
-	checkBWServeDaemon(sys, rep)
-
-	if got := buf.String(); !strings.Contains(got, "locked") {
-		t.Fatalf("expected a locked-daemon info line, got: %s", got)
-	}
-}
-
-func TestCheckBWServeDaemon_Unlocked(t *testing.T) {
-	var buf bytes.Buffer
-	rep := capture(&buf)
-	sys := &System{BWServeStatus: func() (string, error) { return "unlocked", nil }}
-
-	checkBWServeDaemon(sys, rep)
-
-	if got := buf.String(); !strings.Contains(got, "unlocked") {
-		t.Fatalf("expected an unlocked-daemon pass line, got: %s", got)
+	if got := statusOfLine(buf.String(), "daemon exited"); got != StatusWarn {
+		t.Fatalf("want the exited WARN, got:\n%s", buf.String())
 	}
 }
 
@@ -48,7 +160,7 @@ func TestCheckBWServeDaemon_StatusUnreadable(t *testing.T) {
 	rep := capture(&buf)
 	sys := &System{BWServeStatus: func() (string, error) { return "", errors.New("boom") }}
 
-	checkBWServeDaemon(sys, rep)
+	checkBWServeDaemon(sys, &Config{DotfilesDir: t.TempDir()}, rep)
 
 	if got := buf.String(); !strings.Contains(got, "boom") {
 		t.Fatalf("expected the underlying error surfaced, got: %s", got)

--- a/cli/internal/doctor/checks_test.go
+++ b/cli/internal/doctor/checks_test.go
@@ -468,7 +468,7 @@ func statusOfLine(output, needle string) Status {
 		if !strings.Contains(line, needle) {
 			continue
 		}
-		for _, s := range []Status{StatusPass, StatusFail, StatusWarn, StatusSkip} {
+		for _, s := range []Status{StatusPass, StatusFail, StatusWarn, StatusSkip, StatusInfo} {
 			if strings.Contains(line, statusTag[s]) {
 				return s
 			}

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -87,7 +87,7 @@ func Run(opts Options) (int, error) {
 		checkSecrets(sys, cfg, rep)
 		checkSecretsTooling(sys, cfg, rep)
 		checkBitwardenReach(sys, rep)
-		checkBWServeDaemon(sys, rep)
+		checkBWServeDaemon(sys, cfg, rep)
 		checkBWMapping(sys, cfg, rep)
 		checkAgentConfigSecrets(sys, rep)
 		checkHiveBackendCanServe(sys, rep)

--- a/cli/internal/doctor/system.go
+++ b/cli/internal/doctor/system.go
@@ -102,6 +102,12 @@ type System struct {
 	// state (secrets.BWServeDaemon.Status's own contract) — only a genuinely
 	// unparseable response surfaces as err. CLI-024-secrets-bw-serve, AC4.
 	BWServeStatus func() (string, error)
+	// ProcessAlive reports whether pid names a live process (secrets.ProcessAlive
+	// in production: signal 0 on Unix, OpenProcess + GetExitCodeProcess on
+	// Windows). It is what lets the bw serve check tell "the daemon died" from
+	// "the daemon was never started": a pid file with nothing listening is the
+	// only trace a detached daemon leaves behind (#1315).
+	ProcessAlive func(pid int) bool
 	// ResolveSecret resolves ONE registry entry to its plaintext value through the
 	// same Loader `dotf secrets run` uses. It exists because the PAT-expiry check
 	// used to read its token from the ambient environment, which ADR-028
@@ -199,6 +205,7 @@ func realSystem() *System {
 		BWServeStatus: func() (string, error) {
 			return (&secrets.BWServeDaemon{Client: secrets.BWServeClient{}}).Status()
 		},
+		ProcessAlive:  secrets.ProcessAlive,
 		ResolveSecret: resolveSecret,
 		BWItemNames: func() ([]string, error) {
 			return secrets.BWServeReader{Client: secrets.BWServeClient{}}.ItemNames()

--- a/cli/internal/doctor/testhelpers_test.go
+++ b/cli/internal/doctor/testhelpers_test.go
@@ -83,6 +83,9 @@ func newSys(env map[string]string, onPath []string, cmdOut map[string]string) *S
 		// Default: no daemon running — the common case (nothing has run `dotf
 		// secrets unlock`). Tests exercising the daemon states inject their own.
 		BWServeStatus: func() (string, error) { return "absent", nil },
+		// Default: no recorded pid is alive. Tests exercising the "alive but not
+		// answering" branch inject their own.
+		ProcessAlive: func(int) bool { return false },
 		// Default: nothing is provisioned on this box, so PAT resolution reports
 		// the secret absent and the check SKIPs. It mirrors the pre-REFACTOR-012
 		// default (no token in the environment ⇒ SKIP), so full-sweep tests that

--- a/cli/internal/secrets/bwserve.go
+++ b/cli/internal/secrets/bwserve.go
@@ -383,6 +383,11 @@ type BWServeDaemon struct {
 
 	Client BWServeClient // talks to the daemon once it's up
 
+	// State is where the daemon's stdout+stderr and pid land (bwserve_state.go,
+	// #1315). The zero value records nothing — tests of the HTTP half need no
+	// filesystem — and production always sets it (cmd.bwDaemonAddr).
+	State BWServeState
+
 	// newCmd is the process-construction seam, overridable in tests so
 	// Start()'s retry/timeout behavior is testable without a real bw binary.
 	// nil -> bwServeCommand.
@@ -418,8 +423,7 @@ func (d *BWServeDaemon) Start(pollTimeout time.Duration) error {
 	if d.Running() {
 		return nil
 	}
-	cmd := d.command()
-	if err := cmd.Start(); err != nil {
+	if err := d.spawn(d.command()); err != nil {
 		return fmt.Errorf("start bw serve: %w", err)
 	}
 	deadline := time.Now().Add(pollTimeout)
@@ -430,6 +434,38 @@ func (d *BWServeDaemon) Start(pollTimeout time.Duration) error {
 		time.Sleep(100 * time.Millisecond)
 	}
 	return fmt.Errorf("bw serve did not become reachable within %s", pollTimeout)
+}
+
+// spawn starts cmd with its stdout+stderr appended to the state log and
+// records its pid — the trace #1315 found missing. With no State it is the
+// bare cmd.Start() it used to be.
+//
+// The log is handed to the child as an *os.File on purpose: os/exec then
+// connects the descriptor directly, with no copying goroutine in THIS process,
+// which is what lets `dotf` exit while the detached daemon keeps writing. Our
+// own handle is closed once the child holds its copy.
+func (d *BWServeDaemon) spawn(cmd *exec.Cmd) error {
+	if !d.State.enabled() {
+		return cmd.Start()
+	}
+	logf, err := d.State.openLog()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = logf.Close() }()
+	cmd.Stdout = logf
+	cmd.Stderr = logf
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	pid := cmd.Process.Pid
+	markStart(logf, pid, time.Now())
+	if err := d.State.WritePID(pid); err != nil {
+		// The daemon IS running; failing here is loud rather than silent, and
+		// the log's start marker still names the pid for whoever reads it.
+		return fmt.Errorf("bw serve started (pid %d) but its trace is incomplete: %w", pid, err)
+	}
+	return nil
 }
 
 // Unlock delegates to the client — see BWServeClient.Unlock's contract.

--- a/cli/internal/secrets/bwserve_state.go
+++ b/cli/internal/secrets/bwserve_state.go
@@ -1,0 +1,242 @@
+package secrets
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// BWServeState is where a dotf-managed bw serve daemon leaves its trace: the
+// log its stdout+stderr append to, and the pid file naming the process that
+// was started.
+//
+// It exists because of what #1315 was. The daemon is detached from every
+// console by design (WIN-012 — that is the whole point of one unlock serving
+// every later terminal), so nobody is ever watching its stderr; and Start()
+// ran it with nil stdio and recorded no pid. On the Windows work box
+// (2026-08-27) it died twice within minutes of `dotf secrets unlock`, and the
+// only evidence was that nothing listened on 8087 any more. A process nobody
+// can watch has to leave its evidence behind itself.
+//
+// Dir is the deploy dir's state area, <DOTFILES_DIR>/state — beside the
+// DR-drill marker (doctor/checks_dr.go), and for the same reason: a daemon's
+// death is a property of THIS box, not of the source tree. Callers derive it
+// through NewBWServeState from their own deploy-dir resolution (env.DotfilesDir
+// in the CLI, cfg.DotfilesDir in doctor) so the writer and the reader can never
+// disagree on where the files are.
+type BWServeState struct {
+	// Dir is the state directory. "" writes and reads nothing — the pre-#1315
+	// behaviour, kept so tests of the HTTP half need no filesystem. Production
+	// always sets it.
+	Dir string
+}
+
+const (
+	bwServeStateSubdir = "state"
+	bwServeLogName     = "bw-serve.log"
+	bwServePIDName     = "bw-serve.pid"
+
+	// bwServeLogCap bounds the log. A log over the cap is rotated to `.log.1`
+	// (replacing the previous one) the next time a daemon is started, so the
+	// two files together never exceed twice this. A few hundred KB holds many
+	// Node stack traces, which is what bw serve emits when it dies.
+	bwServeLogCap = 256 * 1024
+
+	// bwServeTailBytes is how much of the log LastLogLines reads. The last
+	// lines are the evidence; the whole file never travels into a report.
+	bwServeTailBytes = 16 * 1024
+
+	// bwServeLogLineWidth caps each reported line. Doctor prints these on one
+	// report line, and a Node stack frame can run to hundreds of characters.
+	bwServeLogLineWidth = 160
+)
+
+// NewBWServeState places the state area under dotfilesDir. An empty dotfilesDir
+// yields a disabled state rather than a relative "state/" in the cwd.
+func NewBWServeState(dotfilesDir string) BWServeState {
+	if dotfilesDir == "" {
+		return BWServeState{}
+	}
+	return BWServeState{Dir: filepath.Join(dotfilesDir, bwServeStateSubdir)}
+}
+
+func (s BWServeState) enabled() bool { return s.Dir != "" }
+
+// LogPath is the daemon's log; "" when the state is disabled.
+func (s BWServeState) LogPath() string {
+	if !s.enabled() {
+		return ""
+	}
+	return filepath.Join(s.Dir, bwServeLogName)
+}
+
+// PIDPath is the daemon's pid file; "" when the state is disabled.
+func (s BWServeState) PIDPath() string {
+	if !s.enabled() {
+		return ""
+	}
+	return filepath.Join(s.Dir, bwServePIDName)
+}
+
+// openLog opens the log for appending — rotating it first when it is over the
+// cap — and creates the state dir on first use. 0700/0600: nothing here is a
+// secret (bw serve writes diagnostics to stdio, never vault material), but the
+// directory sits beside the DR escrow and inherits its posture.
+func (s BWServeState) openLog() (*os.File, error) {
+	if err := os.MkdirAll(s.Dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create bw serve state dir: %w", err)
+	}
+	if err := s.rotateIfOver(bwServeLogCap); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(s.LogPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open bw serve log: %w", err)
+	}
+	return f, nil
+}
+
+// rotateIfOver moves the log aside once it exceeds capBytes. Rename over an
+// existing `.log.1` replaces it, so exactly one generation is kept. A rename
+// can fail while a still-alive daemon holds the file open (Windows, when the
+// handle was not opened with FILE_SHARE_DELETE); truncating then keeps the cap
+// honest at the cost of the older half, which beats a log that grows without
+// bound.
+func (s BWServeState) rotateIfOver(capBytes int64) error {
+	fi, err := os.Stat(s.LogPath())
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("stat bw serve log: %w", err)
+	}
+	if fi.Size() <= capBytes {
+		return nil
+	}
+	if err := os.Rename(s.LogPath(), s.LogPath()+".1"); err == nil {
+		return nil
+	}
+	if err := os.Truncate(s.LogPath(), 0); err != nil {
+		return fmt.Errorf("rotate bw serve log: %w", err)
+	}
+	return nil
+}
+
+// WritePID records the started daemon's pid, replacing whatever a previous
+// start left behind.
+func (s BWServeState) WritePID(pid int) error {
+	if err := os.MkdirAll(s.Dir, 0o700); err != nil {
+		return fmt.Errorf("create bw serve state dir: %w", err)
+	}
+	if err := os.WriteFile(s.PIDPath(), []byte(strconv.Itoa(pid)+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write bw serve pid file: %w", err)
+	}
+	return nil
+}
+
+// ReadPID returns the recorded pid. A missing file — no daemon was ever
+// started from this deploy dir, or the state is disabled — reports
+// os.ErrNotExist (wrapped), which callers tell apart from an unparseable one.
+func (s BWServeState) ReadPID() (int, error) {
+	if !s.enabled() {
+		return 0, fmt.Errorf("bw serve state disabled: %w", os.ErrNotExist)
+	}
+	raw, err := os.ReadFile(s.PIDPath())
+	if err != nil {
+		return 0, err
+	}
+	text := strings.TrimSpace(string(raw))
+	pid, err := strconv.Atoi(text)
+	if err != nil || pid <= 0 {
+		return 0, fmt.Errorf("%s: not a pid: %q", s.PIDPath(), text)
+	}
+	return pid, nil
+}
+
+// LastLogLines returns at most n trailing non-empty lines of the log, each cut
+// to bwServeLogLineWidth. It reads only the tail of the file, so a log at its
+// cap costs the same as an empty one. A missing log yields no lines and no
+// error: the caller is reporting a dead daemon, and "it left no log" is a
+// finding, not a failure of the reporter.
+func (s BWServeState) LastLogLines(n int) ([]string, error) {
+	if !s.enabled() || n <= 0 {
+		return nil, nil
+	}
+	f, err := os.Open(s.LogPath())
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	start := fi.Size() - bwServeTailBytes
+	if start < 0 {
+		start = 0
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return nil, err
+	}
+	raw, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(raw), "\n")
+	if start > 0 && len(lines) > 0 {
+		lines = lines[1:] // the seek landed mid-line; the fragment is not a line
+	}
+	return tailLines(lines, n), nil
+}
+
+// tailLines keeps the last n non-empty lines, trimmed and width-capped.
+func tailLines(lines []string, n int) []string {
+	kept := make([]string, 0, n)
+	for i := len(lines) - 1; i >= 0 && len(kept) < n; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if len(line) > bwServeLogLineWidth {
+			line = line[:bwServeLogLineWidth] + "…"
+		}
+		kept = append(kept, line)
+	}
+	for i, j := 0, len(kept)-1; i < j; i, j = i+1, j-1 {
+		kept[i], kept[j] = kept[j], kept[i]
+	}
+	return kept
+}
+
+// markStart writes the one line dotf itself contributes to the log: which pid
+// it started and when. It is what separates one daemon's output from the
+// next's in an append-only file, and it is written by dotf rather than the
+// child so it lands even if bw serve prints nothing before dying.
+func markStart(w io.Writer, pid int, now time.Time) {
+	_, _ = fmt.Fprintf(w, "==== dotf: started bw serve pid %d at %s ====\n", pid, now.UTC().Format(time.RFC3339))
+}
+
+// Trace names where the daemon left its trace, for `dotf secrets unlock` and
+// `lock` to print beside their confirmation: an operator who reads "unlocked"
+// also learns where to look when the daemon is gone by the next call. A daemon
+// this dotf did not start has no pid file, and that is said rather than
+// guessed at.
+func (d *BWServeDaemon) Trace() string {
+	logPath := d.State.LogPath()
+	if logPath == "" {
+		return "no state dir — pid and log not recorded"
+	}
+	pid, err := d.State.ReadPID()
+	if err != nil {
+		return fmt.Sprintf("pid unknown — not started by this dotf; log %s", logPath)
+	}
+	return fmt.Sprintf("pid %d, log %s", pid, logPath)
+}

--- a/cli/internal/secrets/bwserve_state_test.go
+++ b/cli/internal/secrets/bwserve_state_test.go
@@ -1,0 +1,320 @@
+package secrets
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNewBWServeState_DerivesPathsFromDeployDir(t *testing.T) {
+	s := NewBWServeState(filepath.Join("home", ".dotfiles"))
+	wantLog := filepath.Join("home", ".dotfiles", "state", "bw-serve.log")
+	wantPID := filepath.Join("home", ".dotfiles", "state", "bw-serve.pid")
+	if s.LogPath() != wantLog || s.PIDPath() != wantPID {
+		t.Fatalf("paths = %q, %q; want %q, %q", s.LogPath(), s.PIDPath(), wantLog, wantPID)
+	}
+}
+
+// An empty deploy dir must not silently become a relative "state/" in whatever
+// the cwd happens to be.
+func TestNewBWServeState_EmptyDeployDirIsDisabled(t *testing.T) {
+	s := NewBWServeState("")
+	if s.LogPath() != "" || s.PIDPath() != "" {
+		t.Fatalf("disabled state must have no paths, got %q %q", s.LogPath(), s.PIDPath())
+	}
+	if _, err := s.ReadPID(); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("ReadPID on a disabled state: want ErrNotExist, got %v", err)
+	}
+	lines, err := s.LastLogLines(3)
+	if err != nil || lines != nil {
+		t.Fatalf("LastLogLines on a disabled state: want nil, nil; got %v, %v", lines, err)
+	}
+}
+
+func TestBWServeState_PIDRoundTrip(t *testing.T) {
+	s := NewBWServeState(t.TempDir())
+	if _, err := s.ReadPID(); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("no pid file yet: want ErrNotExist, got %v", err)
+	}
+	if err := s.WritePID(4242); err != nil {
+		t.Fatalf("WritePID: %v", err)
+	}
+	pid, err := s.ReadPID()
+	if err != nil || pid != 4242 {
+		t.Fatalf("ReadPID = %d, %v; want 4242", pid, err)
+	}
+}
+
+func TestBWServeState_ReadPID_RejectsGarbage(t *testing.T) {
+	s := NewBWServeState(t.TempDir())
+	if err := os.MkdirAll(s.Dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.PIDPath(), []byte("not-a-pid\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := s.ReadPID()
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("garbage pid file must be an error distinct from absence, got %v", err)
+	}
+}
+
+func TestBWServeState_LastLogLines(t *testing.T) {
+	s := NewBWServeState(t.TempDir())
+
+	// No log at all: no lines, no error — "it left no log" is a finding.
+	lines, err := s.LastLogLines(3)
+	if err != nil || len(lines) != 0 {
+		t.Fatalf("missing log: want no lines and no error, got %v, %v", lines, err)
+	}
+
+	f, err := s.openLog()
+	if err != nil {
+		t.Fatalf("openLog: %v", err)
+	}
+	long := strings.Repeat("x", bwServeLogLineWidth+50)
+	_, _ = f.WriteString("one\n\ntwo\r\nthree\n" + long + "\nfive\n")
+	_ = f.Close()
+
+	lines, err = s.LastLogLines(3)
+	if err != nil {
+		t.Fatalf("LastLogLines: %v", err)
+	}
+	if len(lines) != 3 {
+		t.Fatalf("want 3 lines, got %d: %q", len(lines), lines)
+	}
+	if lines[0] != "three" || lines[2] != "five" {
+		t.Fatalf("want the last three non-empty lines in order, got %q", lines)
+	}
+	if len(lines[1]) > bwServeLogLineWidth+len("…") || !strings.HasSuffix(lines[1], "…") {
+		t.Fatalf("a long line must be cut to the width and marked, got %d bytes", len(lines[1]))
+	}
+}
+
+// LastLogLines reads only the tail: a log far larger than the tail window
+// still yields its final lines, and the fragment the seek lands in is dropped
+// rather than reported as a line.
+func TestBWServeState_LastLogLines_ReadsOnlyTheTail(t *testing.T) {
+	s := NewBWServeState(t.TempDir())
+	f, err := s.openLog()
+	if err != nil {
+		t.Fatal(err)
+	}
+	filler := strings.Repeat("filler line that is long enough to matter\n", (2*bwServeTailBytes)/40)
+	_, _ = f.WriteString(filler + "last\n")
+	_ = f.Close()
+
+	lines, err := s.LastLogLines(1)
+	if err != nil || len(lines) != 1 || lines[0] != "last" {
+		t.Fatalf("want [last], got %v, %v", lines, err)
+	}
+}
+
+func writeLogOfSize(t *testing.T, s BWServeState, size int) {
+	t.Helper()
+	if err := os.MkdirAll(s.Dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.LogPath(), bytes.Repeat([]byte("y"), size), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// AC2: over the cap the log is moved to .log.1 and a fresh one opened; the
+// previous .log.1 is replaced, so the bound is two generations.
+func TestBWServeState_RotateOverCap(t *testing.T) {
+	s := NewBWServeState(t.TempDir())
+	rotated := s.LogPath() + ".1"
+	if err := os.MkdirAll(s.Dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rotated, []byte("stale generation"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeLogOfSize(t, s, bwServeLogCap+1)
+
+	f, err := s.openLog()
+	if err != nil {
+		t.Fatalf("openLog: %v", err)
+	}
+	_ = f.Close()
+
+	fi, err := os.Stat(s.LogPath())
+	if err != nil || fi.Size() != 0 {
+		t.Fatalf("fresh log after rotation: size %d, err %v", fi.Size(), err)
+	}
+	old, err := os.Stat(rotated)
+	if err != nil || old.Size() != bwServeLogCap+1 {
+		t.Fatalf(".log.1 must hold the previous generation (%d bytes), got %d, %v", bwServeLogCap+1, old.Size(), err)
+	}
+}
+
+// At or under the cap nothing moves: a log that rotated on every start would
+// throw away exactly the lines a fresh death is diagnosed from.
+func TestBWServeState_RotateLeavesLogUnderCap(t *testing.T) {
+	s := NewBWServeState(t.TempDir())
+	writeLogOfSize(t, s, bwServeLogCap)
+
+	f, err := s.openLog()
+	if err != nil {
+		t.Fatalf("openLog: %v", err)
+	}
+	_ = f.Close()
+
+	if _, err := os.Stat(s.LogPath() + ".1"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("no rotation expected at the cap, got %v", err)
+	}
+	fi, _ := os.Stat(s.LogPath())
+	if fi.Size() != bwServeLogCap {
+		t.Fatalf("log must be untouched, size %d", fi.Size())
+	}
+}
+
+// When the rename cannot happen the cap still holds: a directory squatting on
+// the .log.1 name makes the rename fail on every OS, and the log is truncated.
+func TestBWServeState_RotateFallsBackToTruncate(t *testing.T) {
+	s := NewBWServeState(t.TempDir())
+	writeLogOfSize(t, s, bwServeLogCap+1)
+	if err := os.MkdirAll(filepath.Join(s.LogPath()+".1", "occupied"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := s.openLog()
+	if err != nil {
+		t.Fatalf("openLog: %v", err)
+	}
+	_ = f.Close()
+
+	fi, err := os.Stat(s.LogPath())
+	if err != nil || fi.Size() != 0 {
+		t.Fatalf("log must be truncated when it cannot be renamed: size %d, err %v", fi.Size(), err)
+	}
+}
+
+// gatedFakeServe answers /status only once the fake daemon has been spawned:
+// Start() must see "unreachable" first (so it spawns) and "reachable" after
+// (so it returns), with the transition tied to the spawn itself.
+func gatedFakeServe(spawned *atomic.Bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !spawned.Load() {
+			http.Error(w, "not yet", http.StatusServiceUnavailable)
+			return
+		}
+		writeEnvelope(w, true, "", map[string]any{
+			"object":   "template",
+			"template": map[string]string{"status": "locked"},
+		})
+	}
+}
+
+// waitForLog polls until the log contains needle or the deadline passes; the
+// child writes asynchronously and a detached child on Windows has no console
+// to flush through.
+func waitForLog(t *testing.T, path, needle string) string {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		raw, _ := os.ReadFile(path)
+		if strings.Contains(string(raw), needle) || time.Now().After(deadline) {
+			return string(raw)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// TestBWServeDaemon_Start_WritesLogAndPID is AC1 and — run on Windows — AC4: a
+// real child, started through Start() with the production detach attributes,
+// gets its stdout AND stderr into the log and its pid into the pid file. The
+// child is a re-exec of this test binary (TestHelperFakeDaemon), not bw.
+func TestBWServeDaemon_Start_WritesLogAndPID(t *testing.T) {
+	var spawned atomic.Bool
+	srv := httptest.NewServer(gatedFakeServe(&spawned))
+	defer srv.Close()
+
+	state := NewBWServeState(t.TempDir())
+	var child *exec.Cmd
+	d := &BWServeDaemon{
+		Client: BWServeClient{BaseURL: srv.URL, HTTPClient: &http.Client{Timeout: time.Second}},
+		State:  state,
+		newCmd: func(string, int) *exec.Cmd {
+			child = fakeDaemonCmd(t)
+			spawned.Store(true)
+			return child
+		},
+	}
+	t.Cleanup(func() { reap(t, child) })
+
+	if err := d.Start(5 * time.Second); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if child == nil || child.Process == nil {
+		t.Fatal("Start did not spawn the child")
+	}
+
+	pid, err := state.ReadPID()
+	if err != nil {
+		t.Fatalf("pid file after Start: %v", err)
+	}
+	if pid != child.Process.Pid {
+		t.Fatalf("pid file holds %d, child is %d", pid, child.Process.Pid)
+	}
+	if !ProcessAlive(pid) {
+		t.Fatalf("recorded pid %d is not alive", pid)
+	}
+
+	log := waitForLog(t, state.LogPath(), "fake daemon: stderr line")
+	for _, want := range []string{"fake daemon: stdout line", "fake daemon: stderr line", "started bw serve pid " + strconv.Itoa(pid)} {
+		if !strings.Contains(log, want) {
+			t.Errorf("log lacks %q:\n%s", want, log)
+		}
+	}
+	if got := d.Trace(); !strings.Contains(got, "pid "+strconv.Itoa(pid)) || !strings.Contains(got, state.LogPath()) {
+		t.Fatalf("Trace() = %q; want the pid and the log path", got)
+	}
+}
+
+// The zero State keeps the pre-#1315 contract: Start spawns and records
+// nothing, and Trace says so instead of inventing a path.
+func TestBWServeDaemon_Start_NoStateDirWritesNothing(t *testing.T) {
+	var spawned atomic.Bool
+	srv := httptest.NewServer(gatedFakeServe(&spawned))
+	defer srv.Close()
+
+	var child *exec.Cmd
+	d := &BWServeDaemon{
+		Client: BWServeClient{BaseURL: srv.URL, HTTPClient: &http.Client{Timeout: time.Second}},
+		newCmd: func(string, int) *exec.Cmd {
+			child = fakeDaemonCmd(t)
+			spawned.Store(true)
+			return child
+		},
+	}
+	t.Cleanup(func() { reap(t, child) })
+
+	if err := d.Start(5 * time.Second); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if child.Stdout != nil || child.Stderr != nil {
+		t.Fatal("with no state dir the child's stdio must stay unset")
+	}
+	if got := d.Trace(); !strings.Contains(got, "not recorded") {
+		t.Fatalf("Trace() with no state dir = %q", got)
+	}
+}
+
+func TestBWServeDaemon_Trace_NoPIDFileIsSaidNotGuessed(t *testing.T) {
+	d := &BWServeDaemon{State: NewBWServeState(t.TempDir())}
+	got := d.Trace()
+	if !strings.Contains(got, "pid unknown") || !strings.Contains(got, d.State.LogPath()) {
+		t.Fatalf("Trace() = %q; want 'pid unknown' and the log path", got)
+	}
+}

--- a/cli/internal/secrets/procalive_test.go
+++ b/cli/internal/secrets/procalive_test.go
@@ -1,0 +1,79 @@
+package secrets
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestHelperFakeDaemon is the child half of the process-level tests here. Re-
+// executed as a helper process it prints one line on each stream and then
+// sleeps until killed — the shape of a daemon: something that starts, says a
+// little, and stays. Skipped (not failed) when run as an ordinary test.
+func TestHelperFakeDaemon(t *testing.T) {
+	if os.Getenv("DOTF_FAKE_DAEMON") != "1" {
+		t.Skip("helper process only")
+	}
+	_, _ = fmt.Fprintln(os.Stdout, "fake daemon: stdout line")
+	_, _ = fmt.Fprintln(os.Stderr, "fake daemon: stderr line")
+	time.Sleep(60 * time.Second)
+	os.Exit(0)
+}
+
+// fakeDaemonCmd builds a command that re-executes the test binary as
+// TestHelperFakeDaemon, carrying the PRODUCTION detach attributes: on Windows
+// that is DETACHED_PROCESS, which is precisely the combination AC4 has to
+// prove (a detached child with redirected stdio still starts).
+func fakeDaemonCmd(t *testing.T) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHelperFakeDaemon$") //nolint:gosec // re-exec of the test binary itself
+	cmd.Env = append(os.Environ(), "DOTF_FAKE_DAEMON=1")
+	cmd.SysProcAttr = bwServeDetachAttr()
+	return cmd
+}
+
+// reap kills a helper and waits for it, so a killed pid is also a reaped one
+// — the state ProcessAlive is specified against.
+func reap(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	if cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+}
+
+// TestProcessAlive is AC6 by effect: a running child is alive, the same pid is
+// not once killed and reaped. Both halves matter — a probe that always said
+// "alive" would pass the first and a probe that always said "dead" the second.
+func TestProcessAlive(t *testing.T) {
+	cmd := fakeDaemonCmd(t)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if !ProcessAlive(pid) {
+		reap(t, cmd)
+		t.Fatalf("ProcessAlive(%d) = false for a running child", pid)
+	}
+	reap(t, cmd)
+	if ProcessAlive(pid) {
+		t.Fatalf("ProcessAlive(%d) = true after the child was killed and reaped", pid)
+	}
+}
+
+func TestProcessAlive_NonPositivePIDIsDead(t *testing.T) {
+	for _, pid := range []int{0, -1} {
+		if ProcessAlive(pid) {
+			t.Fatalf("ProcessAlive(%d) must be false", pid)
+		}
+	}
+}
+
+func TestProcessAlive_SelfIsAlive(t *testing.T) {
+	if !ProcessAlive(os.Getpid()) {
+		t.Fatal("ProcessAlive(own pid) = false")
+	}
+}

--- a/cli/internal/secrets/procalive_unix.go
+++ b/cli/internal/secrets/procalive_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package secrets
+
+import (
+	"errors"
+	"syscall"
+)
+
+// ProcessAlive reports whether pid names a live process. It is the liveness
+// half of the bw serve trace (#1315): a pid file with nothing listening on the
+// port means "the daemon died" only if the pid is gone, and "still starting,
+// or something else wearing that pid" if it is not.
+//
+// Signal 0 performs the permission check and delivers nothing. EPERM means the
+// process exists but belongs to another user — alive, for this question. A
+// killed-but-unreaped child is still alive to kill(2); the daemon is spawned
+// under Setsid by a dotf that exits, so init reaps it and the case does not
+// arise in production. Windows equivalent in procalive_windows.go.
+func ProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	return errors.Is(err, syscall.EPERM)
+}

--- a/cli/internal/secrets/procalive_windows.go
+++ b/cli/internal/secrets/procalive_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package secrets
+
+import (
+	"errors"
+	"syscall"
+)
+
+// Win32 constants the syscall package does not export. Kept local like
+// detachedProcess (bwserve_windows.go): promoting golang.org/x/sys to a direct
+// dependency for two documented, fixed values is not worth the diff.
+const (
+	// processQueryLimitedInformation is the least access that lets
+	// GetExitCodeProcess answer, and it is granted on processes of a higher
+	// integrity level where PROCESS_QUERY_INFORMATION is refused.
+	processQueryLimitedInformation = 0x1000
+	// stillActive is the exit code GetExitCodeProcess reports for a process
+	// that has not exited.
+	stillActive = 259
+)
+
+// ProcessAlive reports whether pid names a live process — the Windows half of
+// the bw serve trace (#1315); see procalive_unix.go for the question it
+// answers. os.FindProcess is not enough here: on Windows it succeeds for any
+// pid that opens, exited or not, so the exit code has to be read.
+//
+// ERROR_ACCESS_DENIED from OpenProcess means the process exists but cannot be
+// opened from this token — alive, the same reading Unix gives EPERM.
+func ProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	h, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid)) //nolint:gosec // pid > 0 checked above
+	if err != nil {
+		return errors.Is(err, syscall.ERROR_ACCESS_DENIED)
+	}
+	defer func() { _ = syscall.CloseHandle(h) }()
+	var code uint32
+	if err := syscall.GetExitCodeProcess(h, &code); err != nil {
+		return false
+	}
+	return code == stillActive
+}

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -260,3 +260,4 @@ tags: [lessons, index, dotfiles]
 | [239 - Re-measure a filed bug on the current toolchain before implementing its fix](lesson-239-re-measure-a-filed-bug-on-the-current-toolchain-before.md) | 2026-08-27 |  |
 | [240 - A partial mirror the code believes absent: the check that could have flagged the gap was the one switched off](lesson-240-a-partial-mirror-the-code-believes-absent-the-check.md) | 2026-08-27 |  |
 | [241 - Re-running a command just to print what it already told you inherits its exit status, silently, under `pipefail`](lesson-241-re-running-a-command-just-to-print-what-it-already.md) | 2026-08-27 |  |
+| [242 - A process nobody can watch must leave its own trace, and the redirect has to survive the parent](lesson-242-a-process-nobody-can-watch-must-leave-its-own-trace.md) | 2026-08-27 |  |

--- a/docs/lessons/lesson-242-a-process-nobody-can-watch-must-leave-its-own-trace.md
+++ b/docs/lessons/lesson-242-a-process-nobody-can-watch-must-leave-its-own-trace.md
@@ -1,0 +1,52 @@
+# Lesson 242 — A process nobody can watch must leave its own trace, and the redirect has to survive the parent
+
+**Date:** 2026-08-27
+**Context:** CLI-057 (#1315) — the `bw serve` daemon `dotf secrets unlock` starts died twice within minutes on the Windows work box and left nothing behind: no log, no pid, no listener.
+**Category:** secrets, bw serve, os/exec, observability, windows
+
+## What happened
+
+`BWServeDaemon.Start()` ran `cmd.Start()` with `Stdout`/`Stderr` unset and
+recorded no pid. That was not an oversight so much as a consequence of the
+design: the daemon is detached from every console on purpose (`Setsid` on
+Unix, `DETACHED_PROCESS` on Windows — lesson 237), because one unlock has to
+serve every later terminal. A process detached from every console has, by
+construction, no observer. When it died, the only evidence was that port 8087
+stopped answering, and diagnosing it meant hand-starting an instrumented
+`bw serve` and waiting for it to die again.
+
+The fix is a bounded log the daemon's stdio appends to, a pid file beside it,
+and a doctor branch that reads both when nothing answers: *daemon exited —
+last lines: …* versus *never started* versus *pid alive but not answering*.
+
+## The lesson
+
+1. **Detachment and observability pull in opposite directions; pay for both.**
+   Detaching a child is the moment its stderr loses its last reader. Redirect
+   before you detach, or accept that every death is silent.
+
+2. **The redirect must be a file descriptor the child owns, never a pipe the
+   parent drains.** `os/exec` treats an `*os.File` specially: the descriptor
+   is handed to the child directly and no goroutine runs in the parent. Any
+   other `io.Writer` — a `bytes.Buffer`, a pipe — makes `os/exec` spawn a
+   copying goroutine that lives only as long as the parent, and the parent is
+   a CLI that exits in milliseconds. The naive fix would have compiled, passed
+   a test that called `Wait()`, and lost every line the moment `dotf` returned.
+
+3. **"Absent" was two facts wearing one message.** Before this change doctor
+   said *no daemon running* for both a fresh box and a daemon that had just
+   crashed. A pid file is the cheapest thing that separates them, and the
+   liveness probe behind it needs the real Win32 call (`OpenProcess` +
+   `GetExitCodeProcess`): `os.FindProcess` succeeds on Windows for any pid
+   that opens, exited or not.
+
+4. **Measure the belief, don't comment it.** "A `DETACHED_PROCESS` child with
+   redirected handles still starts" was a belief until a Go test on the box
+   started a real detached child through `Start()` and read its lines back
+   from the log. Same rule as lesson 240.
+
+## Related
+
+- Lesson 237 — `CREATE_NEW_PROCESS_GROUP` is not detachment
+- Lesson 240 — a belief about an environment encoded as an early return
+- `cli/internal/secrets/bwserve_state.go`, `procalive_{unix,windows}.go`

--- a/specs/CLI-057-bw-serve-observability/features.json
+++ b/specs/CLI-057-bw-serve-observability/features.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "CLI-057-bw-serve-observability-f1",
+    "behavior": "Start() with a state dir appends the daemon's stdout+stderr to <state>/bw-serve.log and writes <state>/bw-serve.pid with the child's pid; no state dir writes nothing",
+    "verification": "cd cli && go test ./internal/secrets/ -run 'TestBWServeDaemon_Start_WritesLogAndPID|TestBWServeDaemon_Start_NoStateDirWritesNothing'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-057-bw-serve-observability-f2",
+    "behavior": "The log is bounded: over the cap it rotates to bw-serve.log.1 (replacing the previous one), and a failed rename falls back to truncation",
+    "verification": "cd cli && go test ./internal/secrets/ -run 'TestBWServeState_Rotate'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-057-bw-serve-observability-f3",
+    "behavior": "dotf secrets unlock and lock print the daemon pid and log path on success, and say 'pid unknown' when no pid file exists",
+    "verification": "cd cli && go test ./internal/cmd/ -run 'TestSecretsUnlock|TestSecretsLock'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-057-bw-serve-observability-f4",
+    "behavior": "On Windows a detached child (DETACHED_PROCESS) with redirected stdio starts through Start() and its output lands in the log",
+    "verification": "cd cli && go test ./internal/secrets/ -run 'TestBWServeDaemon_Start_WritesLogAndPID' -v",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-057-bw-serve-observability-f5",
+    "behavior": "doctor: absent daemon + dead recorded pid -> WARN 'daemon exited' with last log lines; alive recorded pid -> WARN 'alive but not answering'; no pid file -> Info as before",
+    "verification": "cd cli && go test ./internal/doctor/ -run 'TestCheckBWServeDaemon'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-057-bw-serve-observability-f6",
+    "behavior": "ProcessAlive(pid) is true for a running child and false once it is killed and reaped, on Unix and Windows",
+    "verification": "cd cli && go test ./internal/secrets/ -run 'TestProcessAlive'",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CLI-057-bw-serve-observability/proposal.md
+++ b/specs/CLI-057-bw-serve-observability/proposal.md
@@ -1,0 +1,59 @@
+---
+id: "CLI-057-bw-serve-observability"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-08-27"
+issue: "mlorentedev/dotfiles#1315"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# CLI-057-bw-serve-observability
+
+> The `bw serve` daemon `dotf secrets unlock` starts leaves no trace when it dies: no log, no pid, nothing for doctor to read.
+
+## Why
+
+<!-- from issue #1315: CLI-057: the bw serve daemon dotf starts has no observability - nil stdio, no pid file, no log - so its deaths leave no trace -->
+
+`BWServeDaemon.Start()` (`cli/internal/secrets/bwserve.go`) runs `cmd.Start()` with `Stdout`/`Stderr` unset — the null device — and records nothing about the process it spawned. On the Windows work box (2026-08-27) the daemon died twice within minutes of `dotf secrets unlock`; every wrapper then failed with "no bw serve daemon is running", and the only way to learn *why* was to hand-start an instrumented `bw serve` and wait for it to die again. A daemon whose whole purpose is to outlive the terminal that started it (WIN-012, `DETACHED_PROCESS`) has, by construction, nobody watching its stderr — so the process itself has to leave the evidence behind.
+
+## What
+
+- `Start()` appends the daemon's stdout+stderr to a **bounded** log file and writes a **pid file** beside it, both under the deploy dir's state area (`<DOTFILES_DIR>/state/bw-serve.log`, `bw-serve.pid`). The paths are derived from the existing deploy-dir resolution (`env.DotfilesDir` in the CLI, `cfg.DotfilesDir` in doctor) through one function in the secrets package — never a literal at a call site. The log rotates once (`.log` → `.log.1`) when it exceeds a fixed cap, so two files bound its growth.
+- `dotf secrets unlock` and `dotf secrets lock` print the daemon's pid and the log path on success.
+- `dotf doctor`'s bw serve section distinguishes "never started" from "started and gone": when nothing answers on the port but a pid file exists, it reports either *daemon exited* with the last log lines (pid not alive) or *pid alive but not answering* (pid alive). Liveness is probed cross-platform through the doctor `System` seam (`kill -0` on Unix; `OpenProcess` + `GetExitCodeProcess` on Windows, stdlib `syscall` only — `golang.org/x/sys` stays indirect).
+- Windows stays the primary target: `DETACHED_PROCESS` is kept, and a Go test proves on this box that a detached child with redirected stdio still starts and its output lands in the log.
+
+## Out of scope
+
+- Restarting a dead daemon automatically (a supervisor). This PR makes the death visible; deciding what to do about it is a different change.
+- Diagnosing *why* the daemon died on the work box. That needs the log this PR creates.
+- Syncing the vault cache after unlock — CLI-056 (#1316), stacked on this PR.
+- Changing the bind address, port, or the detach flags (WIN-012 / #1293 settled those).
+
+## Risks / open questions
+
+- **Detached child + redirected handles on Windows.** `DETACHED_PROCESS` creates the child with no console; file handles are inherited independently of the console, so redirection must keep working — but that is a belief until measured, which is why AC4 is a Windows-run Go test rather than a comment. Resolved by the test.
+- **Log content.** `bw serve` writes startup lines and Node stack traces to stdio, not vault material; doctor still shows only the last few lines, truncated, so the report cannot become a channel for a value. Resolved: cap lines and width in the reader.
+- **Rotation with the daemon holding the file open.** Renaming an open file works on Unix and on Windows for handles Go opens (`FILE_SHARE_DELETE`); if the rename fails, truncation is the fallback so the cap still holds. Resolved by design.
+- **Pid reuse.** A recorded pid may be alive as a different process. Doctor says "alive but not answering" rather than claiming the daemon is up. Accepted: the message names the ambiguity.
+- **Closing #1315 trips the archive gate**, and `dotf spec archive` needs an adversarial review that runs `dotf secrets run` against the live daemon this cluster is forbidden to touch. Resolved: the PR uses `Refs #1315`; review + archive are deferred to the owner (Definition of Done skip, stated in the PR body).
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [ ] **AC1** `Start()` with a state dir spawns the daemon with stdout+stderr appended to `<state>/bw-serve.log` and writes `<state>/bw-serve.pid` holding the child's pid; with no state dir it behaves as before (no files).
+- [ ] **AC2** The log is bounded: when it exceeds the cap at start time, it is rotated to `bw-serve.log.1` (replacing any previous `.1`) and a fresh log is opened; if the rename fails the log is truncated instead.
+- [ ] **AC3** `dotf secrets unlock` and `dotf secrets lock` print the pid and the log path on success; when no pid file exists (daemon started by something else) they say so instead of guessing.
+- [ ] **AC4** On Windows, a Go test starts a real long-running fake binary through `Start()` with the production detach attributes and asserts the log and pid files appear, then kills it.
+- [ ] **AC5** `dotf doctor`: absent daemon + no pid file → the existing Info line; absent + pid file + pid dead → WARN "daemon exited" with the last log lines; absent + pid file + pid alive → WARN "alive but not answering"; running states unchanged. Asserted by status tag, and the pid-file branch is mutation-checked.
+- [ ] **AC6** Liveness probe: `ProcessAlive(pid)` is true for a running child and false after it is killed and reaped, on both Unix and Windows.
+
+## References
+
+- Bitácora board: `mlorentedev/dotfiles#1315`
+- Related: #1293 (WIN-012 acceptance, the death this makes visible), #1316 (CLI-056, stacked)
+- Related ADR: `docs/adr/adr-028-secrets-two-tier-bitwarden-age.md` (the facade the daemon serves)
+- Related lessons: 237 (`CREATE_NEW_PROCESS_GROUP` is not detachment), 235 ("I cannot reproduce it" is a statement about the instrument)

--- a/specs/CLI-057-bw-serve-observability/tasks.md
+++ b/specs/CLI-057-bw-serve-observability/tasks.md
@@ -1,0 +1,37 @@
+---
+tags: [spec, tasks]
+created: "2026-08-27"
+---
+
+# Tasks - CLI-057-bw-serve-observability
+
+> TDD order. One PR off main, `Refs #1315` (archive + adversarial review deferred to the owner — see proposal "Risks").
+
+## Setup
+
+- [x] Branch `feat/bw-serve-observability` off `origin/main` (84448bb) in worktree `dotfiles-wt-secrets-daemon`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+- [x] [P] [AC1] [AC2] Failing tests in `cli/internal/secrets/bwserve_state_test.go`: `BWServeState` paths derive from the deploy dir; `openLog` appends, rotates over the cap, replaces a stale `.log.1`; `ReadPID` / `LastLogLines` round-trip
+- [x] [AC1] [AC2] Implement `bwserve_state.go`: `NewBWServeState(dotfilesDir)`, `LogPath`/`PIDPath`, `openLog` (rotate-or-truncate), `WritePID`, `ReadPID`, `LastLogLines`
+- [x] [P] [AC6] Failing test `TestProcessAlive` (helper process: alive → kill+wait → dead) in `procalive_test.go`
+- [x] [AC6] Implement `procalive_unix.go` (`kill -0`, EPERM = alive) and `procalive_windows.go` (`OpenProcess` + `GetExitCodeProcess`, access-denied = alive)
+- [x] [AC1] [AC4] Failing test `TestBWServeDaemon_Start_WritesLogAndPID`: `newCmd` seam returns a real helper process carrying `bwServeDetachAttr()`; assert pid file = child pid, log carries the child's stdout+stderr lines; kill + reap
+- [x] [AC1] Wire `Start()`: `State` field, open log, redirect stdio to the `*os.File` (no copy goroutine, so `dotf` can exit), write pid after `cmd.Start()`
+- [x] [P] [AC5] Failing table test in `checks_bw_serve_test.go`: absent/no pid, absent/pid dead (last lines shown), absent/pid alive, locked, unlocked — by status tag
+- [x] [AC5] `System.ProcessAlive` seam (prod `secrets.ProcessAlive`, `newSys` default), `checkBWServeDaemon(sys, cfg, rep)` reads the pid file under `cfg.DotfilesDir`
+- [x] [AC5] Mutation check: remove the pid-file branch, watch the table fail, restore (3 subtests red, see `verification.md`)
+- [x] [P] [AC3] Failing tests: `unlock` and `lock` output names pid + log path; no pid file → "pid unknown"
+- [x] [AC3] `bwDaemonAddr` sets `State` from `env.DotfilesDir(env.Home())`; unlock/lock print `Trace()`
+
+## Closing
+
+- [x] Every acceptance criterion is covered by at least one test
+- [x] `features.json` entries carry non-vacuous verification commands
+- [x] `go build ./... && go vet ./... && GOOS=windows go vet ./... && go test ./... && golangci-lint run ./...` clean
+- [x] No unrelated changes in the diff
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder; `## Review triage` posted; `dotf pr triage-queue` exit 0

--- a/specs/CLI-057-bw-serve-observability/verification.md
+++ b/specs/CLI-057-bw-serve-observability/verification.md
@@ -1,0 +1,59 @@
+---
+tags: [spec, verification]
+created: "2026-08-27"
+---
+
+# Verification - CLI-057-bw-serve-observability
+
+## Evidence
+
+Run on the Windows work box (go1.26.0 windows/amd64), 2026-08-27, in worktree `dotfiles-wt-secrets-daemon`.
+
+- [x] **AC1** log + pid on Start → `TestBWServeDaemon_Start_WritesLogAndPID` (real child through `Start()`, pid file == child pid, log carries the child's stdout AND stderr lines plus dotf's start marker); zero State keeps the old contract → `TestBWServeDaemon_Start_NoStateDirWritesNothing`.
+- [x] **AC2** bounded log → `TestBWServeState_RotateOverCap` (over the cap → `.log.1`, previous `.1` replaced, fresh log is empty), `TestBWServeState_RotateLeavesLogUnderCap`, `TestBWServeState_RotateFallsBackToTruncate` (rename blocked → truncated).
+- [x] **AC3** unlock/lock print the trace → `TestSecretsUnlock_Succeeds_PasswordNeverInOutput`, `TestSecretsLock` (assert `pid 4242` + log path); no pid file → `TestSecretsUnlock_NoPIDFileIsSaidNotGuessed` ("pid unknown", never an invented pid).
+- [x] **AC4** detached child + redirected stdio on Windows → `TestBWServeDaemon_Start_WritesLogAndPID` run on this box: the helper carries `bwServeDetachAttr()` (= `CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS`), starts, and its lines land in the log (`--- PASS (0.16s)`).
+- [x] **AC5** doctor branches by status tag → `TestCheckBWServeDaemon_States` (6 rows: never started → INFO; pid gone → WARN "daemon exited" with the log's last lines; pid gone + empty log → "log is empty"; pid alive → WARN "alive but nothing answers"; locked → INFO; unlocked → OK), `TestCheckBWServeDaemon_UnreadablePIDFileIsAWarn`, `TestCheckBWServeDaemon_NilProcessAliveReadsAsGone`.
+- [x] **AC6** liveness → `TestProcessAlive` (running child true → killed+reaped false), `TestProcessAlive_SelfIsAlive`, `TestProcessAlive_NonPositivePIDIsDead`. Windows impl exercised on this box; Unix impl vetted with `GOOS=linux go vet` and runs on the CI Linux leg.
+
+### Mutation checks (revert the fix, watch the guard fail, restore)
+
+- doctor: `case errors.Is(err, os.ErrNotExist)` → `case err == nil || errors.Is(...)` (a valid pid file rendered as the old "no daemon running" Info):
+  `--- FAIL: TestCheckBWServeDaemon_States` — 3 subtests (pid gone with lines, pid gone empty log, pid alive). Restored.
+- secrets: `if !d.State.enabled()` → `if true` (bare `cmd.Start()`, the pre-#1315 spawn):
+  `--- FAIL: TestBWServeDaemon_Start_WritesLogAndPID — pid file after Start: ... bw-serve.pid: The system cannot find the path specified.` Restored.
+
+## Test status
+
+```
+go build ./... && go vet ./... && GOOS=windows go vet ./... && GOOS=linux go vet ./... && go test ./...
+ok  	github.com/mlorentedev/dotfiles/cli/internal/cmd	18.394s
+ok  	github.com/mlorentedev/dotfiles/cli/internal/doctor	20.136s
+ok  	github.com/mlorentedev/dotfiles/cli/internal/secrets	4.946s
+(all other packages ok; none skipped)
+golangci-lint run ./...   → 0 issues.   (2.12.2, the versions.conf pin)
+```
+
+- No regressions in the existing suite: yes.
+- Live daemon on this box deliberately NOT exercised: the main session owns `bw serve` here (a live experiment was running), so no `dotf secrets unlock|lock` and no doctor run against it. The Windows-specific claim (AC4) is proven by the Go test on this box instead.
+
+## Decisions made during implementation
+
+- **`*os.File` handed to the child, never a pipe.** `os/exec` connects an `*os.File` directly with no copy goroutine; any other writer needs `Wait()` in a parent that exits in milliseconds. Lesson 241.
+- **Rotation at start time, one generation, truncate as fallback.** Rotating on every start would discard exactly the lines a fresh death is diagnosed from; rotating over the cap bounds growth to two files; a rename blocked by an open handle truncates rather than growing.
+- **Liveness through the `System` seam, stdlib `syscall` only.** `golang.org/x/sys` stays an indirect dependency; the two Win32 constants the syscall package lacks are local, like `detachedProcess`.
+- **`Refs #1315`, not `Closes`.** Closing trips the archive gate, and `dotf spec archive` needs an adversarial review that runs `dotf secrets run` against the live daemon this session must not touch. Review + archive are deferred to the owner — a stated Definition-of-Done skip, not a silent one.
+- **Info → Warn, never Fail.** The shellout fallback still works; `reportAgentLaunchability` already prices an absent daemon for the wrappers.
+
+## Promotion candidates
+
+- [x] Lesson for the repo's `docs/lessons/`: yes — lesson 242 (in this PR).
+- [ ] ADR-worthy decision: no.
+- [ ] New pattern candidate for `00_meta/patterns/`: no.
+
+## Archive checklist
+
+- [ ] `dotf spec review CLI-057-bw-serve-observability` PASS (owner: needs an unlocked daemon on a box this cluster does not own)
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/CLI-057-bw-serve-observability/` -> `specs/archive/CLI-057-bw-serve-observability/`
+- [ ] Bitácora #1315 closed with the PR link (ADR-018)


### PR DESCRIPTION
## Summary

- `BWServeDaemon.Start()` ran `bw serve` with nil stdio and recorded no pid, so a daemon that is detached from every console by design (WIN-012) died without a trace — on the Windows work box it went down twice within minutes of `dotf secrets unlock` and the only evidence was that nothing listened on 8087 (#1315).
- Now: the daemon's stdout+stderr append to `<DOTFILES_DIR>/state/bw-serve.log` (rotated once over 256 KiB, truncated if the rename is blocked — two files bound it) and `bw-serve.pid` is written beside it. Both paths come from one function in the secrets package, derived from the existing deploy-dir resolution (`env.DotfilesDir` in the CLI, `cfg.DotfilesDir` in doctor), never a literal at a call site.
- `dotf secrets unlock` / `lock` print the pid and the log path (`unlocked (pid 1234, log …/state/bw-serve.log)`); a daemon dotf did not start is reported as `pid unknown`, not guessed.
- `dotf doctor` splits "absent" into three facts: never started (Info, as before), **daemon exited** (WARN, with the log's last three lines), and **pid alive but nothing answers** (WARN). Liveness goes through a new `System.ProcessAlive` seam: `kill -0` on Unix, `OpenProcess` + `GetExitCodeProcess` on Windows via stdlib `syscall` only (`golang.org/x/sys` stays indirect; the two missing Win32 constants are local, like `detachedProcess`).
- The one Windows belief that mattered — a `DETACHED_PROCESS` child with redirected stdio still starts — is measured, not commented: a Go test starts a real detached child through `Start()` on the box and reads its lines back from the log.

Refs #1315 (not `Closes` — see below). Stacked: #1316 (CLI-056, unlock never syncs) builds on this branch.

## SDD checklist

- [x] Issue exists on the bitácora GitHub Project (`Refs #1315`)
- [x] Diff conforms to ~300 LOC atomic cap — ~270 executable production lines (`bwserve_state.go` 161, `procalive_*.go` 39, the rest in `bwserve.go` / doctor / cmd); tests and the spec excluded
- [x] Spec folder `specs/CLI-057-bw-serve-observability/` is included in this PR
- [x] `proposal.md` has filled Why / What / Acceptance criteria
- [x] `tasks.md` is in TDD order
- [x] `verification.md` filled (evidence + mutation checks)

**Definition-of-Done skip, stated:** the spec is left **active** and #1315 is `Refs`, not `Closes`. Closing trips the archive gate, and `dotf spec archive` needs an adversarial review that runs `dotf secrets run` against the live `bw serve` daemon on this box — which the main session owns and this branch must not touch. Review + archive are the owner's next step: `dotf spec review CLI-057-bw-serve-observability` on a box with an unlocked daemon, then `dotf spec archive`, and the issue moves to Done with that archive PR.

The adjacency notice about #1316 (it names `secrets_unlock.go` too) is the stacked PR, not the same defect: this PR is the daemon's trace, that one is the cache sync after unlock.

## Test plan

- [x] `cd cli && go build ./... && go vet ./... && GOOS=windows go vet ./... && GOOS=linux go vet ./... && go test ./...` — all packages `ok` (cmd 18.4s, doctor 20.1s, secrets 4.9s), run on the Windows work box (go1.26.0 windows/amd64)
- [x] `golangci-lint run ./...` — `0 issues.` (2.12.2, the `versions.conf` pin)
- [x] Mutation checks (revert fix → guard fails → restore):
  - doctor: pid-file branch collapsed to the old Info → `--- FAIL: TestCheckBWServeDaemon_States` (3 subtests: pid gone with lines, pid gone empty log, pid alive)
  - secrets: `spawn` reverted to bare `cmd.Start()` → `--- FAIL: TestBWServeDaemon_Start_WritesLogAndPID — pid file after Start: … bw-serve.pid: The system cannot find the path specified.`
- [x] Windows-specific (AC4), on this box: `TestBWServeDaemon_Start_WritesLogAndPID` starts a re-exec of the test binary with `bwServeDetachAttr()` (= `CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS`), stdio redirected to the log; pid file == child pid; log holds the child's stdout line, stderr line and dotf's start marker — `PASS (0.16s)`
- [x] Manual verification: deliberately **none against the live daemon** — the main session was running an experiment on it. `dotf secrets unlock|lock` and doctor were not run here; the Windows claim is carried by the Go test above.

## Notes for the reviewer

- `checks_test.go`'s `statusOfLine` gained `StatusInfo` in its tag list so the new table can assert the Info row by tag like the others.
- `verification.md` records the deferred archive; `tasks.md`'s last box (PR opened, triage posted) closes with this PR's triage comment.
- lesson 242 (`docs/lessons/`): a process nobody can watch must leave its own trace, and the redirect has to be an `*os.File` — any other writer makes `os/exec` spawn a copy goroutine that dies with the CLI.