### PR TITLE
feat(setup): Windows installs Claude Code and agy through their official installers, as Linux has since ADR-009

### DIFF
--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -429,6 +429,48 @@ if ($wingetCmd) {
 }
 
 # ============================================================================
+# 1d. AGENT BINARIES WITH AN OFFICIAL INSTALLER (AI-041, #1325)
+# ============================================================================
+# setup-linux.sh has installed Claude Code (claude.ai/install.sh) and the
+# Antigravity CLI (antigravity.google/cli/install.sh) since ADR-009; Windows
+# never did, so on a clean box every block below that gates on `claude` (MCP
+# registration, plugins, both session hooks) and the agy config deploy were
+# dead until a human installed the binaries by hand. Both vendors ship a
+# Windows installer (install.ps1); ADR-036 class 3 (official installer on every
+# OS, like uv), run in a child pwsh exactly as the uv/Bun installers are, and
+# skipped when the binary is already on PATH - the pattern-setup-script-
+# idempotence shape of the Linux blocks.
+function Install-AgentBinary {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Command,
+        [Parameter(Mandatory)][string]$InstallerUrl,
+        [Parameter(Mandatory)][string]$BinDir
+    )
+    if (Get-Command $Command -ErrorAction SilentlyContinue) {
+        Write-Info "$Name already installed"
+        return
+    }
+    Write-Info "Installing $Name via official installer..."
+    $installer = Join-Path $env:TEMP ("$Command-install.ps1")
+    try {
+        Invoke-RestMethod $InstallerUrl -OutFile $installer
+        & (Get-Process -Id $PID).Path -NoProfile -ExecutionPolicy Bypass -File $installer 2>$null
+        Remove-Item -Path $installer -Force -ErrorAction SilentlyContinue
+        if (($env:PATH -split ';') -notcontains $BinDir) { $env:PATH = "$BinDir;$env:PATH" }
+        if (Get-Command $Command -ErrorAction SilentlyContinue) {
+            Write-Success "$Name installed"
+        } else {
+            Write-Warn "$Name installer ran but '$Command' is not on PATH -- open a new shell or install manually ($InstallerUrl)"
+        }
+    } catch {
+        Write-Warn "$Name install failed -- re-run setup or install manually ($InstallerUrl): $_"
+    }
+}
+Install-AgentBinary -Name "Claude Code" -Command "claude" -InstallerUrl "https://claude.ai/install.ps1" -BinDir "$env:USERPROFILE\.local\bin"
+Install-AgentBinary -Name "Antigravity CLI (agy)" -Command "agy" -InstallerUrl "https://antigravity.google/cli/install.ps1" -BinDir "$env:LOCALAPPDATA\agy\bin"
+
+# ============================================================================
 # 2. DEPLOY CLAUDE CONFIGURATION
 # ============================================================================
 

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -232,6 +232,22 @@ setup() {
 }
 
 # MCP registration must check existence before adding, not blindly retry.
+@test "setup-windows.ps1 installs Claude Code and agy via their official installers when absent (AI-041, #1325)" {
+    # setup-linux.sh provisions both; on Windows every block gating on `claude`
+    # and the agy config deploy were dead on a clean box. Child pwsh, skip when
+    # on PATH, before the MCP block that needs the binary.
+    grep -qF 'function Install-AgentBinary' "$PS1_SCRIPT"
+    grep -qF 'https://claude.ai/install.ps1' "$PS1_SCRIPT"
+    grep -qF 'https://antigravity.google/cli/install.ps1' "$PS1_SCRIPT"
+    grep -qF -- '-NoProfile -ExecutionPolicy Bypass -File $installer' "$PS1_SCRIPT"
+    install_line=$(grep -n 'Install-AgentBinary -Name "Claude Code"' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
+    mcp_line=$(grep -n 'claude mcp get' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
+    [ "$install_line" -lt "$mcp_line" ]
+    # parity: the Linux script installs the same two through the same vendors
+    grep -qF 'https://claude.ai/install.sh' "$DOTFILES_DIR/setup-linux.sh"
+    grep -qF 'https://antigravity.google/cli/install.sh' "$DOTFILES_DIR/setup-linux.sh"
+}
+
 @test "setup-windows.ps1 MCP registration checks existence with claude mcp get" {
     grep -q 'claude mcp get' "$PS1_SCRIPT"
 }


### PR DESCRIPTION
`setup-linux.sh` has provisioned Claude Code (`claude.ai/install.sh`) and the Antigravity CLI (`antigravity.google/cli/install.sh`) for months; on Windows every block that gates on `claude` (MCP registration, plugins, both session hooks) and the agy config deploy were dead on a clean box until a human installed the binaries by hand (AI-041, #1325). Both vendors ship `install.ps1` — measured HTTP 200 on 2026-08-28 — so this is ADR-036 class 3, the official installer on every OS, no channel change.

- `Install-AgentBinary` (one helper, two calls): skip when the command is on PATH; run the installer in a child `pwsh` exactly as the uv/Bun installers are (a remote installer must not rewrite this session's environment); put the vendor's bin dir on the session PATH once; say plainly when the binary still does not resolve. Placed before the MCP block that needs `claude`.
- Guard: `tests/setup-windows.bats` asserts the helper, both URLs, the child-pwsh invocation, the ordering before `claude mcp get`, and the Linux parity.

Evidence: parse 0 errors, PSScriptAnalyzer 0 findings (repo settings), ASCII delta 0, `bats tests/setup-windows.bats` all ok; on the work box both binaries are present, so both calls take the idempotent branch (`already installed`). The install branch runs for real on the CI runner, where `test-windows` starts clean — its Pester/gate output is the proof that the MCP and plugin blocks now execute there.

Closes #1325.

## SDD skip rationale
Parity block mirroring an existing Linux one, under 50 production lines; no new contract.