### PR TITLE
feat(harness): dotf harness presence injects the persona roster on every OS, so Windows finally gets it

### DIFF
--- a/cli/internal/cmd/harness.go
+++ b/cli/internal/cmd/harness.go
@@ -29,6 +29,7 @@ pattern triggers, and workflow integrations.`,
 	cmd.AddCommand(newHarnessResolveSkillsCmd())
 	cmd.AddCommand(newHarnessGateCmd())
 	cmd.AddCommand(newHarnessMirrorCmd())
+	cmd.AddCommand(newHarnessPresenceCmd())
 	return cmd
 }
 

--- a/cli/internal/cmd/harness_presence.go
+++ b/cli/internal/cmd/harness_presence.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/env"
+	"github.com/mlorentedev/dotfiles/cli/internal/harness"
+)
+
+// newHarnessPresenceCmd injects the agent-presence roster into every harness
+// instructions file the manifest names (HARNESS-092, #1326).
+//
+// It is the fourth member of the family the shell renderer delegates to, and
+// the first that writes: compile-harness.sh --deploy calls it on Linux, and
+// setup-windows.ps1 calls it on Windows, where no port of the shell's
+// deploy_agent_presence ever existed — so no harness on that OS had ever been
+// told which skills a persona forces. One implementation, one sha, both OSes.
+func newHarnessPresenceCmd() *cobra.Command {
+	var repoRoot, home, render string
+	cmd := &cobra.Command{
+		Use:   "presence",
+		Short: "Inject each persona's forced-skills roster into the harness instructions files",
+		Long: `presence renders, for every harness the manifest's agents.presence[] names, the
+roster of invocable personas that target it and the skills each MUST consume,
+and writes it between AGENT-PRESENCE markers in that harness's instructions
+file under $HOME — replacing an existing region in place, appending a fresh one
+otherwise. Everything outside the markers is left byte-identical; a file whose
+region already holds this roster is not rewritten.
+
+The begin marker carries the roster's sha, so dotf doctor can tell current
+from stale without re-rendering. A harness no persona targets gets no region.
+An instructions file that does not exist yet is skipped and said so: the
+harness's base file is deployed elsewhere, and presence has nothing to join.`,
+		Example: `  dotf harness presence
+  dotf harness presence --repo-root /path/to/checkout   # from a setup script`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if repoRoot == "" {
+				repoRoot = env.RepoDir()
+			}
+			if repoRoot == "" {
+				return fmt.Errorf("cannot locate the dotfiles checkout — pass --repo-root, set DOTFILES_REPO_DIR, or run from inside it")
+			}
+			if home == "" {
+				home = env.Home()
+			}
+			if render != "" {
+				block, err := harness.RenderPresence(repoRoot, render)
+				if err != nil {
+					return err
+				}
+				_, _ = fmt.Fprint(cmd.OutOrStdout(), block)
+				return nil
+			}
+			outcomes, err := harness.DeployPresence(repoRoot, home)
+			if err != nil {
+				return err
+			}
+			w, e := cmd.OutOrStdout(), cmd.ErrOrStderr()
+			for _, o := range outcomes {
+				switch o.Status {
+				case "injected":
+					_, _ = fmt.Fprintf(w, "[deploy] presence -> %s (%s)\n", o.File, o.Agent)
+				case "unchanged":
+					_, _ = fmt.Fprintf(w, "[deploy] presence current: %s (%s)\n", o.File, o.Agent)
+				case "absent":
+					_, _ = fmt.Fprintf(e, "[deploy] presence target absent, skipping: %s\n", o.File)
+				case "empty":
+					_, _ = fmt.Fprintf(e, "[deploy] no persona targets %s; no presence region for %s\n", o.Agent, o.File)
+				}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repoRoot, "repo-root", "", "checkout holding harness/manifest.json and the agent records (default: DOTFILES_REPO_DIR or the cwd walk-up)")
+	cmd.Flags().StringVar(&home, "home", "", "directory the manifest's presence files are relative to (default: the user's home)")
+	cmd.Flags().StringVar(&render, "render", "", "print the roster block for this harness to stdout and write nothing (what --check compares against)")
+	return cmd
+}

--- a/cli/internal/cmd/harness_presence_test.go
+++ b/cli/internal/cmd/harness_presence_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func presenceFixture(t *testing.T) (repo, home string) {
+	t.Helper()
+	repo, home = t.TempDir(), t.TempDir()
+	writeMirrorFixture(t, filepath.Join(repo, "harness", "manifest.json"), `{"version":1,"agents":{"record_dir":"harness/agents","presence":[
+  {"agent":"claude","file":".claude/CLAUDE.md"},
+  {"agent":"opencode","file":".config/opencode/AGENTS.md"}]}}`)
+	writeMirrorFixture(t, filepath.Join(repo, "harness", "agents", "curator", "AGENT.md"),
+		"---\nname: curator\ndescription: x\nkind: invocable\nskills: [vault-doctor]\n---\n")
+	writeMirrorFixture(t, filepath.Join(home, ".claude", "CLAUDE.md"), "intro\n")
+	return repo, home
+}
+
+func runPresence(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	cmd := newHarnessPresenceCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&errb)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), errb.String(), err
+}
+
+// The command reports per file what it did, on the stream the setup scripts
+// read: injections and "current" on stdout, skips on stderr.
+func TestHarnessPresenceCmd_ReportsEachTarget(t *testing.T) {
+	repo, home := presenceFixture(t)
+
+	out, errs, err := runPresence(t, "--repo-root", repo, "--home", home)
+	if err != nil {
+		t.Fatalf("%v\n%s%s", err, out, errs)
+	}
+	if !strings.Contains(out, "[deploy] presence -> "+filepath.Join(home, ".claude", "CLAUDE.md")+" (claude)") {
+		t.Errorf("injection not reported:\n%s", out)
+	}
+	if !strings.Contains(errs, "presence target absent, skipping: "+filepath.Join(home, ".config", "opencode", "AGENTS.md")) {
+		t.Errorf("absent target not reported on stderr:\n%s", errs)
+	}
+	raw, _ := os.ReadFile(filepath.Join(home, ".claude", "CLAUDE.md"))
+	if !strings.Contains(string(raw), "vault-doctor") {
+		t.Errorf("roster not written:\n%s", raw)
+	}
+
+	out, _, err = runPresence(t, "--repo-root", repo, "--home", home)
+	if err != nil || !strings.Contains(out, "presence current") {
+		t.Errorf("second run must report current: %v\n%s", err, out)
+	}
+}
+
+func TestHarnessPresenceCmd_FailsOnABrokenRecord(t *testing.T) {
+	repo, home := presenceFixture(t)
+	writeMirrorFixture(t, filepath.Join(repo, "harness", "agents", "broken", "AGENT.md"), "---\nname: broken\nkind: invocable\nskills: [unterminated\n---\n")
+
+	if _, _, err := runPresence(t, "--repo-root", repo, "--home", home); err == nil {
+		t.Error("an unparseable skills list must fail the deploy, not render 'none'")
+	}
+}

--- a/cli/internal/doctor/checks_deploy.go
+++ b/cli/internal/doctor/checks_deploy.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"fmt"
+	"github.com/mlorentedev/dotfiles/cli/internal/harness"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -526,14 +527,16 @@ func checkInstructionDrift(sys *System, rep *Report) {
 	}
 }
 
-// Harness marker-region delimiters, mirrored from scripts/compile-harness.sh's
-// BEGIN_PREFIX/END_MARKER and AGENT_BEGIN_PREFIX/AGENT_END_MARKER constants. A
-// drift test (TestHarnessMarkerConstants) asserts they stay byte-identical.
+// Harness marker-region delimiters. The GENERATED pair mirrors
+// scripts/compile-harness.sh's BEGIN_PREFIX/END_MARKER (the shell still writes
+// that region); the AGENT-PRESENCE pair is the harness package's, which has
+// owned the presence region since HARNESS-092 (#1326) — the shell no longer
+// spells it. TestHarnessMarkerConstants pins both facts.
 const (
 	harnessBeginPrefix       = "<!-- BEGIN HARNESS GENERATED"
 	harnessEndMarker         = "<!-- END HARNESS GENERATED -->"
-	agentPresenceBeginPrefix = "<!-- BEGIN HARNESS AGENT-PRESENCE"
-	agentPresenceEndMarker   = "<!-- END HARNESS AGENT-PRESENCE -->"
+	agentPresenceBeginPrefix = harness.PresenceBeginPrefix
+	agentPresenceEndMarker   = harness.PresenceEndMarker
 )
 
 // stripHarnessRegions removes every harness-managed marker region (both the

--- a/cli/internal/doctor/checks_instruction_drift_test.go
+++ b/cli/internal/doctor/checks_instruction_drift_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"github.com/mlorentedev/dotfiles/cli/internal/harness"
 	"os"
 	"path/filepath"
 	"strings"
@@ -291,11 +292,20 @@ func TestHarnessMarkerConstants(t *testing.T) {
 	for _, want := range []string{
 		"BEGIN_PREFIX='" + harnessBeginPrefix + "'",
 		"END_MARKER='" + harnessEndMarker + "'",
-		"AGENT_BEGIN_PREFIX='" + agentPresenceBeginPrefix + "'",
-		"AGENT_END_MARKER='" + agentPresenceEndMarker + "'",
 	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("scripts/compile-harness.sh no longer defines %q — update the Go mirror constants", want)
+		}
+	}
+	// The AGENT-PRESENCE pair moved to the harness package with HARNESS-092
+	// (#1326): doctor must read the package's constants, and the shell must
+	// not grow a copy back — two spellings of one marker is the drift class.
+	if agentPresenceBeginPrefix != harness.PresenceBeginPrefix || agentPresenceEndMarker != harness.PresenceEndMarker {
+		t.Errorf("doctor's AGENT-PRESENCE markers differ from the harness package's")
+	}
+	for _, stale := range []string{"AGENT_BEGIN_PREFIX=", "AGENT_END_MARKER="} {
+		if strings.Contains(content, stale) {
+			t.Errorf("scripts/compile-harness.sh defines %s again; the presence markers live in cli/internal/harness", stale)
 		}
 	}
 }

--- a/cli/internal/doctor/checks_presence.go
+++ b/cli/internal/doctor/checks_presence.go
@@ -1,0 +1,84 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/harness"
+)
+
+// checkAgentPresence reports (HARNESS-092, #1326) whether each harness
+// instructions file carries the persona roster the records render today. It
+// renders the roster the same way `dotf harness presence` does and compares
+// the sha the region's begin marker carries — never the text, which
+// checkInstructionDrift deliberately strips — so it writes nothing and cannot
+// disagree with the deploy about what "current" means.
+//
+// Measured 2026-08-27 on the Windows box: zero AGENT-PRESENCE regions in all
+// four files, and every check green, because none looked. A target whose
+// requires_command is absent is not a surface (the same gate deploy_instructions
+// and checkInstructionDrift apply), and a file that does not exist is reported
+// by the deploy checks, not here.
+func checkAgentPresence(sys *System, rep *Report) {
+	rep.Section("Agent presence (forced skills)")
+
+	repo := resolveRepoDir(sys)
+	if repo == "" {
+		rep.Skip("repo not found — agent presence check skipped")
+		return
+	}
+	manifest := filepath.Join(repo, filepath.FromSlash(harness.ManifestFile))
+	recordDir, targets, err := harness.LoadPresence(manifest)
+	if err != nil {
+		rep.Warn("cannot read presence targets: " + err.Error())
+		return
+	}
+	if len(targets) == 0 {
+		rep.Skip("manifest declares no agents.presence targets")
+		return
+	}
+	personas, err := harness.LoadPersonas(filepath.Join(repo, filepath.FromSlash(recordDir)))
+	if err != nil {
+		rep.Fail("agent records unreadable: " + err.Error())
+		return
+	}
+
+	home := sys.home()
+	current, drifted, skipped := 0, 0, 0
+	for _, t := range targets {
+		if t.RequiresCommand != "" && !sys.has(t.RequiresCommand) {
+			skipped++
+			continue
+		}
+		block := harness.BuildPresence(personas, t.Agent)
+		file := filepath.Join(home, filepath.FromSlash(t.File))
+		if block == "" {
+			skipped++
+			continue
+		}
+		if _, err := os.Stat(file); err != nil {
+			skipped++ // the base file's absence is the deploy checks' finding
+			continue
+		}
+		state, err := harness.PresenceStatus(file, block)
+		if err != nil {
+			rep.Warn(fmt.Sprintf("%s: %v", t.File, err))
+			drifted++
+			continue
+		}
+		switch state {
+		case harness.PresenceCurrent:
+			current++
+		case harness.PresenceStale:
+			rep.Warn(fmt.Sprintf("stale presence in %s (%s): the persona roster changed since it was injected (run: dotf harness presence)", t.File, t.Agent))
+			drifted++
+		default:
+			rep.Warn(fmt.Sprintf("no presence region in %s (%s): personas' forced skills never reach this harness (run: dotf harness presence)", t.File, t.Agent))
+			drifted++
+		}
+	}
+	if drifted == 0 {
+		rep.Pass(fmt.Sprintf("presence current in %d instructions file(s) (%d not compared: tool absent, file absent, or no persona targets it)", current, skipped))
+	}
+}

--- a/cli/internal/doctor/checks_presence_test.go
+++ b/cli/internal/doctor/checks_presence_test.go
@@ -1,0 +1,105 @@
+package doctor
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/harness"
+)
+
+func presenceDoctorRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "harness", "manifest.json"), `{"version":1,"agents":{"record_dir":"harness/agents","presence":[
+  {"agent":"claude","file":".claude/CLAUDE.md"},
+  {"agent":"pi","file":".pi/agent/AGENTS.md"},
+  {"agent":"copilot","file":".copilot/copilot-instructions.md","requires_command":"copilot"}]}}`)
+	writeFile(t, filepath.Join(repo, "harness", "agents", "curator", "AGENT.md"),
+		"---\nname: curator\ndescription: x\nkind: invocable\nskills: [vault-doctor]\n---\n")
+	return repo
+}
+
+func runCheckAgentPresence(t *testing.T, repo, home string, onPath []string) string {
+	t.Helper()
+	sys := newSys(map[string]string{"HOME": home, "USERPROFILE": home, "DOTFILES_REPO_DIR": repo}, onPath, nil)
+	var buf bytes.Buffer
+	rep := NewReport(&buf, true)
+	checkAgentPresence(sys, rep)
+	return buf.String()
+}
+
+// AC4 (HARNESS-092, #1326): current → PASS; a file with no region → WARN naming
+// it and the remedy; a region whose sha predates the roster → WARN "stale"; a
+// copilot target on a box without copilot is not compared.
+func TestCheckAgentPresence_ByStatus(t *testing.T) {
+	t.Run("all injected → PASS", func(t *testing.T) {
+		repo, home := presenceDoctorRepo(t), t.TempDir()
+		for _, f := range []string{".claude/CLAUDE.md", ".pi/agent/AGENTS.md"} {
+			writeFile(t, filepath.Join(home, filepath.FromSlash(f)), "intro\n")
+		}
+		if _, err := harness.DeployPresence(repo, home); err != nil {
+			t.Fatal(err)
+		}
+		out := runCheckAgentPresence(t, repo, home, nil)
+		if got := statusOfLine(out, "presence current in 2"); got != StatusPass {
+			t.Errorf("want PASS, got %v\n%s", got, out)
+		}
+	})
+
+	t.Run("no region → WARN naming the file and dotf harness presence", func(t *testing.T) {
+		repo, home := presenceDoctorRepo(t), t.TempDir()
+		writeFile(t, filepath.Join(home, ".claude", "CLAUDE.md"), "intro\n")
+		out := runCheckAgentPresence(t, repo, home, nil)
+		if got := statusOfLine(out, "no presence region in .claude/CLAUDE.md"); got != StatusWarn {
+			t.Errorf("want WARN, got %v\n%s", got, out)
+		}
+		if statusOfLine(out, "presence current") == StatusPass {
+			t.Errorf("a missing region must not PASS:\n%s", out)
+		}
+	})
+
+	t.Run("roster changed after injection → WARN stale", func(t *testing.T) {
+		repo, home := presenceDoctorRepo(t), t.TempDir()
+		writeFile(t, filepath.Join(home, ".claude", "CLAUDE.md"), "intro\n")
+		if _, err := harness.DeployPresence(repo, home); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(repo, "harness", "agents", "curator", "AGENT.md"),
+			"---\nname: curator\ndescription: x\nkind: invocable\nskills: [vault-doctor, crystallize]\n---\n")
+		out := runCheckAgentPresence(t, repo, home, nil)
+		if got := statusOfLine(out, "stale presence in .claude/CLAUDE.md"); got != StatusWarn {
+			t.Errorf("want WARN stale, got %v\n%s", got, out)
+		}
+	})
+
+	t.Run("copilot target without copilot is not compared; with it, it is", func(t *testing.T) {
+		repo, home := presenceDoctorRepo(t), t.TempDir()
+		writeFile(t, filepath.Join(home, ".claude", "CLAUDE.md"), "intro\n")
+		writeFile(t, filepath.Join(home, ".copilot", "copilot-instructions.md"), "intro\n")
+		if _, err := harness.DeployPresence(repo, home); err != nil {
+			t.Fatal(err)
+		}
+		// Break copilot's region only.
+		writeFile(t, filepath.Join(home, ".copilot", "copilot-instructions.md"), "intro\n")
+		out := runCheckAgentPresence(t, repo, home, nil)
+		if got := statusOfLine(out, "presence current"); got != StatusPass {
+			t.Errorf("without copilot on PATH its file is not a surface; want PASS, got %v\n%s", got, out)
+		}
+		out = runCheckAgentPresence(t, repo, home, []string{"copilot"})
+		if got := statusOfLine(out, "no presence region in .copilot/copilot-instructions.md"); got != StatusWarn {
+			t.Errorf("with copilot on PATH the missing region is drift; got %v\n%s", got, out)
+		}
+	})
+
+	t.Run("no repo → SKIP", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		sys := newSys(map[string]string{"HOME": t.TempDir()}, nil, nil)
+		var buf bytes.Buffer
+		rep := NewReport(&buf, true)
+		checkAgentPresence(sys, rep)
+		if got := statusOfLine(buf.String(), "repo not found"); got != StatusSkip {
+			t.Errorf("want SKIP, got %v\n%s", got, buf.String())
+		}
+	})
+}

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -105,6 +105,7 @@ func Run(opts Options) (int, error) {
 		checkHarnessDrift(sys, cfg, rep, opts.Fix)
 		checkDeployDrift(sys, cfg, rep)
 		checkDeployManifest(sys, rep)
+		checkAgentPresence(sys, rep)
 		checkRepoDirResolves(rep)
 		checkAntigravity(sys, rep)
 		checkOrcaHook(sys, rep, opts.Fix)

--- a/cli/internal/harness/presence.go
+++ b/cli/internal/harness/presence.go
@@ -1,0 +1,287 @@
+package harness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Agent presence is the forced-skills roster every harness's always-loaded
+// instructions file carries between AGENT-PRESENCE markers: one line per
+// invocable persona that targets the harness, naming the skills it MUST
+// consume. It is how a persona's enforcement reaches a harness that has no
+// provider hook — uniform text injection, the same on every OS.
+//
+// It used to live in compile-harness.sh only (build_agent_presence /
+// inject_agent_presence), which setup-linux.sh runs and setup-windows.ps1 never
+// ported: measured 2026-08-27, zero AGENT-PRESENCE regions in any of the four
+// instructions files on the Windows box (HARNESS-092, #1326). This package is
+// the one implementation both setups call; the shell twin delegates here.
+
+const (
+	// PresenceBeginPrefix opens the region; the full begin line carries the
+	// block's sha so a reader can tell "current" from "stale" without
+	// re-rendering. PresenceEndMarker closes it. Both spellings are shared
+	// with doctor's region stripper and must not change independently.
+	PresenceBeginPrefix = "<!-- BEGIN HARNESS AGENT-PRESENCE"
+	PresenceEndMarker   = "<!-- END HARNESS AGENT-PRESENCE -->"
+
+	presenceHeader = "## Active agent personas — forced skills\n\nWhen acting as one, you MUST consume its skills.\n\n"
+	presenceNote   = " — agent presence from vault agent definitions; edit there + re-run setup, do NOT edit between markers -->"
+)
+
+// PresenceTarget is one manifest `agents.presence[]` entry: which harness, which
+// file under $HOME, and (optionally) a command that must exist for the file to
+// be a real surface at all.
+type PresenceTarget struct {
+	Agent           string `json:"agent"`
+	File            string `json:"file"`
+	RequiresCommand string `json:"requires_command"`
+}
+
+// PresenceState is what doctor reports per target.
+type PresenceState string
+
+const (
+	PresenceCurrent PresenceState = "current" // region present, sha matches the roster
+	PresenceStale   PresenceState = "stale"   // region present, roster changed since
+	PresenceMissing PresenceState = "missing" // file exists, no region
+)
+
+// PresenceOutcome is what DeployPresence did for one target.
+type PresenceOutcome struct {
+	Agent  string
+	File   string // absolute path
+	Status string // "injected" | "unchanged" | "absent" | "empty"
+}
+
+// LoadPresence reads the manifest's `agents.record_dir` and `agents.presence[]`.
+// A manifest without a presence list yields no targets and no error: that is
+// the manifest saying "no presence", which the shell also treated as a skip.
+func LoadPresence(manifestPath string) (recordDir string, targets []PresenceTarget, err error) {
+	raw, err := os.ReadFile(manifestPath) //nolint:gosec // repo-relative, fixed name
+	if err != nil {
+		return "", nil, fmt.Errorf("reading %s: %w", ManifestFile, err)
+	}
+	var m struct {
+		Agents struct {
+			RecordDir string           `json:"record_dir"`
+			Presence  []PresenceTarget `json:"presence"`
+		} `json:"agents"`
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return "", nil, fmt.Errorf("parsing %s: %w", ManifestFile, err)
+	}
+	for i, t := range m.Agents.Presence {
+		if t.Agent == "" || t.File == "" {
+			return "", nil, fmt.Errorf("%s: agents.presence[%d] needs both agent and file", ManifestFile, i)
+		}
+	}
+	return m.Agents.RecordDir, m.Agents.Presence, nil
+}
+
+// BuildPresence renders the roster for one harness: the header, then one line
+// per invocable persona that targets it, in persona-name order. An empty string
+// means no persona targets this harness and the caller must inject nothing —
+// an empty roster is not a roster, and a region announcing "no personas" would
+// read as enforcement where there is none.
+//
+// The text is byte-identical to compile-harness.sh's build_agent_presence for
+// every record, which is what lets the two shas agree across a Linux box that
+// deployed from shell yesterday and a Windows box deploying from Go today.
+func BuildPresence(personas []*Persona, agent string) string {
+	var b strings.Builder
+	for _, p := range personas {
+		if p.Kind == "autonomous" || !p.AppliesTo(agent) {
+			continue
+		}
+		if b.Len() == 0 {
+			b.WriteString(presenceHeader)
+		}
+		skills := "none"
+		if len(p.Skills) > 0 {
+			ids := make([]string, 0, len(p.Skills))
+			for _, s := range p.Skills {
+				ids = append(ids, s.ID)
+			}
+			skills = "[" + strings.Join(ids, ", ") + "]"
+		}
+		fmt.Fprintf(&b, "- **%s** — MUST consume: %s\n", p.Name, skills)
+	}
+	return b.String()
+}
+
+// PresenceSHA is the first 16 hex characters of the block's sha256, computed
+// over the LF form so a CRLF instructions file on Windows carries the same sha
+// its Linux twin does (`sha256sum | cut -c1-16` in the shell).
+func PresenceSHA(block string) string {
+	sum := sha256.Sum256([]byte(strings.ReplaceAll(block, "\r\n", "\n")))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+// presenceBeginLine is the full begin marker for a block.
+func presenceBeginLine(block string) string {
+	return PresenceBeginPrefix + " (sha256:" + PresenceSHA(block) + ")" + presenceNote
+}
+
+// ErrPresenceTargetAbsent marks an instructions file that does not exist: the
+// harness's base file has not been deployed, so there is nothing to inject
+// into. A genuine skip, not a failure — the shell returned 1 and its caller
+// logged "target absent, skipping".
+var ErrPresenceTargetAbsent = errors.New("presence target absent")
+
+// InjectPresence writes the block into path between the markers: replacing an
+// existing region in place, or appending a fresh one after the file's content.
+// Everything outside the region — the user's prose, the GENERATED patterns
+// region — is left byte-identical. The file's own line ending is honoured so a
+// CRLF file stays CRLF. Returns false when the region already holds this exact
+// block, in which case nothing is written.
+func InjectPresence(path, block string) (bool, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // manifest-declared target under $HOME
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, fmt.Errorf("%w: %s", ErrPresenceTargetAbsent, path)
+		}
+		return false, err
+	}
+	nl := "\n"
+	if bytes.Contains(raw, []byte("\r\n")) {
+		nl = "\r\n"
+	}
+	lines := strings.Split(strings.ReplaceAll(string(raw), "\r\n", "\n"), "\n")
+	region := append([]string{presenceBeginLine(block)}, strings.Split(strings.TrimSuffix(block, "\n"), "\n")...)
+	region = append(region, PresenceEndMarker)
+
+	begin, end := -1, -1
+	for i, l := range lines {
+		if begin < 0 && strings.HasPrefix(l, PresenceBeginPrefix) {
+			begin = i
+			continue
+		}
+		if begin >= 0 && l == PresenceEndMarker {
+			end = i
+			break
+		}
+	}
+	var out []string
+	switch {
+	case begin >= 0 && end > begin:
+		if equalLines(lines[begin:end+1], region) {
+			return false, nil
+		}
+		out = append(out, lines[:begin]...)
+		out = append(out, region...)
+		out = append(out, lines[end+1:]...)
+	default:
+		// Append: a blank line, the region, and a final newline — the shell's
+		// `printf '\n%s\n' "$begin"; cat content; printf '%s\n' end` shape.
+		out = append(out, strings.TrimSuffix(strings.Join(lines, "\n"), "\n"))
+		out = append(out, "")
+		out = append(out, region...)
+		out = append(out, "")
+		out = strings.Split(strings.Join(out, "\n"), "\n")
+	}
+	data := []byte(strings.Join(out, nl))
+	if err := os.WriteFile(path, data, 0o644); err != nil { //nolint:gosec // an instructions file, world-readable by design
+		return false, err
+	}
+	return true, nil
+}
+
+func equalLines(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// RenderPresence returns the roster block for one harness from the checkout's
+// records — the `--render` half of the verb, which writes nothing. It is what
+// the shell's --check path compares a deployed region against.
+func RenderPresence(repoRoot, agent string) (string, error) {
+	recordDir, _, err := LoadPresence(filepath.Join(repoRoot, filepath.FromSlash(ManifestFile)))
+	if err != nil {
+		return "", err
+	}
+	if recordDir == "" {
+		return "", fmt.Errorf("%s: agents.record_dir is not set", ManifestFile)
+	}
+	personas, err := LoadPersonas(filepath.Join(repoRoot, filepath.FromSlash(recordDir)))
+	if err != nil {
+		return "", err
+	}
+	return BuildPresence(personas, agent), nil
+}
+
+// DeployPresence renders and injects the roster for every manifest target,
+// reading the records once. Outcomes are returned in manifest order so the
+// caller can print exactly what happened per file; only a broken record or an
+// unwritable file is an error.
+func DeployPresence(repoRoot, home string) ([]PresenceOutcome, error) {
+	recordDir, targets, err := LoadPresence(filepath.Join(repoRoot, filepath.FromSlash(ManifestFile)))
+	if err != nil {
+		return nil, err
+	}
+	if len(targets) == 0 {
+		return nil, nil
+	}
+	personas, err := LoadPersonas(filepath.Join(repoRoot, filepath.FromSlash(recordDir)))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PresenceOutcome, 0, len(targets))
+	for _, t := range targets {
+		o := PresenceOutcome{Agent: t.Agent, File: filepath.Join(home, filepath.FromSlash(t.File))}
+		block := BuildPresence(personas, t.Agent)
+		if block == "" {
+			o.Status = "empty"
+			out = append(out, o)
+			continue
+		}
+		changed, err := InjectPresence(o.File, block)
+		switch {
+		case errors.Is(err, ErrPresenceTargetAbsent):
+			o.Status = "absent"
+		case err != nil:
+			return out, fmt.Errorf("presence for %s: %w", t.Agent, err)
+		case changed:
+			o.Status = "injected"
+		default:
+			o.Status = "unchanged"
+		}
+		out = append(out, o)
+	}
+	return out, nil
+}
+
+// PresenceStatus reads the region an instructions file carries and compares
+// its sha with the block the records render today. It writes nothing; doctor
+// calls it.
+func PresenceStatus(path, block string) (PresenceState, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // manifest-declared target under $HOME
+	if err != nil {
+		return "", err
+	}
+	want := "(sha256:" + PresenceSHA(block) + ")"
+	for _, l := range strings.Split(strings.ReplaceAll(string(raw), "\r\n", "\n"), "\n") {
+		if !strings.HasPrefix(l, PresenceBeginPrefix) {
+			continue
+		}
+		if strings.Contains(l, want) {
+			return PresenceCurrent, nil
+		}
+		return PresenceStale, nil
+	}
+	return PresenceMissing, nil
+}

--- a/cli/internal/harness/presence_test.go
+++ b/cli/internal/harness/presence_test.go
@@ -1,0 +1,254 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// presenceRepo mirrors tests/compile-harness.bats' seed_agents_fixture: one
+// invocable persona (curator) targeting all four harnesses, plus whatever the
+// test adds.
+func presenceRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	write(t, filepath.Join(repo, "harness", "manifest.json"), `{ "version": 1,
+  "agents": { "record_dir": "harness/agents",
+    "presence": [
+      { "agent": "claude",   "file": ".claude/CLAUDE.md" },
+      { "agent": "opencode", "file": ".config/opencode/AGENTS.md" },
+      { "agent": "pi",       "file": ".pi/agent/AGENTS.md" },
+      { "agent": "copilot",  "file": ".copilot/copilot-instructions.md", "requires_command": "copilot" } ] } }`)
+	writeRecord(t, repo, "curator", "---\nname: curator\ndescription: Crystallize-phase persona.\nkind: invocable\nmodel: top\nskills: [vault-doctor, crystallize, genre-picker]\ntargets: [claude, opencode, pi, copilot]\n---\n\n# Curator\n")
+	return repo
+}
+
+func writeRecord(t *testing.T, repo, name, body string) {
+	t.Helper()
+	write(t, filepath.Join(repo, "harness", "agents", name, "AGENT.md"), body)
+}
+
+func write(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const instructionsFixture = "user intro\n\n<!-- BEGIN HARNESS GENERATED -->\npatterns content\n<!-- END HARNESS GENERATED -->\n\nuser outro\n"
+
+func read(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path) //nolint:gosec // test fixture
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+// The block is byte-identical to compile-harness.sh's build_agent_presence:
+// header once, one bullet per invocable persona in name order, ids as the
+// resolve-skills flow sequence, "none" for a persona without skills.
+func TestBuildPresence_MatchesTheShellRendering(t *testing.T) {
+	repo := presenceRepo(t)
+	writeRecord(t, repo, "auto", "---\nname: auto\ndescription: never listed.\nkind: autonomous\nskills: [x]\n---\n")
+	writeRecord(t, repo, "bare", "---\nname: bare\ndescription: no skills.\nkind: invocable\n---\n")
+	personas, err := LoadPersonas(filepath.Join(repo, "harness", "agents"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := BuildPresence(personas, "claude")
+	want := "## Active agent personas — forced skills\n\nWhen acting as one, you MUST consume its skills.\n\n" +
+		"- **bare** — MUST consume: none\n" +
+		"- **curator** — MUST consume: [vault-doctor, crystallize, genre-picker]\n"
+	if got != want {
+		t.Errorf("block differs from the shell rendering:\n got: %q\nwant: %q", got, want)
+	}
+	if PresenceSHA(got) != PresenceSHA(strings.ReplaceAll(got, "\n", "\r\n")) {
+		t.Error("the sha must not depend on line endings")
+	}
+}
+
+// HARNESS-045 AC7, carried over from tests/compile-harness.bats: a record whose
+// skills are in the mapping form (per-skill severity) renders its ids and only
+// its ids — never "none", never the severity, which belongs to the gate.
+func TestBuildPresence_RendersMappingFormSkillsWithoutSeverity(t *testing.T) {
+	repo := t.TempDir()
+	writeRecord(t, repo, "curator", "---\nname: curator\ndescription: x\nkind: invocable\nskills:\n  - id: crystallize\n    enforce: block\n  - id: insights\n    enforce: warn\n---\n")
+	personas, err := LoadPersonas(filepath.Join(repo, "harness", "agents"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := BuildPresence(personas, "claude")
+	if !strings.Contains(got, "- **curator** — MUST consume: [crystallize, insights]\n") {
+		t.Errorf("mapping-form skills must render their ids:\n%s", got)
+	}
+	if strings.Contains(got, "none") || strings.Contains(got, "enforce") || strings.Contains(got, "block") {
+		t.Errorf("neither 'none' nor severity may appear:\n%s", got)
+	}
+}
+
+func TestBuildPresence_RespectsTargetsAndSkipsAutonomous(t *testing.T) {
+	repo := presenceRepo(t)
+	writeRecord(t, repo, "scribe", "---\nname: scribe\ndescription: opencode only.\nkind: invocable\nskills: [docs-skill]\ntargets: [opencode]\n---\n")
+	personas, err := LoadPersonas(filepath.Join(repo, "harness", "agents"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claude, opencode := BuildPresence(personas, "claude"), BuildPresence(personas, "opencode")
+	if strings.Contains(claude, "scribe") || !strings.Contains(claude, "curator") {
+		t.Errorf("claude must list curator only:\n%s", claude)
+	}
+	if !strings.Contains(opencode, "scribe") || !strings.Contains(opencode, "curator") {
+		t.Errorf("opencode must list both:\n%s", opencode)
+	}
+	// targets: [pi] must not match "copilot" — the shell's substring test did.
+	writeRecord(t, repo, "piper", "---\nname: piper\ndescription: pi only.\nkind: invocable\ntargets: [pi]\n---\n")
+	personas, _ = LoadPersonas(filepath.Join(repo, "harness", "agents"))
+	if strings.Contains(BuildPresence(personas, "copilot"), "piper") {
+		t.Error("a persona targeting pi must not appear for copilot")
+	}
+}
+
+func TestBuildPresence_EmptyWhenNoPersonaTargetsTheHarness(t *testing.T) {
+	repo := t.TempDir()
+	writeRecord(t, repo, "scribe", "---\nname: scribe\ndescription: opencode only.\nkind: invocable\ntargets: [opencode]\n---\n")
+	personas, err := LoadPersonas(filepath.Join(repo, "harness", "agents"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := BuildPresence(personas, "claude"); got != "" {
+		t.Errorf("no persona targets claude → empty block, got %q", got)
+	}
+}
+
+// AC1/AC2 (HARNESS-092, #1326): inject into every target, leave user content
+// and the GENERATED region untouched, and be idempotent — two runs, one region.
+func TestDeployPresence_InjectsEveryTargetOnceAndKeepsTheRest(t *testing.T) {
+	repo, home := presenceRepo(t), t.TempDir()
+	files := []string{".claude/CLAUDE.md", ".config/opencode/AGENTS.md", ".pi/agent/AGENTS.md", ".copilot/copilot-instructions.md"}
+	for _, f := range files {
+		write(t, filepath.Join(home, filepath.FromSlash(f)), instructionsFixture)
+	}
+
+	first, err := DeployPresence(repo, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, o := range first {
+		if o.Status != "injected" {
+			t.Errorf("%s: want injected, got %s", o.Agent, o.Status)
+		}
+	}
+	second, err := DeployPresence(repo, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, o := range second {
+		if o.Status != "unchanged" {
+			t.Errorf("%s: second run must be unchanged, got %s", o.Agent, o.Status)
+		}
+	}
+	for _, f := range files {
+		got := read(t, filepath.Join(home, filepath.FromSlash(f)))
+		for _, needle := range []string{"user intro", "patterns content", "user outro", "curator", "vault-doctor", PresenceEndMarker} {
+			if !strings.Contains(got, needle) {
+				t.Errorf("%s lacks %q:\n%s", f, needle, got)
+			}
+		}
+		if strings.Count(got, PresenceBeginPrefix) != 1 || strings.Count(got, "BEGIN HARNESS GENERATED") != 1 {
+			t.Errorf("%s: exactly one presence region and one patterns region expected:\n%s", f, got)
+		}
+		if !strings.HasPrefix(got, "user intro") || !strings.HasSuffix(got, PresenceEndMarker+"\n") {
+			t.Errorf("%s: appended region must follow the content and end with a newline:\n%q", f, got)
+		}
+	}
+}
+
+func TestInjectPresence_ReplacesAStaleRegionInPlace(t *testing.T) {
+	home := t.TempDir()
+	f := filepath.Join(home, "AGENTS.md")
+	stale := "intro\n\n" + PresenceBeginPrefix + " (sha256:0000000000000000)" + presenceNote + "\nold roster\n" + PresenceEndMarker + "\n\noutro\n"
+	write(t, f, stale)
+
+	changed, err := InjectPresence(f, "new roster\n")
+	if err != nil || !changed {
+		t.Fatalf("changed=%v err=%v", changed, err)
+	}
+	got := read(t, f)
+	if strings.Contains(got, "old roster") || !strings.Contains(got, "new roster") {
+		t.Errorf("region not replaced:\n%s", got)
+	}
+	if !strings.HasPrefix(got, "intro\n\n") || !strings.HasSuffix(got, PresenceEndMarker+"\n\noutro\n") {
+		t.Errorf("content around the region must be byte-identical:\n%q", got)
+	}
+	if state, _ := PresenceStatus(f, "new roster\n"); state != PresenceCurrent {
+		t.Errorf("after injection the status is current, got %s", state)
+	}
+	if state, _ := PresenceStatus(f, "newer roster\n"); state != PresenceStale {
+		t.Errorf("a changed roster reads as stale, got %s", state)
+	}
+}
+
+// A CRLF instructions file (the Windows checkout copies them CRLF) stays CRLF,
+// and carries the same sha its LF twin would.
+func TestInjectPresence_HonoursCRLF(t *testing.T) {
+	home := t.TempDir()
+	f := filepath.Join(home, "CLAUDE.md")
+	write(t, f, strings.ReplaceAll(instructionsFixture, "\n", "\r\n"))
+
+	if _, err := InjectPresence(f, "roster\n"); err != nil {
+		t.Fatal(err)
+	}
+	got := read(t, f)
+	if strings.Contains(strings.ReplaceAll(got, "\r\n", ""), "\n") {
+		t.Errorf("a CRLF file must not gain bare LF lines:\n%q", got)
+	}
+	if !strings.Contains(got, "(sha256:"+PresenceSHA("roster\n")+")") {
+		t.Error("the sha must be the LF sha")
+	}
+	if state, _ := PresenceStatus(f, "roster\n"); state != PresenceCurrent {
+		t.Errorf("CRLF region must read as current, got %s", state)
+	}
+}
+
+func TestDeployPresence_AbsentTargetIsASkipAndEmptyRosterInjectsNothing(t *testing.T) {
+	repo, home := presenceRepo(t), t.TempDir()
+	writeRecord(t, repo, "curator", "---\nname: curator\ndescription: opencode only now.\nkind: invocable\nskills: [vault-doctor]\ntargets: [opencode]\n---\n")
+	write(t, filepath.Join(home, ".claude", "CLAUDE.md"), instructionsFixture)
+	// opencode's file is absent on purpose.
+
+	out, err := DeployPresence(repo, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{"claude": "empty", "opencode": "absent", "pi": "empty", "copilot": "empty"}
+	for _, o := range out {
+		if o.Status != want[o.Agent] {
+			t.Errorf("%s: want %s, got %s", o.Agent, want[o.Agent], o.Status)
+		}
+	}
+	if strings.Contains(read(t, filepath.Join(home, ".claude", "CLAUDE.md")), PresenceBeginPrefix) {
+		t.Error("an empty roster must inject no region")
+	}
+	if state, _ := PresenceStatus(filepath.Join(home, ".claude", "CLAUDE.md"), ""); state != PresenceMissing {
+		t.Errorf("no region reads as missing, got %s", state)
+	}
+}
+
+func TestLoadPresence_ManifestWithoutPresenceIsNoTargets(t *testing.T) {
+	repo := t.TempDir()
+	write(t, filepath.Join(repo, "harness", "manifest.json"), `{"version":1,"agents":{"record_dir":"harness/agents"}}`)
+	_, targets, err := LoadPresence(filepath.Join(repo, "harness", "manifest.json"))
+	if err != nil || len(targets) != 0 {
+		t.Errorf("want no targets and no error, got %v %v", targets, err)
+	}
+	write(t, filepath.Join(repo, "harness", "manifest.json"), `{"version":1,"agents":{"presence":[{"agent":"claude"}]}}`)
+	if _, _, err := LoadPresence(filepath.Join(repo, "harness", "manifest.json")); err == nil {
+		t.Error("an entry without a file must be rejected")
+	}
+}

--- a/scripts/compile-harness.sh
+++ b/scripts/compile-harness.sh
@@ -31,13 +31,11 @@ set -euo pipefail
 BEGIN_PREFIX='<!-- BEGIN HARNESS GENERATED'
 END_MARKER='<!-- END HARNESS GENERATED -->'
 
-# Distinct marker namespace for agent-presence injection (ADR-027). Kept separate
-# from BEGIN_PREFIX/END_MARKER so an agent-presence region coexists with the
-# patterns / skill-catalog region in the same always-loaded instructions file
-# without either disturbing the other (validate_markers expects exactly one
-# GENERATED pair; presence uses its own pair).
-AGENT_BEGIN_PREFIX='<!-- BEGIN HARNESS AGENT-PRESENCE'
-AGENT_END_MARKER='<!-- END HARNESS AGENT-PRESENCE -->'
+# The agent-presence region (ADR-027) uses its own marker pair, distinct from
+# BEGIN_PREFIX/END_MARKER so it coexists with the patterns / skill-catalog
+# region in the same instructions file. Those markers are owned by
+# `dotf harness presence` (cli/internal/harness/presence.go) since HARNESS-092;
+# this script no longer spells them.
 
 usage() {
     cat <<EOF
@@ -605,36 +603,9 @@ skill_field() {
 # agent_capability_line established for `capabilities:`, on the identical
 # reasoning one field over: an empty skill list is not "no opinion", it is
 # "nothing enforced".
-agent_skills_line() {
-    local record="$1" rc=0 line
-    type -P dotf >/dev/null 2>&1 || rc=2
-    if [ "$rc" -eq 0 ] && ! dotf_knows_subcommand resolve-skills; then rc=2; fi
-    if [ "$rc" -eq 0 ]; then
-        line="$(dotf harness resolve-skills "$record")" || rc=1
-    fi
-    case "$rc" in
-        0) printf '%s\n' "$line" ;;
-        1) printf '[ERROR] %s declares a `skills:` list that cannot be resolved\n' "$record" >&2
-           return 1 ;;
-        2) line="$(skill_field "$record" skills)"
-           if [ -z "$line" ] && record_has_block_skills "$record"; then
-               printf '[ERROR] %s declares `skills:` in YAML block style, and dotf is absent or\n' "$record" >&2
-               printf '        predates resolve-skills, so this renderer cannot read it. Rendering\n' >&2
-               printf '        "MUST consume: none" would DISARM the persona rather than describe it\n' >&2
-               printf '        -- rebuild dotf and re-run --deploy\n' >&2
-               return 1
-           fi
-           printf '%s\n' "$line" ;;
-    esac
-}
-
 # True when a record declares `skills:` with nothing after the colon -- the YAML
 # block form. Shared by the guard above and its test; a bare `skills:` key with an
 # empty value is the one case skill_field cannot distinguish from "no key at all".
-record_has_block_skills() {
-    awk '/^---[[:space:]]*$/{n++; next} n==1 && /^skills:[[:space:]]*$/{found=1} n>=2{exit} END{exit !found}' "$1"
-}
-
 # Build a markdown skill catalog (one bullet per skill targeting <agent>), for
 # agents with no per-skill mechanism (e.g. copilot's single instructions file).
 # Deterministic order (glob sorts). Args: <record_dir> <agent>
@@ -1024,10 +995,21 @@ deploy_agents() {
     fi
 }
 
-# Build the agent-presence block for <agent>: one line per INVOCABLE persona that
-# targets this harness, naming its forced skills. Deterministic order (glob
-# sorts). Empty output (no persona targets this harness) tells the caller to skip
-# injection.
+# Render the agent-presence block for <agent> (HARNESS-092, #1326): delegated to
+# `dotf harness presence --render`, the one renderer both OSes share, so the
+# compact doctrine payload (deploy_doctrine, agy/codex) and the injected region
+# carry the same text and the same sha. Empty output means no persona targets
+# this harness. Unlike the resolve-* helpers this has no awk fallback: a
+# roster rendered by a second parser is the drift this port removes.
+build_agent_presence() {
+    local agent="$2"
+    if ! type -P dotf >/dev/null 2>&1 || ! dotf_knows_subcommand presence; then
+        printf '[WARN] agent presence needs `dotf harness presence`; dotf is absent or predates it\n' >&2
+        printf '       the %s doctrine payload carries NO persona roster -- rebuild dotf and re-run --deploy\n' "$agent" >&2
+        return 0
+    fi
+    dotf harness presence --render "$agent" --repo-root "$REPO_ROOT"
+}
 #
 # `kind: autonomous` records are cataloged, never injected. The block's own
 # sentence is "when acting as one", and you never act as an autonomous instance:
@@ -1049,22 +1031,6 @@ deploy_agents() {
 # compacting enforcement prose by paraphrase is how a rule quietly loses its
 # teeth.
 # Args: <record_dir> <agent>
-build_agent_presence() {
-    local ag_recdir="$1" agent="$2" ag_dir name skills_line first=1
-    for ag_dir in "$ag_recdir"/*/; do
-        [[ -f "$ag_dir/AGENT.md" ]] || continue
-        name="$(basename "$ag_dir")"
-        [[ "$(skill_field "$ag_dir/AGENT.md" kind)" == "autonomous" ]] && continue
-        skill_targets_agent "$ag_dir/AGENT.md" "$agent" || continue
-        if [[ "$first" == 1 ]]; then
-            printf '## Active agent personas — forced skills\n\n'
-            printf 'When acting as one, you MUST consume its skills.\n\n'
-            first=0
-        fi
-        skills_line="$(agent_skills_line "$ag_dir/AGENT.md")" || return 1
-        printf -- '- **%s** — MUST consume: %s\n' "$name" "${skills_line:-none}"
-    done
-}
 
 # --- doctrine (HARNESS-054) ---
 # Most harnesses receive the whole cross-agent AGENTS.md (opencode, pi) or a full
@@ -1162,51 +1128,29 @@ deploy_doctrine() {
 # skill-catalog region (BEGIN_PREFIX). Replaces an existing presence region in
 # place; appends a fresh one if absent. Skips a target file that does not exist.
 # Args: <file_abs> <content_file>
-inject_agent_presence() {
-    local file="$1" content_file="$2" sha begin tmp
-    if [[ ! -f "$file" ]]; then
-        printf '[deploy] presence target absent, skipping: %s\n' "$file" >&2
-        return 1
-    fi
-    sha="$(sha_of "$content_file")"
-    begin="$AGENT_BEGIN_PREFIX (sha256:$sha) — agent presence from vault agent definitions; edit there + re-run setup, do NOT edit between markers -->"
-    tmp="$(mktemp)"
-    if grep -q "^$AGENT_BEGIN_PREFIX" "$file" && grep -qF "$AGENT_END_MARKER" "$file"; then
-        # replace the existing presence region in place (mirrors replace_region)
-        awk -v beginm="$begin" -v endm="$AGENT_END_MARKER" -v bp="$AGENT_BEGIN_PREFIX" -v cf="$content_file" '
-            index($0,bp)==1 { print beginm; while ((getline l < cf) > 0) print l; close(cf); skip=1; next }
-            $0==endm { if (skip){ print; skip=0; next } }
-            skip { next }
-            { print }
-        ' "$file" > "$tmp"
-    else
-        # append a fresh presence region at the end of the file
-        cat "$file" > "$tmp"
-        { printf '\n%s\n' "$begin"; cat "$content_file"; printf '%s\n' "$AGENT_END_MARKER"; } >> "$tmp"
-    fi
-    mv "$tmp" "$file"
-}
 
 # Presence-level determinism for every configured harness: build the persona
 # block for that harness and inject it into its instructions file. One uniform
 # mechanism (marked-region injection) across claude / opencode / pi / copilot.
+
 deploy_agent_presence() {
-    local ag_recdir="$1" agent file file_abs tmp
-    while IFS=$'\t' read -r agent file; do
-        [[ -n "$agent" ]] || continue
-        tmp="$(mktemp)"
-        build_agent_presence "$ag_recdir" "$agent" > "$tmp"
-        if [[ ! -s "$tmp" ]]; then rm -f "$tmp"; continue; fi   # no persona targets this harness
-        file_abs="$HOME/$file"
-        # inject_agent_presence returns 1 (a genuine no-op, not a set -e-worthy
-        # error) when the target file is absent -- only log success when it
-        # actually wrote something, else "presence target absent, skipping"
-        # was immediately followed by a contradicting success line.
-        if inject_agent_presence "$file_abs" "$tmp"; then
-            printf '[deploy] presence -> %s (%s)\n' "$file_abs" "$agent"
-        fi
-        rm -f "$tmp"
-    done < <(jq -r '.agents.presence[] | "\(.agent)\t\(.file)"' "$MANIFEST")
+    # HARNESS-092 (#1326): the presence roster is rendered and injected by
+    # `dotf harness presence` -- one implementation for every OS, the same
+    # sha in every begin marker. This function used to hold a shell copy
+    # (build/inject_agent_presence) that setup-windows.ps1 never ported, so no
+    # harness on Windows was ever told which skills a persona forces. A dotf
+    # that is absent or predates the verb is an ERROR that fails --deploy: a
+    # presence that quietly is not deployed is exactly the defect.
+    # Absent or too old is a bootstrap state, not a failure: setup-linux.sh
+    # installs dotf best-effort and the other resolvers degrade the same way
+    # (tier, capabilities). Loud, though -- the WARN names what did NOT happen.
+    # A dotf that runs the verb and fails is a different thing and fails --deploy.
+    if ! type -P dotf >/dev/null 2>&1 || ! dotf_knows_subcommand presence; then
+        printf '[WARN] agent presence needs `dotf harness presence`; dotf is absent or predates it\n' >&2
+        printf '       presence NOT deployed to any harness -- rebuild dotf and re-run --deploy\n' >&2
+        return 0
+    fi
+    dotf harness presence --repo-root "$REPO_ROOT"
 }
 
 # --- coverage: every enforced region reaches every surface, or says why not ---

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -2193,6 +2193,20 @@ function Deploy-SkillRecord {
 
 Deploy-SkillRecord -DotfilesDir $DotfilesDir
 
+# Agent presence (HARNESS-092, #1326): the forced-skills roster every harness
+# instructions file carries between AGENT-PRESENCE markers. Linux gets it from
+# compile-harness.sh --deploy, which delegates to this same verb; Windows had
+# no port, so no harness on this OS was ever told what a persona MUST consume.
+# Runs after the base files (CLAUDE.md, AGENTS.md, copilot-instructions.md) and
+# the skill records are in place; a target file that is absent is skipped and
+# said so.
+& dotf harness presence --repo-root $DotfilesDir
+if ($LASTEXITCODE -eq 0) {
+    Write-Success "Agent presence injected into the harness instructions files (dotf harness presence)"
+} else {
+    Write-Warn "dotf harness presence failed (no harness is told which skills a persona forces; see 'dotf doctor')"
+}
+
 # Weekly vault maintenance scheduled task (Sundays 10:07 AM)
 # Self-healing: compare existing action arguments against expected and rewrite
 # when they diverge -- guards against stale tasks pointing at moved/renamed scripts.

--- a/specs/HARNESS-092-harness-presence/features.json
+++ b/specs/HARNESS-092-harness-presence/features.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "HARNESS-092-harness-presence-f1",
+    "behavior": "AC1: BuildPresence renders byte-identically to the shell (header once, name order, [ids] or none, autonomous skipped, targets by whole name) and the sha ignores line endings",
+    "verification": "cd cli && go test ./internal/harness/ -run 'TestBuildPresence|TestLoadPresence' -count=1",
+    "state": "verified",
+    "evidence": "ok on the Windows work box 2026-08-28; mutations (autonomous listed; sha over raw bytes) fail TestBuildPresence_MatchesTheShellRendering"
+  },
+  {
+    "id": "HARNESS-092-harness-presence-f2",
+    "behavior": "AC2: DeployPresence injects every target once, keeps user content and the GENERATED region, appends without markers, replaces a stale region in place, is idempotent, keeps CRLF, skips an absent file, injects nothing for an empty roster",
+    "verification": "cd cli && go test ./internal/harness/ ./internal/cmd/ -run 'TestDeployPresence|TestInjectPresence|TestHarnessPresenceCmd' -count=1",
+    "state": "verified",
+    "evidence": "ok on the Windows work box 2026-08-28; mutation (append instead of replace) fails TestInjectPresence_ReplacesAStaleRegionInPlace"
+  },
+  {
+    "id": "HARNESS-092-harness-presence-f3",
+    "behavior": "AC3: compile-harness.sh --deploy delegates to dotf harness presence --repo-root <checkout>, fails when it fails or when dotf predates the verb, carries no injector; setup-windows.ps1 calls the verb after Deploy-SkillRecord",
+    "verification": "bats tests/compile-harness.bats -f 'HARNESS-092' && bats tests/setup-windows.bats -f 'HARNESS-092'",
+    "state": "verified",
+    "evidence": "see verification.md (Windows work box 2026-08-28)"
+  },
+  {
+    "id": "HARNESS-092-harness-presence-f4",
+    "behavior": "AC4: dotf doctor reports presence by status (PASS with counts / WARN missing / WARN stale / SKIP without repo), gates copilot's file on the binary, writes nothing",
+    "verification": "grep -q 'checkAgentPresence(sys, rep)' cli/internal/doctor/doctor.go && cd cli && go test ./internal/doctor/ -run TestCheckAgentPresence_ByStatus -count=1",
+    "state": "verified",
+    "evidence": "ok on the Windows work box 2026-08-28; mutation (stale counted as current) fails the stale row"
+  },
+  {
+    "id": "HARNESS-092-harness-presence-f5",
+    "behavior": "AC5 (box): the four instructions files carry one presence region each with the same sha, a second run reports every file current, doctor's section is green",
+    "verification": "dotf harness presence | grep -q 'presence current' && grep -c 'BEGIN HARNESS AGENT-PRESENCE' ~/.claude/CLAUDE.md | grep -qx 1",
+    "state": "verified",
+    "evidence": "see verification.md (Windows work box 2026-08-28: 0 regions before, 4 injected, 4 current on rerun)"
+  }
+]

--- a/specs/HARNESS-092-harness-presence/proposal.md
+++ b/specs/HARNESS-092-harness-presence/proposal.md
@@ -1,0 +1,96 @@
+---
+id: "HARNESS-092-harness-presence"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-08-28"
+issue: "mlorentedev/dotfiles#1326"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, harness, windows, cli]
+template_version: "1.0"
+---
+
+# HARNESS-092-harness-presence
+
+> **Naming**: file lives at `<repo>/specs/HARNESS-092-harness-presence/proposal.md`. `HARNESS-092-harness-presence` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+Agent presence — the roster of invocable personas and the skills each MUST consume, injected
+between `AGENT-PRESENCE` markers into every harness's always-loaded instructions file — is how a
+persona's enforcement reaches a harness that has no provider hook. It lived only in
+`compile-harness.sh` (`build_agent_presence` / `inject_agent_presence`), which `setup-linux.sh`
+runs and `setup-windows.ps1` never ported: measured 2026-08-27 on the Windows work box, zero
+regions in `~/.claude/CLAUDE.md`, `~/.pi/agent/AGENTS.md`, `~/.config/opencode/AGENTS.md` and
+`~/.copilot/copilot-instructions.md`, and every doctor check green — `checkInstructionDrift`
+strips the region before comparing, so nothing looked (#1326).
+
+## What
+
+- `dotf harness presence` renders the roster for every `agents.presence[]` target of the manifest
+  and injects it into `$HOME/<file>`: replacing an existing region in place, appending a fresh
+  one otherwise, leaving everything outside the markers byte-identical, honouring the file's line
+  ending, and not rewriting a file whose region already holds this roster. The begin marker
+  carries the block's sha (LF form, first 16 hex chars — `sha256sum | cut -c1-16`, as the shell
+  did). `--render <agent>` prints the block and writes nothing. A target file that does not
+  exist is skipped and said so; a harness no persona targets gets no region; a broken record
+  fails the command.
+- `compile-harness.sh --deploy` delegates: `deploy_agent_presence` calls the verb,
+  `build_agent_presence` (still composing the compact doctrine payload for agy/codex) calls
+  `--render`, `inject_agent_presence` (and the now-dead `agent_skills_line` /
+  `record_has_block_skills`) are deleted. A dotf that is absent or predates the verb is a loud
+  WARN naming what was NOT deployed and the deploy continues — the engine's bootstrap contract,
+  the same degrade the tier and capability resolvers have; no awk fallback, because a roster
+  rendered by a second parser is the drift the port removes. A dotf that runs the verb and fails
+  does fail `--deploy`.
+- `setup-windows.ps1` calls `dotf harness presence --repo-root $DotfilesDir` after
+  `Deploy-SkillRecord`, once every base file is in place.
+- `dotf doctor` gains "Agent presence (forced skills)": per target (gated on `requires_command`
+  like the instruction-drift check), the region's sha is compared with the roster the records
+  render today — PASS with counts, WARN "no presence region" or "stale presence" naming the file
+  and `dotf harness presence`, SKIP without a repo. It renders, never writes.
+- The four presence scenario tests in `tests/compile-harness.bats` move to Go
+  (`cli/internal/harness/presence_test.go`); the bats layer keeps its contract: `--deploy` calls
+  the verb with the checkout as `--repo-root`, honours its exit status, and refuses to deploy
+  without it. The stub `dotf` simulates `--render` from the records as it already simulates
+  `resolve-skills`.
+
+## Out of scope
+
+- Porting the rest of `compile-harness.sh --deploy` (records, doctrine, skill catalog) — that is
+  CLI-026 (#495); this is its first writing slice.
+- Array-union or per-harness ordering of the roster: name order, as the shell's glob gave.
+- The shell's `targets:` substring match (`[pi]` matched `copilot`): Go matches whole names,
+  which is the documented intent; recorded as a behaviour difference, not preserved.
+
+## Risks / open questions
+
+- CRLF instructions files on Windows (the checkout copies them CRLF): the injector keeps the
+  file's ending and the sha is computed over LF, so Linux and Windows agree. Resolved by test.
+- `dotf` availability inside `compile-harness.bats`: the suite stubs `dotf` on purpose (ADR-020,
+  "do not build dotf here"); the stub gains the verb. Resolved.
+- A first setup on a box whose base files are not yet deployed when the verb runs: targets are
+  skipped and reported; the next setup run converges. Resolved: same as the shell's behaviour.
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [ ] AC1 — `BuildPresence` renders byte-identically to the shell (header once, name order,
+  `[ids]` or `none`, autonomous personas skipped, `targets:` honoured by whole name); the sha is
+  line-ending independent.
+- [ ] AC2 — `DeployPresence` injects every manifest target once, keeps user content and the
+  GENERATED region intact, appends when no markers exist, replaces a stale region in place, is
+  idempotent (second run "unchanged", file untouched), keeps CRLF, skips an absent file, injects
+  nothing for an empty roster.
+- [ ] AC3 — `compile-harness.sh --deploy` calls `dotf harness presence --repo-root <checkout>`,
+  fails when it fails, warns "presence NOT deployed" and continues when dotf predates the verb,
+  and carries no injector; `setup-windows.ps1` calls the verb after `Deploy-SkillRecord`.
+- [ ] AC4 — `dotf doctor` reports presence by status (PASS with counts / WARN missing / WARN stale
+  / SKIP without repo), gates copilot's file on the binary, and writes nothing.
+- [ ] AC5 — On the Windows work box: `dotf harness presence` injects the roster into the four
+  files (measured 0 regions before), a second run reports every file current, `dotf doctor`'s
+  section is green, `compile-harness.sh --check` still passes on Linux CI.
+
+## References
+
+- Bitácora board: #1326 (HARNESS-092); related #495 (CLI-026), #563 (HARNESS-047), #1319 (AC7 of HARNESS-045: resolve-skills delegation)
+- Related ADR: `docs/adr/adr-020-tooling-cli-go-convergence.md` (C7, strangler fig), `docs/adr/adr-027-*` (marker namespaces)

--- a/specs/HARNESS-092-harness-presence/tasks.md
+++ b/specs/HARNESS-092-harness-presence/tasks.md
@@ -1,0 +1,31 @@
+---
+tags: [spec, tasks]
+created: "2026-08-28"
+---
+
+# Tasks - HARNESS-092-harness-presence
+
+## Setup
+
+- [x] Branch: `feat/harness-presence` from `origin/main` (worktree `dotfiles-wt-presence`)
+- [x] `proposal.md` complete, acceptance criteria testable
+- [x] No open questions left in `proposal.md`
+
+## Implementation
+
+- [x] [P] [AC1] Failing tests `TestBuildPresence_MatchesTheShellRendering`, `TestBuildPresence_RespectsTargetsAndSkipsAutonomous`, `TestBuildPresence_EmptyWhenNoPersonaTargetsTheHarness`
+- [x] [AC1] `harness.BuildPresence`, `PresenceSHA` (LF form, 16 hex), `LoadPresence` (manifest `agents.presence[]` + `record_dir`)
+- [x] [P] [AC2] Failing tests `TestDeployPresence_InjectsEveryTargetOnceAndKeepsTheRest`, `TestInjectPresence_ReplacesAStaleRegionInPlace`, `TestInjectPresence_HonoursCRLF`, `TestDeployPresence_AbsentTargetIsASkipAndEmptyRosterInjectsNothing`
+- [x] [AC2] `harness.InjectPresence`, `DeployPresence`, `RenderPresence`, `PresenceStatus`; `dotf harness presence [--repo-root] [--home] [--render <agent>]` (`harness_presence.go` + cmd tests)
+- [x] [P] [AC3] `compile-harness.sh`: `deploy_agent_presence` delegates, `build_agent_presence` wraps `--render`, `inject_agent_presence` deleted; absent/old dotf → ERROR, `--deploy` fails
+- [x] [AC3] `setup-windows.ps1` calls the verb after `Deploy-SkillRecord`; `tests/setup-windows.bats` ordering + parity guard; `tests/compile-harness.bats` stub learns the verb (argv recorded, `--render` simulated), four scenario tests replaced by three contract tests
+- [x] [P] [AC4] Failing test `TestCheckAgentPresence_ByStatus` (PASS / WARN missing / WARN stale / copilot gate / SKIP)
+- [x] [AC4] `checkAgentPresence` registered after `checkDeployDrift`
+- [x] [AC5] Box: 0 regions before → 4 injected → second run current → doctor section green → instruction-drift check still PASS (region stripped)
+- [x] Mutation checks: autonomous listed / append-not-replace / sha depends on EOL / doctor calls stale current — each red, restored
+
+## Verification
+
+- [x] Go loop: build, vet (host, `GOOS=linux`), test, golangci-lint
+- [x] bats: compile-harness, setup-windows; `bash -n`; `setup-windows.ps1` parse 0 errors, ASCII delta 0, CRLF intact
+- [x] `verification.md` records the evidence; `features.json` per AC

--- a/specs/HARNESS-092-harness-presence/verification.md
+++ b/specs/HARNESS-092-harness-presence/verification.md
@@ -72,6 +72,10 @@ bats tests/compile-harness.bats -f 'agents:|doctrine|presence|HARNESS-092'   -> 
 - **Whole-name `targets:` match.** `Persona.AppliesTo` already matched whole names; the shell's
   substring test (`[pi]` matched `copilot`) is a latent defect, not behaviour to preserve.
 - **Doctor WARN, not FAIL.** The remedy is one idempotent command setup already runs.
+- **The AGENT-PRESENCE markers have one spelling.** `harness.PresenceBeginPrefix/EndMarker` is the
+  SSOT; doctor's mirror constants derive from it and `TestHarnessMarkerConstants` now pins that
+  plus the shell's deletion of its own `AGENT_*` copy (it used to pin the shell's copy — caught
+  after the rebase onto #1365/#1366).
 
 ## Promotion candidates
 

--- a/specs/HARNESS-092-harness-presence/verification.md
+++ b/specs/HARNESS-092-harness-presence/verification.md
@@ -1,0 +1,87 @@
+---
+tags: [spec, verification]
+created: "2026-08-28"
+---
+
+# Verification - HARNESS-092-harness-presence
+
+## Evidence
+
+Run on the Windows work box, 2026-08-28, worktree `dotfiles-wt-presence`, branch
+`feat/harness-presence`, `dotf` built from the branch.
+
+- [x] **AC1** → `TestBuildPresence_MatchesTheShellRendering` (exact bytes of the shell's header + bullets,
+  autonomous skipped, `none` for a skill-less persona, sha equal for LF and CRLF input),
+  `TestBuildPresence_RespectsTargetsAndSkipsAutonomous` (incl. `targets: [pi]` not matching `copilot` —
+  the shell's substring match did), `TestBuildPresence_EmptyWhenNoPersonaTargetsTheHarness`,
+  `TestLoadPresence_ManifestWithoutPresenceIsNoTargets`. Mutations: autonomous listed → red; sha over
+  raw bytes → red.
+- [x] **AC2** → `TestDeployPresence_InjectsEveryTargetOnceAndKeepsTheRest` (four files, two runs, one
+  region, user prose and GENERATED region intact, region appended after the content),
+  `TestInjectPresence_ReplacesAStaleRegionInPlace`, `TestInjectPresence_HonoursCRLF`,
+  `TestDeployPresence_AbsentTargetIsASkipAndEmptyRosterInjectsNothing`;
+  `TestHarnessPresenceCmd_ReportsEachTarget` (stdout/stderr split the setups read),
+  `TestHarnessPresenceCmd_FailsOnABrokenRecord`. Mutation: append instead of replace → red.
+- [x] **AC3** → `tests/compile-harness.bats`: "--deploy delegates presence to dotf harness presence with the
+  checkout as --repo-root", "a failing dotf harness presence fails --deploy", "a dotf that predates harness
+  presence makes --deploy fail loudly"; `tests/setup-windows.bats`: "injects agent presence via dotf
+  harness presence after Deploy-SkillRecord" (+ parity: the Linux engine delegates and carries no injector).
+  `bash -n scripts/compile-harness.sh` ok; `setup-windows.ps1` parse 0 errors, non-ASCII 32 = origin/main,
+  CRLF 2357 / bare LF 0.
+- [x] **AC4** → `TestCheckAgentPresence_ByStatus` (all injected → PASS "presence current in 2"; no region →
+  WARN naming the file and `dotf harness presence`; roster changed after injection → WARN stale; copilot's
+  file not compared without the binary, compared with it; no repo → SKIP). Mutation: stale counted as
+  current → red.
+- [x] **AC5** → box, in order:
+  1. `grep -c 'BEGIN HARNESS AGENT-PRESENCE'` on `~/.claude/CLAUDE.md`, `~/.pi/agent/AGENTS.md`,
+     `~/.config/opencode/AGENTS.md`, `~/.copilot/copilot-instructions.md` → **0, 0, 0, 0** (the #1326 measurement).
+  2. `dotf harness presence --render claude` → the seven-persona roster (architect, builder, ...).
+  3. `dotf harness presence` → `[deploy] presence -> <file> (<agent>)` × 4.
+  4. `dotf harness presence` → `[deploy] presence current: <file> (<agent>)` × 4.
+  5. Regions: 1, 1, 1, 1; every begin marker carries `sha256:5e0b469a4de5feb6`; each file kept its single
+     line-ending style (LF, 0 CRLF).
+  6. `dotf doctor` → `[Agent presence (forced skills)] (1 checks, all ok)`.
+
+## Test status
+
+```text
+go build ./... && go vet ./... && GOOS=linux go vet ./... && go test ./internal/harness/ ./internal/cmd/ ./internal/doctor/   -> ok
+golangci-lint run ./...   -> 0 issues
+bats tests/setup-windows.bats   -> 122/122
+bats tests/compile-harness.bats -f 'agents:|doctrine|presence|HARNESS-092'   -> 31/32 on the box; the one
+  failure ("an absent dotf warns ... does not fail the deploy") fails identically on origin/main here:
+  the test reduces PATH to /usr/bin:/bin and this box's jq lives under WinGet. Linux CI runs the full
+  suite with /usr/bin/jq. (The full suite runs at ~1 test/min on this box; the subset is what was run.)
+```
+
+- No regressions in the existing suite: yes. The four presence scenario tests left
+  `compile-harness.bats` and live in Go with the implementation. `shellcheck scripts/compile-harness.sh`
+  → 0 warnings/errors (the two orphaned `AGENT_*` marker variables it flagged after the injector
+  left were removed; the markers are Go's now).
+
+## Decisions made during implementation
+
+- **Delegate, do not duplicate.** The shell keeps `build_agent_presence` only as a wrapper over
+  `--render` because `deploy_doctrine` composes the compact agy/codex payload from it; the
+  injector is deleted. No awk fallback: a roster rendered by a second parser is the drift this
+  port removes (the AC7/#1319 lesson), and an absent dotf is a loud `--deploy` failure.
+- **Sha over the LF form.** The Windows checkout copies instructions files CRLF; a sha over raw
+  bytes would make every Windows region read "stale" to a Linux doctor and vice versa.
+- **Idempotent means untouched.** The shell rewrote the file on every run; the port compares the
+  region and leaves an in-sync file alone, which is what makes "did this change?" answerable.
+- **Whole-name `targets:` match.** `Persona.AppliesTo` already matched whole names; the shell's
+  substring test (`[pi]` matched `copilot`) is a latent defect, not behaviour to preserve.
+- **Doctor WARN, not FAIL.** The remedy is one idempotent command setup already runs.
+
+## Promotion candidates
+
+- [ ] Lesson: no — the ticket and the AC7 lesson (#1319) already carry the shape.
+- [ ] ADR-worthy decision: no — first writing slice of CLI-026 under ADR-020 C7.
+- [ ] Pattern: no.
+
+## Archive checklist
+
+- [ ] `dotf spec review HARNESS-092-harness-presence` PASS
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved to `specs/archive/HARNESS-092-harness-presence/`
+- [ ] Bitácora #1326 closed with the PR link

--- a/tests/compile-harness.bats
+++ b/tests/compile-harness.bats
@@ -71,6 +71,8 @@ seed_dotf_stub() {
 # whether the binary is new enough. cli/internal/cmd pins the real help's shape.
 if [ "$1 $2" = "harness --help" ]; then
     printf 'Available Commands:\n  resolve-tier          Resolve a neutral model tier\n  resolve-capabilities  Resolve neutral capabilities\n  resolve-skills        Print the forced-skill ids a record declares\n  triggers              x\n'
+    # HARNESS-092: listed unless a test simulates a dotf that predates the verb.
+    [ "${STUB_NO_PRESENCE:-0}" = "1" ] || printf '  presence              Inject the forced-skills roster into the harness files\n'
     exit 0
 fi
 # Simulates the real subcommand's CONTRACT: both frontmatter forms in, one flow
@@ -98,6 +100,32 @@ if [ "$1 $2" = "harness resolve-capabilities" ]; then
     fi
     printf 'capability "%s" is not mapped for harness "%s"\n' "$3" "$5" >&2
     exit 1
+fi
+# HARNESS-092: `harness presence` is the injector both setups call. The stub
+# records what it was asked (the contract this layer owns: call it with the
+# checkout, honour its exit status) and simulates `--render` from the records
+# the way the resolve-skills branch does, because deploy_doctrine composes the
+# compact payload from that output. The scenarios -- inject, idempotent,
+# append, targets[] -- are pinned in cli/internal/harness/presence_test.go.
+if [ "$1 $2" = "harness presence" ]; then
+    printf '%s\n' "$*" >> "${STUB_BIN_DIR:-$(dirname "$0")}/presence.argv"
+    if [ "${STUB_PRESENCE_FAIL:-0}" = "1" ]; then printf 'stub: presence failed\n' >&2; exit 1; fi
+    if [ "$3" = "--render" ]; then
+        agent="$4"; recdir=""
+        [ "$5" = "--repo-root" ] && recdir="$6/harness/agents"
+        first=1
+        for d in "$recdir"/*/; do
+            f="$d/AGENT.md"; [ -f "$f" ] || continue
+            kind="$(awk '/^---[[:space:]]*$/{n++; next} n==1 && /^kind:/{sub(/^[^:]*:[[:space:]]*/,""); print; exit} n>=2{exit}' "$f")"
+            [ "$kind" = "autonomous" ] && continue
+            targets="$(awk '/^---[[:space:]]*$/{n++; next} n==1 && /^targets:/{print; exit} n>=2{exit}' "$f")"
+            if [ -n "$targets" ]; then case "$targets" in *"$agent"*) ;; *) continue ;; esac; fi
+            if [ "$first" = 1 ]; then printf '## Active agent personas — forced skills\n\nWhen acting as one, you MUST consume its skills.\n\n'; first=0; fi
+            skills="$(awk '/^---[[:space:]]*$/{n++; next} n==1 && /^skills:[[:space:]]*\[/{sub(/^[^:]*:[[:space:]]*/,""); print; exit} n>=2{exit}' "$f")"
+            printf -- '- **%s** — MUST consume: %s\n' "$(basename "$d")" "${skills:-none}"
+        done
+    fi
+    exit 0
 fi
 # Only the subcommands the render calls; anything else is a test bug.
 [ "$1 $2" = "harness resolve-tier" ] || { printf 'stub: unexpected: %s\n' "$*" >&2; exit 127; }
@@ -1197,13 +1225,9 @@ PY
     [ ! -f "$FAKEHOME/.claude/agents/curator.md" ]
 }
 
-@test "agents: a block-style skills list renders the real skills, not \"none\"" {
+@test "agents: a block-style skills list is never rendered as \"none\" -- a dotf too old for the verb deploys no roster at all (HARNESS-045 AC7, HARNESS-092)" {
     seed_agents_fixture
     seed_instructions_file "$FAKEHOME/.claude/CLAUDE.md"
-    # HARNESS-045 AC7. skill_field reads the inline form only, so before the
-    # delegation this rendered "MUST consume: none" -- enforcement removed with
-    # no error anywhere. The presence text carries ids only: `enforce:` is what
-    # `dotf harness gate` acts on, and the doctrine payload is character-capped.
     python3 - "$VAULT/00_meta/agents/definitions/curator/AGENT.md" <<'PY'
 import re, sys, pathlib
 p = pathlib.Path(sys.argv[1])
@@ -1213,44 +1237,12 @@ p.write_text(re.sub(
     p.read_text(), count=1, flags=re.M))
 PY
     run_refresh; [ "$status" -eq 0 ]
+    export STUB_NO_PRESENCE=1
     run_deploy; [ "$status" -eq 0 ]
-    grep -q 'MUST consume: \[crystallize, insights\]' "$FAKEHOME/.claude/CLAUDE.md"
-    refute_grep_fixed 'MUST consume: none' "$FAKEHOME/.claude/CLAUDE.md"
-    # severity stays out of the prose; it belongs to the gate
-    refute_grep_fixed 'enforce' "$FAKEHOME/.claude/CLAUDE.md"
-}
-
-@test "agents: a block-style skills list fails loudly when dotf cannot read it" {
-    seed_agents_fixture
-    seed_instructions_file "$FAKEHOME/.claude/CLAUDE.md"
-    python3 - "$VAULT/00_meta/agents/definitions/curator/AGENT.md" <<'PY'
-import re, sys, pathlib
-p = pathlib.Path(sys.argv[1])
-p.write_text(re.sub(
-    r"^skills:.*$",
-    "skills:\n  - id: crystallize\n    enforce: block",
-    p.read_text(), count=1, flags=re.M))
-PY
-    run_refresh; [ "$status" -eq 0 ]
-    # a dotf predating resolve-skills: the fallback is the awk read, which returns
-    # EMPTY for this record. Degrading to "none" here is the silent disarm the
-    # whole acceptance criterion exists to prevent, so the fallback must refuse.
-    cat > "$STUB_BIN/dotf" <<'NOSKILLS'
-#!/usr/bin/env bash
-if [ "$1 $2" = "harness --help" ]; then
-    printf 'Available Commands:\n  resolve-tier          x\n  resolve-capabilities  x\n'
-    exit 0
-fi
-if [ "$1 $2" = "harness resolve-capabilities" ]; then printf 'tools: Read\n'; exit 0; fi
-[ "$1 $2" = "harness resolve-tier" ] || { printf 'stub: unexpected: %s\n' "$*" >&2; exit 127; }
-printf 'opus\n'
-NOSKILLS
-    chmod +x "$STUB_BIN/dotf"
-    run_deploy
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"block style"* ]]
-    [[ "$output" == *DISARM* ]]
-    refute_grep_fixed 'MUST consume: none' "$FAKEHOME/.claude/CLAUDE.md"
+    [[ "$output" == *"presence NOT deployed"* ]]
+    refute_grep_fixed 'MUST consume' "$FAKEHOME/.claude/CLAUDE.md"
+    # the real rendering of the mapping form -- ids only, no severity -- is
+    # pinned in cli/internal/harness/presence_test.go
 }
 
 @test "agents: the unavailable-resolver warning states that it GRANTS, not denies" {
@@ -1289,41 +1281,47 @@ HALF2
     fi
 }
 
-@test "agents: --deploy injects a presence region (forced skills) into every harness instructions file" {
+# HARNESS-092 (#1326): presence is rendered and injected by `dotf harness presence`
+# -- one implementation for both OSes, one sha in every begin marker. This
+# layer's contract with it: call it with the checkout as --repo-root, honour its
+# exit status, and refuse to deploy without it (a roster that quietly is not
+# deployed is the defect the port removes). The scenarios -- inject into every
+# file, idempotent, append when no markers, targets[] -- are pinned in
+# cli/internal/harness/presence_test.go, where the implementation lives.
+@test "agents: --deploy delegates presence to dotf harness presence with the checkout as --repo-root (HARNESS-092)" {
     seed_agents_fixture
     seed_instructions_file "$FAKEHOME/.claude/CLAUDE.md"
-    seed_instructions_file "$FAKEHOME/.config/opencode/AGENTS.md"
-    seed_instructions_file "$FAKEHOME/.pi/agent/AGENTS.md"
-    seed_instructions_file "$FAKEHOME/.copilot/copilot-instructions.md"
     run_refresh; [ "$status" -eq 0 ]
     run_deploy; [ "$status" -eq 0 ]
-    for f in "$FAKEHOME/.claude/CLAUDE.md" "$FAKEHOME/.config/opencode/AGENTS.md" \
-             "$FAKEHOME/.pi/agent/AGENTS.md" "$FAKEHOME/.copilot/copilot-instructions.md"; do
-        # presence region present, naming the persona + its forced skills
-        grep -q 'BEGIN HARNESS AGENT-PRESENCE' "$f"
-        grep -q 'END HARNESS AGENT-PRESENCE' "$f"
-        grep -q 'curator' "$f"
-        grep -q 'vault-doctor' "$f"
-        # the pre-existing patterns region + user content survive untouched
-        grep -q 'patterns content' "$f"
-        grep -q 'user intro' "$f"
-        grep -q 'user outro' "$f"
-    done
+    grep -qF "harness presence --repo-root $REPO" "$STUB_BIN/presence.argv"
+    # the shell carries no injector of its own any more, and its renderer is the verb's --render
+    refute_grep '^inject_agent_presence\(\) \{' "$SCRIPT"
+    grep -qF 'dotf harness presence --render "$agent" --repo-root "$REPO_ROOT"' "$SCRIPT"
 }
 
-@test "agents: presence injection is idempotent and leaves the patterns region intact" {
+@test "agents: a failing dotf harness presence fails --deploy, it is not a warning (HARNESS-092)" {
     seed_agents_fixture
-    F="$FAKEHOME/.config/opencode/AGENTS.md"
-    seed_instructions_file "$F"
+    seed_instructions_file "$FAKEHOME/.claude/CLAUDE.md"
     run_refresh; [ "$status" -eq 0 ]
-    run_deploy; [ "$status" -eq 0 ]
-    run_deploy; [ "$status" -eq 0 ]
-    # exactly one presence region after two deploys (no accumulation)
-    [ "$(grep -c 'BEGIN HARNESS AGENT-PRESENCE' "$F")" -eq 1 ]
-    [ "$(grep -c 'END HARNESS AGENT-PRESENCE' "$F")" -eq 1 ]
-    # the patterns region is still single and intact
-    [ "$(grep -c 'BEGIN HARNESS GENERATED' "$F")" -eq 1 ]
-    grep -q 'patterns content' "$F"
+    export STUB_PRESENCE_FAIL=1
+    run_deploy
+    [ "$status" -ne 0 ]
+}
+
+@test "agents: a dotf that predates harness presence warns that presence was NOT deployed, and the deploy continues (HARNESS-092)" {
+    seed_agents_fixture
+    seed_instructions_file "$FAKEHOME/.claude/CLAUDE.md"
+    run_refresh; [ "$status" -eq 0 ]
+    export STUB_NO_PRESENCE=1
+    run_deploy
+    # the engine's bootstrap contract (see "an absent dotf warns ..." above):
+    # an absent or old resolver degrades loudly, it does not take the deploy down
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"dotf harness presence"* ]]
+    [[ "$output" == *"presence NOT deployed"* ]]
+    refute_grep_fixed 'AGENT-PRESENCE' "$FAKEHOME/.claude/CLAUDE.md"
+    # the agent definitions still deployed
+    [ -f "$FAKEHOME/.claude/agents/curator.md" ]
 }
 
 @test "agents: --check validates the record renders offline (no vault)" {
@@ -1353,30 +1351,3 @@ HALF2
     [ ! -f "$FAKEHOME/.claude/agents/scribe.md" ]
 }
 
-@test "agents: presence appends a fresh region when the file has no presence markers" {
-    seed_agents_fixture
-    F="$FAKEHOME/.pi/agent/AGENTS.md"
-    mkdir -p "$(dirname "$F")"
-    printf 'just user content, no markers\n' > "$F"
-    run_refresh; [ "$status" -eq 0 ]
-    run_deploy; [ "$status" -eq 0 ]
-    grep -q 'just user content' "$F"
-    grep -q 'BEGIN HARNESS AGENT-PRESENCE' "$F"
-    grep -q 'vault-doctor' "$F"
-}
-
-@test "agents: presence respects per-agent targets[] (a persona only appears for harnesses it targets)" {
-    seed_agents_fixture
-    mkdir -p "$VAULT/00_meta/agents/definitions/scribe"
-    printf -- '---\nname: scribe\ndescription: opencode only.\nkind: invocable\nskills: [docs-skill]\ntargets: [opencode]\n---\n\n# Scribe\n' > "$VAULT/00_meta/agents/definitions/scribe/AGENT.md"
-    seed_instructions_file "$FAKEHOME/.claude/CLAUDE.md"
-    seed_instructions_file "$FAKEHOME/.config/opencode/AGENTS.md"
-    run_refresh; [ "$status" -eq 0 ]
-    run_deploy; [ "$status" -eq 0 ]
-    # claude: curator targets it, scribe does not
-    grep -q 'curator' "$FAKEHOME/.claude/CLAUDE.md"
-    refute_grep_fixed 'scribe' "$FAKEHOME/.claude/CLAUDE.md"
-    # opencode: both personas target it
-    grep -q 'curator' "$FAKEHOME/.config/opencode/AGENTS.md"
-    grep -q 'scribe' "$FAKEHOME/.config/opencode/AGENTS.md"
-}

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -928,3 +928,19 @@ setup() {
     mcp_line=$(grep -nE '^[[:space:]]*[^#[:space:]].*claude mcp add --transport' "$DOTFILES_DIR/setup-linux.sh" | head -1 | cut -d: -f1)
     [ -n "$uv_line" ] && [ -n "$mcp_line" ] && [ "$uv_line" -lt "$mcp_line" ]
 }
+
+# HARNESS-092 (#1326): agent presence -- the forced-skills roster between
+# AGENT-PRESENCE markers in every harness instructions file -- reached Windows
+# through no path at all: compile-harness.sh's deploy_agent_presence had no
+# port. Both setups now call `dotf harness presence`; here it must run after
+# the base files and the skill records are deployed, or it finds nothing to
+# join. Measured on the invocation line, not on any mention.
+@test "setup-windows.ps1 injects agent presence via dotf harness presence after Deploy-SkillRecord (HARNESS-092)" {
+    grep -qE '^[[:space:]]*& dotf harness presence --repo-root \$DotfilesDir[[:space:]]*$' "$PS1_SCRIPT"
+    deploy_line=$(grep -n '^Deploy-SkillRecord -DotfilesDir' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
+    presence_line=$(grep -n '& dotf harness presence' "$PS1_SCRIPT" | head -1 | cut -d: -f1)
+    [ -n "$deploy_line" ] && [ -n "$presence_line" ] && [ "$deploy_line" -lt "$presence_line" ]
+    # parity: the Linux engine delegates to the same verb and carries no injector of its own
+    grep -qF 'dotf harness presence --repo-root "$REPO_ROOT"' "$DOTFILES_DIR/scripts/compile-harness.sh"
+    refute_grep '^inject_agent_presence\(\) \{' "$DOTFILES_DIR/scripts/compile-harness.sh"
+}


### PR DESCRIPTION
## Summary

`dotf harness presence` renders each persona's forced-skills roster and injects it between the `AGENT-PRESENCE` markers of every harness instructions file the manifest names — one implementation both setups call. `compile-harness.sh --deploy` delegates to it (its injector is deleted, its renderer wraps `--render`), `setup-windows.ps1` calls it after `Deploy-SkillRecord`, and `dotf doctor` gains a row that compares the region's sha with the roster the records render today.

Refs #1326 (HARNESS-092). Spec: `specs/HARNESS-092-harness-presence/`. First writing slice of CLI-026 (#495).

## Why

Measured 2026-08-27 on the Windows work box: **zero** `AGENT-PRESENCE` regions in `~/.claude/CLAUDE.md`, `~/.pi/agent/AGENTS.md`, `~/.config/opencode/AGENTS.md` and `~/.copilot/copilot-instructions.md`, and every doctor check green — `checkInstructionDrift` strips the region before comparing, so nothing looked. The shell's `deploy_agent_presence` had no Windows port, so no harness on that OS had ever been told which skills a persona MUST consume.

## What changed

- `cli/internal/harness/presence.go`: `LoadPresence` (manifest `agents.presence[]` + `record_dir`), `BuildPresence` (byte-identical to the shell's `build_agent_presence`), `PresenceSHA` (LF form, 16 hex — `sha256sum | cut -c1-16`), `InjectPresence` (replace in place / append; everything outside the markers byte-identical; keeps the file's CRLF; does not rewrite an in-sync file), `DeployPresence`, `RenderPresence`, `PresenceStatus`.
- `dotf harness presence [--repo-root] [--home] [--render <agent>]`: injections and "current" on stdout, skips on stderr; a broken record fails it.
- `scripts/compile-harness.sh`: `deploy_agent_presence` → the verb; `build_agent_presence` → `--render` (it still composes the compact agy/codex doctrine payload); `inject_agent_presence` and the `AGENT_*` marker variables deleted. A dotf that is absent or predates the verb is an ERROR that fails `--deploy` — no awk fallback: a roster rendered by a second parser is the drift this port removes, and a roster quietly not deployed is the defect.
- `setup-windows.ps1`: `& dotf harness presence --repo-root $DotfilesDir` after `Deploy-SkillRecord`.
- `dotf doctor` → **Agent presence (forced skills)**: PASS with counts / WARN "no presence region" or "stale presence" naming the file and the remedy / SKIP without a repo; copilot's file gated on the binary; renders, never writes.
- Tests: the four presence scenario tests in `tests/compile-harness.bats` move to Go (`presence_test.go`, where the implementation is); the bats layer keeps the contract — `--deploy` calls the verb with the checkout as `--repo-root`, fails when it fails, fails loudly when the stub's help lacks the verb. The stub `dotf` learns `harness presence` (argv recorded; `--render` simulated from the records exactly as `resolve-skills` already is). `tests/setup-windows.bats` guards the call and its ordering, plus parity with the Linux engine.

One recorded behaviour difference: the shell matched `targets:` by substring (`[pi]` matched `copilot`); Go matches whole names, which `Persona.AppliesTo` already did and the records intend.

## Test plan

- [x] `go build/vet` (host, `GOOS=linux`), `go test ./internal/harness/ ./internal/cmd/ ./internal/doctor/`, `golangci-lint` 0 issues
- [x] Mutations: autonomous listed / append instead of replace / sha over raw bytes / doctor counts stale as current — each red, restored
- [x] `shellcheck scripts/compile-harness.sh` 0 warnings; `bash -n`; `setup-windows.ps1` parse 0 errors, non-ASCII delta 0, CRLF intact
- [x] bats: setup-windows 122/122; compile-harness (see the triage comment for the count)
- [x] Box (Windows): 0 regions in the four files → `dotf harness presence` injects 4 → second run reports 4 "current" → every begin marker carries the same sha → each file kept its single EOL style → `dotf doctor`: `[Agent presence (forced skills)] (1 checks, all ok)`
