### PR TITLE
fix(secrets): unlock syncs the daemon's vault cache, and doctor reports that cache's age

### DIFF
--- a/cli/internal/cmd/secrets_unlock.go
+++ b/cli/internal/cmd/secrets_unlock.go
@@ -49,8 +49,7 @@ func newSecretsUnlockCmd() *cobra.Command {
 				return err
 			}
 			if st == "unlocked" {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "already unlocked (%s)\n", d.Trace())
-				return nil
+				return reportSynced(cmd, d, "already unlocked")
 			}
 			_, _ = fmt.Fprint(cmd.ErrOrStderr(), "Bitwarden master password: ")
 			pw, err := readPassword()
@@ -62,13 +61,32 @@ func newSecretsUnlockCmd() *cobra.Command {
 			if err := d.Unlock(string(pw)); err != nil {
 				return err
 			}
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "unlocked (%s)\n", d.Trace())
-			return nil
+			return reportSynced(cmd, d, "unlocked")
 		},
 	}
 	c.Flags().DurationVar(&startTimeout, "start-timeout", 15*time.Second,
 		"how long to wait for the daemon to become reachable after starting it")
 	return c
+}
+
+// reportSynced syncs the daemon's vault cache and prints what it now serves
+// from. "Unlock" means "the daemon serves current secrets", so the sync is part
+// of it (CLI-056, #1316): on the Windows work box a daemon whose cache was
+// twelve days old resolved a rotated token to its old value and a newer item to
+// "not found", and doctor read both as dead credentials. A failed sync is an
+// error, not a warning — a daemon that answers from a stale cache is exactly
+// the silent partial state this closes.
+func reportSynced(cmd *cobra.Command, d *secrets.BWServeDaemon, verb string) error {
+	if err := d.Sync(); err != nil {
+		return fmt.Errorf("%s, but the daemon's vault sync failed — reads would come from a stale cache: %w", verb, err)
+	}
+	st, err := d.Client.StatusDetail()
+	if err != nil {
+		return fmt.Errorf("%s and synced, but the daemon's status is unreadable: %w", verb, err)
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s, vault cache synced at %s (%s)\n",
+		verb, st.LastSync.UTC().Format(time.RFC3339), d.Trace())
+	return nil
 }
 
 // newSecretsLockCmd re-locks the daemon (AC6) without stopping the process —

--- a/cli/internal/cmd/secrets_unlock_test.go
+++ b/cli/internal/cmd/secrets_unlock_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,16 +17,27 @@ import (
 // fakeBWServeHandler mirrors the internal/secrets package's fake — kept
 // local (not exported from there) since only this package's command tests
 // need an httptest double of bw serve's REST API.
-func fakeBWServeHandler(t *testing.T, status *string, unlockPassword string) http.HandlerFunc {
+func fakeBWServeHandler(t *testing.T, status *string, unlockPassword string, sync *fakeSync) http.HandlerFunc {
 	t.Helper()
+	if sync == nil {
+		sync = &fakeSync{}
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/status":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"success": true,
-				"data":    map[string]string{"status": *status},
+				"data":    map[string]string{"status": *status, "lastSync": sync.lastSync},
 			})
+		case r.Method == http.MethodPost && r.URL.Path == "/sync":
+			if sync.fail {
+				_ = json.NewEncoder(w).Encode(map[string]any{"success": false, "message": "sync failed: server unreachable"})
+				return
+			}
+			sync.calls++
+			sync.lastSync = fakeSyncStamp
+			_ = json.NewEncoder(w).Encode(map[string]any{"success": true, "data": map[string]any{"object": "message", "title": "Syncing complete."}})
 		case r.Method == http.MethodPost && r.URL.Path == "/unlock":
 			var body struct {
 				Password string `json:"password"`
@@ -46,6 +58,19 @@ func fakeBWServeHandler(t *testing.T, status *string, unlockPassword string) htt
 	}
 }
 
+// fakeSync is what the fake daemon saw on POST /sync (CLI-056): unlock must
+// sync exactly once after a successful unlock and never after a failed one,
+// and a failed sync must surface as an error rather than a stale cache.
+type fakeSync struct {
+	calls    int
+	fail     bool
+	lastSync string // what /status reports; empty until the first sync
+}
+
+// fakeSyncStamp is the lastSync the fake daemon reports after a sync, so the
+// confirmation line can be asserted byte-for-byte.
+const fakeSyncStamp = "2026-08-28T02:26:00Z"
+
 // fakeDaemonPID is the pid the fake daemon's trace records, so a test can
 // assert unlock/lock print it (#1315) without a process behind it.
 const fakeDaemonPID = 4242
@@ -55,7 +80,17 @@ const fakeDaemonPID = 4242
 // leaves behind. It returns the state so tests can assert on its paths.
 func withFakeDaemon(t *testing.T, status *string, unlockPassword string) secrets.BWServeState {
 	t.Helper()
-	srv := httptest.NewServer(fakeBWServeHandler(t, status, unlockPassword))
+	state, _ := withFakeDaemonSync(t, status, unlockPassword, nil)
+	return state
+}
+
+// withFakeDaemonSync is withFakeDaemon plus the sync ledger (CLI-056).
+func withFakeDaemonSync(t *testing.T, status *string, unlockPassword string, sync *fakeSync) (secrets.BWServeState, *fakeSync) {
+	t.Helper()
+	if sync == nil {
+		sync = &fakeSync{}
+	}
+	srv := httptest.NewServer(fakeBWServeHandler(t, status, unlockPassword, sync))
 	t.Cleanup(srv.Close)
 	state := secrets.NewBWServeState(t.TempDir())
 	if err := state.WritePID(fakeDaemonPID); err != nil {
@@ -69,7 +104,7 @@ func withFakeDaemon(t *testing.T, status *string, unlockPassword string) secrets
 		}
 	}
 	t.Cleanup(func() { bwDaemonAddr = old })
-	return state
+	return state, sync
 }
 
 // assertTrace is AC3 of CLI-057: a confirmation line names the daemon's pid
@@ -222,5 +257,57 @@ func TestSecretsUnlock_NoPIDFileIsSaidNotGuessed(t *testing.T) {
 	}
 	if strings.Contains(out, "pid 4242") {
 		t.Fatalf("a removed pid file must not be reported as a pid, got: %q", out)
+	}
+}
+
+// CLI-056 (#1316): unlock syncs the daemon's vault cache, once, after a
+// successful unlock — the daemon then serves current items, not the cache it
+// booted with. Rows: correct password → one sync and the stamp in the
+// confirmation; already unlocked → still one sync (idempotent unlock, fresh
+// cache); wrong password → no sync; sync failure → an error that never carries
+// the password.
+func TestSecretsUnlock_SyncsTheDaemonCache(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     string
+		typed      string
+		syncFail   bool
+		wantErr    bool
+		wantCalls  int
+		wantSubstr string
+	}{
+		{"correct password syncs once", "locked", "hunter2", false, false, 1, "unlocked, vault cache synced at " + fakeSyncStamp},
+		{"already unlocked still syncs", "unlocked", "", false, false, 1, "already unlocked, vault cache synced at " + fakeSyncStamp},
+		{"wrong password never syncs", "locked", "wrong", false, true, 0, ""},
+		{"sync failure is an error", "locked", "hunter2", true, true, 0, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status := tc.status
+			_, sync := withFakeDaemonSync(t, &status, "hunter2", &fakeSync{fail: tc.syncFail})
+			withFakePassword(t, tc.typed, nil)
+
+			out, errOut, err := runUnlock(t)
+
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr %v\n%s", err, tc.wantErr, out)
+			}
+			if sync.calls != tc.wantCalls {
+				t.Errorf("POST /sync calls = %d, want %d", sync.calls, tc.wantCalls)
+			}
+			if tc.wantSubstr != "" && !strings.Contains(out, tc.wantSubstr) {
+				t.Errorf("stdout must carry %q, got %q", tc.wantSubstr, out)
+			}
+			if tc.typed != "" {
+				for _, s := range []string{out, errOut, fmt.Sprint(err)} {
+					if strings.Contains(s, tc.typed) {
+						t.Errorf("the password leaked into the output: %q", s)
+					}
+				}
+			}
+			if tc.syncFail && !strings.Contains(fmt.Sprint(err), "vault sync failed") {
+				t.Errorf("a failed sync must be named as such, got: %v", err)
+			}
+		})
 	}
 }

--- a/cli/internal/doctor/checks_bw_mapping.go
+++ b/cli/internal/doctor/checks_bw_mapping.go
@@ -15,7 +15,9 @@ import (
 // If the vault was synced within this window, a missing item is considered a
 // genuine absence (FAIL). If the vault has not been synced or is older than
 // this window, doctor emits a WARN indicating the item was not found in the
-// local cache and advising a `dotf secrets sync`.
+// local cache and advising a `dotf secrets unlock`, which syncs the daemon's
+// cache (CLI-056). The remedy used to name `dotf secrets sync`, which
+// materializes CI secrets and refreshes no cache at all.
 const bwMappingStaleSync = 24 * time.Hour
 
 // checkBWMapping asserts that every Bitwarden item the registry names actually
@@ -104,12 +106,12 @@ func checkBWMapping(sys *System, cfg *Config, rep *Report) {
 				item, strings.Join(ids, ", ")))
 		} else if lastSync.IsZero() {
 			rep.Warn(fmt.Sprintf(
-				"%s: not found in local vault cache (never synced), named by %s — run `dotf secrets sync` to refresh; if missing from vault, every unscoped `dotf secrets run` fails on it",
+				"%s: not found in local vault cache (never synced), named by %s — run `dotf secrets unlock` (syncs the daemon's cache) to refresh; if missing from vault, every unscoped `dotf secrets run` fails on it",
 				item, strings.Join(ids, ", ")))
 		} else {
 			age := sys.Now().Sub(lastSync).Round(time.Minute)
 			rep.Warn(fmt.Sprintf(
-				"%s: not found in local vault cache (last synced %s ago), named by %s — run `dotf secrets sync` to refresh; if missing from vault, every unscoped `dotf secrets run` fails on it",
+				"%s: not found in local vault cache (last synced %s ago), named by %s — run `dotf secrets unlock` (syncs the daemon's cache) to refresh; if missing from vault, every unscoped `dotf secrets run` fails on it",
 				item, age, strings.Join(ids, ", ")))
 		}
 	}

--- a/cli/internal/doctor/checks_bw_mapping_test.go
+++ b/cli/internal/doctor/checks_bw_mapping_test.go
@@ -163,8 +163,8 @@ func TestCheckBWMapping_StaleCacheWarnsInsteadOfFails(t *testing.T) {
 	if !strings.Contains(out, "not found in local vault cache (last synced 48h0m0s ago)") {
 		t.Errorf("expected stale cache message with age, got:\n%s", out)
 	}
-	if !strings.Contains(out, "dotf secrets sync") {
-		t.Errorf("expected remediation action 'dotf secrets sync', got:\n%s", out)
+	if !strings.Contains(out, "dotf secrets unlock") {
+		t.Errorf("expected remediation action 'dotf secrets unlock', got:\n%s", out)
 	}
 }
 
@@ -196,7 +196,7 @@ func TestCheckBWMapping_UnsyncedCacheWarnsInsteadOfFails(t *testing.T) {
 	if !strings.Contains(out, "not found in local vault cache (never synced)") {
 		t.Errorf("expected never synced message, got:\n%s", out)
 	}
-	if !strings.Contains(out, "dotf secrets sync") {
-		t.Errorf("expected remediation action 'dotf secrets sync', got:\n%s", out)
+	if !strings.Contains(out, "dotf secrets unlock") {
+		t.Errorf("expected remediation action 'dotf secrets unlock', got:\n%s", out)
 	}
 }

--- a/cli/internal/doctor/checks_bw_serve.go
+++ b/cli/internal/doctor/checks_bw_serve.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
 )
@@ -36,8 +37,10 @@ func checkBWServeDaemon(sys *System, cfg *Config, rep *Report) {
 		reportAbsentBWServe(sys, secrets.NewBWServeState(cfg.DotfilesDir), rep)
 	case "locked":
 		rep.Info("daemon running, locked — run `dotf secrets unlock` to use it")
+		reportBWServeCacheAge(sys, rep)
 	case "unlocked":
 		rep.Pass("daemon running and unlocked")
+		reportBWServeCacheAge(sys, rep)
 	default:
 		rep.Warn("unrecognised bw serve status " + strconv.Quote(st))
 	}
@@ -78,4 +81,39 @@ func reportAbsentBWServe(sys *System, state secrets.BWServeState, rep *Report) {
 	}
 	rep.Warn(fmt.Sprintf("daemon exited — pid %d recorded in %s is gone; last lines: %s — run `dotf secrets unlock` to restart it (full log: %s)",
 		pid, state.PIDPath(), tail, state.LogPath()))
+}
+
+// bwServeStaleCache is the age past which the daemon's own vault cache is
+// reported. Tighter than bwStaleSync (the CLI cache's token-expiry horizon)
+// because this cache decides what every daemon-served read returns, and since
+// CLI-056 `dotf secrets unlock` refreshes it for free.
+const bwServeStaleCache = 7 * 24 * time.Hour
+
+// reportBWServeCacheAge says how old the cache the daemon answers from is. It
+// is a different number from `bw status`'s lastSync (checkBWSyncAge): the CLI
+// and the daemon cache independently. On the Windows work box a daemon cache
+// twelve days behind resolved a rotated token to its old value and a newer
+// item to "not found", and doctor's PAT tier called the token dead (CLI-056,
+// #1316) — this row is the one-line diagnosis that was missing.
+func reportBWServeCacheAge(sys *System, rep *Report) {
+	ts, err := sys.BWServeLastSync()
+	if err != nil {
+		rep.Warn("daemon vault cache age unreadable (" + err.Error() + ")")
+		return
+	}
+	if ts.IsZero() {
+		rep.Warn("daemon has never synced its vault cache — every daemon-served read resolves against nothing; run `dotf secrets unlock` (it syncs)")
+		return
+	}
+	age := sys.Now().Sub(ts)
+	days := int(age.Hours() / 24)
+	switch {
+	case age < 0:
+		rep.Warn("daemon lastSync is in the future — check the system clock; cache age cannot be judged")
+	case age > bwServeStaleCache:
+		rep.Warn(fmt.Sprintf("daemon vault cache is %dd old (>%dd) — items created or rotated since resolve as missing or stale; run `dotf secrets unlock` (it syncs) (CLI-056)",
+			days, int(bwServeStaleCache.Hours()/24)))
+	default:
+		rep.Pass(fmt.Sprintf("daemon vault cache synced %dd ago", days))
+	}
 }

--- a/cli/internal/doctor/checks_bw_serve_test.go
+++ b/cli/internal/doctor/checks_bw_serve_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mlorentedev/dotfiles/cli/internal/secrets"
 )
@@ -164,5 +165,42 @@ func TestCheckBWServeDaemon_StatusUnreadable(t *testing.T) {
 
 	if got := buf.String(); !strings.Contains(got, "boom") {
 		t.Fatalf("expected the underlying error surfaced, got: %s", got)
+	}
+}
+
+// CLI-056 (#1316): the daemon's own cache age is reported whenever the daemon
+// answers, from the seam that reads ITS /status — not `bw status`, whose cache
+// is a different one. One row per branch, asserted by status tag.
+func TestCheckBWServeDaemon_CacheAge(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   string
+		lastSync time.Time
+		err      error
+		want     Status
+		needle   string
+	}{
+		{"fresh cache → PASS", "unlocked", fixedTestNow.Add(-2 * 24 * time.Hour), nil, StatusPass, "cache synced 2d ago"},
+		{"eight days old → WARN naming unlock", "unlocked", fixedTestNow.Add(-8 * 24 * time.Hour), nil, StatusWarn, "cache is 8d old"},
+		{"never synced → WARN", "unlocked", time.Time{}, nil, StatusWarn, "never synced"},
+		{"locked daemon still reports its cache", "locked", fixedTestNow.Add(-9 * 24 * time.Hour), nil, StatusWarn, "cache is 9d old"},
+		{"future stamp → WARN clock", "unlocked", fixedTestNow.Add(24 * time.Hour), nil, StatusWarn, "in the future"},
+		{"status unreadable → WARN", "unlocked", time.Time{}, errors.New("dial tcp: refused"), StatusWarn, "cache age unreadable"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dotfiles := t.TempDir()
+			writeBWServeTrace(t, dotfiles, 4242, "")
+			sys := bwServeSys(tc.status, true)
+			sys.BWServeLastSync = func() (time.Time, error) { return tc.lastSync, tc.err }
+			var buf bytes.Buffer
+			rep := capture(&buf)
+
+			checkBWServeDaemon(sys, &Config{DotfilesDir: dotfiles}, rep)
+
+			if got := statusOfLine(buf.String(), tc.needle); got != tc.want {
+				t.Fatalf("line mentioning %q: status %q, want %q\n%s", tc.needle, tagOf(got), tagOf(tc.want), buf.String())
+			}
+		})
 	}
 }

--- a/cli/internal/doctor/checks_pat.go
+++ b/cli/internal/doctor/checks_pat.go
@@ -152,7 +152,10 @@ func probePATSecret(sys *System, s patSecret, warnDays int, rep *Report) {
 	case err != nil:
 		rep.Warn(fmt.Sprintf("%s: could not reach api.github.com (%v) — liveness check skipped", s.name, err))
 	case status == http.StatusUnauthorized:
-		rep.Fail(fmt.Sprintf("%s: token invalid or expired (HTTP 401) — rotate it", s.name))
+		// A 401 is also what a STALE VAULT CACHE looks like: the daemon served
+		// the token's previous value (CLI-056, #1316). Name that first — it is
+		// the cheaper and, measured once, the likelier cause.
+		rep.Fail(fmt.Sprintf("%s: token rejected (HTTP 401) — if the vault cache is stale run `dotf secrets unlock` (it syncs); otherwise rotate it", s.name))
 	case status != http.StatusOK:
 		rep.Warn(fmt.Sprintf("%s: unexpected HTTP %d from api.github.com — liveness inconclusive", s.name, status))
 	default:

--- a/cli/internal/doctor/checks_pat_test.go
+++ b/cli/internal/doctor/checks_pat_test.go
@@ -67,7 +67,7 @@ func TestCheckPATExpiry_Classification(t *testing.T) {
 		wantSubstr   string
 	}{
 		// The probe branches.
-		{"http 401 → FAIL", 401, nil, false, nil, "", 1, "token invalid or expired (HTTP 401)"},
+		{"http 401 → FAIL", 401, nil, false, nil, "", 1, "token rejected (HTTP 401)"},
 		{"expiry within threshold → WARN", 200, days(5), false, nil, "", 0, "expires in 5 day(s)"},
 		{"valid with runway → PASS", 200, days(60), false, nil, "", 0, "valid, expires in 60 day(s)"},
 		{"network error → WARN", 0, nil, true, nil, "", 0, "could not reach api.github.com"},

--- a/cli/internal/doctor/system.go
+++ b/cli/internal/doctor/system.go
@@ -102,6 +102,14 @@ type System struct {
 	// state (secrets.BWServeDaemon.Status's own contract) — only a genuinely
 	// unparseable response surfaces as err. CLI-024-secrets-bw-serve, AC4.
 	BWServeStatus func() (string, error)
+	// BWServeLastSync returns when the daemon's OWN cache last pulled from the
+	// server (secrets.BWServeClient.StatusDetail in production); zero when it
+	// never has. It is a different number from BWLastSync — `bw status` reports
+	// the CLI's cache, and the two sync independently (secrets.BWSyncer) — and
+	// it is the one that decides what a daemon-served read returns: on the
+	// Windows work box a 12-day-old daemon cache resolved a rotated PAT to its
+	// old value and doctor called the token dead (CLI-056, #1316).
+	BWServeLastSync func() (time.Time, error)
 	// ProcessAlive reports whether pid names a live process (secrets.ProcessAlive
 	// in production: signal 0 on Unix, OpenProcess + GetExitCodeProcess on
 	// Windows). It is what lets the bw serve check tell "the daemon died" from
@@ -204,6 +212,10 @@ func realSystem() *System {
 		BWBackedSecrets: bwBackedSecrets,
 		BWServeStatus: func() (string, error) {
 			return (&secrets.BWServeDaemon{Client: secrets.BWServeClient{}}).Status()
+		},
+		BWServeLastSync: func() (time.Time, error) {
+			st, err := secrets.BWServeClient{}.StatusDetail()
+			return st.LastSync, err
 		},
 		ProcessAlive:  secrets.ProcessAlive,
 		ResolveSecret: resolveSecret,

--- a/cli/internal/doctor/testhelpers_test.go
+++ b/cli/internal/doctor/testhelpers_test.go
@@ -83,6 +83,9 @@ func newSys(env map[string]string, onPath []string, cmdOut map[string]string) *S
 		// Default: no daemon running — the common case (nothing has run `dotf
 		// secrets unlock`). Tests exercising the daemon states inject their own.
 		BWServeStatus: func() (string, error) { return "absent", nil },
+		// Default: the daemon's cache is as fresh as the clock, so the cache-age
+		// WARN stays quiet unless a test ages it deliberately.
+		BWServeLastSync: func() (time.Time, error) { return fixedTestNow, nil },
 		// Default: no recorded pid is alive. Tests exercising the "alive but not
 		// answering" branch inject their own.
 		ProcessAlive: func(int) bool { return false },

--- a/cli/internal/secrets/bwserve.go
+++ b/cli/internal/secrets/bwserve.go
@@ -71,9 +71,11 @@ type bwServeEnvelope struct {
 // undocumented behavior of a third-party CLI, not a contract this package
 // controls.
 type bwServeStatusData struct {
-	Status   string `json:"status"` // unauthenticated | locked | unlocked
+	Status   string `json:"status"`   // unauthenticated | locked | unlocked
+	LastSync string `json:"lastSync"` // RFC3339, or empty/null when never synced
 	Template *struct {
-		Status string `json:"status"`
+		Status   string `json:"status"`
+		LastSync string `json:"lastSync"`
 	} `json:"template"`
 }
 
@@ -84,6 +86,47 @@ func (d bwServeStatusData) status() string {
 		return d.Template.Status
 	}
 	return d.Status
+}
+
+// lastSync mirrors status() for the sync timestamp, same shape preference.
+func (d bwServeStatusData) lastSync() string {
+	if d.Template != nil && d.Template.LastSync != "" {
+		return d.Template.LastSync
+	}
+	return d.LastSync
+}
+
+// BWServeStatus is what /status says about the daemon: its lock state and when
+// ITS cache last pulled from the server. LastSync is the daemon's own number,
+// not `bw status`'s — the two caches are independent (BWSyncer's doc), and a
+// read served by the daemon is only as fresh as this timestamp. Zero when the
+// daemon has never synced.
+type BWServeStatus struct {
+	State    string
+	LastSync time.Time
+}
+
+// StatusDetail is Status plus the daemon's lastSync (CLI-056). It is what
+// `dotf secrets unlock` prints after syncing and what doctor's cache-age WARN
+// reads, so the number the operator sees is the one the daemon serves from.
+func (c BWServeClient) StatusDetail() (BWServeStatus, error) {
+	data, err := c.call(http.MethodGet, "/status", nil)
+	if err != nil {
+		return BWServeStatus{}, err
+	}
+	var st bwServeStatusData
+	if err := json.Unmarshal(data, &st); err != nil {
+		return BWServeStatus{}, fmt.Errorf("GET /status: unparseable data: %w", err)
+	}
+	out := BWServeStatus{State: st.status()}
+	if raw := st.lastSync(); raw != "" {
+		ts, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			return out, fmt.Errorf("GET /status: lastSync %q is not RFC3339: %w", raw, err)
+		}
+		out.LastSync = ts
+	}
+	return out, nil
 }
 
 // ErrBWServeUnreachable marks a daemon that did not answer at all (not

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -261,3 +261,4 @@ tags: [lessons, index, dotfiles]
 | [240 - A partial mirror the code believes absent: the check that could have flagged the gap was the one switched off](lesson-240-a-partial-mirror-the-code-believes-absent-the-check.md) | 2026-08-27 |  |
 | [241 - Re-running a command just to print what it already told you inherits its exit status, silently, under `pipefail`](lesson-241-re-running-a-command-just-to-print-what-it-already.md) | 2026-08-27 |  |
 | [242 - A process nobody can watch must leave its own trace, and the redirect has to survive the parent](lesson-242-a-process-nobody-can-watch-must-leave-its-own-trace.md) | 2026-08-27 |  |
+| [243 - A guard that reads a cache reports the cache's age as the credential's health](lesson-243-a-guard-that-reads-a-cache-reports-the-cache-not-the-credential.md) | 2026-08-28 |  |

--- a/docs/lessons/lesson-243-a-guard-that-reads-a-cache-reports-the-cache-not-the-credential.md
+++ b/docs/lessons/lesson-243-a-guard-that-reads-a-cache-reports-the-cache-not-the-credential.md
@@ -1,0 +1,43 @@
+# Lesson 243 — A guard that reads a cache reports the cache's age as the credential's health
+
+**Date:** 2026-08-28
+**Context:** CLI-056 (#1316) — on the Windows work box `dotf doctor` reported the bitácora PAT as "token invalid or expired (HTTP 401) — rotate it" and `dotf secrets verify` reported the `dockerhub` item as "not found". Both credentials were in daily use by the owner.
+**Category:** secrets, bw serve, doctor, diagnosis
+
+## What happened
+
+`dotf secrets unlock` started and unlocked the `bw serve` daemon and never
+synced it. The daemon answered every read from the vault cache it booted with,
+which on this box was twelve days old (`lastSync 2026-08-15`). A token rotated
+after that date resolved to its previous value — GitHub answered 401 — and an
+item created after that date did not exist. Doctor's PAT tier then said the
+one thing a 401 can mean when the value is assumed current: rotate it.
+
+The owner's objection was the whole diagnosis: "I use both every day." A
+`POST /sync` to the daemon advanced `lastSync` to now, `dotf secrets verify`
+went from 2 failed to 35 ok, and the PAT tier passed. Nothing about the
+credentials had changed.
+
+## The rule
+
+A check that reads through a cache is measuring the cache first and the
+thing second. Before a message names the expensive remedy (rotate, re-login,
+recreate), the check must either refresh the cache or say that it did not:
+"token rejected — if the vault cache is stale run `dotf secrets unlock`;
+otherwise rotate it" costs nothing and points at the cheaper cause first.
+
+Two caches, two clocks: `bw status` reports the CLI's cache, the daemon's
+`/status` reports its own, and they sync independently. Doctor already aged
+the first (BUG-074); the one that decides what a daemon-served read returns
+was unmeasured. The fix that closes the class: `unlock` syncs (the daemon
+serves current secrets by construction), doctor reports the daemon's cache
+age, and the 401 message names the stale-cache possibility before the
+rotation.
+
+## How to apply
+
+- When a diagnostic reads through a cache, print the cache's age next to the
+  verdict, or refresh it first. A verdict without the age is a guess.
+- The remedy in a FAIL message is ordered by cost: refresh before rotate.
+- "I use it daily" from the owner is evidence about the credential, not about
+  the copy the tool read — reconcile the two before repeating the verdict.


### PR DESCRIPTION
Stacked on #1348 (base: `feat/bw-serve-observability`); merge that first.

On the Windows work box the `bw serve` daemon answered from a cache twelve days old (`lastSync 2026-08-15`): a token rotated since resolved to its previous value and doctor called it dead ("HTTP 401 — rotate it"), and an item created since resolved as "not found". Both credentials were in daily use. `dotf secrets unlock` started and unlocked the daemon and never synced it; one `POST /sync` fixed both readings without touching a credential (`dotf secrets verify` 2 failed → 35 ok; doctor 128 → 130 passed).

- **unlock**: after a successful unlock — and on the already-unlocked path — the daemon syncs; a failed sync is an error, never a warning; the confirmation prints the daemon's `lastSync` (`BWServeClient.StatusDetail`).
- **doctor**: the bw serve section reports the daemon's OWN cache age (WARN past 7 days, or never synced) via a `System` seam — a different clock from `bw status`'s `lastSync`, which `checkBWSyncAge` already ages.
- **messages**: the PAT 401 FAIL names the stale-cache remedy before rotation; the bw-mapping remedy names `dotf secrets unlock` instead of the CI-only `dotf secrets sync`.
- **Lesson 243**: a guard that reads a cache reports the cache's age as the credential's health.

Tests: `TestSecretsUnlock_SyncsTheDaemonCache` (correct password → one sync + stamp; already unlocked → still syncs; wrong password → never; sync failure → error, password never in output), `TestCheckBWServeDaemon_CacheAge` (six rows by status tag). Mutation-checked on the box: removing the `Sync()` call fails the first, unwiring `reportBWServeCacheAge` fails the second.

Evidence (Windows work box): `go build/vet`, `GOOS=windows|linux go vet`, `go test ./...` all ok; `golangci-lint` 0 issues.

Closes #1316. Refs #1315, #1293.

## SDD skip rationale
Bug fix with an obvious, measured cause (unlock never synced); the change is one call plus a doctor row and two message edits, the rest is tests and a lesson. Original scaffolding (seam + `StatusDetail`) by the secrets-cluster agent; finished and verified by the main session after the agent hit the account session limit.