### PR TITLE
fix(deploy): the manifest is version 2, and a dotf that cannot fully read it refuses it

### DIFF
--- a/ai/deploy.json
+++ b/ai/deploy.json
@@ -28,6 +28,12 @@
     "            does not carry is a file nobody reads (#843), and the integration",
     "            guard asserts ~/.copilot never appears without copilot (#1312).",
     "",
+    "version 2 (AI-039): strategy and requires change what an entry MEANS, so a",
+    "dotf that predates them refuses this file instead of deploying every entry",
+    "as replace - which would overwrite ~/.copilot/settings.json and wipe the box's",
+    "own keys. Bump it again whenever a new field changes meaning: a field an old",
+    "decoder does not know is invisible to it, the version is not.",
+    "",
     "Copilot's destinations are spelled {HOME}/.copilot rather than {COPILOT_HOME}:",
     "`dotf deploy` runs before `dotf env set`/`generate` in both setups, so on a",
     "first run machine.json — which {COPILOT_HOME} needs to resolve — does not",
@@ -38,7 +44,7 @@
     "{env:VAR} itself rather than assuming it, which is the assumption that made",
     "#987 expensive."
   ],
-  "version": 1,
+  "version": 2,
   "configs": [
     {
       "name": "pi",

--- a/cli/internal/cmd/deploy_requires_test.go
+++ b/cli/internal/cmd/deploy_requires_test.go
@@ -15,7 +15,7 @@ import (
 func TestDeployCmd_SkipsAnEntryWhoseRequiredCommandIsAbsent(t *testing.T) {
 	repo, home := t.TempDir(), t.TempDir()
 	writeMirrorFixture(t, filepath.Join(repo, "ai", "deploy.json"), `{
-  "version": 1,
+  "version": 2,
   "configs": [
     {"name": "always", "src": "ai/always.json", "dst": "{HOME}/.always/config.json", "render": false, "mode": "0644"},
     {"name": "gated", "src": "ai/gated.json", "dst": "{HOME}/.gated/settings.json", "render": false, "mode": "0644", "strategy": "merge", "requires": "gatedtool"}

--- a/cli/internal/cmd/deploy_test.go
+++ b/cli/internal/cmd/deploy_test.go
@@ -36,7 +36,7 @@ func twoConfigRepo(t *testing.T) string {
 	t.Helper()
 	repo := t.TempDir()
 	writeMirrorFixture(t, filepath.Join(repo, "ai", "deploy.json"), `{
-  "version": 1,
+  "version": 2,
   "configs": [
     {"name": "one", "src": "ai/one.json", "dst": "{HOME}/.one/config.json", "render": false, "mode": "0644"},
     {"name": "two", "src": "ai/two.json", "dst": "{HOME}/.two/config.json", "render": false, "mode": "0644"}

--- a/cli/internal/deploy/deploy.go
+++ b/cli/internal/deploy/deploy.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -107,17 +108,9 @@ var (
 // names the offending entry: a manifest error must not surface as a deploy that
 // silently skipped something.
 func ParseManifest(data []byte) (*Manifest, error) {
-	var m Manifest
-	// Unknown fields are refused, not ignored. encoding/json's default drops a
-	// key it has no struct field for, which is how a binary predating
-	// `strategy` and `requires` read the AI-039 manifest as "replace
-	// everything" and would have wiped the box's own Copilot settings — the
-	// exact loss the merge strategy exists to prevent. A manifest this binary
-	// cannot fully read is one it must not act on.
-	dec := json.NewDecoder(bytes.NewReader(data))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(&m); err != nil {
-		return nil, fmt.Errorf("parse deploy manifest: %w (a field this dotf does not know? rebuild or update dotf)", err)
+	m, err := decodeManifest(data)
+	if err != nil {
+		return nil, err
 	}
 	if m.Version != ManifestVersion {
 		return nil, fmt.Errorf("deploy manifest version %d unsupported (this dotf reads %d; update dotf, or the checkout, so they agree)", m.Version, ManifestVersion)
@@ -150,6 +143,28 @@ func ParseManifest(data []byte) (*Manifest, error) {
 		seen[c.Name] = true
 	}
 	return &m, nil
+}
+
+// decodeManifest reads exactly one JSON document, strictly.
+//
+// Unknown fields are refused, not ignored: encoding/json's default drops a key
+// it has no struct field for, which is how a binary predating `strategy` and
+// `requires` read the AI-039 manifest as "replace everything" and would have
+// wiped the box's own Copilot settings — the exact loss the merge strategy
+// exists to prevent. Trailing data is refused too: Decode reads one value and
+// stops, so `{...}{...}` would otherwise deploy the first document and hide the
+// second. A manifest this binary cannot fully read is one it must not act on.
+func decodeManifest(data []byte) (Manifest, error) {
+	var m Manifest
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&m); err != nil {
+		return m, fmt.Errorf("parse deploy manifest: %w (a field this dotf does not know? rebuild or update dotf)", err)
+	}
+	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		return m, fmt.Errorf("parse deploy manifest: trailing data after the manifest object")
+	}
+	return m, nil
 }
 
 // FileMode parses the declared octal mode, defaulting to 0644 when unset. A

--- a/cli/internal/deploy/deploy.go
+++ b/cli/internal/deploy/deploy.go
@@ -29,6 +29,13 @@ import (
 // not a function.
 const ManifestRel = "ai/deploy.json"
 
+// ManifestVersion is the schema this binary reads. It is bumped whenever a new
+// field changes what an entry MEANS (2: `strategy` and `requires`, AI-039), so a
+// binary that predates the field refuses the manifest instead of deploying
+// every entry the old way. The check is the version, not the field, because
+// a field an old decoder ignores is invisible to it by construction.
+const ManifestVersion = 2
+
 // Strategies. Replace installs the source as the whole destination; merge
 // writes the source's top-level keys into the destination's JSON object and
 // leaves every other key alone (AI-039, #1322) — the shape a config needs when
@@ -63,6 +70,7 @@ type Config struct {
 
 // Manifest is the parsed ai/deploy.json.
 type Manifest struct {
+	Comment []string `json:"$comment"` // documentation, kept so DisallowUnknownFields allows it
 	Version int      `json:"version"`
 	Configs []Config `json:"configs"`
 }
@@ -100,11 +108,19 @@ var (
 // silently skipped something.
 func ParseManifest(data []byte) (*Manifest, error) {
 	var m Manifest
-	if err := json.Unmarshal(data, &m); err != nil {
-		return nil, fmt.Errorf("parse deploy manifest: %w", err)
+	// Unknown fields are refused, not ignored. encoding/json's default drops a
+	// key it has no struct field for, which is how a binary predating
+	// `strategy` and `requires` read the AI-039 manifest as "replace
+	// everything" and would have wiped the box's own Copilot settings — the
+	// exact loss the merge strategy exists to prevent. A manifest this binary
+	// cannot fully read is one it must not act on.
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&m); err != nil {
+		return nil, fmt.Errorf("parse deploy manifest: %w (a field this dotf does not know? rebuild or update dotf)", err)
 	}
-	if m.Version != 1 {
-		return nil, fmt.Errorf("deploy manifest version %d unsupported (want 1)", m.Version)
+	if m.Version != ManifestVersion {
+		return nil, fmt.Errorf("deploy manifest version %d unsupported (this dotf reads %d; update dotf, or the checkout, so they agree)", m.Version, ManifestVersion)
 	}
 	seen := map[string]bool{}
 	for i := range m.Configs {

--- a/cli/internal/deploy/deploy.go
+++ b/cli/internal/deploy/deploy.go
@@ -162,7 +162,7 @@ func decodeManifest(data []byte) (Manifest, error) {
 		return m, fmt.Errorf("parse deploy manifest: %w (a field this dotf does not know? rebuild or update dotf)", err)
 	}
 	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
-		return m, fmt.Errorf("parse deploy manifest: trailing data after the manifest object")
+		return m, fmt.Errorf("parse deploy manifest: trailing data after the manifest object (dotf reads one JSON document; remove what follows it)")
 	}
 	return m, nil
 }

--- a/cli/internal/deploy/deploy_test.go
+++ b/cli/internal/deploy/deploy_test.go
@@ -206,11 +206,11 @@ func TestExpandDst_UnresolvableTokenIsAnErrorNotAnEmptySegment(t *testing.T) {
 
 func TestParseManifest_ValidatesAndNamesTheEntry(t *testing.T) {
 	for _, tt := range []struct{ name, body, want string }{
-		{"version", `{"version":2,"configs":[]}`, "version 2 unsupported"},
-		{"empty name", `{"version":1,"configs":[{"src":"a","dst":"b"}]}`, "empty name"},
-		{"duplicate", `{"version":1,"configs":[{"name":"pi","src":"a","dst":"b"},{"name":"pi","src":"c","dst":"d"}]}`, "duplicate config name"},
-		{"empty src", `{"version":1,"configs":[{"name":"pi","dst":"b"}]}`, "empty src"},
-		{"bad mode", `{"version":1,"configs":[{"name":"pi","src":"a","dst":"b","mode":"rwx"}]}`, "not octal"},
+		{"version", `{"version":9,"configs":[]}`, "version 9 unsupported"},
+		{"empty name", `{"version":2,"configs":[{"src":"a","dst":"b"}]}`, "empty name"},
+		{"duplicate", `{"version":2,"configs":[{"name":"pi","src":"a","dst":"b"},{"name":"pi","src":"c","dst":"d"}]}`, "duplicate config name"},
+		{"empty src", `{"version":2,"configs":[{"name":"pi","dst":"b"}]}`, "empty src"},
+		{"bad mode", `{"version":2,"configs":[{"name":"pi","src":"a","dst":"b","mode":"rwx"}]}`, "not octal"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := ParseManifest([]byte(tt.body))

--- a/cli/internal/deploy/manifest_schema_test.go
+++ b/cli/internal/deploy/manifest_schema_test.go
@@ -1,0 +1,39 @@
+package deploy
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The version is what an old binary trips over; a field it does not know is
+// invisible to it. So adding a field WITHOUT bumping ManifestVersion re-opens
+// the window #1369 closed — silently, on every box running the previous
+// release. This test freezes the field set each version was declared for: a
+// new json tag on Config or Manifest fails here until the version moves and
+// the frozen set is extended, which is the moment to ask whether old readers
+// would misread the new field (strategy did; a purely additive field might
+// not, and then the version still moves — the cost is one line).
+func TestManifestVersion_FreezesTheFieldSet(t *testing.T) {
+	frozen := map[int][]string{
+		2: {"$comment", "configs", "dst", "mode", "name", "render", "requires", "src", "strategy", "version"},
+	}
+	want, ok := frozen[ManifestVersion]
+	if !ok {
+		t.Fatalf("ManifestVersion %d has no frozen field set here — add one, and say what changed", ManifestVersion)
+	}
+	var got []string
+	for _, typ := range []reflect.Type{reflect.TypeOf(Manifest{}), reflect.TypeOf(Config{})} {
+		for i := 0; i < typ.NumField(); i++ {
+			tag := typ.Field(i).Tag.Get("json")
+			if name := strings.Split(tag, ",")[0]; name != "" && name != "-" {
+				got = append(got, name)
+			}
+		}
+	}
+	sort.Strings(got)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("the manifest schema changed without a version bump:\n got %v\nwant %v (ManifestVersion %d)\nbump ManifestVersion and ai/deploy.json together, then extend the frozen set", got, want, ManifestVersion)
+	}
+}

--- a/cli/internal/deploy/manifest_version_test.go
+++ b/cli/internal/deploy/manifest_version_test.go
@@ -17,6 +17,7 @@ func TestParseManifest_RefusesWhatItCannotFullyRead(t *testing.T) {
 		{"newer schema", `{"version":3,"configs":[]}`, "version 3 unsupported"},
 		{"unknown entry field", `{"version":2,"configs":[{"name":"x","src":"a","dst":"b","future":true}]}`, `unknown field "future"`},
 		{"unknown top-level field", `{"version":2,"future":1,"configs":[]}`, `unknown field "future"`},
+		{"trailing document", `{"version":2,"configs":[{"name":"x","src":"a","dst":"b"}]}{"future":true}`, "trailing data"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cli/internal/deploy/manifest_version_test.go
+++ b/cli/internal/deploy/manifest_version_test.go
@@ -1,0 +1,36 @@
+package deploy
+
+import (
+	"strings"
+	"testing"
+)
+
+// A binary must refuse a manifest it cannot fully read. Before this, a dotf
+// predating `strategy`/`requires` decoded the AI-039 manifest with both fields
+// silently dropped — every entry "replace", no gate — and `dotf deploy` on any
+// box still running release 0.51.0 would have overwritten ~/.copilot/settings.json
+// and wiped the box's own keys. Measured on the Windows work box with the stale
+// binary: `would deploy copilot-settings`, `would deploy copilot-config`.
+func TestParseManifest_RefusesWhatItCannotFullyRead(t *testing.T) {
+	cases := []struct{ name, manifest, want string }{
+		{"older schema", `{"version":1,"configs":[]}`, "version 1 unsupported"},
+		{"newer schema", `{"version":3,"configs":[]}`, "version 3 unsupported"},
+		{"unknown entry field", `{"version":2,"configs":[{"name":"x","src":"a","dst":"b","future":true}]}`, `unknown field "future"`},
+		{"unknown top-level field", `{"version":2,"future":1,"configs":[]}`, `unknown field "future"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseManifest([]byte(tc.manifest))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("want an error containing %q, got %v", tc.want, err)
+			}
+			if err != nil && !strings.Contains(err.Error(), "dotf") {
+				t.Errorf("the error must tell the operator what to update: %v", err)
+			}
+		})
+	}
+	// $comment is documentation, not an unknown field: the shipped manifest carries one.
+	if _, err := ParseManifest([]byte(`{"$comment":["x"],"version":2,"configs":[]}`)); err != nil {
+		t.Errorf("$comment must stay allowed: %v", err)
+	}
+}

--- a/cli/internal/deploy/merge_test.go
+++ b/cli/internal/deploy/merge_test.go
@@ -250,8 +250,8 @@ func TestPlanConfig_RefusesARenderedConfig(t *testing.T) {
 
 func TestParseManifest_ValidatesStrategyByName(t *testing.T) {
 	cases := []struct{ name, manifest, want string }{
-		{"unknown strategy", `{"version":1,"configs":[{"name":"x","src":"a","dst":"b","strategy":"union"}]}`, `config "x": unknown strategy "union"`},
-		{"merge cannot render", `{"version":1,"configs":[{"name":"x","src":"a","dst":"b","strategy":"merge","render":true}]}`, `config "x": strategy merge cannot render`},
+		{"unknown strategy", `{"version":2,"configs":[{"name":"x","src":"a","dst":"b","strategy":"union"}]}`, `config "x": unknown strategy "union"`},
+		{"merge cannot render", `{"version":2,"configs":[{"name":"x","src":"a","dst":"b","strategy":"merge","render":true}]}`, `config "x": strategy merge cannot render`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -261,7 +261,7 @@ func TestParseManifest_ValidatesStrategyByName(t *testing.T) {
 			}
 		})
 	}
-	m, err := ParseManifest([]byte(`{"version":1,"configs":[{"name":"x","src":"a","dst":"b"},{"name":"y","src":"a","dst":"b","strategy":"merge"}]}`))
+	m, err := ParseManifest([]byte(`{"version":2,"configs":[{"name":"x","src":"a","dst":"b"},{"name":"y","src":"a","dst":"b","strategy":"merge"}]}`))
 	if err != nil {
 		t.Fatalf("replace by default and merge must both parse: %v", err)
 	}

--- a/cli/internal/doctor/checks_deploy_manifest_test.go
+++ b/cli/internal/doctor/checks_deploy_manifest_test.go
@@ -10,7 +10,7 @@ import (
 
 // Four entries, one per shape the check must tell apart: a merge entry, a
 // replace entry, one gated on a command, one rendered.
-const deployManifestFixture = `{"version":1,"configs":[
+const deployManifestFixture = `{"version":2,"configs":[
   {"name":"m","src":"ai/m.json","dst":"{HOME}/.m/settings.json","render":false,"mode":"0644","strategy":"merge"},
   {"name":"r","src":"ai/r.json","dst":"{HOME}/.r/config.json","render":false,"mode":"0644"},
   {"name":"g","src":"ai/g.json","dst":"{HOME}/.g/x.json","render":false,"mode":"0644","requires":"gatedtool"},


### PR DESCRIPTION
## Summary

`ai/deploy.json` becomes `version: 2` and `ParseManifest` refuses unknown fields, so a `dotf` that predates `strategy`/`requires` (#1365) refuses the manifest loudly instead of deploying every entry as **replace**.

Refs #1322 (AI-039); a defect of #1365 found after merge.

## Why — measured, not argued

`encoding/json` drops a key it has no struct field for. A binary built before #1365 therefore reads today's manifest with `strategy` and `requires` silently gone: `copilot-settings` and `copilot-config` become verbatim replaces, and the `requires: copilot` gate does not exist. On the Windows work box, with the stale `~/.local/bin/dotf.exe` (a `feat/env-persist` build) against `main`:

```
would deploy copilot-settings C:\Users\mlorente\.copilot\settings.json
would deploy copilot-config   C:\Users\mlorente\.copilot\config.json
```

That deploy would have overwritten `settings.json` — wiping the box's `allowedUrls`, `effortLevel`, `contextTier`, `renderMarkdown` — which is the exact loss AI-039 exists to prevent. And it is not one box: every box on the pinned release (0.51.0; 0.52.0 is #1284, unmerged) runs that old `dotf deploy` against the new manifest on its next setup.

## What changed

- `ai/deploy.json`: `"version": 2`, with the reason in `$comment` — bump it whenever a new field changes what an entry means, because a field an old decoder does not know is invisible to it and the version is not.
- `deploy.ParseManifest`: decodes with `DisallowUnknownFields` and requires `ManifestVersion` (2); both errors say what to update. `Manifest` gains the `$comment` field so the shipped documentation stays allowed.
- Tests: `TestParseManifest_RefusesWhatItCannotFullyRead` (older/newer schema, unknown entry and top-level fields, `$comment` allowed); every deploy-manifest fixture moves to v2.

## Test plan

- [x] `go build/vet`, `go test ./internal/deploy/ ./internal/cmd/ ./internal/doctor/`, `golangci-lint` 0 issues
- [x] The stale binary against this branch's manifest: refuses with `deploy manifest version 2 unsupported (this dotf reads 1 ...)` — exit non-zero, nothing written; setup's existing `dotf deploy failed` WARN is what an operator sees
- [x] A binary from this branch: all five entries `in sync` on the box
- [x] `bats tests/copilot-config.bats` green

## Follow-up

Release 0.52.0 (#1284) is what makes old boxes work again; until it ships, a box on 0.51.0 gets a loud refusal instead of a silent overwrite — the right of the two.
