### PR TITLE
docs(adr): Copilot's hook contract, measured on the box, recorded in ADR-027 and the ADR-010 parity row

### DIFF
--- a/docs/adr/adr-010-agent-harness-parity.md
+++ b/docs/adr/adr-010-agent-harness-parity.md
@@ -46,7 +46,7 @@ For each primitive, the matrix has one of four states per agent: ✅ portable, �
 | **MCP servers** | ✅ `settings.json` MCP block | ✅ `opencode.jsonc` MCP block (mirrors mcp-servers.json) | ➖ no MCP support in Gemini CLI | ➖ no MCP support in Copilot CLI | ✅ MCP-aware | ⚠ unknown |
 | **Sub-agents** | ✅ Task tool with `subagent_type` | ⚠ `opencode agent` + agent=build/explore/plan modes (different trigger semantics) | ❌ not supported | ❌ not supported | ⚠ unknown | ⚠ unknown |
 | **Memory layer** | ✅ `claude-mem` MCP (Anthropic-specific) | ⚠ Hive vault MCP partially (lessons, not transcripts) | ❌ no memory | ❌ no memory | ⚠ unknown | ⚠ unknown |
-| **Hooks (SessionStart, PreToolUse, etc.)** | ✅ `settings.json` hooks | ⚠ `opencode plugin` (npm-distributed JS, different paradigm) | ❌ no hook surface | ❌ no hook surface | ⚠ unknown | ⚠ unknown |
+| **Hooks (SessionStart, PreToolUse, etc.)** | ✅ `settings.json` hooks | ⚠ `opencode plugin` (npm-distributed JS, different paradigm) | ✅ `~/.gemini/settings.json` hooks (BeforeAgent/BeforeTool; measured 2026-08-26, `harness/manifest.json` `bind_comment`) | ✅ `~/.copilot/hooks/*.json` (SessionStart/PreToolUse, deny by exit 2 or `permissionDecision`; measured 2026-08-29 on CLI 1.0.81 — ADR-027 amendment) | ⚠ unknown | ⚠ unknown |
 | **Status line** | ✅ `/statusline-setup` | ⚠ partial (TUI footer, not user-customisable) | ❌ no TUI | ❌ no TUI | ⚠ unknown | ⚠ unknown |
 | **Slash commands UX** | ✅ `/<name>` discovery | ✅ `/<name>` discovery | ⚠ different format | ❌ no slash commands | ⚠ unknown | ⚠ unknown |
 

--- a/docs/adr/adr-027-cross-harness-agent-pipeline.md
+++ b/docs/adr/adr-027-cross-harness-agent-pipeline.md
@@ -25,6 +25,42 @@ created: "2026-06-21"
 > orchestration policy §3 left open — who decides to fan out, and under what budget — is defined.
 > Everything else below stands.
 
+> **Amended 2026-08-29 (#803, HARNESS-052): Copilot's hook capability was measured on the
+> Windows work box against Copilot CLI 1.0.81, and §3's "confirmed for claude/opencode/pi;
+> agy open" is superseded on two counts.** agy was measured on 2026-08-26 and recorded in
+> `harness/manifest.json`'s `bind_comment` (`~/.gemini/settings.json` declares BeforeAgent,
+> AfterAgent, BeforeTool, AfterTool): a `command-hook` target, not a presence-only one.
+> Copilot is **capable**. Its contract is recorded here, not as a verdict, so the emission —
+> HARNESS-045 AC1, `dotf harness bind` — can write the `bind[]` entry without re-measuring:
+>
+> - **Where:** `~/.copilot/hooks/*.json`; every file in the directory is read (the probe file
+>   fired alongside Orca's `orca.json`). Ours is therefore a separate file: Orca's regeneration
+>   of its own (lesson 111) never meets it and ours never rewrites theirs — coexistence by file,
+>   with no marker to find.
+> - **Shape:** `{"version": 1, "hooks": {"<Event>": [{"type": "command", "powershell": "…",
+>   "bash": "…", "timeoutSec": N}]}}`, no `matcher` key. The OS picks the command key: Windows
+>   ran `powershell` and never `bash`; `bash` on Linux is inferred from the schema, not measured.
+> - **Events measured firing:** `SessionStart`, `PreToolUse`, `PostToolUse`, `SessionEnd`, each
+>   with JSON on stdin in Claude's shape — `hook_event_name`, `session_id`, `cwd`, and on the
+>   tool events `tool_name` + `tool_input` (`PostToolUse` adds `tool_result`). `UserPromptSubmit`
+>   and `PostToolUseFailure` are declared by `orca.json` and were not probed.
+> - **Deny:** both answers block the call and the model is told. Exit code 2 renders as
+>   "Denied by preToolUse hook: hook exited with code 2" — the hook's stderr text is **not**
+>   surfaced. `{"permissionDecision": "deny", "permissionDecisionReason": "…"}` on stdout with
+>   exit 0 renders as "Denied by preToolUse hook: <reason>". So `dotf harness gate`'s exit-code
+>   contract blocks correctly on Copilot but loses the which-skill-and-why message: the Copilot
+>   entry needs the JSON answer (a `gate` output mode, or a wrapper translating exit → JSON),
+>   which is the one way it is not a clone of Claude's. An erroring hook also denies —
+>   fail-closed, on lesson 111's evidence rather than a fresh measurement.
+> - **Timeout:** `timeoutSec` of at least 30. Lesson 111 measured 5 s plus PowerShell's cold
+>   start as intermittent "hook errored" denials.
+> - **Gate:** `requires_command: copilot`, as the presence and agents entries already carry
+>   (BUG-003: nothing creates `~/.copilot` when the binary is absent).
+>
+> Presence event `SessionStart`, action event `PreToolUse`. The emission is the open half of
+> #803 and rides on HARNESS-045 AC1; the `bind[]` entry is written there, in that command's
+> entry shape.
+
 Accepted (model). The **authoring** of definitions and the **engine** (render + offline CI) are NOT gated. Only the **cross-machine auto-deploy** step inherits ADR-026's `knowledge#120` gate. Lands via the existing `HARNESS-001` deploy-engine epic — not a new infrastructure track.
 
 ## Date
@@ -76,7 +112,7 @@ A definition's `skills:` / `enforce:` declarations are **not decorative**. At de
 - **Action (gate):** progress is blocked unless the required step ran — Claude `PreToolUse`/`Stop` (exit 2), OpenCode `tool.execute.before`, pi `tool_call` (cf. the `pi-permission-system` precedent that already gates skills).
 - **Invocation (dispatch):** a command/router spawns the role deterministically (`/review` → reviewer), not the model deciding if it remembers.
 
-Cross-provider hook capability is confirmed for claude/opencode/pi; **agy hook capability is the one open verification item**. The declaration is agnostic; the hook emission is provider-specific (Claude JSON hooks vs OpenCode/pi TS plugins) and lives in the compile layer. A hook cannot be forgotten, bypassed, or reasoned around — this is the mechanism that converts an infrautilized library into one that is impossible to skip.
+Cross-provider hook capability is confirmed for claude/opencode/pi, and — per the 2026-08-29 amendment above — for agy (measured 2026-08-26) and copilot (measured 2026-08-29, Copilot CLI 1.0.81); no harness is presence-only. The declaration is agnostic; the hook emission is provider-specific (Claude JSON hooks vs OpenCode/pi TS plugins) and lives in the compile layer. A hook cannot be forgotten, bypassed, or reasoned around — this is the mechanism that converts an infrautilized library into one that is impossible to skip.
 
 ### 4. Coexistence by `kind` — invocable vs autonomous
 
@@ -123,7 +159,7 @@ The set of agents is derived from clustering the actual `00_meta/{skills,pattern
 
 - New render kinds, including a non-trivial **MD→YAML transpose** for agy.
 - The engine grows a **hook-emission** responsibility (per-provider hook config), a new surface to maintain and drift-check.
-- **agy hook capability unverified** — open item; until confirmed, agy gets presence-level enforcement only.
+- ~~**agy hook capability unverified**~~ — closed by measurement on 2026-08-26 (`harness/manifest.json` `bind_comment`); Copilot's closed on 2026-08-29 (amendment above). Both are `command-hook` targets.
 - A third drift axis (definition ↔ render-commit) on top of ADR-026's two; needs the same ADR-012-style assertion on the committed render.
 - Library consolidation (patterns→skills, merges, deprecations) is deferred to an evidence-based pass run by `curator` after deploy — intentionally not a blocker.
 


### PR DESCRIPTION
## Summary

Measured on the Windows work box against Copilot CLI 1.0.81, closing the first acceptance criterion of #803 (HARNESS-052): *Copilot hook capability verified empirically and the finding recorded*.

- Copilot reads **every** `~/.copilot/hooks/*.json` — the probe file fired alongside Orca's `orca.json`, so our hooks live in their own file and coexistence is by file, with nothing to find by marker.
- `SessionStart`, `PreToolUse`, `PostToolUse`, `SessionEnd` fire with JSON on stdin in Claude's shape (`hook_event_name`, `session_id`, `cwd`, `tool_name`, `tool_input`).
- Deny: exit code 2 blocks the call; `{"permissionDecision":"deny","permissionDecisionReason":"…"}` blocks too. Only the JSON surfaces the reason — exit 2 renders as "hook exited with code 2", the hook's stderr is dropped. That is the one way the Copilot entry is not a clone of Claude's: `dotf harness gate` blocks correctly but loses the which-skill-and-why message.
- `timeoutSec` at least 30 (lesson 111: 5 s plus PowerShell's cold start denied intermittently).

**ADR-027**: an amendment block carries the contract, so HARNESS-045 AC1 (`dotf harness bind`) can write the `bind[]` entry without re-measuring; §3 and the risk line are reconciled with the agy measurement `harness/manifest.json` has recorded since 2026-08-26 (the ADR still called agy "the one open verification item").
**ADR-010**: the hooks row — the Gemini CLI and Copilot CLI cells read `❌ no hook surface`; both are measured surfaces now. The stale MCP cell in the same table belongs to #163 and is left alone.

## What this does not do

- No `bind[]` entry. `feat/bind-hooks-into-setup` (HARNESS-045 AC1, in flight on another box) rewrites that block and defines the entry shape; an entry in today's shape would conflict and arrive dead. #803 stays open for the emission half, the way #1326 stays open for its doctrine half.
- Not measured, and marked as such in the record: `bash` on Linux (Windows ran `powershell` only), `UserPromptSubmit` / `PostToolUseFailure` (declared by `orca.json`, not probed), exit-1 semantics.

## SDD skip rationale

Documentation-only change: two ADR files record a measurement, no production code. The emission it enables is spec'd under HARNESS-045.

## Verification

Three probe runs, each with a throwaway `~/.copilot/hooks/dotf-probe.json` removed afterwards:

```
EVENT=SessionStart STDIN={"hook_event_name":"SessionStart","session_id":"5d8b0149-…","cwd":"…","source":"new","initial_prompt":"…"}
EVENT=PreToolUse   STDIN={"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"echo probe-803",…}}
EVENT=PostToolUse  STDIN={"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{…},"tool_result":{"result_type":"success",…}}
EVENT=SessionEnd   STDIN={"hook_event_name":"SessionEnd","reason":"complete"}

exit2:    tool did NOT run :: Denied by preToolUse hook: hook exited with code 2
denyjson: tool did NOT run :: Denied by preToolUse hook: blocked by probe (denyjson)
```
