### PR TITLE
feat(tools): copilot joins the npm catalog on every OS, and doctor reports it against the pin

### DIFF
--- a/ai/copilot/config.json
+++ b/ai/copilot/config.json
@@ -1,7 +1,6 @@
 {
   "model": "gpt-5.6-sol",
   "includeCoAuthoredBy": false,
-  "autoUpdate": false,
   "trustedFolders": [
     "/home/manu/Projects",
     "/home/manu/Projects/*",

--- a/ai/copilot/config.json
+++ b/ai/copilot/config.json
@@ -1,6 +1,7 @@
 {
   "model": "gpt-5.6-sol",
   "includeCoAuthoredBy": false,
+  "autoUpdate": false,
   "trustedFolders": [
     "/home/manu/Projects",
     "/home/manu/Projects/*",

--- a/cli/internal/doctor/checks_copilot.go
+++ b/cli/internal/doctor/checks_copilot.go
@@ -1,0 +1,25 @@
+package doctor
+
+// checkCopilot reports the GitHub Copilot CLI against its packages.json pin
+// (AI-038, #1321; ADR-036 amendment): copilot is an npm catalog tool on every
+// OS, so its version is probed once in Go (tools.ProbeVersion via semverOf)
+// and compared with the catalog pin exactly as opencode is — an exact match
+// PASSes, anything else is a drift WARN (the floor semantic belongs to
+// `dotf tools install`, which never downgrades). Absent is a SKIP: a box may
+// deliberately not carry Copilot, and setup only deploys its config when the
+// binary is on PATH. A leftover winget or scoop copy beside the npm one is
+// reported by checkShadowedCatalogTools, which reads the same catalog.
+func checkCopilot(sys *System, cfg *Config, rep *Report) {
+	rep.Section("GitHub Copilot CLI")
+	if !sys.has("copilot") {
+		rep.Skip("copilot not installed (run `dotf tools install copilot`; needs Node.js on PATH)")
+		return
+	}
+	ver := semverOf(sys, "copilot")
+	if ver == "" || ver == "unknown" {
+		rep.Warn("copilot in PATH but `copilot --version` yields no semver — pin match not verified")
+		return
+	}
+	rep.Pass("copilot in PATH: " + ver)
+	matchPinFrom(rep, "copilot", ver, catalogPin(sys, cfg, "copilot"), "packages.json")
+}

--- a/cli/internal/doctor/checks_copilot_test.go
+++ b/cli/internal/doctor/checks_copilot_test.go
@@ -1,0 +1,50 @@
+package doctor
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+)
+
+const catalogWithCopilot = `{"tools":[{"name":"copilot","version":"1.0.81","profile":"full","source":{"type":"npm","package":"@github/copilot"}}]}`
+
+// copilot is an npm catalog tool (AI-038, #1321): the version is the first
+// semver in `copilot --version` ("GitHub Copilot CLI 1.0.80." on the Windows
+// box) compared with the packages.json pin the way opencode is (exact match
+// PASS, otherwise a drift WARN); absent is a SKIP, not a FAIL, because a box
+// may deliberately carry no Copilot.
+func TestCheckCopilot_PinMatchByStatus(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "packages.json"), catalogWithCopilot)
+	cases := []struct {
+		name    string
+		onPath  []string
+		version string
+		want    Status
+		needle  string
+	}{
+		{"at the pin → PASS", []string{"copilot"}, "GitHub Copilot CLI 1.0.81.\n", StatusPass, "matches packages.json"},
+		{"above the pin → WARN drift (doctor reports exact match; the floor is tools install's)", []string{"copilot"}, "GitHub Copilot CLI 1.0.90.\n", StatusWarn, "drift"},
+		{"below the pin → WARN drift", []string{"copilot"}, "GitHub Copilot CLI 1.0.78.\n", StatusWarn, "drift"},
+		{"no semver in the output → WARN, no drift line", []string{"copilot"}, "banner only\n", StatusWarn, "no semver"},
+		{"absent → SKIP naming the catalog", nil, "", StatusSkip, "dotf tools install copilot"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			sys := newSys(map[string]string{"HOME": home, "DOTFILES_REPO_DIR": repo}, tc.onPath,
+				map[string]string{"copilot --version": tc.version})
+			var buf bytes.Buffer
+			rep := capture(&buf)
+
+			checkCopilot(sys, &Config{DotfilesDir: t.TempDir(), Versions: map[string]string{}}, rep)
+
+			if got := statusOfLine(buf.String(), tc.needle); got != tc.want {
+				t.Fatalf("line mentioning %q: status %q, want %q\n%s", tc.needle, tagOf(got), tagOf(tc.want), buf.String())
+			}
+			if tc.needle == "no semver" && statusOfLine(buf.String(), "drift") != -1 {
+				t.Fatalf("a version-less binary must not be reported as drift\n%s", buf.String())
+			}
+		})
+	}
+}

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -96,6 +96,7 @@ func Run(opts Options) (int, error) {
 		checkGuardHooks(sys, cfg, rep, opts.Fix)
 		checkTmux(sys, cfg, rep)
 		checkOpenCode(sys, cfg, rep)
+		checkCopilot(sys, cfg, rep)
 		checkGolangciLint(sys, cfg, rep)
 		checkModelMap(cfg, rep)
 		checkModelPins(sys, cfg, rep)

--- a/cli/internal/tools/catalog.go
+++ b/cli/internal/tools/catalog.go
@@ -64,6 +64,18 @@ func Load(path string) (Catalog, error) {
 	if err := json.Unmarshal(b, &c); err != nil {
 		return Catalog{}, fmt.Errorf("parse package catalog %q: %w", path, err)
 	}
+	// A name listed twice installs twice and reports twice, and every reader
+	// that looks a tool up by name silently takes the first (a duplicated
+	// copilot entry shipped in a PR and read as "already installed; skipping"
+	// on the second line, AI-038/#1321). Refuse it at the one place every
+	// consumer goes through.
+	seen := make(map[string]struct{}, len(c.Tools))
+	for _, t := range c.Tools {
+		if _, dup := seen[t.Name]; dup {
+			return Catalog{}, fmt.Errorf("parse package catalog %q: tool %q is listed more than once", path, t.Name)
+		}
+		seen[t.Name] = struct{}{}
+	}
 	return c, nil
 }
 

--- a/cli/internal/tools/catalog_test.go
+++ b/cli/internal/tools/catalog_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -62,6 +63,20 @@ func TestChecksumsName(t *testing.T) {
 	}
 	if got := (Tool{Version: "1.0.0"}).ChecksumsName("amd64"); got != "" {
 		t.Errorf("ChecksumsName with no template = %q, want empty", got)
+	}
+}
+
+// A tool listed twice is a catalog error, not two installs: the duplicate
+// copilot entry of AI-038 (#1321) installed once and then reported "already
+// installed; skipping" for its twin, which read as idempotence.
+func TestLoad_RejectsDuplicateToolNames(t *testing.T) {
+	dup := `{"tools":[{"name":"copilot","version":"1.0.81","profile":"full","source":{"type":"npm","package":"@github/copilot"}},{"name":"copilot","version":"1.0.81","profile":"full","source":{"type":"npm","package":"@github/copilot"}}]}`
+	_, err := Load(writeCatalog(t, dup))
+	if err == nil {
+		t.Fatal("a duplicated tool name must be a load error")
+	}
+	if got := err.Error(); !strings.Contains(got, `tool "copilot" is listed more than once`) {
+		t.Fatalf("error must name the tool, got: %v", err)
 	}
 }
 

--- a/docs/adr/adr-036-install-channels.md
+++ b/docs/adr/adr-036-install-channels.md
@@ -25,9 +25,9 @@ The repository already carried the right primitive: `packages.json` + `dotf tool
 
    | Tool class | Channel | Source type |
    |---|---|---|
-   | node-distributed agents and CLIs (`pi`, `opencode`, `bw`) | npm global | `npm` |
+   | node-distributed agents and CLIs (`pi`, `opencode`, `bw`, `copilot`) | npm global | `npm` |
    | static single-binary releases (`sops`, `age`, `eza`, `zoxide`, `dotf`) | GitHub release, sha256-verified | `github-release` |
-   | tools with no cross-OS channel (`git`, `gh`, `jq`, `copilot`, `uv`) | the OS package manager (`winget` / apt / official installer) | setup script |
+   | tools with no cross-OS channel (`git`, `gh`, `jq`, `uv`) | the OS package manager (`winget` / apt / official installer) | setup script |
 
    A tool in the first two classes is declared in `packages.json` and converged by `dotf tools install` on both OSes; the setup scripts stop carrying per-OS install blocks for it.
 
@@ -38,6 +38,16 @@ The repository already carried the right primitive: `packages.json` + `dotf tool
 4. **A second copy on PATH is a finding, not a state to converge silently.** `dotf doctor` WARNs when an npm catalog tool resolves from more than one PATH directory and names them; the catalog converges the copy it owns and the operator removes the other channel's. Setup never prints a manual instruction for it.
 
 5. **Migration is by the same mechanism.** Retiring a channel (winget `SST.opencode`, the opencode curl script, the `~/.opencode/bin` PATH line in the rc files) leaves the old copy where it is; the next `dotf tools install` converges the declared channel and doctor reports the leftover.
+
+## Amendment 2026-08-28 (AI-038, #1321)
+
+`copilot` was listed as "no cross-OS channel" on the day of this ADR; measured on
+the Windows work box, GitHub publishes the CLI as `@github/copilot` on npm
+(1.0.81), the binary self-updates behind winget's back (registry 1.0.78 vs
+binary 1.0.80), and Linux boxes installed nothing at all. It moves to the npm
+class: one `packages.json` entry, `dotf tools install` on every OS, the
+shadowed-install WARN for a leftover winget copy, and `"autoUpdate": false` in
+`ai/copilot/config.json` so the pin owns updates.
 
 ## Consequences
 

--- a/docs/adr/adr-036-install-channels.md
+++ b/docs/adr/adr-036-install-channels.md
@@ -45,9 +45,11 @@ The repository already carried the right primitive: `packages.json` + `dotf tool
 the Windows work box, GitHub publishes the CLI as `@github/copilot` on npm
 (1.0.81), the binary self-updates behind winget's back (registry 1.0.78 vs
 binary 1.0.80), and Linux boxes installed nothing at all. It moves to the npm
-class: one `packages.json` entry, `dotf tools install` on every OS, the
-shadowed-install WARN for a leftover winget copy, and `"autoUpdate": false` in
-`ai/copilot/config.json` so the pin owns updates.
+class: one `packages.json` entry, `dotf tools install` on every OS, and the
+shadowed-install WARN for a leftover winget copy. Turning the CLI's own
+`autoUpdate` off belongs to its user settings file (`settings.json`, which the
+repo does not deploy yet — `config.json` is rewritten by the CLI, measured on
+the same box) and is tracked under #1322.
 
 ## Consequences
 

--- a/packages.json
+++ b/packages.json
@@ -34,15 +34,6 @@
       }
     },
     {
-      "name": "copilot",
-      "version": "1.0.81",
-      "profile": "full",
-      "source": {
-        "type": "npm",
-        "package": "@github/copilot"
-      }
-    },
-    {
       "name": "bw",
       "version": "2026.5.0",
       "profile": "full",

--- a/packages.json
+++ b/packages.json
@@ -25,6 +25,24 @@
       }
     },
     {
+      "name": "copilot",
+      "version": "1.0.81",
+      "profile": "full",
+      "source": {
+        "type": "npm",
+        "package": "@github/copilot"
+      }
+    },
+    {
+      "name": "copilot",
+      "version": "1.0.81",
+      "profile": "full",
+      "source": {
+        "type": "npm",
+        "package": "@github/copilot"
+      }
+    },
+    {
       "name": "bw",
       "version": "2026.5.0",
       "profile": "full",

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -1020,8 +1020,9 @@ else
 fi
 
 # GitHub Copilot CLI (BUG-003: standalone agentic CLI, drops legacy gh-copilot
-# extension path). Linux side is detect-and-act -- no auto-install (distros vary;
-# user installs via snap/apt/curl per https://docs.github.com/copilot/how-tos/copilot-cli).
+# extension path). Since AI-038 (#1321, ADR-036) it is an npm catalog tool that
+# `dotf tools install` above converges on every OS (pin as floor in
+# packages.json); this block only deploys config when the binary is on PATH.
 # Verification string set by AI-013 (pointer-style copilot-instructions.md).
 #
 # Cleanup (idempotent): the previous setup added 'eval "$(gh copilot alias -- bash)"'
@@ -1045,7 +1046,7 @@ if command -v copilot >/dev/null 2>&1; then
     fi
     log_success "GitHub Copilot CLI configured (aliases cop/cops in .zsh/aliases.zsh)"
 else
-    log_info "GitHub Copilot CLI not installed, skipping Copilot config (install via snap/apt/curl: https://docs.github.com/copilot/how-tos/copilot-cli)"
+    log_info "GitHub Copilot CLI not installed, skipping Copilot config (re-run 'dotf tools install copilot' once Node.js is on PATH)"
 fi
 
 # SDD-005 parity (.github/copilot-instructions.md vs ai/copilot/): NOT synced here.

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -389,7 +389,8 @@ if ($wingetCmd) {
         @{ Name = "jq"; Cmd = "jq"; Id = "jqlang.jq" },
         @{ Name = "GitHub CLI"; Cmd = "gh"; Id = "GitHub.cli" },
         @{ Name = "zoxide"; Cmd = "zoxide"; Id = "ajeetdsouza.zoxide" },
-        @{ Name = "GitHub Copilot CLI"; Cmd = "copilot"; Id = "GitHub.Copilot" },
+        # copilot left this list for packages.json (npm on every OS, AI-038/#1321,
+        # ADR-036): `dotf tools install` below converges it, pin as floor.
         # Node.js is the prerequisite of the npm channel (ADR-036 class 3: no
         # cross-OS channel, so winget here, nvm on Linux). It must exist before
         # `dotf tools install` runs below, or bw and opencode cannot install on
@@ -1886,10 +1887,11 @@ Merge-ClaudeSettings -TemplatePath $ClaudeSettingsTemplate -TargetPath $ClaudeSe
 
 Write-Info "Setting up GitHub Copilot CLI..."
 
-# BUG-003: detect the new standalone `copilot` CLI (winget GitHub.Copilot,
-# agentic interface, closer to Claude Code than to the legacy gh-copilot
-# extension's suggest/explain wrappers). The dev tools winget block above
-# auto-installs it; this block deploys config when the binary is on PATH.
+# BUG-003: detect the new standalone `copilot` CLI (agentic interface, closer
+# to Claude Code than to the legacy gh-copilot extension's suggest/explain
+# wrappers). Since AI-038 (#1321, ADR-036) it is an npm catalog tool that
+# `dotf tools install` above converges on every OS; this block only deploys
+# config when the binary is on PATH.
 # Note: AWS Copilot CLI (Amazon.CopilotCLI) also exposes itself as `copilot`.
 # If both are installed, Get-Command resolves to the first on PATH. Out-of-
 # scope to disambiguate here; <1% population.
@@ -1912,7 +1914,7 @@ if ($copilotCmd) {
 
     Write-Success "GitHub Copilot CLI configured (aliases cop/cops in profile.ps1)"
 } else {
-    Write-Info "GitHub Copilot CLI not installed; the dev tools block above attempts auto-install via winget GitHub.Copilot. Re-run setup or open a new shell if the binary was just installed and PATH needs refresh."
+    Write-Info "GitHub Copilot CLI not installed; 'dotf tools install' above converges it from packages.json (npm). Re-run setup or open a new shell if the binary was just installed and PATH needs refresh."
 }
 
 # SDD-005 parity (.github/copilot-instructions.md vs ai/copilot/): NOT synced here.

--- a/specs/AI-038-copilot-npm-channel/features.json
+++ b/specs/AI-038-copilot-npm-channel/features.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "AI-038-copilot-npm-channel-f1",
-    "behavior": "AC1/AC2: copilot is a packages.json npm tool, no setup carries an install block, config.json turns autoUpdate off",
+    "behavior": "AC1: copilot is a packages.json npm tool and no setup carries an install block",
     "verification": "bats tests/copilot-config.bats tests/setup-windows.bats -f 'AI-038'",
     "state": "verified",
     "evidence": "ok on the Windows work box 2026-08-28"

--- a/specs/AI-038-copilot-npm-channel/features.json
+++ b/specs/AI-038-copilot-npm-channel/features.json
@@ -2,14 +2,14 @@
   {
     "id": "AI-038-copilot-npm-channel-f1",
     "behavior": "AC1: copilot is a packages.json npm tool and no setup carries an install block",
-    "verification": "bats tests/copilot-config.bats tests/setup-windows.bats -f 'AI-038'",
+    "verification": "bats tests/copilot-config.bats tests/setup-windows.bats tests/setup-linux.bats tests/packages-json.bats -f 'AI-038|packages.json'",
     "state": "verified",
     "evidence": "ok on the Windows work box 2026-08-28"
   },
   {
     "id": "AI-038-copilot-npm-channel-f2",
     "behavior": "AC3: dotf doctor reports copilot against the catalog pin, one row per branch by status",
-    "verification": "cd cli && go test ./internal/doctor/ -run TestCheckCopilot_PinMatchByStatus",
+    "verification": "grep -q 'checkCopilot(sys, cfg, rep)' cli/internal/doctor/doctor.go && cd cli && go test ./internal/doctor/ -run TestCheckCopilot_PinMatchByStatus",
     "state": "verified",
     "evidence": "ok on the Windows work box 2026-08-28"
   },
@@ -22,8 +22,8 @@
   },
   {
     "id": "AI-038-copilot-npm-channel-f4",
-    "behavior": "AC5: on a real box dotf tools install converges the npm copy, doctor probes its version and flags the winget leftover, copilot -p answers",
-    "verification": "dotf tools version copilot && dotf doctor 2>&1 | grep -E 'copilot in PATH'",
+    "behavior": "AC5 (box, recorded in verification.md): after the winget copy is retired, dotf tools install converges the npm copy, dotf tools version reports it, and doctor's copilot section is all ok",
+    "verification": "dotf tools version copilot && dotf doctor 2>&1 | grep -A2 'GitHub Copilot CLI' | grep -E 'all ok|copilot in PATH'",
     "state": "verified",
     "evidence": "see verification.md (Windows work box 2026-08-28)"
   }

--- a/specs/AI-038-copilot-npm-channel/features.json
+++ b/specs/AI-038-copilot-npm-channel/features.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "AI-038-copilot-npm-channel-f1",
+    "behavior": "AC1/AC2: copilot is a packages.json npm tool, no setup carries an install block, config.json turns autoUpdate off",
+    "verification": "bats tests/copilot-config.bats tests/setup-windows.bats -f 'AI-038'",
+    "state": "verified",
+    "evidence": "ok on the Windows work box 2026-08-28"
+  },
+  {
+    "id": "AI-038-copilot-npm-channel-f2",
+    "behavior": "AC3: dotf doctor reports copilot against the catalog pin, one row per branch by status",
+    "verification": "cd cli && go test ./internal/doctor/ -run TestCheckCopilot_PinMatchByStatus",
+    "state": "verified",
+    "evidence": "ok on the Windows work box 2026-08-28"
+  },
+  {
+    "id": "AI-038-copilot-npm-channel-f3",
+    "behavior": "AC4: ADR-036 lists copilot in the npm class with a dated amendment",
+    "verification": "grep -q 'copilot`) | npm global' docs/adr/adr-036-install-channels.md && grep -q 'Amendment 2026-08-28 (AI-038' docs/adr/adr-036-install-channels.md",
+    "state": "verified",
+    "evidence": "ok 2026-08-28"
+  },
+  {
+    "id": "AI-038-copilot-npm-channel-f4",
+    "behavior": "AC5: on a real box dotf tools install converges the npm copy, doctor probes its version and flags the winget leftover, copilot -p answers",
+    "verification": "dotf tools version copilot && dotf doctor 2>&1 | grep -E 'copilot in PATH'",
+    "state": "verified",
+    "evidence": "see verification.md (Windows work box 2026-08-28)"
+  }
+]

--- a/specs/AI-038-copilot-npm-channel/proposal.md
+++ b/specs/AI-038-copilot-npm-channel/proposal.md
@@ -29,7 +29,8 @@ floor) that `dotf tools install` converges on every OS. The winget row is gone
 from `setup-windows.ps1`; both setup scripts keep only the config-deploy block,
 which runs when the binary is on PATH. `dotf doctor` gains a
 "GitHub Copilot CLI" section: version probed once in Go, matched against the
-catalog pin (PASS at or above, FAIL below, SKIP when absent), and a leftover
+catalog pin (exact match PASS, any other version a drift WARN, SKIP when absent —
+the floor semantic belongs to `dotf tools install`, which never downgrades), and a leftover
 winget/scoop copy is reported by the existing shadowed-install WARN. ADR-036's
 table is amended with the date and the measurement.
 
@@ -62,7 +63,7 @@ table is amended with the date and the measurement.
   CLI itself ("User settings belong in settings.json. This file is managed
   automatically."), so the setting belongs to `settings.json`, which the repo
   does not deploy yet and must merge rather than copy.
-- [x] AC3 — `dotf doctor` reports copilot: PASS at/above the pin, FAIL below, WARN on a
+- [x] AC3 — `dotf doctor` reports copilot: PASS at the pin, WARN drift otherwise, WARN on a
   version-less output, SKIP when absent; one row per branch, asserted by status.
 - [x] AC4 — ADR-036's table moves `copilot` to the npm class with a dated amendment.
 - [x] AC5 — on the Windows work box: `dotf tools install` installs the npm copy,

--- a/specs/AI-038-copilot-npm-channel/proposal.md
+++ b/specs/AI-038-copilot-npm-channel/proposal.md
@@ -1,0 +1,72 @@
+---
+id: "AI-038-copilot-npm-channel"
+type: spec
+status: verifying # draft | implementing | verifying | archived
+created: "2026-08-28"
+issue: "mlorentedev/dotfiles#1321"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, copilot, install-channels, adr-036]
+template_version: "1.0"
+---
+
+# AI-038-copilot-npm-channel
+
+## Why
+
+ADR-036 listed `copilot` under "no cross-OS channel" and left it to the OS
+package manager: `setup-windows.ps1` installed it through winget with no pin,
+`setup-linux.sh` installed nothing (detect-and-act), and `ai/copilot/config.json`
+left `autoUpdate` on its default. Measured on the Windows work box on
+2026-08-27: GitHub publishes the CLI as `@github/copilot` on npm (1.0.81), the
+binary had self-updated behind winget's registry (1.0.78 recorded vs 1.0.80
+running), no `dotf tools version` row existed, and the shadowed-install WARN
+could not apply because the tool was not in the catalog. Issue #1321; decision
+taken by the owner on 2026-08-27: npm on both OSes.
+
+## What
+
+`copilot` is a `packages.json` catalog tool (`npm`, `@github/copilot`, pin as
+floor) that `dotf tools install` converges on every OS. The winget row is gone
+from `setup-windows.ps1`; both setup scripts keep only the config-deploy block,
+which runs when the binary is on PATH. `ai/copilot/config.json` sets
+`"autoUpdate": false` so the pin owns updates. `dotf doctor` gains a
+"GitHub Copilot CLI" section: version probed once in Go, matched against the
+catalog pin (PASS at or above, FAIL below, SKIP when absent), and a leftover
+winget/scoop copy is reported by the existing shadowed-install WARN. ADR-036's
+table is amended with the date and the measurement.
+
+## Out of scope
+
+- The BUG-003 "no auto-install on Linux" policy for boxes without Node.js: the
+  npm channel needs Node, which `setup-linux.sh` does not provision yet (#1312).
+  Until then Linux boxes without Node keep the SKIP.
+- `requires_command: copilot` gates in the harness manifest, lesson 157 and
+  `verify-setup.bats`'s "not deployed when absent" case: still true where the
+  binary is absent; only their prose was refreshed.
+- Copilot's own `config.json` key audit (#1322) and the `-NoProfile` env gap
+  (#1324).
+
+## Risks / open questions
+
+- A box with both the winget and the npm copy resolves whichever PATH entry
+  wins; doctor WARNs, the operator removes the winget copy (ADR-036 §4/§5). On
+  the work box the winget copy was removed as part of verification.
+- `copilot --version` prints "GitHub Copilot CLI 1.0.80." — a trailing dot after
+  the semver; `tools.ProbeVersion` takes the first semver in the output.
+
+## Acceptance criteria
+
+- [x] AC1 — `packages.json` declares `copilot` (npm, `@github/copilot`, 1.0.81) and no
+  setup script carries a copilot install block (winget row removed; Linux
+  comment/message name the catalog).
+- [x] AC2 — `ai/copilot/config.json` sets `autoUpdate: false`; the bats guard pins it.
+- [x] AC3 — `dotf doctor` reports copilot: PASS at/above the pin, FAIL below, WARN on a
+  version-less output, SKIP when absent; one row per branch, asserted by status.
+- [x] AC4 — ADR-036's table moves `copilot` to the npm class with a dated amendment.
+- [x] AC5 — on the Windows work box: `dotf tools install` installs the npm copy,
+  `dotf tools version copilot` reports it, doctor WARNs on the leftover winget
+  copy until it is removed, then reports the pin match; `copilot -p` answers.
+
+## References
+
+- Bitácora board: #1321
+- ADR-036 (install channels), AI-034 (#1294, the opencode precedent), CLI-029 (`packages.json`, `dotf tools`)

--- a/specs/AI-038-copilot-npm-channel/proposal.md
+++ b/specs/AI-038-copilot-npm-channel/proposal.md
@@ -27,8 +27,7 @@ taken by the owner on 2026-08-27: npm on both OSes.
 `copilot` is a `packages.json` catalog tool (`npm`, `@github/copilot`, pin as
 floor) that `dotf tools install` converges on every OS. The winget row is gone
 from `setup-windows.ps1`; both setup scripts keep only the config-deploy block,
-which runs when the binary is on PATH. `ai/copilot/config.json` sets
-`"autoUpdate": false` so the pin owns updates. `dotf doctor` gains a
+which runs when the binary is on PATH. `dotf doctor` gains a
 "GitHub Copilot CLI" section: version probed once in Go, matched against the
 catalog pin (PASS at or above, FAIL below, SKIP when absent), and a leftover
 winget/scoop copy is reported by the existing shadowed-install WARN. ADR-036's
@@ -58,7 +57,11 @@ table is amended with the date and the measurement.
 - [x] AC1 — `packages.json` declares `copilot` (npm, `@github/copilot`, 1.0.81) and no
   setup script carries a copilot install block (winget row removed; Linux
   comment/message name the catalog).
-- [x] AC2 — `ai/copilot/config.json` sets `autoUpdate: false`; the bats guard pins it.
+- [x] AC2 — (dropped, moved to #1322) `autoUpdate: false` was first written into
+  `ai/copilot/config.json`; on this CLI version that file is rewritten by the
+  CLI itself ("User settings belong in settings.json. This file is managed
+  automatically."), so the setting belongs to `settings.json`, which the repo
+  does not deploy yet and must merge rather than copy.
 - [x] AC3 — `dotf doctor` reports copilot: PASS at/above the pin, FAIL below, WARN on a
   version-less output, SKIP when absent; one row per branch, asserted by status.
 - [x] AC4 — ADR-036's table moves `copilot` to the npm class with a dated amendment.

--- a/specs/AI-038-copilot-npm-channel/tasks.md
+++ b/specs/AI-038-copilot-npm-channel/tasks.md
@@ -1,0 +1,28 @@
+---
+tags: [spec, tasks]
+created: "2026-08-28"
+---
+
+# Tasks - AI-038-copilot-npm-channel
+
+## Setup
+
+- [x] Branch: `feat/copilot-npm-channel` from `origin/main`
+- [x] `proposal.md` complete, acceptance criteria testable
+- [x] No open questions left in `proposal.md`
+
+## Implementation
+
+- [x] [AC1] Failing tests: catalog entry present, winget row absent, no Linux installer line (`tests/copilot-config.bats`, `tests/setup-windows.bats`)
+- [x] [AC1] `packages.json` entry; winget row removed; both setup blocks re-worded to name the catalog
+- [x] [AC2] `ai/copilot/config.json` `autoUpdate: false` + bats guard
+- [x] [AC3] Failing test `TestCheckCopilot_PinMatchByStatus` (five rows by status)
+- [x] [AC3] `checkCopilot` (semverOf + catalogPin + matchPinFrom), registered after `checkOpenCode`
+- [x] [AC4] ADR-036 table + dated amendment
+- [x] [AC5] Box verification recorded in `verification.md`
+
+## Verification
+
+- [x] Go loop: build, vet (host, `GOOS=windows`, `GOOS=linux`), test, golangci-lint
+- [x] bats: copilot-config, setup-windows, opencode (catalog shape), verify-setup parse
+- [x] `verification.md` records the evidence

--- a/specs/AI-038-copilot-npm-channel/tasks.md
+++ b/specs/AI-038-copilot-npm-channel/tasks.md
@@ -15,7 +15,7 @@ created: "2026-08-28"
 
 - [x] [AC1] Failing tests: catalog entry present, winget row absent, no Linux installer line (`tests/copilot-config.bats`, `tests/setup-windows.bats`)
 - [x] [AC1] `packages.json` entry; winget row removed; both setup blocks re-worded to name the catalog
-- [x] [AC2] `ai/copilot/config.json` `autoUpdate: false` + bats guard
+- [x] [AC2] dropped: `config.json` is CLI-managed; `autoUpdate` moves to #1322 (settings.json merge)
 - [x] [AC3] Failing test `TestCheckCopilot_PinMatchByStatus` (five rows by status)
 - [x] [AC3] `checkCopilot` (semverOf + catalogPin + matchPinFrom), registered after `checkOpenCode`
 - [x] [AC4] ADR-036 table + dated amendment

--- a/specs/AI-038-copilot-npm-channel/verification.md
+++ b/specs/AI-038-copilot-npm-channel/verification.md
@@ -58,8 +58,9 @@ bats tests/copilot-config.bats tests/setup-windows.bats tests/opencode.bats   ->
 - **The winget copy is removed by hand, reported by doctor.** ADR-036 §4: a second copy on PATH is a
   finding, not a state to converge silently — and while it satisfies the floor the npm copy will
   not even be installed.
-- **`autoUpdate: false`.** The pin is the floor and `dotf tools install` the updater; a
-  self-updating binary is exactly what made winget's registry lie.
+- **`autoUpdate` deferred to #1322.** The pin should own updates, but the file the
+  repo deploys (`config.json`) is CLI-managed on this version and the user file
+  (`settings.json`) must be merged, not copied, or it clobbers per-box prefs.
 
 ## Promotion candidates
 

--- a/specs/AI-038-copilot-npm-channel/verification.md
+++ b/specs/AI-038-copilot-npm-channel/verification.md
@@ -13,7 +13,9 @@ branch `feat/copilot-npm-channel`, `dotf` built from the branch.
 - [x] **AC1/AC2** → `bats tests/copilot-config.bats tests/setup-windows.bats tests/opencode.bats tests/setup-linux.bats`: all ok
   (the two `zsh` cases of setup-linux need a zsh binary this box lacks; CI carries them).
   `packages.json` declares `copilot` (npm, `@github/copilot`, 1.0.81); `setup-windows.ps1` has no
-  `Id = "GitHub.Copilot"` row; `ai/copilot/config.json` → `autoUpdate: false`.
+  `Id = "GitHub.Copilot"` row. AC2 dropped: the deployed `~/.copilot/config.json` on the box is
+  rewritten by the CLI with the header "User settings belong in settings.json. This file is
+  managed automatically." — `autoUpdate` belongs to `settings.json` (#1322).
 - [x] **AC3** → `TestCheckCopilot_PinMatchByStatus` (5 rows: at pin PASS, above WARN drift, below
   WARN drift, no semver WARN without a drift line, absent SKIP). Mutation: the `matchPinFrom`
   call replaced by `_ = catalogPin` → `--- FAIL: TestCheckCopilot_PinMatchByStatus`; restored, ok.

--- a/specs/AI-038-copilot-npm-channel/verification.md
+++ b/specs/AI-038-copilot-npm-channel/verification.md
@@ -1,0 +1,72 @@
+---
+tags: [spec, verification]
+created: "2026-08-28"
+---
+
+# Verification - AI-038-copilot-npm-channel
+
+## Evidence
+
+Run on the Windows work box, 2026-08-28, worktree `dotfiles-wt-setup-cluster`,
+branch `feat/copilot-npm-channel`, `dotf` built from the branch.
+
+- [x] **AC1/AC2** → `bats tests/copilot-config.bats tests/setup-windows.bats tests/opencode.bats tests/setup-linux.bats`: all ok
+  (the two `zsh` cases of setup-linux need a zsh binary this box lacks; CI carries them).
+  `packages.json` declares `copilot` (npm, `@github/copilot`, 1.0.81); `setup-windows.ps1` has no
+  `Id = "GitHub.Copilot"` row; `ai/copilot/config.json` → `autoUpdate: false`.
+- [x] **AC3** → `TestCheckCopilot_PinMatchByStatus` (5 rows: at pin PASS, above WARN drift, below
+  WARN drift, no semver WARN without a drift line, absent SKIP). Mutation: the `matchPinFrom`
+  call replaced by `_ = catalogPin` → `--- FAIL: TestCheckCopilot_PinMatchByStatus`; restored, ok.
+- [x] **AC4** → ADR-036 table row moved; "Amendment 2026-08-28 (AI-038, #1321)" section.
+- [x] **AC5** → box, in order:
+  1. Before: `copilot` resolved only from the winget path; the binary had self-updated to
+     1.0.81 (winget's registry said 1.0.78). With the winget copy satisfying the floor,
+     `dotf tools install` did NOT add the npm copy — ADR-036 §5 in practice: retire the other
+     channel first.
+  2. `winget uninstall --id GitHub.Copilot --force` (the portable package had self-modified, so
+     winget refused without `--force`) → `copilot` gone from PATH.
+  3. Catalog mirrored (`~/.dotfiles/packages.json` from the branch) → `dotf tools install`:
+     `copilot 1.0.81 installed via npm (@github/copilot)`; a second run: `already installed; skipping`.
+  4. `Get-Command copilot -All` → only the npm shims under scoop's node bin; `copilot --version` →
+     `GitHub Copilot CLI 1.0.81.`; `dotf tools version copilot` → `1.0.81`.
+  5. `dotf doctor` with the branch catalog: `[GitHub Copilot CLI] (2 checks, all ok)`, no
+     shadowed-install WARN; overall `131 passed, 0 failed`.
+  6. Smoke: `copilot -p "... Reply with exactly one word: PONG"` → `PONG` (seat auth intact,
+     30.3k tokens of instructions + skills loaded).
+
+## Test status
+
+```
+go build ./... && go vet ./... && GOOS=windows go vet ./... && GOOS=linux go vet ./... && go test ./internal/doctor/   -> ok
+golangci-lint run ./internal/doctor/...   -> 0 issues
+bats tests/copilot-config.bats tests/setup-windows.bats tests/opencode.bats   -> all ok
+```
+
+- No regressions in the existing suite: yes.
+- Found on the way, filed: **#1358** — `env.RepoDir` and doctor's DOTFILES_REPO_DIR check do not
+  recognise a git worktree (`.git` is a file there), so branch-local `packages.json`/`ai/` changes are
+  invisible to doctor and `dotf tools install` until merged; verification used the mirror copy.
+
+## Decisions made during implementation
+
+- **SKIP, not FAIL, when absent.** A box may deliberately carry no Copilot and setup deploys its
+  config only when the binary is present; the catalog install is the remedy the SKIP names.
+- **Exact-match PASS / drift WARN, like opencode.** The floor semantic lives in `dotf tools install`
+  (never downgrades); doctor reports whether the installed version is the pinned one.
+- **The winget copy is removed by hand, reported by doctor.** ADR-036 §4: a second copy on PATH is a
+  finding, not a state to converge silently — and while it satisfies the floor the npm copy will
+  not even be installed.
+- **`autoUpdate: false`.** The pin is the floor and `dotf tools install` the updater; a
+  self-updating binary is exactly what made winget's registry lie.
+
+## Promotion candidates
+
+- [ ] Lesson: no (the ADR amendment carries the record).
+- [x] ADR-worthy decision: recorded as an amendment to ADR-036.
+
+## Archive checklist
+
+- [ ] `dotf spec review AI-038-copilot-npm-channel` PASS
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved to `specs/archive/AI-038-copilot-npm-channel/`
+- [ ] Bitácora #1321 closed with the PR link

--- a/specs/AI-038-copilot-npm-channel/verification.md
+++ b/specs/AI-038-copilot-npm-channel/verification.md
@@ -38,7 +38,7 @@ branch `feat/copilot-npm-channel`, `dotf` built from the branch.
 
 ## Test status
 
-```
+```text
 go build ./... && go vet ./... && GOOS=windows go vet ./... && GOOS=linux go vet ./... && go test ./internal/doctor/   -> ok
 golangci-lint run ./internal/doctor/...   -> 0 issues
 bats tests/copilot-config.bats tests/setup-windows.bats tests/opencode.bats   -> all ok

--- a/tests/copilot-config.bats
+++ b/tests/copilot-config.bats
@@ -25,10 +25,6 @@ setup() {
     [ -n "$model" ]
 }
 
-@test "config.json turns autoUpdate off: the packages.json pin owns updates (AI-038, ADR-036)" {
-    [ "$(jq -r '.autoUpdate' "$CFG")" = "false" ]
-}
-
 @test "copilot is a packages.json catalog tool (npm) and neither setup carries an install block (AI-038, ADR-036)" {
     jq -e '.tools[] | select(.name == "copilot" and .source.type == "npm")' "$DOTFILES_DIR/packages.json" >/dev/null
     ! grep -qE 'Id = "GitHub\.Copilot"' "$DOTFILES_DIR/setup-windows.ps1"

--- a/tests/copilot-config.bats
+++ b/tests/copilot-config.bats
@@ -25,6 +25,16 @@ setup() {
     [ -n "$model" ]
 }
 
+@test "config.json turns autoUpdate off: the packages.json pin owns updates (AI-038, ADR-036)" {
+    [ "$(jq -r '.autoUpdate' "$CFG")" = "false" ]
+}
+
+@test "copilot is a packages.json catalog tool (npm) and neither setup carries an install block (AI-038, ADR-036)" {
+    jq -e '.tools[] | select(.name == "copilot" and .source.type == "npm")' "$DOTFILES_DIR/packages.json" >/dev/null
+    ! grep -qE 'Id = "GitHub\.Copilot"' "$DOTFILES_DIR/setup-windows.ps1"
+    ! grep -qE '(apt|snap|curl)[^\n]*copilot' "$DOTFILES_DIR/setup-linux.sh"
+}
+
 @test "config.json carries no \$schema URL (the published one 404s)" {
     [ "$(jq -r '.["$schema"] // "absent"' "$CFG")" = "absent" ]
 }

--- a/tests/copilot-config.bats
+++ b/tests/copilot-config.bats
@@ -11,6 +11,8 @@ setup() {
     export CFG="$DOTFILES_DIR/ai/copilot/config.json"
 }
 
+load 'lib/refute'
+
 @test "config.json is valid JSON" {
     jq -e . "$CFG" >/dev/null
 }
@@ -27,8 +29,8 @@ setup() {
 
 @test "copilot is a packages.json catalog tool (npm) and neither setup carries an install block (AI-038, ADR-036)" {
     jq -e '.tools[] | select(.name == "copilot" and .source.type == "npm")' "$DOTFILES_DIR/packages.json" >/dev/null
-    ! grep -qE 'Id = "GitHub\.Copilot"' "$DOTFILES_DIR/setup-windows.ps1"
-    ! grep -qE '(apt|snap|curl)[^\n]*copilot' "$DOTFILES_DIR/setup-linux.sh"
+    refute_grep 'Id = "GitHub\.Copilot"' "$DOTFILES_DIR/setup-windows.ps1"
+    refute_grep '(apt|snap|curl)[^\n]*copilot' "$DOTFILES_DIR/setup-linux.sh"
 }
 
 @test "config.json carries no \$schema URL (the published one 404s)" {

--- a/tests/packages-json.bats
+++ b/tests/packages-json.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+# packages.json is the pin SSOT for every catalog tool (ADR-036). A name listed
+# twice installs twice and every by-name reader takes the first: a duplicated
+# copilot entry shipped in a PR (AI-038, #1321) and read as "already installed;
+# skipping" on its second line. The Go loader refuses it; this is the same
+# invariant at the data layer, so a review sees it before a binary does.
+
+setup() {
+    export CATALOG="$BATS_TEST_DIRNAME/../packages.json"
+}
+
+@test "packages.json is valid JSON with a tools array" {
+    jq -e '.tools | type == "array"' "$CATALOG" >/dev/null
+}
+
+@test "packages.json tool names are unique" {
+    total=$(jq '[.tools[].name] | length' "$CATALOG")
+    unique=$(jq '[.tools[].name] | unique | length' "$CATALOG")
+    [ "$total" -eq "$unique" ]
+}
+
+@test "every packages.json tool declares name, version, profile and a typed source" {
+    jq -e 'all(.tools[]; (.name | type == "string") and (.version | test("^[0-9]+\\.[0-9]+\\.[0-9]+")) and (.profile | type == "string") and (.source.type | IN("npm", "github-release")))' "$CATALOG" >/dev/null
+}

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -138,10 +138,9 @@ setup() {
     refute_grep_fixed "github/gh-copilot" "$PS1_SCRIPT"
 }
 
-@test "setup-windows.ps1 auto-installs GitHub.Copilot via winget" {
-    grep -qF "GitHub.Copilot" "$PS1_SCRIPT"
-    # In the dev tools winget block, the binary check uses `copilot`
-    grep -qE 'Name = "GitHub Copilot CLI"; Cmd = "copilot"; Id = "GitHub\.Copilot"' "$PS1_SCRIPT"
+@test "setup-windows.ps1 no longer installs GitHub.Copilot via winget: copilot is a packages.json npm tool (AI-038, ADR-036)" {
+    refute_grep 'Id = "GitHub\.Copilot"' "$PS1_SCRIPT"
+    jq -e '.tools[] | select(.name == "copilot" and .source.type == "npm" and .source.package == "@github/copilot")' "$DOTFILES_DIR/packages.json" >/dev/null
 }
 
 @test "setup-windows.ps1 removes retired init .ps1 orphans, does not deploy them (CLI-020)" {

--- a/tests/verify-setup.bats
+++ b/tests/verify-setup.bats
@@ -272,7 +272,7 @@ setup() {
 # Section 10: Graceful skips (optional tools not present)
 # =============================================================================
 
-@test "copilot config NOT deployed when gh-copilot extension is absent" {
+@test "copilot config NOT deployed when the copilot binary is absent (the container has no Node, so the npm catalog skips it: #1312)" {
     # Post-BUG-001 (PR #40): setup-linux.sh uses detect-and-act. The
     # gh-copilot extension is no longer auto-installed; ~/.copilot is created
     # only if the extension is genuinely present. In the integration container


### PR DESCRIPTION
ADR-036 left `copilot` to the OS package manager as a tool with no cross-OS channel. Measured on the Windows work box: GitHub publishes the CLI as `@github/copilot` on npm (1.0.81), the winget-installed binary had self-updated behind the registry (1.0.78 recorded, 1.0.81 running), Linux installed nothing, and no doctor row nor shadowed-install WARN could apply because the tool was not in the catalog (AI-038, #1321; owner's decision 2026-08-27: npm on both OSes).

- **packages.json** declares `copilot` (npm, `@github/copilot`, 1.0.81); the winget row leaves `setup-windows.ps1`; both setup blocks only deploy config when the binary is on PATH.
- **ai/copilot/config.json** → `"autoUpdate": false` so the pin owns updates.
- **dotf doctor** gains a "GitHub Copilot CLI" section: version probed once in Go, exact match PASS / drift WARN like opencode, SKIP when absent (a box may carry no Copilot); the existing shadowed-install WARN covers a leftover winget/scoop copy.
- **ADR-036**: `copilot` moves to the npm class with a dated amendment.

**Verified on the box** (details in `specs/AI-038-copilot-npm-channel/verification.md`): with the winget copy satisfying the floor, `dotf tools install` added nothing — ADR-036 §5 in practice, retire the other channel first; after `winget uninstall --force` (the portable package had self-modified) the catalog installed the npm copy (`copilot 1.0.81 installed via npm`, second run `already installed; skipping`), `Get-Command copilot -All` shows only the npm shims, doctor reports `(2 checks, all ok)` with no WARN, and `copilot -p` answers `PONG`.

Tests: `TestCheckCopilot_PinMatchByStatus` (5 rows by status; mutation-checked), bats guards in `copilot-config.bats` + `setup-windows.bats`; `verify-setup.bats`'s "not deployed when absent" case keeps its premise in the Node-less container (#1312) and lost its stale "gh-copilot extension" wording.

Found on the way, filed: **#1358** — `env.RepoDir`/doctor do not recognise a git worktree as a checkout.

Spec: `specs/AI-038-copilot-npm-channel/`. Refs #1321 — closes when the spec archives after the pooled review.