### PR TITLE
feat(env): dotf env persist writes the contract variables where a profile-less process reads them

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	github.com/spf13/cobra v1.10.2
 	go.yaml.in/yaml/v3 v3.0.5
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 )

--- a/cli/internal/cmd/env.go
+++ b/cli/internal/cmd/env.go
@@ -25,6 +25,7 @@ func newEnvCmd() *cobra.Command {
 	cmd.AddCommand(newEnvGenerateCmd())
 	cmd.AddCommand(newEnvPathCmd())
 	cmd.AddCommand(newEnvSetCmd())
+	cmd.AddCommand(newEnvPersistCmd())
 	return cmd
 }
 

--- a/cli/internal/cmd/env_persist.go
+++ b/cli/internal/cmd/env_persist.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/env"
+	"github.com/spf13/cobra"
+)
+
+// userEnvStore is the seam tests replace so the command never touches a real
+// registry; production resolves the OS store.
+var userEnvStore = env.NewUserEnvStore
+
+// newEnvPersistCmd is CLI-058 (#1324): the ADR-025 cascade exists only in the
+// rc files, so a process started with no profile — Copilot's `pwsh
+// -NoProfile` tool calls, a Scheduled Task — sees none of DOTFILES_REPO_DIR,
+// DOTFILES_DIR, VAULT_PATH, SCRIPTS_DIR... `persist` writes the same resolved
+// values `generate` renders into the per-user persistent scope, touching only
+// what differs, so a second run is a no-op.
+func newEnvPersistCmd() *cobra.Command {
+	var check bool
+	cmd := &cobra.Command{
+		Use:   "persist",
+		Short: "Write the resolved contract variables into the per-user persistent scope (Windows: HKCU\\Environment)",
+		Long: "persist resolves every structural variable exactly as `generate` does\n" +
+			"(env-contract.json defaults + machine.json overrides) and writes each one\n" +
+			"into the OS's per-user persistent environment, the scope a process\n" +
+			"started without a profile inherits. Idempotent: only values that differ\n" +
+			"are written. --check reports drift without writing (non-zero when drifted).\n" +
+			"Where the OS has no such scope (Linux, macOS) it is a no-op: the rc files\n" +
+			"source paths.sh and unit files carry their own environment.",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			store, err := userEnvStore()
+			if errors.Is(err, env.ErrUserEnvUnsupported) {
+				cmd.Printf("nothing to persist on %s: the rc files source the generated path file\n", runtime.GOOS)
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			home := env.Home()
+			contractPath := env.ResolveContractPath()
+			if contractPath == "" {
+				return fmt.Errorf("env-contract.json not found: set DOTFILES_DIR or run from the repo")
+			}
+			vars, err := env.ResolveVars(contractPath, env.MachinePath(home), runtime.GOOS, home)
+			if err != nil {
+				return err
+			}
+			if check {
+				drift, err := env.Drift(vars, store)
+				if err != nil {
+					return err
+				}
+				if len(drift) > 0 {
+					for _, v := range drift {
+						cmd.Printf("drift: %s\n", v.Name)
+					}
+					return fmt.Errorf("%d variable(s) not persisted at user scope — run `dotf env persist`", len(drift))
+				}
+				cmd.Printf("ok: %d variable(s) persisted at user scope\n", len(vars))
+				return nil
+			}
+			res, err := env.Persist(vars, store)
+			if err != nil {
+				return err
+			}
+			changed := 0
+			for _, r := range res {
+				if r.Changed {
+					changed++
+					cmd.Printf("persisted %s\n", r.Name)
+				}
+			}
+			cmd.Printf("user scope: %d changed, %d unchanged\n", changed, len(res)-changed)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&check, "check", false, "report variables missing or different at user scope without writing")
+	return cmd
+}

--- a/cli/internal/doctor/checks_env_persist.go
+++ b/cli/internal/doctor/checks_env_persist.go
@@ -1,0 +1,62 @@
+package doctor
+
+import (
+	"fmt"
+	"strings"
+
+	envpkg "github.com/mlorentedev/dotfiles/cli/internal/env"
+)
+
+// checkPersistedEnv (CLI-058, #1324) reports whether the resolved contract
+// variables also live in the per-user PERSISTENT scope — what a process
+// started without a profile inherits (Copilot's `pwsh -NoProfile` tool calls,
+// a Scheduled Task). The rc files' cascade is invisible there: measured on
+// the Windows work box, DOTFILES_REPO_DIR, DOTFILES_DIR, VAULT_PATH and
+// COPILOT_HOME were all empty at User scope while every shell had them, and
+// `dotf harness mirror` inside a Copilot tool call could not find the
+// checkout. WARN, not FAIL: shells keep working; the remedy is one command.
+// Skipped where the OS has no such scope (sys.UserEnv is nil).
+//
+// The contract is located through the seam (checkout via DOTFILES_REPO_DIR,
+// else the deploy mirror), never through the process environment, so the
+// check is testable against a fixture and reads the same file setup mirrored.
+func checkPersistedEnv(sys *System, cfg *Config, rep *Report) {
+	if sys.UserEnv == nil {
+		return
+	}
+	rep.Section("Persisted environment (user scope)")
+	home := sys.home()
+	contractPath := envpkg.ResolveRepoFirst("env-contract.json", sys.Getenv("DOTFILES_REPO_DIR"), cfg.DotfilesDir, "")
+	if contractPath == "" {
+		rep.Skip("env-contract.json not found — nothing to compare")
+		return
+	}
+	vars, err := envpkg.ResolveVars(contractPath, envpkg.MachinePath(home), sys.GOOS, home)
+	if err != nil {
+		rep.Warn("contract variables unresolvable (" + err.Error() + ")")
+		return
+	}
+	drift, err := envpkg.Drift(vars, userEnvAdapter{sys.UserEnv})
+	if err != nil {
+		rep.Warn("user-scope environment unreadable (" + err.Error() + ")")
+		return
+	}
+	if len(drift) == 0 {
+		rep.Pass(fmt.Sprintf("%d contract variable(s) persisted at user scope", len(vars)))
+		return
+	}
+	names := make([]string, 0, len(drift))
+	for _, v := range drift {
+		names = append(names, v.Name)
+	}
+	rep.Warn(fmt.Sprintf("%d contract variable(s) missing or stale at user scope (%s) — profile-less processes such as Copilot tool calls see none of them; run `dotf env persist`",
+		len(drift), strings.Join(names, ", ")))
+}
+
+// userEnvAdapter lets the doctor seam (a function) satisfy env.UserEnvStore.
+type userEnvAdapter struct {
+	get func(name string) (string, bool, error)
+}
+
+func (a userEnvAdapter) Get(name string) (string, bool, error) { return a.get(name) }
+func (userEnvAdapter) Set(string, string) error                { return nil }

--- a/cli/internal/doctor/checks_env_persist_test.go
+++ b/cli/internal/doctor/checks_env_persist_test.go
@@ -1,0 +1,83 @@
+package doctor
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	envpkg "github.com/mlorentedev/dotfiles/cli/internal/env"
+)
+
+const persistContract = `{"env_vars":[
+  {"name":"DOTFILES_REPO_DIR","required":false,"default":{"linux":"$HOME/Projects/dotfiles","windows":"$env:USERPROFILE\\Projects\\dotfiles"},"validation":"path_exists"},
+  {"name":"VAULT_PATH","required":false,"default":{"linux":"$HOME/Projects/knowledge","windows":"$env:USERPROFILE\\Projects\\knowledge"},"validation":"path_exists"}
+]}`
+
+// The persisted-scope check (CLI-058, #1324) compares the resolved contract
+// against the per-user persistent environment through the seam: all present
+// and equal → PASS; missing or different → WARN naming them and the remedy;
+// unreadable → WARN; no seam (an OS without the scope) → no section at all.
+func TestCheckPersistedEnv_ByStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		stored map[string]string // "*" = exactly the resolved value
+		getErr error
+		want   Status
+		needle string
+	}{
+		{"all persisted → PASS", map[string]string{"DOTFILES_REPO_DIR": "*", "VAULT_PATH": "*"}, nil, StatusPass, "persisted at user scope"},
+		{"one missing → WARN naming it", map[string]string{"DOTFILES_REPO_DIR": "*"}, nil, StatusWarn, "VAULT_PATH"},
+		{"one different → WARN naming it", map[string]string{"DOTFILES_REPO_DIR": "*", "VAULT_PATH": `C:\elsewhere`}, nil, StatusWarn, "VAULT_PATH"},
+		{"registry unreadable → WARN", nil, errors.New("access denied"), StatusWarn, "unreadable"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			mirror := filepath.Join(home, ".dotfiles")
+			contract := filepath.Join(mirror, "env-contract.json")
+			writeFile(t, contract, persistContract)
+			resolved, err := envpkg.ResolveVars(contract, envpkg.MachinePath(home), "windows", home)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sys := newSys(map[string]string{"HOME": home, "USERPROFILE": home}, nil, nil)
+			sys.GOOS = "windows"
+			sys.UserEnv = func(name string) (string, bool, error) {
+				if tc.getErr != nil {
+					return "", false, tc.getErr
+				}
+				v, ok := tc.stored[name]
+				if !ok {
+					return "", false, nil
+				}
+				if v == "*" {
+					for _, rv := range resolved {
+						if rv.Name == name {
+							return rv.Value, true, nil
+						}
+					}
+				}
+				return v, true, nil
+			}
+			var buf bytes.Buffer
+			rep := capture(&buf)
+
+			checkPersistedEnv(sys, &Config{DotfilesDir: mirror}, rep)
+
+			if got := statusOfLine(buf.String(), tc.needle); got != tc.want {
+				t.Fatalf("line mentioning %q: status %q, want %q\n%s", tc.needle, tagOf(got), tagOf(tc.want), buf.String())
+			}
+		})
+	}
+
+	t.Run("no seam → no section", func(t *testing.T) {
+		sys := newSys(nil, nil, nil)
+		sys.UserEnv = nil
+		var buf bytes.Buffer
+		checkPersistedEnv(sys, &Config{DotfilesDir: t.TempDir()}, capture(&buf))
+		if buf.Len() != 0 {
+			t.Fatalf("an OS without a per-user scope must print nothing, got\n%s", buf.String())
+		}
+	})
+}

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -66,6 +66,7 @@ func Run(opts Options) (int, error) {
 	// the ~2.8s compile-harness drift gate.
 	if contract != nil {
 		checkContractEnvVars(sys, contract, rep, opts.Fix)
+		checkPersistedEnv(sys, cfg, rep)
 		checkContractPath(sys, contract, rep)
 		checkRequiredBinaries(sys, contract, rep)
 	}

--- a/cli/internal/doctor/system.go
+++ b/cli/internal/doctor/system.go
@@ -110,6 +110,11 @@ type System struct {
 	// Windows work box a 12-day-old daemon cache resolved a rotated PAT to its
 	// old value and doctor called the token dead (CLI-056, #1316).
 	BWServeLastSync func() (time.Time, error)
+
+	// UserEnv reads the per-user PERSISTENT environment (Windows:
+	// HKCU\Environment), the scope a profile-less process inherits; nil where
+	// the OS has no such scope, which skips checkPersistedEnv (CLI-058, #1324).
+	UserEnv func(name string) (string, bool, error)
 	// ProcessAlive reports whether pid names a live process (secrets.ProcessAlive
 	// in production: signal 0 on Unix, OpenProcess + GetExitCodeProcess on
 	// Windows). It is what lets the bw serve check tell "the daemon died" from
@@ -213,6 +218,7 @@ func realSystem() *System {
 		BWServeStatus: func() (string, error) {
 			return (&secrets.BWServeDaemon{Client: secrets.BWServeClient{}}).Status()
 		},
+		UserEnv: userEnvReader(),
 		BWServeLastSync: func() (time.Time, error) {
 			st, err := secrets.BWServeClient{}.StatusDetail()
 			return st.LastSync, err
@@ -334,4 +340,14 @@ func (s *System) versionLine(name string) (string, error) {
 		first = out[:i]
 	}
 	return strings.TrimSpace(first), err
+}
+
+// userEnvReader adapts env.NewUserEnvStore to the seam: a reader where the OS
+// has a per-user persistent scope, nil elsewhere.
+func userEnvReader() func(name string) (string, bool, error) {
+	store, err := env.NewUserEnvStore()
+	if err != nil {
+		return nil
+	}
+	return store.Get
 }

--- a/cli/internal/env/persist.go
+++ b/cli/internal/env/persist.go
@@ -1,0 +1,84 @@
+package env
+
+import (
+	"errors"
+	"fmt"
+)
+
+// UserEnvStore is the per-user PERSISTENT environment: what a process started
+// with no profile at all — Copilot's `pwsh -NoProfile` tool calls, a Scheduled
+// Task, Explorer — inherits. On Windows it is HKCU\Environment; the rc files'
+// cascade (paths.sh / paths.ps1) never reaches those processes, which is why
+// `dotf harness mirror` could not find the checkout from inside a Copilot tool
+// call (CLI-058, #1324).
+type UserEnvStore interface {
+	// Get returns the stored value and whether the name exists.
+	Get(name string) (string, bool, error)
+	// Set writes name=value; a later Get must return it.
+	Set(name, value string) error
+}
+
+// ErrUserEnvUnsupported is returned by NewUserEnvStore where no per-user
+// persistent scope exists that a profile-less process reads (Linux, macOS):
+// there the rc files already source paths.sh, and persisting is a no-op.
+var ErrUserEnvUnsupported = errors.New("no per-user persistent environment scope on this OS")
+
+// PersistResult is one contract variable's outcome.
+type PersistResult struct {
+	Name    string
+	Value   string
+	Changed bool
+}
+
+// Persist writes every resolved contract variable into store, touching only
+// the ones whose stored value differs (idempotent: a second run changes
+// nothing). It stops at the first store error and returns what it did so far.
+func Persist(vars []ResolvedVar, store UserEnvStore) ([]PersistResult, error) {
+	out := make([]PersistResult, 0, len(vars))
+	for _, v := range vars {
+		cur, ok, err := store.Get(v.Name)
+		if err != nil {
+			return out, fmt.Errorf("read persisted %s: %w", v.Name, err)
+		}
+		if ok && cur == v.Value {
+			out = append(out, PersistResult{Name: v.Name, Value: v.Value})
+			continue
+		}
+		if err := store.Set(v.Name, v.Value); err != nil {
+			return out, fmt.Errorf("persist %s: %w", v.Name, err)
+		}
+		out = append(out, PersistResult{Name: v.Name, Value: v.Value, Changed: true})
+	}
+	return out, nil
+}
+
+// Drift lists the resolved variables whose persisted value is missing or
+// different — the read-only half of Persist, for `--check` and for doctor.
+func Drift(vars []ResolvedVar, store UserEnvStore) ([]ResolvedVar, error) {
+	var out []ResolvedVar
+	for _, v := range vars {
+		cur, ok, err := store.Get(v.Name)
+		if err != nil {
+			return out, fmt.Errorf("read persisted %s: %w", v.Name, err)
+		}
+		if !ok || cur != v.Value {
+			out = append(out, v)
+		}
+	}
+	return out, nil
+}
+
+// ResolveVars loads the contract and the machine overrides and resolves every
+// structural variable for goos/home — the same list `dotf env generate`
+// renders, so the persisted scope and the rc files never disagree.
+func ResolveVars(contractPath, machinePath, goos, home string) ([]ResolvedVar, error) {
+	c, err := loadContract(contractPath)
+	if err != nil {
+		return nil, err
+	}
+	m, err := loadMachine(machinePath)
+	if err != nil {
+		return nil, err
+	}
+	return Resolve(c, m, goos, home), nil
+}

--- a/cli/internal/env/persist_other.go
+++ b/cli/internal/env/persist_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package env
+
+// NewUserEnvStore has no per-user persistent scope to offer on this OS: the
+// rc files source paths.sh, and a profile-less process (systemd unit, cron)
+// takes its environment from its own unit file, not from a user registry.
+func NewUserEnvStore() (UserEnvStore, error) { return nil, ErrUserEnvUnsupported }

--- a/cli/internal/env/persist_test.go
+++ b/cli/internal/env/persist_test.go
@@ -1,0 +1,111 @@
+package env
+
+import (
+	"errors"
+	"testing"
+)
+
+// fakeUserEnv records what Persist wrote, so the tests assert the idempotence
+// contract (touch only what differs) without a registry.
+type fakeUserEnv struct {
+	values map[string]string
+	writes []string
+	getErr error
+	setErr error
+}
+
+func (f *fakeUserEnv) Get(name string) (string, bool, error) {
+	if f.getErr != nil {
+		return "", false, f.getErr
+	}
+	v, ok := f.values[name]
+	return v, ok, nil
+}
+
+func (f *fakeUserEnv) Set(name, value string) error {
+	if f.setErr != nil {
+		return f.setErr
+	}
+	f.values[name] = value
+	f.writes = append(f.writes, name)
+	return nil
+}
+
+// Persist writes only what differs: missing and different values are written,
+// equal ones are left alone, and a second run writes nothing (CLI-058, #1324).
+func TestPersist_TouchesOnlyWhatDiffers(t *testing.T) {
+	vars := []ResolvedVar{
+		{Name: "DOTFILES_REPO_DIR", Value: `C:\Users\u\Projects\dotfiles`},
+		{Name: "DOTFILES_DIR", Value: `C:\Users\u\.dotfiles`},
+		{Name: "VAULT_PATH", Value: `C:\Users\u\Projects\knowledge`},
+	}
+	store := &fakeUserEnv{values: map[string]string{
+		"DOTFILES_DIR": `C:\Users\u\.dotfiles`, // equal → untouched
+		"VAULT_PATH":   `C:\Users\u\old-vault`, // different → rewritten
+	}}
+
+	res, err := Persist(vars, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := map[string]bool{}
+	for _, r := range res {
+		changed[r.Name] = r.Changed
+	}
+	if !changed["DOTFILES_REPO_DIR"] || changed["DOTFILES_DIR"] || !changed["VAULT_PATH"] {
+		t.Fatalf("changed flags wrong: %+v", changed)
+	}
+	if len(store.writes) != 2 {
+		t.Fatalf("expected exactly the two differing vars to be written, got %v", store.writes)
+	}
+
+	// Second run: nothing differs, nothing is written.
+	store.writes = nil
+	res, err = Persist(vars, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range res {
+		if r.Changed {
+			t.Fatalf("second run must change nothing, got %+v", r)
+		}
+	}
+	if len(store.writes) != 0 {
+		t.Fatalf("second run wrote %v", store.writes)
+	}
+}
+
+// Drift is the read-only mirror of Persist: it names what Persist would write.
+func TestDrift_NamesMissingAndDifferent(t *testing.T) {
+	vars := []ResolvedVar{
+		{Name: "A", Value: "1"}, {Name: "B", Value: "2"}, {Name: "C", Value: "3"},
+	}
+	store := &fakeUserEnv{values: map[string]string{"A": "1", "B": "x"}}
+	d, err := Drift(vars, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d) != 2 || d[0].Name != "B" || d[1].Name != "C" {
+		t.Fatalf("drift must list B (different) and C (missing), got %+v", d)
+	}
+}
+
+// A store error is surfaced with the variable's name, never swallowed.
+func TestPersist_StoreErrorsNameTheVariable(t *testing.T) {
+	vars := []ResolvedVar{{Name: "DOTFILES_DIR", Value: "x"}}
+	if _, err := Persist(vars, &fakeUserEnv{values: map[string]string{}, setErr: errors.New("access denied")}); err == nil || !contains(err.Error(), "DOTFILES_DIR") {
+		t.Fatalf("set error must name the variable, got %v", err)
+	}
+	if _, err := Drift(vars, &fakeUserEnv{getErr: errors.New("boom")}); err == nil || !contains(err.Error(), "DOTFILES_DIR") {
+		t.Fatalf("get error must name the variable, got %v", err)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/env/persist_windows.go
+++ b/cli/internal/env/persist_windows.go
@@ -1,0 +1,70 @@
+//go:build windows
+
+package env
+
+import (
+	"errors"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// registryUserEnv is the production UserEnvStore: HKCU\Environment, the scope
+// [Environment]::SetEnvironmentVariable(name, value, 'User') writes and every
+// new process reads at start — including the profile-less ones.
+type registryUserEnv struct{}
+
+// NewUserEnvStore returns the per-user persistent environment on Windows.
+func NewUserEnvStore() (UserEnvStore, error) { return registryUserEnv{}, nil }
+
+func (registryUserEnv) Get(name string) (string, bool, error) {
+	k, err := registry.OpenKey(registry.CURRENT_USER, `Environment`, registry.QUERY_VALUE)
+	if err != nil {
+		return "", false, err
+	}
+	defer func() { _ = k.Close() }()
+	v, _, err := k.GetStringValue(name)
+	if errors.Is(err, registry.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return v, true, nil
+}
+
+func (registryUserEnv) Set(name, value string) error {
+	k, err := registry.OpenKey(registry.CURRENT_USER, `Environment`, registry.SET_VALUE)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = k.Close() }()
+	if err := k.SetStringValue(name, value); err != nil {
+		return err
+	}
+	broadcastEnvironmentChange()
+	return nil
+}
+
+// broadcastEnvironmentChange tells running shells and Explorer that the user
+// environment changed (what setx does after writing the same key), so a
+// terminal opened from the taskbar afterwards sees the value without a
+// logoff. Best effort: a failure here leaves the registry correct and only
+// delays visibility to the next logon.
+func broadcastEnvironmentChange() {
+	const (
+		hwndBroadcast   = uintptr(0xffff)
+		wmSettingChange = uintptr(0x001A)
+		smtoAbortIfHung = uintptr(0x0002)
+	)
+	user32 := syscall.NewLazyDLL("user32.dll")
+	proc := user32.NewProc("SendMessageTimeoutW")
+	lparam, err := syscall.UTF16PtrFromString("Environment")
+	if err != nil {
+		return
+	}
+	var result uintptr
+	_, _, _ = proc.Call(hwndBroadcast, wmSettingChange, 0, uintptr(unsafe.Pointer(lparam)),
+		smtoAbortIfHung, 5000, uintptr(unsafe.Pointer(&result)))
+}

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1879,6 +1879,17 @@ if (Get-Command dotf -ErrorAction SilentlyContinue) {
     } else {
         Write-Warn "dotf env generate failed (profile.ps1 falls back to inline defaults)"
     }
+    # The same values at User scope (HKCU\Environment): paths.ps1 only reaches
+    # shells that load the profile, and Copilot runs its tool calls with
+    # -NoProfile, so DOTFILES_REPO_DIR/DOTFILES_DIR/VAULT_PATH were empty there
+    # and dotf could not find the checkout (CLI-058, #1324). Idempotent: only
+    # values that differ are written.
+    dotf env persist | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Success "Persisted the contract variables at User scope (dotf env persist)"
+    } else {
+        Write-Warn "dotf env persist failed (profile-less processes will not see the contract variables)"
+    }
 }
 
 $syncSource = "$DotfilesDir\scripts\dotfiles-sync.ps1"

--- a/specs/CLI-058-env-persist/features.json
+++ b/specs/CLI-058-env-persist/features.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "CLI-058-env-persist-f1",
+    "behavior": "AC1/AC2: Persist writes only what differs and a second run writes nothing; Drift names missing and different values; store errors name the variable",
+    "verification": "cd cli && go test ./internal/env/ -run 'TestPersist|TestDrift'",
+    "state": "verified",
+    "evidence": "ok on the Windows work box 2026-08-28; mutation (Persist writes everything) fails TestPersist_TouchesOnlyWhatDiffers"
+  },
+  {
+    "id": "CLI-058-env-persist-f2",
+    "behavior": "AC4: dotf doctor reports the persisted scope by status (PASS / WARN naming the variables / WARN unreadable / no section without a seam)",
+    "verification": "grep -q 'checkPersistedEnv(sys, cfg, rep)' cli/internal/doctor/doctor.go && cd cli && go test ./internal/doctor/ -run TestCheckPersistedEnv_ByStatus",
+    "state": "verified",
+    "evidence": "ok on the Windows work box 2026-08-28; mutation (Drift never reports) fails the WARN rows"
+  },
+  {
+    "id": "CLI-058-env-persist-f3",
+    "behavior": "AC5: setup-windows.ps1 runs dotf env persist after dotf env generate",
+    "verification": "bats tests/setup-windows.bats -f 'CLI-058'",
+    "state": "verified",
+    "evidence": "ok on the Windows work box 2026-08-28"
+  },
+  {
+    "id": "CLI-058-env-persist-f4",
+    "behavior": "AC3/AC6 (box): persist is idempotent, --check agrees, and a process built from the registry environment sees the variables",
+    "verification": "dotf env persist --check && dotf env persist | grep -q '0 changed'",
+    "state": "verified",
+    "evidence": "see verification.md (Windows work box 2026-08-28)"
+  }
+]

--- a/specs/CLI-058-env-persist/proposal.md
+++ b/specs/CLI-058-env-persist/proposal.md
@@ -1,0 +1,76 @@
+---
+id: "CLI-058-env-persist"
+type: spec
+status: verifying # draft | implementing | verifying | archived
+created: "2026-08-28"
+issue: "mlorentedev/dotfiles#1324"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, env-contract, adr-025, windows, copilot]
+template_version: "1.0"
+---
+
+# CLI-058-env-persist
+
+## Why
+
+The ADR-025 cascade (`env-contract.json` defaults + `machine.json` overrides)
+reaches a process only through the rc files: `paths.ps1` is dot-sourced by
+`profile.ps1`, `paths.sh` by `.bashrc`/`.zshrc`. A process started without a
+profile inherits none of it — and Copilot runs every tool call as `pwsh
+-NoProfile -NoLogo` by default. Measured on the Windows work box on 2026-08-27:
+`DOTFILES_REPO_DIR`, `DOTFILES_DIR`, `VAULT_PATH` and `COPILOT_HOME` were empty at
+User scope while every shell had them; inside a Copilot tool call `dotf`
+resolved (User PATH) but `dotf harness mirror` could not locate the checkout and
+the instructions' fallback `$DOTFILES_REPO_DIR/AGENTS.md` was unresolvable.
+Issue #1324.
+
+## What
+
+`dotf env persist` resolves every structural variable exactly as `dotf env
+generate` does and writes each into the OS's per-user persistent scope —
+`HKCU\Environment` on Windows, the scope `[Environment]::SetEnvironmentVariable(...,
+'User')` writes and every new process reads — touching only values that differ,
+and broadcasting `WM_SETTINGCHANGE` so a terminal opened afterwards sees them.
+`--check` reports drift without writing. Where the OS has no such scope (Linux,
+macOS) the command is a no-op that says so: the rc files source `paths.sh` and
+unit files carry their own environment. `setup-windows.ps1` calls it right after
+`dotf env generate`. `dotf doctor` gains a "Persisted environment (user scope)"
+section that WARNs, naming the variables, when the persisted values are missing
+or stale.
+
+## Out of scope
+
+- Setting `powershellFlags: []` in Copilot's config (would load the interactive
+  profile on every tool call — the ticket names it as the wrong fix).
+- Machine scope (`HKLM`): per-user is what the contract describes and needs no
+  elevation.
+- Linux `environment.d`: no profile-less consumer on the Linux boxes reads it
+  today; the command is an explicit no-op there so setup scripts stay symmetric.
+
+## Risks / open questions
+
+- A value the user set by hand at User scope is overwritten by the contract's
+  resolution — the same rule the cascade already applies (`machine.json` is the
+  override surface, not the registry).
+- `AGE_KEY_PATH` / `SOPS_AGE_KEY_FILE` are contract variables and are persisted
+  too: they are paths to the key file, never the key.
+
+## Acceptance criteria
+
+- [x] AC1 — `dotf env persist` writes every resolved contract variable at user
+  scope and a second run changes nothing (only values that differ are written).
+- [x] AC2 — `--check` names missing/stale variables and exits non-zero; exits zero
+  when all are persisted.
+- [x] AC3 — on an OS without a per-user persistent scope the command is a no-op
+  that says so and exits zero.
+- [x] AC4 — `dotf doctor` reports the persisted scope: PASS when all variables
+  match, WARN naming the missing/stale ones with the remedy, WARN when the store
+  is unreadable, no section where the OS has no such scope.
+- [x] AC5 — `setup-windows.ps1` calls `dotf env persist` after `dotf env generate`.
+- [x] AC6 — on the Windows work box: after `dotf env persist`, a process started
+  with a fresh environment built from the registry (`Start-Process
+  -UseNewEnvironment`, no profile, no inheritance) sees the variables.
+
+## References
+
+- Bitácora board: #1324
+- ADR-025 (paths resolve at setup), CLI-039 (`dotf env generate`), #1323 (Copilot instructions outside repos)

--- a/specs/CLI-058-env-persist/tasks.md
+++ b/specs/CLI-058-env-persist/tasks.md
@@ -1,0 +1,29 @@
+---
+tags: [spec, tasks]
+created: "2026-08-28"
+---
+
+# Tasks - CLI-058-env-persist
+
+## Setup
+
+- [x] Branch: `feat/env-persist` from `origin/main`
+- [x] `proposal.md` complete, acceptance criteria testable
+- [x] No open questions left in `proposal.md`
+
+## Implementation
+
+- [x] [AC1] Failing test `TestPersist_TouchesOnlyWhatDiffers` (fake store; second run writes nothing)
+- [x] [AC1] `env.Persist` + `env.UserEnvStore`; Windows store on `HKCU\Environment` (`x/sys/windows/registry`) with `WM_SETTINGCHANGE` broadcast; `env.ResolveVars` shared with `generate`
+- [x] [AC2] `env.Drift` (+ `TestDrift_NamesMissingAndDifferent`); `dotf env persist --check`
+- [x] [AC3] `NewUserEnvStore` returns `ErrUserEnvUnsupported` off Windows; the command prints the no-op and exits 0
+- [x] [AC4] Failing test `TestCheckPersistedEnv_ByStatus` (four rows by status + no-seam case); `checkPersistedEnv` through the `System.UserEnv` seam, registered after the contract env vars
+- [x] [AC5] `setup-windows.ps1` calls `dotf env persist` after `dotf env generate`; bats ordering guard
+- [x] [AC6] Box: `--check` → 10 drifted; `persist` → 10 changed; `--check` ok; `persist` → 0 changed; `Start-Process -UseNewEnvironment` child sees the values
+- [x] Mutation checks: Persist writing everything fails AC1's test; Drift never reporting fails AC4's test
+
+## Verification
+
+- [x] Go loop: build, vet (host, `GOOS=windows`, `GOOS=linux`), test, golangci-lint (0 issues)
+- [x] bats: setup-windows; parse + ASCII delta 0 on `setup-windows.ps1`
+- [x] `verification.md` records the evidence

--- a/specs/CLI-058-env-persist/verification.md
+++ b/specs/CLI-058-env-persist/verification.md
@@ -1,0 +1,72 @@
+---
+tags: [spec, verification]
+created: "2026-08-28"
+---
+
+# Verification - CLI-058-env-persist
+
+## Evidence
+
+Run on the Windows work box, 2026-08-28, worktree `dotfiles-wt-setup-cluster`,
+branch `feat/env-persist`, `dotf` built from the branch.
+
+- [x] **AC1/AC2** → `TestPersist_TouchesOnlyWhatDiffers`, `TestDrift_NamesMissingAndDifferent`,
+  `TestPersist_StoreErrorsNameTheVariable`. Mutation: `Persist` treating every value as different
+  → `--- FAIL: TestPersist_TouchesOnlyWhatDiffers`; restored.
+- [x] **AC3** → `persist_other.go` returns `ErrUserEnvUnsupported`; `env_persist.go` prints
+  `nothing to persist on <os>` and returns nil (exercised by the `GOOS=linux go vet` build and by
+  the CI `test (ubuntu-latest)` job compiling both files).
+- [x] **AC4** → `TestCheckPersistedEnv_ByStatus` (all persisted PASS; one missing WARN naming it;
+  one different WARN naming it; store error WARN "unreadable"; nil seam → no section). Mutation:
+  `Drift` never reporting → the two WARN rows fail; restored. Live: `dotf doctor` shows
+  `[Persisted environment (user scope)] (1 checks, all ok)` after the persist below.
+- [x] **AC5** → `tests/setup-windows.bats` "persists the contract variables at User scope after
+  generating paths.ps1"; parse 0 errors; ASCII delta 0.
+- [x] **AC6** → box, in order:
+  1. `dotf env persist --check` → `drift: ...` × 10, exit 1 (every contract variable missing at
+     User scope — the measured starting state).
+  2. `dotf env persist` → `persisted ...` × 10, `user scope: 10 changed, 1 unchanged`.
+  3. `dotf env persist --check` → `ok: 11 variable(s) persisted at user scope`.
+  4. `dotf env persist` → `user scope: 0 changed, 11 unchanged` (idempotent).
+  5. `[Environment]::GetEnvironmentVariable(n, 'User')` → DOTFILES_REPO_DIR, DOTFILES_DIR,
+     VAULT_PATH, SCRIPTS_DIR, COPILOT_HOME all set to the resolved paths.
+  6. `Start-Process pwsh -NoProfile -UseNewEnvironment` (a fresh environment built from the
+     registry, no inheritance from the launching shell, no profile) prints the same five values —
+     the profile-less consumer Copilot's tool calls are.
+
+## Test status
+
+```text
+go build ./... && go vet ./... && GOOS=windows go vet ./... && GOOS=linux go vet ./... && go test ./internal/env/ ./internal/doctor/ ./internal/cmd/   -> ok
+golangci-lint run ./...   -> 0 issues
+bats tests/setup-windows.bats   -> all ok
+```
+
+- No regressions in the existing suite: yes.
+- `golang.org/x/sys` becomes a direct dependency (`go mod tidy`): the registry API is the
+  first production use; the earlier `bwserve_windows.go` constant stays stdlib.
+
+## Decisions made during implementation
+
+- **One resolver, two sinks.** `env.ResolveVars` is what `generate` renders and what `persist`
+  writes, so the rc files and the registry can never disagree by construction.
+- **Store as an interface, registry behind a build tag.** `UserEnvStore` keeps the logic and the
+  tests OS-agnostic; `persist_windows.go` is the only file that knows about `HKCU\Environment`.
+- **Broadcast, best effort.** `WM_SETTINGCHANGE` is what `setx` sends; a failure leaves the
+  registry correct and only delays visibility to the next logon.
+- **Doctor WARN, not FAIL.** Shells keep working without the persisted scope; the remedy is one
+  idempotent command that setup now runs.
+- **No-op, not error, off Windows.** Setup scripts call the same verb on both OSes without a
+  per-OS branch; Linux prints one line and exits 0.
+
+## Promotion candidates
+
+- [ ] Lesson: no (the ticket and this spec carry the measurement).
+- [ ] ADR-worthy decision: no — it implements ADR-025's cascade for a scope it did not name.
+
+## Archive checklist
+
+- [ ] `dotf spec review CLI-058-env-persist` PASS
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved to `specs/archive/CLI-058-env-persist/`
+- [ ] Bitácora #1324 closed with the PR link

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -247,6 +247,15 @@ setup() {
     grep -qF 'https://antigravity.google/cli/install.sh' "$DOTFILES_DIR/setup-linux.sh"
 }
 
+@test "setup-windows.ps1 persists the contract variables at User scope after generating paths.ps1 (CLI-058, #1324)" {
+    # paths.ps1 only reaches profile-loading shells; Copilot's -NoProfile tool
+    # calls and Scheduled Tasks read HKCU\Environment, which setup now fills.
+    grep -qF 'dotf env persist' "$PS1_SCRIPT"
+    gen_line=$(grep -n 'dotf env generate | Out-Null' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
+    persist_line=$(grep -n 'dotf env persist | Out-Null' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
+    [ "$gen_line" -lt "$persist_line" ]
+}
+
 @test "setup-windows.ps1 MCP registration checks existence with claude mcp get" {
     grep -q 'claude mcp get' "$PS1_SCRIPT"
 }


### PR DESCRIPTION
The ADR-025 cascade reaches a process only through the rc files, and Copilot runs every tool call as `pwsh -NoProfile`: measured on the Windows work box, `DOTFILES_REPO_DIR`, `DOTFILES_DIR`, `VAULT_PATH` and `COPILOT_HOME` were empty at User scope while every shell had them, and `dotf harness mirror` could not find the checkout from inside a Copilot tool call (CLI-058, #1324).

- **`dotf env persist`**: resolves every structural variable exactly as `generate` does (one resolver, `env.ResolveVars`) and writes it into the per-user persistent scope — `HKCU\Environment` via `x/sys/windows/registry`, plus the `WM_SETTINGCHANGE` broadcast `setx` sends — touching only values that differ; `--check` reports drift and exits non-zero. Off Windows it is a no-op that says so (the rc files source `paths.sh`).
- **setup-windows.ps1** calls it right after `dotf env generate` (bats ordering guard).
- **`dotf doctor`** gains "Persisted environment (user scope)": PASS when every variable matches, WARN naming the missing/stale ones with the remedy, WARN when the store is unreadable, no section where the OS has no such scope (`System.UserEnv` seam).
- `golang.org/x/sys` becomes a direct dependency (first production use of the registry API).

**Verified on the box** (details in `specs/CLI-058-env-persist/verification.md`): `--check` → 10 drifted; `persist` → 10 changed; `--check` → ok; `persist` → 0 changed (idempotent); then a `pwsh -NoProfile` started with `Start-Process -UseNewEnvironment` — a fresh environment built from the registry, no inheritance from the launching shell (a marker set there did not arrive) — prints the five values. Doctor's new section reads `(1 checks, all ok)`.

Tests: `TestPersist_TouchesOnlyWhatDiffers`, `TestDrift_NamesMissingAndDifferent`, `TestPersist_StoreErrorsNameTheVariable`, `TestCheckPersistedEnv_ByStatus` (four rows by status + no-seam case); mutation-checked (Persist writing everything; Drift never reporting). Go loop incl. `GOOS=linux|windows go vet`, golangci-lint 0 issues; bats setup-windows ok; `.ps1` parse clean, ASCII delta 0.

Spec: `specs/CLI-058-env-persist/`. Refs #1324 — closes when the spec archives after the pooled review. Follow-up this unlocks: #1323 (the pointer's `$DOTFILES_REPO_DIR` fallback now resolves in Copilot tool calls).