### PR TITLE
fix(setup): scripts deploy to the contract's directory, and the retired ones are swept

### DIFF
--- a/.github/scripts/doctor-gate-known-failures.txt
+++ b/.github/scripts/doctor-gate-known-failures.txt
@@ -8,8 +8,3 @@
 # A real-box defect never goes here: it is fixed or ticketed, and the gate stays
 # red until then.
 
-# WIN-013 (#1310): env-contract SCRIPTS_DIR defaults to ~/.dotfiles/scripts on
-# Windows, but setup-windows.ps1 deploys scripts to ~/scripts and nothing
-# creates the contract path, so the contract check fails on every fresh box.
-# example:   [FAIL] SCRIPTS_DIR=C:\Users\runneradmin\.dotfiles\scripts (path does not exist)
-SCRIPTS_DIR=.*\.dotfiles\\scripts \(path does not exist\)

--- a/.github/scripts/doctor-gate.ps1
+++ b/.github/scripts/doctor-gate.ps1
@@ -25,6 +25,11 @@ function Test-DoctorGate {
         [Parameter(Mandatory)][AllowEmptyCollection()][AllowEmptyString()][AllowNull()][string[]]$Lines,
         [Parameter(Mandatory)][AllowEmptyCollection()][AllowEmptyString()][AllowNull()][string[]]$Patterns
     )
+    # A list with no entries reaches here as $null, which [string[]] binds as
+    # one null element: it matched nothing and was reported STALE, failing the
+    # gate the moment its last row was retired (WIN-013). Zero rows is the
+    # steady state of a list that only shrinks, so drop empties up front.
+    $Patterns = @($Patterns | Where-Object { $_ })
     $failures = @($Lines | Where-Object { $_ -match '^\s*\[FAIL\]' })
     $unexpected = @($failures | Where-Object {
         $line = $_
@@ -41,7 +46,10 @@ function Test-DoctorGate {
 function Read-KnownFailures {
     param([Parameter(Mandatory)][string]$Path)
     if (-not (Test-Path -LiteralPath $Path)) { return @() }
-    @(Get-Content -LiteralPath $Path | ForEach-Object { $_.Trim() } | Where-Object { $_ -and -not $_.StartsWith('#') })
+    # `return ,$entries` hands the caller a real (possibly empty) array; a bare
+    # @(...) unrolls to nothing and arrives as $null (WIN-013 emptied the list).
+    $entries = @(Get-Content -LiteralPath $Path | ForEach-Object { $_.Trim() } | Where-Object { $_ -and -not $_.StartsWith('#') })
+    return ,$entries
 }
 
 if ($MyInvocation.InvocationName -ne '.') {

--- a/env-contract.json
+++ b/env-contract.json
@@ -126,7 +126,7 @@
       "$HOME/.local/bin"
     ],
     "windows": [
-      "$env:USERPROFILE\\scripts",
+      "$env:USERPROFILE\\.dotfiles\\scripts",
       "$env:USERPROFILE\\.local\\bin"
     ]
   },

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1731,6 +1731,8 @@ foreach ($initOrphan in @(
 # itself and the User PATH entry that names it are left alone: pruning a User
 # PATH entry is the 2048-char hazard #148 warned about, and the directory may
 # hold the user's own scripts.
+# MEM-002: claude-mem-heal.ps1 is in this removal list on purpose (the guard
+# tests/guard-no-claude-mem.bats strips MEM-002 cleanup blocks before scanning).
 $retiredScripts = @(
     "claude-mem-heal.ps1", "claude-session-start.ps1", "diff-check.ps1",
     "doctor.ps1", "healthcheck.ps1", "knowledge-crystallize.ps1",

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -76,7 +76,12 @@ $DotfilesDir = $PSScriptRoot
 $DotfilesDest = "$env:USERPROFILE\.dotfiles"
 $ClaudeHome = "$env:USERPROFILE\.claude"
 $GeminiHome = "$env:USERPROFILE\.gemini"
-$ScriptsDir = "$env:USERPROFILE\scripts"
+# SCRIPTS_DIR per env-contract.json: under the deploy dir, the same shape as
+# Linux ($HOME/.dotfiles/scripts) and what dotf doctor's contract check, the
+# profile fallback and required_path_entries all expect (WIN-013, #1310). The
+# pre-contract location is kept only to be cleaned.
+$ScriptsDir = "$DotfilesDest\scripts"
+$LegacyScriptsDir = "$env:USERPROFILE\scripts"
 
 # ============================================================================
 # HELPER FUNCTIONS
@@ -1716,6 +1721,45 @@ foreach ($initOrphan in @(
 # CLI-050: knowledge-crystallize.ps1 retired — `dotf vault crystallize` is the
 # sole implementation now, and it needs no per-machine deploy step since it
 # ships inside the dotf binary itself.
+
+# WIN-013 (#1310): every script this section deploys now lands in $ScriptsDir
+# (the contract's ~\.dotfiles\scripts). Two kinds of leftovers are removed on
+# every run, idempotently: scripts retired by earlier tickets (measured still
+# present on a real box on 2026-08-27), from both locations; and the live
+# scripts' copies in the pre-contract ~\scripts, which would otherwise shadow
+# nothing today but drift the day one of them changes. The legacy directory
+# itself and the User PATH entry that names it are left alone: pruning a User
+# PATH entry is the 2048-char hazard #148 warned about, and the directory may
+# hold the user's own scripts.
+$retiredScripts = @(
+    "claude-mem-heal.ps1", "claude-session-start.ps1", "diff-check.ps1",
+    "doctor.ps1", "healthcheck.ps1", "knowledge-crystallize.ps1",
+    "session-handoff.ps1")
+$deployedScripts = @(
+    "profile-heal.ps1", "orca-hook-tune.ps1", "windows-defaults.ps1",
+    "dotfiles-sync.ps1", "obs-cli.ps1")
+$removedLeftovers = 0
+foreach ($dir in @($ScriptsDir, $LegacyScriptsDir) | Select-Object -Unique) {
+    foreach ($name in $retiredScripts) {
+        $leftover = Join-Path $dir $name
+        if (Test-Path -LiteralPath $leftover) {
+            Remove-Item -LiteralPath $leftover -Force -ErrorAction SilentlyContinue
+            $removedLeftovers++
+        }
+    }
+}
+if ($LegacyScriptsDir -ne $ScriptsDir) {
+    foreach ($name in $deployedScripts) {
+        $stale = Join-Path $LegacyScriptsDir $name
+        if (Test-Path -LiteralPath $stale) {
+            Remove-Item -LiteralPath $stale -Force -ErrorAction SilentlyContinue
+            $removedLeftovers++
+        }
+    }
+}
+if ($removedLeftovers -gt 0) {
+    Write-Info "Removed $removedLeftovers retired or relocated script(s) from $ScriptsDir / $LegacyScriptsDir (WIN-013)"
+}
 
 # CLI-025: claude-session-start.ps1 + session-handoff.ps1 retired — both session
 # hooks now call agnostic `dotf mem` nouns directly (registered below), so there

--- a/specs/WIN-013-scripts-dir-contract/features.json
+++ b/specs/WIN-013-scripts-dir-contract/features.json
@@ -24,7 +24,7 @@
     "id": "WIN-013-scripts-dir-contract-f4",
     "behavior": "AC5: the test-windows doctor gate passes with 0 known runner-only FAILs",
     "verification": "gh run list --branch fix/scripts-dir-contract --workflow ci.yml --limit 1 --json conclusion --jq '.[0].conclusion' | grep -q success",
-    "state": "pending",
-    "evidence": ""
+    "state": "verified",
+    "evidence": "run 33201808112 test-windows: doctor gate: 0 known runner-only FAIL(s), 0 unexpected, 0 stale (2026-08-28)"
   }
 ]

--- a/specs/WIN-013-scripts-dir-contract/features.json
+++ b/specs/WIN-013-scripts-dir-contract/features.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "WIN-013-scripts-dir-contract-f1",
+    "behavior": "AC1: the contract's Windows SCRIPTS_DIR default, required_path_entries.windows[0] and setup-windows.ps1's $ScriptsDir name the same directory",
+    "verification": "bats tests/env-contract.bats -f 'WIN-013'",
+    "state": "verified",
+    "evidence": "ok on the Windows work box 2026-08-28"
+  },
+  {
+    "id": "WIN-013-scripts-dir-contract-f2",
+    "behavior": "AC2/AC4: setup removes the retired scripts and the legacy copies without touching the User PATH; the deploy guards measure Copy-Item/invocation, not mention",
+    "verification": "bats tests/setup-windows.bats -f 'WIN-013|MEM-002|CLI-019|CLI-018'",
+    "state": "verified",
+    "evidence": "ok on the Windows work box 2026-08-28"
+  },
+  {
+    "id": "WIN-013-scripts-dir-contract-f3",
+    "behavior": "AC3: the gate list carries no WIN-013 row and the gate tooling accepts an empty list",
+    "verification": "! grep -q 'SCRIPTS_DIR' .github/scripts/doctor-gate-known-failures.txt && pwsh -NoProfile -Command 'Invoke-Pester -Path tests/doctor-gate.Tests.ps1 -CI'",
+    "state": "verified",
+    "evidence": "Pester 10/10 on the Windows work box 2026-08-28"
+  },
+  {
+    "id": "WIN-013-scripts-dir-contract-f4",
+    "behavior": "AC5: the test-windows doctor gate passes with 0 known runner-only FAILs",
+    "verification": "gh run list --branch fix/scripts-dir-contract --workflow ci.yml --limit 1 --json conclusion --jq '.[0].conclusion' | grep -q success",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/WIN-013-scripts-dir-contract/proposal.md
+++ b/specs/WIN-013-scripts-dir-contract/proposal.md
@@ -1,0 +1,69 @@
+---
+id: "WIN-013-scripts-dir-contract"
+type: spec
+status: verifying # draft | implementing | verifying | archived
+created: "2026-08-28"
+issue: "mlorentedev/dotfiles#1310"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, windows, env-contract, setup]
+template_version: "1.0"
+---
+
+# WIN-013-scripts-dir-contract
+
+## Why
+
+Four values named the Windows scripts directory and disagreed: the env
+contract's `SCRIPTS_DIR` default (`$env:USERPROFILE\.dotfiles\scripts`),
+`required_path_entries.windows` (`$env:USERPROFILE\scripts`), `setup-windows.ps1`'s
+`$ScriptsDir` (`$env:USERPROFILE\scripts`) and the doctor/profile fallback
+(`$env:DOTFILES_DIR\scripts`). Setup deployed to `~\scripts`, nothing ever
+created the contract path, and `dotf doctor` FAILed `SCRIPTS_DIR=... (path does
+not exist)` on every fresh Windows box — the test-windows gate (#1308) had to
+allow-list it. On the work box `~\scripts` also held seven scripts retired by
+earlier tickets that nothing had ever removed. Issue #1310 (folds #148).
+
+## What
+
+`setup-windows.ps1` deploys scripts to the contract's directory, under the
+deploy dir (`$DotfilesDest\scripts`, the same shape as Linux's
+`$HOME/.dotfiles/scripts`); `required_path_entries.windows` names the same
+directory; the profile fallback already agrees. Every run removes, idempotently,
+the retired scripts from both locations and the pre-contract copies of the
+scripts setup now deploys elsewhere. The gate's WIN-013 row is gone in the same
+change, so a stale row cannot survive it. The legacy `~\scripts` directory and
+its User PATH entry are left in place.
+
+## Out of scope
+
+- Pruning the `~\scripts` entry from the User PATH (the 2048-char hazard #148
+  named); a later ticket may do it with a measured PATH length.
+- Deleting the legacy directory itself — it may hold the user's own scripts.
+- `profile.ps1` consumers of `SCRIPTS_DIR` (`hc`, `project-init`): they read the
+  variable, which the contract renders; unchanged.
+
+## Risks / open questions
+
+- A box whose `~\.dotfiles\scripts` already exists with stale content: setup
+  overwrites the deployed set with `Copy-Item -Force`, as before.
+- The gate list is now empty: `Read-KnownFailures` returns `@()`, which
+  `Test-DoctorGate` accepts (`AllowEmptyCollection`), and the Pester guard that
+  required at least one entry now asserts the parser's count instead.
+
+## Acceptance criteria
+
+- [x] AC1 — the contract's Windows `SCRIPTS_DIR` default, `required_path_entries.windows[0]`
+  and setup's `$ScriptsDir` name the same directory (`~\.dotfiles\scripts`).
+- [x] AC2 — setup removes the seven retired scripts from both locations and the
+  legacy copies of the five deployed scripts, on every run, without touching the
+  User PATH.
+- [x] AC3 — the doctor gate's WIN-013 row is removed in the same change and the
+  gate tooling accepts an empty list.
+- [x] AC4 — the existing "no longer deploys X" guards measure deployment
+  (`Copy-Item` / invocation), not mention, so the removal list can name X.
+- [x] AC5 — the test-windows gate passes with `0 known runner-only FAIL(s)`.
+
+## References
+
+- Bitácora board: #1310 (consolidates #148)
+- ADR-025 (paths resolve at setup), #1305 (`dotf harness mirror` took the same direction for the deploy dir)
+- `env-contract.json`, `setup-windows.ps1`, `.github/scripts/doctor-gate-known-failures.txt`

--- a/specs/WIN-013-scripts-dir-contract/tasks.md
+++ b/specs/WIN-013-scripts-dir-contract/tasks.md
@@ -1,0 +1,29 @@
+---
+tags: [spec, tasks]
+created: "2026-08-28"
+---
+
+# Tasks - WIN-013-scripts-dir-contract
+
+## Setup
+
+- [x] Branch: `fix/scripts-dir-contract` from `origin/main`
+- [x] `proposal.md` complete, acceptance criteria testable
+- [x] No open questions left in `proposal.md`
+
+## Implementation
+
+- [x] [AC1] Failing test: contract default == required_path_entries.windows[0] == setup's `$ScriptsDir` shape (`tests/env-contract.bats`)
+- [x] [AC1] `setup-windows.ps1` `$ScriptsDir = "$DotfilesDest\scripts"`; `env-contract.json` `required_path_entries.windows[0]`
+- [x] [AC2] Failing test: the seven retired names and the legacy-copy sweep are present, the User PATH is untouched (`tests/setup-windows.bats`)
+- [x] [AC2] Removal block after "Deploying scripts..." (retired list x both dirs; deployed list x legacy dir)
+- [x] [AC3] Remove the WIN-013 row from `doctor-gate-known-failures.txt`; Pester guard asserts the parser count (0 allowed)
+- [x] [AC4] `claude-mem-heal`, `diff-check`, `healthcheck|doctor` guards refute `Copy-Item`/invocation instead of mention
+- [x] [AC5] CI `test-windows` gate: `0 known runner-only FAIL(s), 0 unexpected, 0 stale`
+
+## Verification
+
+- [x] bats: env-contract, setup-windows, ci-windows-doctor-gate, profile-heal-ps1
+- [x] Pester: doctor-gate
+- [x] PSScriptAnalyzer: no new findings vs main; parse clean; ASCII delta 0
+- [x] `verification.md` records the evidence

--- a/specs/WIN-013-scripts-dir-contract/verification.md
+++ b/specs/WIN-013-scripts-dir-contract/verification.md
@@ -1,0 +1,65 @@
+---
+tags: [spec, verification]
+created: "2026-08-28"
+---
+
+# Verification - WIN-013-scripts-dir-contract
+
+## Evidence
+
+Run on the Windows work box, 2026-08-28, worktree `dotfiles-wt-setup-cluster`,
+branch `fix/scripts-dir-contract`.
+
+- [x] **AC1** → `tests/env-contract.bats` "SCRIPTS_DIR: the Windows default,
+  required_path_entries and setup-windows.ps1 name the same directory".
+- [x] **AC2** → `tests/setup-windows.bats` "removes every retired script and the
+  legacy ~\scripts copies of the live ones": seven names present in the removal
+  list, `$LegacyScriptsDir` declared, both-dirs sweep, no `SetEnvironmentVariable("PATH"…LegacyScriptsDir`.
+- [x] **AC3** → `.github/scripts/doctor-gate-known-failures.txt` carries no
+  entry; `tests/doctor-gate.Tests.ps1` 10/10 (the example-match guard now asserts
+  the parser's count, 0 included); `Test-DoctorGate` with `@()` patterns and no
+  FAIL lines → 0 unexpected, 0 stale.
+- [x] **AC4** → the MEM-002, CLI-019 and CLI-018 guards refute `Copy-Item.*name`
+  and `&.*name` instead of any mention.
+- [ ] **AC5** → CI `test-windows` gate on the PR head (recorded in the PR).
+
+## Test status
+
+```
+bats tests/env-contract.bats tests/setup-windows.bats tests/ci-windows-doctor-gate.bats tests/profile-heal-ps1.bats   -> all ok
+Invoke-Pester tests/doctor-gate.Tests.ps1   -> 10/10
+Invoke-ScriptAnalyzer setup-windows.ps1 (repo settings)   -> 0 findings (same as main)
+Parser::ParseFile setup-windows.ps1   -> 0 parse errors
+non-ASCII characters in setup-windows.ps1   -> 11 (unchanged from main)
+```
+
+- No regressions in the existing suite: yes.
+- `setup-windows.ps1` was NOT run on this box from the branch (the main
+  session owns machine state); the real migration runs after merge and its
+  outcome is recorded on #1310.
+
+## Decisions made during implementation
+
+- **Align Windows to the contract, not the contract to Windows.** ADR-025 makes
+  the contract the SSOT and `dotf harness mirror` (#1305) already put the deploy
+  tree under `~\.dotfiles`; scripts follow.
+- **Sweep both locations every run.** Idempotent removal of a fixed list is
+  cheaper and more honest than a one-time migration flag that nothing verifies.
+- **Leave the legacy PATH entry.** Rewriting a User PATH from a script is the
+  2048-char hazard #148 named; the new entry is prepended, so resolution order is
+  correct without pruning.
+- **Guards measure deployment, not mention.** Three existing guards failed
+  because the removal list names the retired scripts — the lesson-235 shape; they
+  now refute `Copy-Item`/invocation.
+
+## Promotion candidates
+
+- [ ] Lesson: no — the mention-vs-invariant lesson already exists (235).
+- [ ] ADR-worthy decision: no.
+
+## Archive checklist
+
+- [ ] `dotf spec review WIN-013-scripts-dir-contract` PASS
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved to `specs/archive/WIN-013-scripts-dir-contract/`
+- [ ] Bitácora #1310 closed with the PR link

--- a/specs/WIN-013-scripts-dir-contract/verification.md
+++ b/specs/WIN-013-scripts-dir-contract/verification.md
@@ -21,7 +21,7 @@ branch `fix/scripts-dir-contract`.
   FAIL lines → 0 unexpected, 0 stale.
 - [x] **AC4** → the MEM-002, CLI-019 and CLI-018 guards refute `Copy-Item.*name`
   and `&.*name` instead of any mention.
-- [ ] **AC5** → CI `test-windows` gate on the PR head (recorded in the PR).
+- [x] **AC5** → CI `test-windows` on `1076ed0` (run 33201808112): `doctor gate: 0 known runner-only FAIL(s), 0 unexpected, 0 stale`. The first run of the PR failed `integration` on the second `setup-linux.sh` run with no output; the re-run with the same setup code passed, and the test now prints the run's last 40 lines so a repeat names itself.
 
 ## Test status
 

--- a/tests/doctor-gate.Tests.ps1
+++ b/tests/doctor-gate.Tests.ps1
@@ -55,6 +55,20 @@ Describe 'Test-DoctorGate' {
         $r = Test-DoctorGate -Lines @('Results: 5 passed, 0 failed, 0 warned, 0 skipped') -Patterns @()
         $r.Unexpected.Count + $r.Stale.Count | Should -Be 0
     }
+
+    It 'a list file with no entries yields zero patterns, not one null that reads as stale' {
+        # The last row was retired (WIN-013) and the reader returned $null,
+        # which [string[]] bound as @($null): one pattern matching no FAIL,
+        # reported STALE, gate red on a fully healthy runner.
+        $p = Join-Path $TestDrive 'empty.txt'
+        Set-Content -Path $p -Value @('# only comments', '', '# and blanks')
+        $patterns = Read-KnownFailures -Path $p
+        @($patterns).Count | Should -Be 0
+        $r = Test-DoctorGate -Lines @('Results: 5 passed, 0 failed, 0 warned, 0 skipped') -Patterns $patterns
+        $r.Stale.Count | Should -Be 0
+        $r = Test-DoctorGate -Lines @('Results: 5 passed, 0 failed, 0 warned, 0 skipped') -Patterns $null
+        $r.Stale.Count | Should -Be 0
+    }
 }
 
 Describe 'Read-KnownFailures' {
@@ -90,7 +104,10 @@ Describe 'Read-KnownFailures' {
             $example = $null
             $checked++
         }
-        $checked | Should -BeGreaterThan 0
+        # Every entry the reader returns was checked; zero entries is a valid
+        # state of a list that only shrinks (WIN-013 + TEST-005 emptied it).
+        $entries = Read-KnownFailures -Path $known
+        $checked | Should -Be $entries.Count
     }
 
     It 'every committed entry is a valid regex and names its ticket in a preceding comment' {

--- a/tests/env-contract.bats
+++ b/tests/env-contract.bats
@@ -45,6 +45,18 @@ setup() {
     done
 }
 
+@test "SCRIPTS_DIR: the Windows default, required_path_entries and setup-windows.ps1 name the same directory (WIN-013)" {
+    # Four values disagreed once (contract default, required_path_entries,
+    # setup's $ScriptsDir, the profile fallback) and doctor failed on every
+    # fresh Windows box; the deploy dir is the one shape they all agree on.
+    default=$(jq -r '.env_vars[] | select(.name == "SCRIPTS_DIR") | .default.windows' "$CONTRACT")
+    entry=$(jq -r '.required_path_entries.windows[0]' "$CONTRACT")
+    [ "$default" = '$env:USERPROFILE\.dotfiles\scripts' ]
+    [ "$entry" = "$default" ]
+    grep -qF '$ScriptsDir = "$DotfilesDest\scripts"' "$BATS_TEST_DIRNAME/../setup-windows.ps1"
+    grep -qF '$DotfilesDest = "$env:USERPROFILE\.dotfiles"' "$BATS_TEST_DIRNAME/../setup-windows.ps1"
+}
+
 @test "each new var validation is path_exists" {
     for name in SCRIPTS_DIR AGY_HOME COPILOT_HOME OPENCODE_HOME; do
         validation=$(jq -r ".env_vars[] | select(.name == \"$name\") | .validation" "$CONTRACT")

--- a/tests/guard-no-session-handoff.bats
+++ b/tests/guard-no-session-handoff.bats
@@ -18,7 +18,10 @@ setup() {
 @test "no bats test targets a session-handoff script (would break CI bats glob)" {
     # CI runs `bats tests/*.bats`; a test for the deleted script would fail. Exclude
     # this guard file, which names the script in prose.
-    run grep -rlF --exclude='guard-no-session-handoff.bats' 'session-handoff' "$REPO/tests"
+    # A test that runs it or resolves its path would break; a removal list that
+    # names it (setup-windows.bats, WIN-013) would not, so the guard measures
+    # invocation and path references, not mention.
+    run grep -rlE --exclude='guard-no-session-handoff.bats' '(run |bash |pwsh |scripts/)[^#]*session-handoff' "$REPO/tests"
     [ -z "$output" ]
 }
 

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -151,6 +151,18 @@ setup() {
     refute_grep 'Copy-Item .*init-project\.ps1' "$PS1_SCRIPT"
 }
 
+@test "setup-windows.ps1 removes every retired script and the legacy ~\scripts copies of the live ones (WIN-013)" {
+    # Measured on a real box 2026-08-27: seven retired scripts still sat in
+    # ~\scripts because nothing ever removed them. The list is the guard.
+    for name in claude-mem-heal.ps1 claude-session-start.ps1 diff-check.ps1 doctor.ps1 healthcheck.ps1 knowledge-crystallize.ps1 session-handoff.ps1; do
+        grep -qF "\"$name\"" "$PS1_SCRIPT"
+    done
+    grep -qF '$LegacyScriptsDir = "$env:USERPROFILE\scripts"' "$PS1_SCRIPT"
+    grep -qF 'foreach ($dir in @($ScriptsDir, $LegacyScriptsDir)' "$PS1_SCRIPT"
+    # The legacy PATH entry is deliberately not pruned (2048-char hazard, #148).
+    refute_grep 'SetEnvironmentVariable\("PATH".*LegacyScriptsDir' "$PS1_SCRIPT"
+}
+
 @test "setup-windows.ps1 no longer deploys knowledge-crystallize.ps1 (CLI-050)" {
     # dotf vault crystallize replaced it (#1269); no per-machine deploy step needed.
     refute_grep 'Copy-Item .*knowledge-crystallize\.ps1' "$PS1_SCRIPT"
@@ -164,7 +176,9 @@ setup() {
 # MEM-002: claude-mem-heal.ps1 is retired (ADR-016 Q2). setup-windows.ps1 must
 # NOT deploy it any more.
 @test "setup-windows.ps1 no longer deploys claude-mem-heal.ps1 (MEM-002)" {
-    refute_grep_fixed 'claude-mem-heal.ps1' "$PS1_SCRIPT"
+    # The name may appear in WIN-013's removal list; never in a deploy or a call.
+    refute_grep 'Copy-Item.*claude-mem-heal\.ps1' "$PS1_SCRIPT"
+    refute_grep '&.*claude-mem-heal\.ps1' "$PS1_SCRIPT"
     [ ! -f "$DOTFILES_DIR/scripts/claude-mem-heal.ps1" ]
 }
 
@@ -617,10 +631,9 @@ setup() {
 # reference diff-check.
 
 @test "CLI-019: setup-windows.ps1 no longer deploys diff-check.ps1" {
-    if grep -qF 'diff-check' "$PS1_SCRIPT"; then
-        echo "diff-check still referenced in setup-windows.ps1" >&2
-        return 1
-    fi
+    # The name may appear in WIN-013's removal list; never in a deploy or a call.
+    refute_grep 'Copy-Item.*diff-check' "$PS1_SCRIPT"
+    refute_grep '&.*diff-check' "$PS1_SCRIPT"
 }
 
 @test "CLI-019: powershell/profile.ps1 dch wraps dotf doctor" {
@@ -635,13 +648,15 @@ setup() {
 @test "CLI-019: production callers no longer reference diff-check" {
     [ ! -f "$DOTFILES_DIR/scripts/diff-check.sh" ]
     [ ! -f "$DOTFILES_DIR/scripts/diff-check.ps1" ]
-    for f in setup-linux.sh setup-windows.ps1 powershell/profile.ps1 \
+    for f in setup-linux.sh powershell/profile.ps1 \
              .zsh/aliases.zsh .github/workflows/ci.yml; do
         if grep -qF 'diff-check' "$DOTFILES_DIR/$f"; then
             echo "diff-check still referenced in $f" >&2
             return 1
         fi
     done
+    # setup-windows.ps1 names it only in WIN-013's removal list (guarded above).
+    refute_grep 'Copy-Item.*diff-check' "$PS1_SCRIPT"
 }
 
 # --- CLI-018 (#509): healthcheck.ps1 + doctor.ps1 retired; dotf doctor owns it ---
@@ -656,13 +671,16 @@ setup() {
 }
 
 @test "CLI-018: no production caller references healthcheck.ps1 or doctor.ps1" {
-    for f in setup-linux.sh setup-windows.ps1 powershell/profile.ps1 \
+    for f in setup-linux.sh powershell/profile.ps1 \
              .github/workflows/ci.yml; do
         if grep -qE '(healthcheck|doctor)\.ps1' "$DOTFILES_DIR/$f"; then
             echo "(healthcheck|doctor).ps1 still referenced in $f" >&2
             return 1
         fi
     done
+    # setup-windows.ps1 names them only in WIN-013's removal list: never deployed or called.
+    refute_grep 'Copy-Item.*(healthcheck|doctor)\.ps1' "$PS1_SCRIPT"
+    refute_grep '&.*(healthcheck|doctor)\.ps1' "$PS1_SCRIPT"
 }
 
 # --- CLI-018: dotf doctor as the post-setup diagnostic (replaced WIN-001) ---

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -458,7 +458,11 @@ setup() {
     # Execute second run
     cd "$REPO_DIR"
     run bash setup-linux.sh
-    [ "$status" -eq 0 ]
+    if [ "$status" -ne 0 ]; then
+        echo "second setup-linux.sh run exited $status; last 40 lines:" >&2
+        printf '%s\n' "$output" | tail -40 >&2
+        return 1
+    fi
 
     # Collect hashes after second run
     find "$HOME/.dotfiles" "$HOME/.claude" "$HOME/.gemini" "$HOME/.config/opencode" \


### PR DESCRIPTION
Four values named the Windows scripts directory and disagreed: the env contract's `SCRIPTS_DIR` default (`~\.dotfiles\scripts`), `required_path_entries` (`~\scripts`), `setup-windows.ps1`'s `$ScriptsDir` (`~\scripts`) and the profile fallback (`$env:DOTFILES_DIR\scripts`). Setup deployed to `~\scripts`, nothing created the contract path, and `dotf doctor` FAILed `SCRIPTS_DIR=... (path does not exist)` on every fresh Windows box — the test-windows gate had to allow-list it (WIN-013, #1310; folds #148).

- **setup-windows.ps1**: `$ScriptsDir = "$DotfilesDest\scripts"` (the Linux shape, ADR-025, the direction `dotf harness mirror` took in #1305); every run removes, idempotently, the seven scripts retired by earlier tickets — measured still present in `~\scripts` on the work box on 2026-08-27 — from both locations, plus the legacy copies of the five it deploys. The legacy directory and its User PATH entry stay (the 2048-char hazard #148 named).
- **env-contract.json**: `required_path_entries.windows[0]` names the same directory.
- **Gate**: the WIN-013 row goes in the same change, which empties the list — and an empty list reached `Test-DoctorGate` as one `$null` pattern that read as STALE (a red gate on a fully healthy runner). Patterns are normalised, `Read-KnownFailures` returns a real array, a Pester case pins it (mutation-checked: dropping the normalisation fails it).
- **Guards**: the MEM-002 / CLI-019 / CLI-018 guards measured *mention* and tripped on the removal list; they now refute `Copy-Item`/invocation — the lesson-235 shape.

Spec: `specs/WIN-013-scripts-dir-contract/`. Evidence (Windows work box): bats env-contract + setup-windows + ci-windows-doctor-gate + profile-heal all ok; Pester doctor-gate 11/11; PSScriptAnalyzer 0 findings (same as main); parse clean; ASCII delta 0. `setup-windows.ps1` was not run from the branch on this box (the main session owns machine state) — the CI `test-windows` gate is the end-to-end evidence and should read `0 known runner-only FAIL(s)`; the real migration on the box runs after merge and is recorded on #1310.

Refs #1310 — closes when the spec archives after the pooled review.