### PR TITLE
feat(profile): agyp, the PowerShell twin of the zsh saved-prompt launcher

### DIFF
--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -11,6 +11,31 @@
 Set-Alias -Name c -Value claude
 Set-Alias -Name g -Value agy
 
+# agyp: launch agy with a saved prompt, the PowerShell twin of .zsh/functions.sh's
+# agyp (PARITY-001, #764). Same contract on both sides: the prompt lives at
+# $GEMINI_DIR\prompts\<name>.md, extra words are appended after a blank line,
+# and a missing name or file is a non-terminating error (so $? is false) rather
+# than a launch with an empty prompt.
+#   agyp <prompt-name> [extra words]
+function agyp {
+    param(
+        [Parameter(Position = 0)][string]$Name,
+        [Parameter(ValueFromRemainingArguments = $true)][string[]]$Rest
+    )
+    if (-not $Name) {
+        Write-Error 'usage: agyp <prompt-name> [args]'
+        return
+    }
+    $geminiDir = if ($env:GEMINI_DIR) { $env:GEMINI_DIR } else { Join-Path $env:USERPROFILE '.gemini' }
+    $promptFile = Join-Path (Join-Path $geminiDir 'prompts') "$Name.md"
+    if (-not (Test-Path -LiteralPath $promptFile)) {
+        Write-Error "agyp: prompt not found at $promptFile"
+        return
+    }
+    $prompt = Get-Content -LiteralPath $promptFile -Raw
+    & agy -i ($prompt + "`n`n" + ($Rest -join ' '))
+}
+
 # AI provider endpoints -- NaN community (primary, OpenAI-compatible).
 # API key in $env:NAN_API_KEY -- injected on demand via `dotf secrets run` (wrappers below), not the ambient session.
 $env:NAN_BASE_URL = 'https://api.nan.builders/v1'

--- a/tests/powershell-agyp.Tests.ps1
+++ b/tests/powershell-agyp.Tests.ps1
@@ -1,0 +1,51 @@
+# Pester 5 tests for the agyp function in powershell/profile.ps1 (PARITY-001,
+# #764): the PowerShell twin of .zsh/functions.sh's agyp. The function is
+# lifted out of the profile by its markers so nothing else in the profile runs,
+# and agy is shimmed by a function of the same name that records its arguments.
+
+Describe 'agyp' {
+
+    BeforeAll {
+        $profilePath = (Resolve-Path (Join-Path $PSScriptRoot '..\powershell\profile.ps1')).Path
+        $text = Get-Content -LiteralPath $profilePath -Raw
+        $m = [regex]::Match($text, '(?ms)^function agyp \{.*?^\}')
+        if (-not $m.Success) { throw 'function agyp not found in profile.ps1' }
+        . ([scriptblock]::Create($m.Value))
+
+        $script:Gemini = Join-Path $TestDrive 'gemini'
+        New-Item -ItemType Directory -Force -Path (Join-Path $script:Gemini 'prompts') | Out-Null
+        Set-Content -LiteralPath (Join-Path (Join-Path $script:Gemini 'prompts') 'review.md') -Value 'Review this.' -NoNewline
+        $env:GEMINI_DIR = $script:Gemini
+
+        # The shim: whatever agyp launches lands here instead of the real binary.
+        function global:agy { $script:AgyArgs = $args }
+    }
+
+    AfterAll {
+        Remove-Item -Path Function:\global:agy -ErrorAction SilentlyContinue
+        Remove-Item -Path Env:\GEMINI_DIR -ErrorAction SilentlyContinue
+    }
+
+    BeforeEach { $script:AgyArgs = $null }
+
+    It 'launches agy -i with the prompt file, a blank line, and the extra words' {
+        agyp review fix the tests
+        $script:AgyArgs[0] | Should -Be '-i'
+        $script:AgyArgs[1] | Should -Be "Review this.`n`nfix the tests"
+    }
+
+    It 'launches with the prompt alone when no extra words are given' {
+        agyp review
+        $script:AgyArgs[1] | Should -Be "Review this.`n`n"
+    }
+
+    It 'fails without launching agy when the prompt name is missing' {
+        { agyp -ErrorAction Stop } | Should -Throw -ExpectedMessage '*usage: agyp*'
+        $script:AgyArgs | Should -BeNullOrEmpty
+    }
+
+    It 'fails without launching agy when the prompt file does not exist' {
+        { agyp nope -ErrorAction Stop } | Should -Throw -ExpectedMessage '*prompt not found*nope.md*'
+        $script:AgyArgs | Should -BeNullOrEmpty
+    }
+}

--- a/tests/powershell-profile.bats
+++ b/tests/powershell-profile.bats
@@ -25,6 +25,16 @@ setup() {
     grep -q 'Set-Alias.*-Name g -Value agy' "$PROFILE_SCRIPT"
 }
 
+@test "profile.ps1 defines agyp, the PowerShell twin of .zsh/functions.sh agyp (PARITY-001, #764)" {
+    # Same contract on both sides: prompt at <gemini dir>/prompts/<name>.md,
+    # extra words appended, missing name/file fails without launching agy.
+    grep -qE '^function agyp' "$PROFILE_SCRIPT"
+    grep -q "Join-Path \$geminiDir 'prompts'" "$PROFILE_SCRIPT"
+    grep -q 'agy -i' "$PROFILE_SCRIPT"
+    grep -qE '^agyp\(\)' "$DOTFILES_DIR/.zsh/functions.sh"
+    grep -q '\.gemini/prompts' "$DOTFILES_DIR/.zsh/functions.sh"
+}
+
 # --- OpenCode alias (admin-conditional on Windows; aider sunset) ---
 
 @test "profile.ps1 defines conditional oc alias for opencode (plain, no --pure)" {


### PR DESCRIPTION
`.zsh/functions.sh` has had `agyp` (`agy -i` with `~/.gemini/prompts/<name>.md` plus the extra words) since the Antigravity migration; `powershell/profile.ps1` had no twin, although `agy` is deployed on Windows and the prompts directory is synced there (PARITY-001). Decision on the ticket's own question: the twin, not a recorded asymmetry — unlike `oc --pure` there is no empirical reason for one.

Same contract on both sides: prompt at `$GEMINI_DIR\prompts\<name>.md` (falls back to `~\.gemini`), extra words appended after a blank line, a missing name or file is a non-terminating error with no launch.

Guards: `tests/powershell-profile.bats` ties both definitions to the prompts path; `tests/powershell-agyp.Tests.ps1` lifts the function out of the profile, shims `agy`, and asserts the argument shape (`-i`, prompt + blank line + words) and both error paths.

Evidence (Windows work box): Pester 11/11 (agyp + the profile collision suite), `bats tests/powershell-profile.bats` 15/15, PSScriptAnalyzer clean on the new test, insert is ASCII-only; smoke with the worktree profile dot-sourced in a child `pwsh` and `agy` shimmed: `agyp adversarial-review extra words` launches with the prompt and the words.

Closes #764.

## SDD skip rationale
One ~25-line profile function mirroring an existing shell function plus tests; no new contract.