### PR TITLE
ci(windows): the Pester step sees setup's PATH, and a declared copilot must resolve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,14 @@ jobs:
         run: |
           Install-Module Pester -MinimumVersion 5.5.0 -Force -Scope CurrentUser -SkipPublisherCheck
           Import-Module Pester -MinimumVersion 5.5.0
+          # A later step inherits the runner's original PATH plus GITHUB_PATH only;
+          # the winget Links dir and npm's prefix that setup added to the User
+          # PATH are invisible here, so every suite gated on an installed tool
+          # (copilot-native-skills) computed "absent" at discovery and skipped as
+          # green on every run (TEST-006, #1320). Same helper setup uses.
+          . ./scripts/utils.ps1
+          Sync-SessionPath
+          $env:DOTFILES_CI_EXPECT_COPILOT = '1'
           Invoke-Pester -Path tests -CI
 
       - name: Run PowerShell bats subset (Git Bash, pinned bats)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,8 +339,9 @@ jobs:
           # PATH are invisible here, so every suite gated on an installed tool
           # (copilot-native-skills) computed "absent" at discovery and skipped as
           # green on every run (TEST-006, #1320). Same helper setup uses.
-          . ./scripts/utils.ps1
-          Sync-SessionPath
+          # Computed in a child pwsh: dot-sourcing utils.ps1 into THIS process
+          # would carry its strict mode and helpers into every Pester suite.
+          $env:PATH = (pwsh -NoProfile -Command '. ./scripts/utils.ps1; Sync-SessionPath; $env:PATH')
           $env:DOTFILES_CI_EXPECT_COPILOT = '1'
           Invoke-Pester -Path tests -CI
 

--- a/tests/ci-windows-doctor-gate.bats
+++ b/tests/ci-windows-doctor-gate.bats
@@ -48,3 +48,13 @@ test_windows_job() {
     awk 'BEGIN{ok=1} /^[[:space:]]*$/{seen=0; next} /^#/{ if ($0 ~ /#[0-9]+/) seen=1; next } { if (!seen) { print "no ticket before: " $0; ok=0 } seen=0 } END{exit !ok}' \
         "$DOTFILES_DIR/.github/scripts/doctor-gate-known-failures.txt"
 }
+
+@test "test-windows refreshes PATH and declares copilot before Invoke-Pester (TEST-006)" {
+    # The Pester step inherits the runner's original PATH; without the refresh
+    # every tool-gated suite skipped as green. The declaration turns an absent
+    # copilot on the runner into a FAIL inside the suite.
+    grep -B12 'Invoke-Pester -Path tests -CI' "$CI_YML" | grep -qF '. ./scripts/utils.ps1'
+    grep -B12 'Invoke-Pester -Path tests -CI' "$CI_YML" | grep -qF 'Sync-SessionPath'
+    grep -B12 'Invoke-Pester -Path tests -CI' "$CI_YML" | grep -qF "DOTFILES_CI_EXPECT_COPILOT = '1'"
+    grep -qF 'DOTFILES_CI_EXPECT_COPILOT' "$BATS_TEST_DIRNAME/copilot-native-skills.Tests.ps1"
+}

--- a/tests/ci-windows-doctor-gate.bats
+++ b/tests/ci-windows-doctor-gate.bats
@@ -53,7 +53,7 @@ test_windows_job() {
     # The Pester step inherits the runner's original PATH; without the refresh
     # every tool-gated suite skipped as green. The declaration turns an absent
     # copilot on the runner into a FAIL inside the suite.
-    grep -B12 'Invoke-Pester -Path tests -CI' "$CI_YML" | grep -qF '. ./scripts/utils.ps1'
+    grep -B12 'Invoke-Pester -Path tests -CI' "$CI_YML" | grep -qF "pwsh -NoProfile -Command '. ./scripts/utils.ps1; Sync-SessionPath; \$env:PATH'"
     grep -B12 'Invoke-Pester -Path tests -CI' "$CI_YML" | grep -qF 'Sync-SessionPath'
     grep -B12 'Invoke-Pester -Path tests -CI' "$CI_YML" | grep -qF "DOTFILES_CI_EXPECT_COPILOT = '1'"
     grep -qF 'DOTFILES_CI_EXPECT_COPILOT' "$BATS_TEST_DIRNAME/copilot-native-skills.Tests.ps1"

--- a/tests/copilot-native-skills.Tests.ps1
+++ b/tests/copilot-native-skills.Tests.ps1
@@ -10,6 +10,19 @@
 # time, not in BeforeAll (WIN-004 lesson).
 
 $script:hasCopilot = [bool](Get-Command copilot -ErrorAction SilentlyContinue)
+# On the runner setup installs copilot and the CI step declares it expects it
+# (DOTFILES_CI_EXPECT_COPILOT=1): an absent binary there is a broken PATH or a
+# broken install, not a machine without Copilot, and it must fail loudly. The
+# skip stayed green on every CI run for months (TEST-006, #1320).
+$script:expectCopilot = $env:DOTFILES_CI_EXPECT_COPILOT -eq '1'
+
+Describe 'copilot presence on a runner that declared it' -Skip:(-not $script:expectCopilot) {
+    It 'copilot resolves on PATH when DOTFILES_CI_EXPECT_COPILOT=1' {
+        # Re-probed at run time: Pester 5 does not carry discovery-time script
+        # variables into the Run phase.
+        [bool](Get-Command copilot -ErrorAction SilentlyContinue) | Should -BeTrue -Because 'setup installed copilot and the Pester step refreshed PATH; a skip here would pass a broken injector as green'
+    }
+}
 
 Describe 'copilot native skills (Deploy-SkillRecord end to end)' -Skip:(-not $script:hasCopilot) {
 


### PR DESCRIPTION
The Pester step inherited the runner's original PATH plus `GITHUB_PATH` only; the winget Links dir and npm's prefix that setup added to the User PATH were invisible there, so `tests/copilot-native-skills.Tests.ps1` computed "copilot absent" at discovery and **skipped as green on every CI run** (run 33133162223: `Skipped: 1` right after setup logged the CLI as detected). The one end-to-end test of the Windows skill injector — the one that wrote CRLF for months unobserved — never executed (TEST-006, #1320).

- `ci.yml` Pester step: `. ./scripts/utils.ps1; Sync-SessionPath` (the helper setup itself uses since #1308) and `DOTFILES_CI_EXPECT_COPILOT=1`.
- The suite: under that declaration an absent copilot is a FAIL, re-probed at run time (Pester 5 does not carry discovery-time script variables into the Run phase — the first cut of this test failed on the box for exactly that reason). Without the declaration a machine without Copilot still skips.
- Guard: `tests/ci-windows-doctor-gate.bats` asserts the refresh and the declaration sit before `Invoke-Pester`, and the suite reads the variable.

Evidence (Windows work box): copilot present + declared → 2/2 pass (the injector test really runs); declared + PATH emptied → the presence test FAILs; undeclared + PATH emptied → 2 skipped, as on a box without Copilot. `bats tests/ci-windows-doctor-gate.bats` ok. The CI run of this PR is the proof that counts: the suite must report the injector test as passed, not skipped.

Closes #1320.

## SDD skip rationale
CI step + test gating, under 20 production lines; no contract change.