### PR TITLE
fix(doctor): detect a BUG-020-corrupted PowerShell profile and heal it under --fix

### DIFF
--- a/cli/internal/doctor/checks_profile.go
+++ b/cli/internal/doctor/checks_profile.go
@@ -1,8 +1,29 @@
 package doctor
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
+)
+
+// The dotfiles section of the PowerShell profile is delimited by these two
+// markers — verbatim the strings setup-windows.ps1's splice writes and
+// scripts/profile-heal.ps1 counts. The SSOT (powershell/profile.ps1) contains
+// neither, so a healthy deployed profile carries exactly one of each.
+const (
+	profileStartMarker = "# >>> DOTFILES PROFILE >>>"
+	profileEndMarker   = "# <<< DOTFILES PROFILE <<<"
+
+	// profileMaxBytes is the size signal profile-heal.ps1 heals at (`-gt 1MB`).
+	// A healthy profile is ~7 KB; BUG-020's had compounded to 26 MB / 689K lines
+	// of duplicated sections before anything noticed.
+	profileMaxBytes = 1 << 20
+
+	// profileHealScript is the BUG-020 repair, deployed under SCRIPTS_DIR by
+	// setup-windows.ps1: it backs the corrupted profile up beside itself and
+	// rewrites the dotfiles section from the SSOT.
+	profileHealScript = "profile-heal.ps1"
 )
 
 // checkProfileFiles ports the healthcheck.ps1 §4 residual the .sh→Go
@@ -13,7 +34,13 @@ import (
 //
 // A missing file is a FAIL, matching checkSymlinks' treatment of a missing
 // deployed file (both reproduce the same healthcheck §4 Write-Fail semantics).
-func checkProfileFiles(sys *System, rep *Report) {
+//
+// The Windows profile is also checked for BUG-020 corruption (#531): the
+// retired doctor.ps1 -Fix used to invoke profile-heal.ps1, and after the
+// consolidation a corrupted profile was neither detected nor healed from
+// doctor — existence was the whole test. Under --fix the heal runs through
+// the System seam and is verified by consequence, never by its exit code.
+func checkProfileFiles(sys *System, c *Contract, rep *Report, fix bool) {
 	rep.Section("Deployed config files")
 	home := sys.home()
 
@@ -34,12 +61,35 @@ func checkProfileFiles(sys *System, rep *Report) {
 		return
 	}
 
-	// $PROFILE (CurrentUserCurrentHost) lives under Documents as
-	// Microsoft.PowerShell_profile.ps1, in PowerShell\ for pwsh 7 or
-	// WindowsPowerShell\ for Windows PowerShell 5.1. Documents itself is often
-	// OneDrive-redirected on corporate boxes, so accept that root too — checking
-	// only ~\Documents would false-FAIL there. (Go has no $PROFILE intrinsic; this
-	// enumerates the realistic locations setup-windows.ps1's $PROFILE resolves to.)
+	profile, checked := findPowerShellProfile(home)
+	if profile == "" {
+		rep.Fail("PowerShell profile missing (checked: " + strings.Join(checked, ", ") + ")")
+		return
+	}
+	reasons := profileCorruption(profile)
+	if len(reasons) == 0 {
+		rep.Pass("PowerShell profile exists (" + profile + ")")
+		return
+	}
+	heal := profileHealPath(sys, c)
+	if !fix {
+		rep.Fail(fmt.Sprintf("PowerShell profile corrupted (%s) — BUG-020; run `pwsh -NoProfile -File %s` or `dotf doctor --fix` (backs the profile up, then rebuilds the dotfiles section from powershell/profile.ps1)",
+			strings.Join(reasons, "; "), heal))
+		return
+	}
+	repairProfile(sys, rep, profile, heal)
+}
+
+// findPowerShellProfile returns the first existing $PROFILE
+// (CurrentUserCurrentHost) location and the list it searched.
+//
+// $PROFILE lives under Documents as Microsoft.PowerShell_profile.ps1, in
+// PowerShell\ for pwsh 7 or WindowsPowerShell\ for Windows PowerShell 5.1.
+// Documents itself is often OneDrive-redirected on corporate boxes, so accept
+// that root too — checking only ~\Documents would false-FAIL there. (Go has no
+// $PROFILE intrinsic; this enumerates the realistic locations
+// setup-windows.ps1's $PROFILE resolves to.)
+func findPowerShellProfile(home string) (string, []string) {
 	const leaf = "Microsoft.PowerShell_profile.ps1"
 	var checked []string
 	for _, docRoot := range []string{
@@ -50,10 +100,113 @@ func checkProfileFiles(sys *System, rep *Report) {
 			p := filepath.Join(docRoot, host, leaf)
 			checked = append(checked, p)
 			if pathExists(p) {
-				rep.Pass("PowerShell profile exists (" + p + ")")
-				return
+				return p, checked
 			}
 		}
 	}
-	rep.Fail("PowerShell profile missing (checked: " + strings.Join(checked, ", ") + ")")
+	return "", checked
+}
+
+// profileCorruption returns the BUG-020 signals the profile at path trips, or
+// nil for a healthy one. The two signals are profile-heal.ps1's own, so doctor
+// never flags a profile the heal would leave alone: a size over 1 MiB, and more
+// than one START or END marker (setup's splice replaces the FIRST pair only, so
+// a second pair is the beginning of the accumulation that reached 26 MB).
+//
+// An oversized profile is reported on size alone — counting markers in a
+// 26 MB file proves nothing size has not already proved, and reading it is
+// what the heal's own preflight refuses to do in place.
+func profileCorruption(path string) []string {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return []string{"unreadable: " + err.Error()}
+	}
+	if fi.Size() > profileMaxBytes {
+		return []string{fmt.Sprintf("size %d bytes > 1 MiB", fi.Size())}
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return []string{"unreadable: " + err.Error()}
+	}
+	starts := strings.Count(string(raw), profileStartMarker)
+	ends := strings.Count(string(raw), profileEndMarker)
+	if starts > 1 || ends > 1 {
+		return []string{fmt.Sprintf("duplicate dotfiles markers (start=%d, end=%d; a healthy profile has one pair)", starts, ends)}
+	}
+	return nil
+}
+
+// profileHealPath resolves <SCRIPTS_DIR>\profile-heal.ps1 through the env
+// contract — the variable when set, else the contract's default for this OS
+// dialect — never a literal path, because where scripts deploy is the
+// contract's decision (ADR-025) and it is changing under WIN-013 (#1310).
+// When neither resolves, the token is left visible so the message stays honest
+// about what it could not name.
+func profileHealPath(sys *System, c *Contract) string {
+	dir := sys.Getenv("SCRIPTS_DIR")
+	if dir == "" {
+		dir = contractDefault(sys, c, "SCRIPTS_DIR")
+	}
+	if dir == "" {
+		return `$env:SCRIPTS_DIR\` + profileHealScript
+	}
+	// Host-native join: in production this only runs on Windows (the check is
+	// GOOS-gated), and the tests that exercise it on Linux CI build their
+	// expectations with the same filepath.Join, so the separator never lies.
+	return filepath.Join(dir, profileHealScript)
+}
+
+// contractDefault returns the contract's default for the named env var on this
+// OS dialect, home-expanded, or "" when the contract is absent or declares none.
+func contractDefault(sys *System, c *Contract, name string) string {
+	if c == nil {
+		return ""
+	}
+	for _, e := range c.EnvVars {
+		if e.Name == name {
+			return expandHome(sys, e.Default[contractOS(sys)])
+		}
+	}
+	return ""
+}
+
+// repairProfile runs profile-heal.ps1 against the corrupted profile and reports
+// the OUTCOME, not the invocation: the heal always exits 0 by design (it never
+// blocks a session on a transient failure), so its exit status says nothing.
+// The profile is re-measured afterwards, and only a profile that now passes
+// profileCorruption is a Fix. The heal backs the corrupted file up beside itself
+// before writing, so nothing is lost by running it.
+func repairProfile(sys *System, rep *Report, profile, heal string) {
+	if !isRegularFile(heal) {
+		rep.Fail(fmt.Sprintf("PowerShell profile corrupted, and %s is not deployed at %s — run setup-windows.ps1 to deploy scripts/, then `dotf doctor --fix` again (BUG-020)",
+			profileHealScript, heal))
+		return
+	}
+	if !sys.has("pwsh") {
+		rep.Fail("PowerShell profile corrupted, and pwsh is not in PATH to run " + profileHealScript + " (BUG-020)")
+		return
+	}
+	out, err := sys.CommandOutput("pwsh", "-NoProfile", "-File", heal)
+	if err != nil {
+		rep.Fail(fmt.Sprintf("%s did not run (%s) — profile left as is", profileHealScript, firstLineOr(out, err)))
+		return
+	}
+	if reasons := profileCorruption(profile); len(reasons) > 0 {
+		rep.Fail(fmt.Sprintf("%s ran but the profile is still corrupted (%s) — heal said: %s",
+			profileHealScript, strings.Join(reasons, "; "), firstLineOr(out, nil)))
+		return
+	}
+	rep.Fix("PowerShell profile rebuilt from powershell/profile.ps1 by " + profileHealScript + " (the corrupted copy is backed up beside it; restart PowerShell)")
+}
+
+// firstLineOr renders a subprocess result as one line: its first line of
+// output when it produced one, else the error, else "no output".
+func firstLineOr(out string, err error) string {
+	if l := firstLine(out); l != "" {
+		return l
+	}
+	if err != nil {
+		return err.Error()
+	}
+	return "no output"
 }

--- a/cli/internal/doctor/checks_profile_heal_test.go
+++ b/cli/internal/doctor/checks_profile_heal_test.go
@@ -1,0 +1,256 @@
+package doctor
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// healthyProfile is a deployed profile as setup-windows.ps1 writes it: one
+// START/END pair around the SSOT content.
+const healthyProfile = profileStartMarker + "\r\nfunction prompt { 'ok> ' }\r\n" + profileEndMarker + "\r\n"
+
+// duplicatedProfile is the BUG-020 shape in miniature: the splice replaced the
+// first pair and left a second one behind, so the section is sourced twice.
+const duplicatedProfile = healthyProfile + "\r\n" + healthyProfile
+
+// profileFixture lays down $PROFILE under a temp home and returns its path.
+func profileFixture(t *testing.T, home, content string) string {
+	t.Helper()
+	p := filepath.Join(home, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1")
+	writeFile(t, p, content)
+	return p
+}
+
+// oversizedProfile is over profile-heal.ps1's 1MB signal, structurally healthy
+// (one marker pair) so only size trips.
+func oversizedProfile() string {
+	pad := "# " + strings.Repeat("#", profileMaxBytes+1)
+	return profileStartMarker + "\r\n" + pad + "\r\n" + profileEndMarker + "\r\n"
+}
+
+// #531 (BUG-020 class): a corrupted PowerShell profile was neither detected nor
+// healed once doctor.ps1 -Fix retired — existence was the whole test. The two
+// signals are profile-heal.ps1's own (size > 1MB, more than one marker pair), so
+// what doctor flags is exactly what --fix can clear.
+func TestCheckProfileFiles_DetectsBUG020Corruption(t *testing.T) {
+	cases := []struct {
+		name      string
+		content   string
+		wantFail  int
+		wantSub   string
+		unwantSub string
+	}{
+		{
+			name:     "one marker pair, small → healthy",
+			content:  healthyProfile,
+			wantFail: 0,
+			wantSub:  "PowerShell profile exists",
+		},
+		{
+			name:     "no markers at all → not corruption (setup has not spliced yet)",
+			content:  "function prompt { 'user> ' }\r\n",
+			wantFail: 0,
+			wantSub:  "PowerShell profile exists",
+		},
+		{
+			name:     "two marker pairs → FAIL naming the counts and the heal",
+			content:  duplicatedProfile,
+			wantFail: 1,
+			wantSub:  "duplicate dotfiles markers (start=2, end=2",
+		},
+		{
+			name:     "over 1 MiB → FAIL on size alone",
+			content:  oversizedProfile(),
+			wantFail: 1,
+			wantSub:  "bytes > 1 MiB",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			writeFile(t, filepath.Join(home, ".claude", "CLAUDE.md"), "x")
+			writeFile(t, filepath.Join(home, ".gemini", "AGY.md"), "x")
+			profileFixture(t, home, tc.content)
+			sys := newSys(map[string]string{"HOME": home, "USERPROFILE": home}, nil, nil)
+			sys.GOOS = "windows"
+
+			var buf bytes.Buffer
+			rep := capture(&buf)
+			checkProfileFiles(sys, nil, rep, false)
+
+			if rep.Failures() != tc.wantFail {
+				t.Fatalf("failures = %d, want %d\n%s", rep.Failures(), tc.wantFail, buf.String())
+			}
+			if !strings.Contains(buf.String(), tc.wantSub) {
+				t.Fatalf("output missing %q\n%s", tc.wantSub, buf.String())
+			}
+			if tc.wantFail > 0 && !strings.Contains(buf.String(), "profile-heal.ps1") {
+				t.Fatalf("a corruption FAIL must name the heal script\n%s", buf.String())
+			}
+		})
+	}
+}
+
+// The remedy path is resolved through the env contract, never a literal: the
+// variable when set, else the contract's Windows default, else a visible token.
+// Where scripts deploy is changing under WIN-013 (#1310); a literal here would
+// point at the wrong directory the day it lands.
+func TestCheckProfileFiles_HealPathFollowsTheContract(t *testing.T) {
+	contract := &Contract{EnvVars: []ContractEnvVar{{
+		Name:    "SCRIPTS_DIR",
+		Default: map[string]string{"linux": "$HOME/.dotfiles/scripts", "windows": `$env:USERPROFILE\.dotfiles\scripts`},
+	}}}
+	cases := []struct {
+		name    string
+		env     map[string]string
+		c       *Contract
+		wantSub string
+	}{
+		{
+			name:    "SCRIPTS_DIR set → its value",
+			env:     map[string]string{"SCRIPTS_DIR": `D:\deployed\scripts`},
+			c:       contract,
+			wantSub: filepath.Join(`D:\deployed\scripts`, `profile-heal.ps1`),
+		},
+		{
+			name: "SCRIPTS_DIR unset → the contract's windows default, home-expanded",
+			c:    contract,
+			// The contract default carries backslashes verbatim; only the last
+			// separator is the host's, exactly as profileHealPath builds it.
+			wantSub: filepath.Join(`.dotfiles\scripts`, `profile-heal.ps1`),
+		},
+		{
+			name:    "no contract loaded → the token stays visible rather than a guessed literal",
+			wantSub: `$env:SCRIPTS_DIR\profile-heal.ps1`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			env := map[string]string{"HOME": home, "USERPROFILE": home}
+			for k, v := range tc.env {
+				env[k] = v
+			}
+			sys := newSys(env, nil, nil)
+			sys.GOOS = "windows"
+			got := profileHealPath(sys, tc.c)
+			if !strings.Contains(got, tc.wantSub) {
+				t.Fatalf("heal path = %q, want it to contain %q", got, tc.wantSub)
+			}
+			if tc.c != nil && tc.env == nil && !strings.HasPrefix(got, home) {
+				t.Fatalf("contract default must be home-expanded, got %q", got)
+			}
+		})
+	}
+}
+
+// --fix runs profile-heal.ps1 through the System seam and reports the OUTCOME:
+// the heal exits 0 by design even when it changes nothing, so only a profile
+// that re-measures healthy is a Fix. Never run against the real $PROFILE here —
+// the fake pwsh is the only thing that touches the fixture.
+func TestCheckProfileFiles_FixRunsTheHealAndVerifiesByConsequence(t *testing.T) {
+	type fixture struct {
+		home, profile, heal string
+	}
+	setup := func(t *testing.T, deployHeal bool) fixture {
+		t.Helper()
+		home := t.TempDir()
+		writeFile(t, filepath.Join(home, ".claude", "CLAUDE.md"), "x")
+		writeFile(t, filepath.Join(home, ".gemini", "AGY.md"), "x")
+		profile := profileFixture(t, home, duplicatedProfile)
+		heal := filepath.Join(home, "scripts", profileHealScript)
+		if deployHeal {
+			writeFile(t, heal, "# fake heal\r\n")
+		}
+		return fixture{home: home, profile: profile, heal: heal}
+	}
+	run := func(t *testing.T, fx fixture, onPath []string, pwsh func(args []string) (string, error)) (string, *Report) {
+		t.Helper()
+		sys := newSys(map[string]string{"HOME": fx.home, "USERPROFILE": fx.home, "SCRIPTS_DIR": filepath.Dir(fx.heal)}, onPath, nil)
+		sys.GOOS = "windows"
+		sys.CommandOutput = func(name string, args ...string) (string, error) {
+			if name != "pwsh" {
+				t.Fatalf("unexpected command %s %v", name, args)
+			}
+			return pwsh(args)
+		}
+		var buf bytes.Buffer
+		rep := capture(&buf)
+		checkProfileFiles(sys, nil, rep, true)
+		return buf.String(), rep
+	}
+
+	t.Run("heal rewrites the profile → FIX, invoked as pwsh -NoProfile -File <SCRIPTS_DIR>\\profile-heal.ps1", func(t *testing.T) {
+		fx := setup(t, true)
+		var gotArgs []string
+		out, rep := run(t, fx, []string{"pwsh"}, func(args []string) (string, error) {
+			gotArgs = args
+			if err := os.WriteFile(fx.profile, []byte(healthyProfile), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			return "[profile-heal] rewrote profile from SSOT\n", nil
+		})
+		want := []string{"-NoProfile", "-File", fx.heal}
+		if strings.Join(gotArgs, " ") != strings.Join(want, " ") {
+			t.Fatalf("heal invoked as %v, want %v", gotArgs, want)
+		}
+		if rep.Failures() != 0 || rep.totals[StatusFix] != 1 {
+			t.Fatalf("a verified heal is exactly one FIX and no FAIL; got fail=%d fix=%d\n%s", rep.Failures(), rep.totals[StatusFix], out)
+		}
+		if !strings.Contains(out, "rebuilt from powershell/profile.ps1") {
+			t.Fatalf("the FIX must say what happened\n%s", out)
+		}
+	})
+
+	t.Run("heal exits 0 but changes nothing → FAIL, never a FIX", func(t *testing.T) {
+		fx := setup(t, true)
+		out, rep := run(t, fx, []string{"pwsh"}, func([]string) (string, error) {
+			return "[profile-heal] ERROR: cannot find powershell/profile.ps1 SSOT\n", nil
+		})
+		if rep.totals[StatusFix] != 0 || rep.Failures() != 1 {
+			t.Fatalf("an unrepaired profile must FAIL, not FIX; got fail=%d fix=%d\n%s", rep.Failures(), rep.totals[StatusFix], out)
+		}
+		if !strings.Contains(out, "still corrupted") || !strings.Contains(out, "cannot find powershell/profile.ps1 SSOT") {
+			t.Fatalf("the FAIL must carry the re-measurement and the heal's own line\n%s", out)
+		}
+	})
+
+	t.Run("heal script not deployed → FAIL naming setup, pwsh never invoked", func(t *testing.T) {
+		fx := setup(t, false)
+		out, rep := run(t, fx, []string{"pwsh"}, func([]string) (string, error) {
+			t.Fatal("pwsh must not run when the heal script is absent")
+			return "", nil
+		})
+		if rep.Failures() != 1 || !strings.Contains(out, "not deployed at "+fx.heal) || !strings.Contains(out, "setup-windows.ps1") {
+			t.Fatalf("expected one FAIL naming the missing script and setup\n%s", out)
+		}
+	})
+
+	t.Run("pwsh absent → FAIL, nothing invoked", func(t *testing.T) {
+		fx := setup(t, true)
+		out, rep := run(t, fx, nil, func([]string) (string, error) {
+			t.Fatal("nothing must run without pwsh")
+			return "", nil
+		})
+		if rep.Failures() != 1 || !strings.Contains(out, "pwsh is not in PATH") {
+			t.Fatalf("expected one FAIL naming pwsh\n%s", out)
+		}
+	})
+
+	t.Run("healthy profile under --fix → PASS, heal not invoked", func(t *testing.T) {
+		fx := setup(t, true)
+		if err := os.WriteFile(fx.profile, []byte(healthyProfile), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		out, rep := run(t, fx, []string{"pwsh"}, func([]string) (string, error) {
+			t.Fatal("a healthy profile must not be healed")
+			return "", nil
+		})
+		if rep.Failures() != 0 || rep.totals[StatusFix] != 0 || !strings.Contains(out, "PowerShell profile exists") {
+			t.Fatalf("expected a plain PASS\n%s", out)
+		}
+	})
+}

--- a/cli/internal/doctor/checks_profile_test.go
+++ b/cli/internal/doctor/checks_profile_test.go
@@ -81,7 +81,7 @@ func TestCheckProfileFiles(t *testing.T) {
 
 			var buf bytes.Buffer
 			rep := capture(&buf)
-			checkProfileFiles(sys, rep)
+			checkProfileFiles(sys, nil, rep, false)
 
 			if rep.Failures() != tc.wantFailures {
 				t.Fatalf("failures = %d, want %d\n%s", rep.Failures(), tc.wantFailures, buf.String())

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -76,7 +76,7 @@ func Run(opts Options) (int, error) {
 		checkVersionedPaths(sys, rep)
 		checkVersionMatch(sys, cfg, rep)
 		checkSymlinks(sys, rep)
-		checkProfileFiles(sys, rep)
+		checkProfileFiles(sys, contract, rep, opts.Fix)
 		checkToolHomeEnvVars(sys, rep)
 		checkOptionalTools(sys, cfg, contract, rep)
 		checkVault(sys, rep)

--- a/scripts/profile-heal.ps1
+++ b/scripts/profile-heal.ps1
@@ -15,7 +15,12 @@
     This script detects three corruption signals:
 
       1. Size > 1 MB (healthy profile is ~7 KB; 1 MB is ~140x oversized).
-      2. More than 2 occurrences of the START or END marker.
+      2. More than 1 occurrence of the START or END marker. The SSOT contains
+         neither, so a healthy deployed profile has exactly one pair; setup's
+         splice replaces the first pair only, so a second one is the start of
+         the accumulation. `dotf doctor` flags the same two signals (#531) and
+         --fix runs this script, so the thresholds must agree or doctor would
+         flag a profile this script declines to heal.
       3. PowerShell parser errors when [Parser]::ParseFile is run against it.
 
     When any signal trips, the existing profile is copied to
@@ -114,8 +119,8 @@ function Get-ProfileCorruptionState {
             $endMarker = '# <<< DOTFILES PROFILE <<<'
             $state.StartMarkers = [regex]::Matches($raw, [regex]::Escape($startMarker)).Count
             $state.EndMarkers = [regex]::Matches($raw, [regex]::Escape($endMarker)).Count
-            if ($state.StartMarkers -gt 2 -or $state.EndMarkers -gt 2) {
-                $state.Reasons += "marker counts (start=$($state.StartMarkers), end=$($state.EndMarkers)) exceed 2"
+            if ($state.StartMarkers -gt 1 -or $state.EndMarkers -gt 1) {
+                $state.Reasons += "marker counts (start=$($state.StartMarkers), end=$($state.EndMarkers)) exceed 1"
             }
         } catch {
             $state.Reasons += "unreadable: $($_.Exception.Message)"

--- a/specs/CLI-064-doctor-profile-heal/features.json
+++ b/specs/CLI-064-doctor-profile-heal/features.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "CLI-064-doctor-profile-heal-f1",
+    "behavior": "AC1: a Windows profile over 1 MB or with more than one dotfiles marker pair FAILs naming the heal script; a healthy one PASSes",
+    "verification": "cd cli && go test ./internal/doctor/ -run TestCheckProfileFiles_DetectsBUG020Corruption",
+    "state": "verified",
+    "evidence": "ok on the Windows work box 2026-08-28; mutation (profileCorruption returns nil) fails it"
+  },
+  {
+    "id": "CLI-064-doctor-profile-heal-f2",
+    "behavior": "AC2: the heal path is <SCRIPTS_DIR>\\profile-heal.ps1 resolved from the env contract, never a literal",
+    "verification": "cd cli && go test ./internal/doctor/ -run TestCheckProfileFiles_HealPathFollowsTheContract",
+    "state": "verified",
+    "evidence": "ok on the Windows work box 2026-08-28"
+  },
+  {
+    "id": "CLI-064-doctor-profile-heal-f3",
+    "behavior": "AC3: under --fix the heal runs through the System seam and doctor reports Fix only when the re-read profile carries no signal",
+    "verification": "cd cli && go test ./internal/doctor/ -run TestCheckProfileFiles_FixRunsTheHealAndVerifiesByConsequence",
+    "state": "verified",
+    "evidence": "ok on the Windows work box 2026-08-28; mutation (profileCorruption returns nil) fails it"
+  },
+  {
+    "id": "CLI-064-doctor-profile-heal-f4",
+    "behavior": "AC4/AC5: profile-heal.ps1 and doctor agree on the marker threshold; the non-Windows branch is unchanged",
+    "verification": "grep -q 'StartMarkers -gt 1' scripts/profile-heal.ps1 && cd cli && go test ./internal/doctor/ -run 'TestCheckProfileFiles$'",
+    "state": "verified",
+    "evidence": "ok on the Windows work box 2026-08-28"
+  }
+]

--- a/specs/CLI-064-doctor-profile-heal/proposal.md
+++ b/specs/CLI-064-doctor-profile-heal/proposal.md
@@ -1,0 +1,68 @@
+---
+id: "CLI-064-doctor-profile-heal"
+type: spec
+status: verifying # draft | implementing | verifying | archived
+created: "2026-08-28"
+issue: "mlorentedev/dotfiles#531"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, doctor, windows, profile]
+template_version: "1.0"
+---
+
+# CLI-064-doctor-profile-heal
+
+## Why
+
+CLI-018 retired the Windows `scripts/doctor.ps1` and consolidated every post-setup
+diagnostic onto `dotf doctor`. The retired `doctor.ps1 -Fix` used to invoke
+`scripts/profile-heal.ps1`, the BUG-020 repair for a PowerShell `$PROFILE` that
+setup's marker splice had compounded to 26 MB / 689K lines of duplicated
+sections. After the consolidation `checkProfileFiles` (`checks_profile.go`)
+tested existence only: a 26 MB profile reported PASS, and nothing on the doctor
+path could heal it. The corruption *source* was removed (BUG-022's index-based
+splice), so auto-heal is convenience — doctor blessing a broken profile is the
+defect. Issue #531.
+
+## What
+
+On Windows, `dotf doctor` FAILs the PowerShell profile when it shows either
+BUG-020 signal — larger than 1 MB, or more than one `# >>> DOTFILES PROFILE >>>`
+/ `# <<< DOTFILES PROFILE <<<` pair — naming `<SCRIPTS_DIR>\profile-heal.ps1` as
+the remedy, with `SCRIPTS_DIR` resolved through the env contract (never a
+literal path, so WIN-013's move of `~\scripts` does not break it). Under
+`--fix` doctor runs that script through the `System` seam and re-reads the
+profile: the fix is reported by consequence (the signals are gone), never by
+the script's exit code. `profile-heal.ps1`'s own marker threshold is aligned to
+the same rule (exactly one pair is healthy) so doctor never flags a profile the
+script declines to heal.
+
+## Out of scope
+
+- Linux profiles (`.bashrc`/`.zshrc`) — the splice defect is Windows-only.
+- The parser-error heuristic (`profile-heal.ps1`'s third signal) — it needs a
+  PowerShell parser and stays in the script.
+- Pruning the profile's non-dotfiles content.
+
+## Risks / open questions
+
+- A OneDrive-redirected Documents folder: `findPowerShellProfile` already
+  searches both roots; the heal path is passed absolute.
+- A heal that runs but leaves a signal in place (partial rewrite) is reported as
+  a FAIL with the script named, not as a fix — verified by consequence.
+
+## Acceptance criteria
+
+- [x] AC1 — a Windows profile over 1 MB or with more than one marker pair FAILs
+  with a message naming the heal script's contract path; a healthy one PASSes.
+- [x] AC2 — the heal path is `<SCRIPTS_DIR>\profile-heal.ps1` read from the
+  contract (`SCRIPTS_DIR` env, then the contract default), never a literal.
+- [x] AC3 — under `--fix` the heal runs through the `System` seam and doctor
+  reports Fix only when the re-read profile carries no signal; a heal that
+  changes nothing stays a FAIL.
+- [x] AC4 — `profile-heal.ps1` and doctor agree on the marker threshold (>1).
+- [x] AC5 — non-Windows behaviour is byte-identical (existence checks only).
+
+## References
+
+- Bitácora board: #531
+- BUG-020 (profile compounding), BUG-022 (index-based splice), CLI-018 (doctor consolidation)
+- `scripts/profile-heal.ps1`, `cli/internal/doctor/checks_profile.go`

--- a/specs/CLI-064-doctor-profile-heal/tasks.md
+++ b/specs/CLI-064-doctor-profile-heal/tasks.md
@@ -1,0 +1,29 @@
+---
+tags: [spec, tasks]
+created: "2026-08-28"
+---
+
+# Tasks - CLI-064-doctor-profile-heal
+
+## Setup
+
+- [x] Branch: `fix/doctor-profile-heal` from `origin/main`
+- [x] `proposal.md` complete, acceptance criteria testable
+- [x] No open questions left in `proposal.md`
+
+## Implementation
+
+- [x] [AC1] Failing test: oversized profile and duplicated marker pair FAIL; healthy PASSes (`TestCheckProfileFiles_DetectsBUG020Corruption`)
+- [x] [AC1] `profileCorruption` reads the two BUG-020 signals; `checkProfileFiles` reports them
+- [x] [AC2] Failing test: heal path follows `SCRIPTS_DIR` from the contract (`TestCheckProfileFiles_HealPathFollowsTheContract`)
+- [x] [AC2] `profileHealPath` resolves through the contract, never a literal
+- [x] [AC3] Failing test: `--fix` runs the heal via the seam and is verified by consequence (`TestCheckProfileFiles_FixRunsTheHealAndVerifiesByConsequence`)
+- [x] [AC3] `repairProfile` shells out through `System` and re-reads the profile
+- [x] [AC4] `scripts/profile-heal.ps1` marker threshold aligned to doctor's (>1)
+- [x] [AC5] `TestCheckProfileFiles` (existing) unchanged on the Linux branch
+- [x] Mutation check: `profileCorruption` returning nil fails AC1 and AC3 tests
+
+## Verification
+
+- [x] Go loop: build, vet (host, `GOOS=windows`, `GOOS=linux`), test, golangci-lint
+- [x] `verification.md` records the evidence

--- a/specs/CLI-064-doctor-profile-heal/verification.md
+++ b/specs/CLI-064-doctor-profile-heal/verification.md
@@ -1,0 +1,69 @@
+---
+tags: [spec, verification]
+created: "2026-08-28"
+---
+
+# Verification - CLI-064-doctor-profile-heal
+
+## Evidence
+
+Run on the Windows work box (go1.26, windows/amd64), 2026-08-28, worktree
+`dotfiles-wt-doctor-cluster`, branch `fix/doctor-profile-heal`.
+
+- [x] **AC1** → `TestCheckProfileFiles_DetectsBUG020Corruption` (healthy → PASS;
+  1 MB + 1 byte → FAIL "larger than 1 MB"; two marker pairs → FAIL "marker
+  pairs"; message names the heal path).
+- [x] **AC2** → `TestCheckProfileFiles_HealPathFollowsTheContract` (`SCRIPTS_DIR`
+  set → that dir; unset → the contract default; never `~\scripts` literal).
+- [x] **AC3** → `TestCheckProfileFiles_FixRunsTheHealAndVerifiesByConsequence`
+  (fake `System` records the `pwsh -NoProfile -File <heal>` invocation and
+  rewrites the fixture; a heal that leaves the signal in place stays FAIL).
+- [x] **AC4** → `scripts/profile-heal.ps1` threshold `-gt 1` (was `-gt 2`),
+  comment records why the two must agree.
+- [x] **AC5** → `TestCheckProfileFiles` (pre-existing) unchanged and green.
+
+### Mutation check (revert the fix, watch the guard fail, restore)
+
+`profileCorruption` forced to return nil (corruption never detected):
+`--- FAIL: TestCheckProfileFiles_DetectsBUG020Corruption`,
+`--- FAIL: TestCheckProfileFiles_FixRunsTheHealAndVerifiesByConsequence`.
+Restored; both green.
+
+## Test status
+
+```
+go build ./... && go vet ./... && GOOS=windows go vet ./... && GOOS=linux go vet ./... && go test ./...
+ok  	github.com/mlorentedev/dotfiles/cli/internal/doctor
+(all other packages ok)
+golangci-lint run ./...   → 0 issues.   (2.12.2, the versions.conf pin)
+```
+
+- No regressions in the existing suite: yes.
+- `profile-heal.ps1` was NOT run against the real profile on this box (the
+  profile is healthy: one marker pair, ~7 KB); the shell-out is exercised
+  through the seam in AC3.
+
+## Decisions made during implementation
+
+- **Detection is the defect, heal is convenience.** The corruption source is
+  gone (BUG-022), so the FAIL is what matters; `--fix` is the retired
+  `doctor.ps1 -Fix` behaviour restored on the doctor path.
+- **Verify by consequence.** The heal script's exit code is not the evidence;
+  the re-read profile without the two signals is.
+- **Contract path, not literal.** WIN-013 (#1310) moves `~\scripts` to
+  `~\.dotfiles\scripts`; a literal here would break the remedy the day it merges.
+- **Thresholds agree.** The script used `>2` markers; doctor uses `>1` (the SSOT
+  contains none, so one pair is healthy). The script was aligned rather than
+  doctor loosened.
+
+## Promotion candidates
+
+- [ ] Lesson: no (the pattern — verify by consequence, contract over literal — is already lessons 235 and 240).
+- [ ] ADR-worthy decision: no.
+
+## Archive checklist
+
+- [ ] `dotf spec review CLI-064-doctor-profile-heal` PASS
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved to `specs/archive/CLI-064-doctor-profile-heal/`
+- [ ] Bitácora #531 closed with the PR link

--- a/tests/profile-heal-ps1.bats
+++ b/tests/profile-heal-ps1.bats
@@ -49,9 +49,9 @@ setup() {
     grep -qE '\.(Length|Size)\s+-gt\s+1MB|Size\s+-gt\s+1MB' "$PS1_SCRIPT"
 }
 
-@test "profile-heal.ps1 detects marker-count corruption (> 2 of either marker)" {
+@test "profile-heal.ps1 detects marker-count corruption (> 1 of either marker)" {
     grep -qE 'markerCount|MarkerCount|StartMatches|EndMatches|StartMarkers|EndMarkers' "$PS1_SCRIPT"
-    grep -qE -- '-gt\s+2' "$PS1_SCRIPT"
+    grep -qE -- '-gt\s+1' "$PS1_SCRIPT"
 }
 
 @test "profile-heal.ps1 detects parser errors as a corruption signal" {


### PR DESCRIPTION
`checkProfileFiles` tested existence only: a 26 MB profile compounded by the old marker splice reported PASS, and the heal the retired `doctor.ps1 -Fix` used to run (`scripts/profile-heal.ps1`) had no caller on the doctor path after CLI-018 (#531).

- **Windows**: FAIL on either BUG-020 signal — larger than 1 MB, or more than one `# >>> DOTFILES PROFILE >>>` / `# <<< DOTFILES PROFILE <<<` pair — naming `<SCRIPTS_DIR>\profile-heal.ps1` resolved through the env contract (never a literal, so WIN-013's move of `~\scripts` cannot break the remedy).
- **`--fix`**: runs the heal through the `System` seam and verifies by consequence — the re-read profile must carry no signal, or the FAIL stands.
- **`profile-heal.ps1`**: marker threshold `>2` → `>1` so the script and doctor agree (the SSOT contains no markers; one pair is healthy).
- Non-Windows branch unchanged.

Spec: `specs/CLI-064-doctor-profile-heal/` (verification.md carries the evidence and the mutation check: `profileCorruption` returning nil fails the AC1 and AC3 tests).

Evidence (Windows work box): `go build/vet`, `GOOS=windows|linux go vet`, `go test ./...` ok; `golangci-lint` 0 issues. The real profile on this box is healthy (one pair, ~7 KB) and was not touched.

Refs #531 — the issue closes when the spec archives after the pooled review (the archive-on-merge gate refuses a Closes on an active spec, as on #1348). Implementation by the doctor-cluster agent, finished and verified by the main session after the agent was stopped (account session limit).