### PR TITLE
fix(doctor): the profile doctor measures is the one pwsh names, and the heal is told which file

### DIFF
--- a/cli/internal/doctor/checks_profile.go
+++ b/cli/internal/doctor/checks_profile.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // The dotfiles section of the PowerShell profile is delimited by these two
@@ -61,23 +62,51 @@ func checkProfileFiles(sys *System, c *Contract, rep *Report, fix bool) {
 		return
 	}
 
-	profile, checked := findPowerShellProfile(home)
+	profile, source := profileTarget(sys, home)
 	if profile == "" {
-		rep.Fail("PowerShell profile missing (checked: " + strings.Join(checked, ", ") + ")")
+		rep.Fail("PowerShell profile missing (" + source + ")")
 		return
 	}
 	reasons := profileCorruption(profile)
 	if len(reasons) == 0 {
-		rep.Pass("PowerShell profile exists (" + profile + ")")
+		rep.Pass("PowerShell profile exists (" + profile + "; " + source + ")")
 		return
 	}
 	heal := profileHealPath(sys, c)
 	if !fix {
-		rep.Fail(fmt.Sprintf("PowerShell profile corrupted (%s) — BUG-020; run `pwsh -NoProfile -File %s` or `dotf doctor --fix` (backs the profile up, then rebuilds the dotfiles section from powershell/profile.ps1)",
-			strings.Join(reasons, "; "), heal))
+		rep.Fail(fmt.Sprintf("PowerShell profile corrupted (%s; target %s, %s) — BUG-020; run `pwsh -NoProfile -File %s -ProfilePath %s` or `dotf doctor --fix` (backs the profile up, then rebuilds it from powershell/profile.ps1; content outside the dotfiles markers survives only in the backup)",
+			strings.Join(reasons, "; "), profile, source, heal, profile))
 		return
 	}
 	repairProfile(sys, rep, profile, heal)
+}
+
+// profileQueryTimeout bounds the `$PROFILE` question. `-NoProfile` skips the
+// profile itself, so a healthy pwsh answers in well under a second; ten seconds
+// covers a cold start on a loaded box without letting doctor hang.
+const profileQueryTimeout = 10 * time.Second
+
+// profileTarget names the file doctor measures and --fix heals, and says how
+// it was found (CLI-066, #1364).
+//
+// ONE SOURCE OF TRUTH: the heal resolves `$PROFILE` inside pwsh, so doctor asks
+// pwsh the same question and measures that answer. findPowerShellProfile
+// guesses four roots under Documents; on a box whose Documents folder is
+// redirected anywhere else it measured one file (or none) while the heal
+// rewrote another — detect and heal split, silently. The enumeration survives
+// only as the fallback for a box without pwsh on PATH (where the heal could not
+// run either) or a pwsh that does not answer, and the row says which answered.
+func profileTarget(sys *System, home string) (path, source string) {
+	if !sys.has("pwsh") {
+		p, checked := findPowerShellProfile(home)
+		return p, "enumerated, pwsh not on PATH; checked: " + strings.Join(checked, ", ")
+	}
+	out, _, err := sys.CommandOutputBounded(profileQueryTimeout, "pwsh", "-NoProfile", "-Command", "$PROFILE")
+	if p := strings.TrimSpace(firstLine(out)); err == nil && p != "" {
+		return p, "resolved by pwsh $PROFILE"
+	}
+	p, checked := findPowerShellProfile(home)
+	return p, fmt.Sprintf("enumerated, pwsh did not answer $PROFILE (%s); checked: %s", firstLineOr(out, err), strings.Join(checked, ", "))
 }
 
 // findPowerShellProfile returns the first existing $PROFILE
@@ -175,7 +204,13 @@ func contractDefault(sys *System, c *Contract, name string) string {
 // blocks a session on a transient failure), so its exit status says nothing.
 // The profile is re-measured afterwards, and only a profile that now passes
 // profileCorruption is a Fix. The heal backs the corrupted file up beside itself
-// before writing, so nothing is lost by running it.
+// before writing, so nothing is lost by running it — though only the backup
+// keeps what lived outside the dotfiles markers.
+//
+// The heal is told WHICH file (`-ProfilePath`, CLI-066): the one doctor just
+// measured, so the two cannot disagree on a box whose Documents folder is
+// redirected. It runs through the bounded seam like every other probe that
+// shells out; a heal that hangs must not hang doctor.
 func repairProfile(sys *System, rep *Report, profile, heal string) {
 	if !isRegularFile(heal) {
 		rep.Fail(fmt.Sprintf("PowerShell profile corrupted, and %s is not deployed at %s — run setup-windows.ps1 to deploy scripts/, then `dotf doctor --fix` again (BUG-020)",
@@ -186,7 +221,7 @@ func repairProfile(sys *System, rep *Report, profile, heal string) {
 		rep.Fail("PowerShell profile corrupted, and pwsh is not in PATH to run " + profileHealScript + " (BUG-020)")
 		return
 	}
-	out, err := sys.CommandOutput("pwsh", "-NoProfile", "-File", heal)
+	out, _, err := sys.CommandOutputBounded(profileHealTimeout, "pwsh", "-NoProfile", "-File", heal, "-ProfilePath", profile)
 	if err != nil {
 		rep.Fail(fmt.Sprintf("%s did not run (%s) — profile left as is", profileHealScript, firstLineOr(out, err)))
 		return
@@ -196,8 +231,12 @@ func repairProfile(sys *System, rep *Report, profile, heal string) {
 			profileHealScript, strings.Join(reasons, "; "), firstLineOr(out, nil)))
 		return
 	}
-	rep.Fix("PowerShell profile rebuilt from powershell/profile.ps1 by " + profileHealScript + " (the corrupted copy is backed up beside it; restart PowerShell)")
+	rep.Fix("PowerShell profile rebuilt from powershell/profile.ps1 by " + profileHealScript + " at " + profile + " (the corrupted copy is backed up beside it and is the only place content outside the dotfiles markers survives; restart PowerShell)")
 }
+
+// profileHealTimeout bounds the heal: it reads one file, writes a backup and a
+// rewrite — seconds, not minutes. A minute is generous on a loaded box.
+const profileHealTimeout = 60 * time.Second
 
 // firstLineOr renders a subprocess result as one line: its first line of
 // output when it produced one, else the error, else "no output".

--- a/cli/internal/doctor/checks_profile_heal_test.go
+++ b/cli/internal/doctor/checks_profile_heal_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // healthyProfile is a deployed profile as setup-windows.ps1 writes it: one
@@ -171,11 +172,24 @@ func TestCheckProfileFiles_FixRunsTheHealAndVerifiesByConsequence(t *testing.T) 
 		t.Helper()
 		sys := newSys(map[string]string{"HOME": fx.home, "USERPROFILE": fx.home, "SCRIPTS_DIR": filepath.Dir(fx.heal)}, onPath, nil)
 		sys.GOOS = "windows"
+		// Every shell-out of this check goes through the BOUNDED seam (CLI-066):
+		// the unbounded one must never be reached.
 		sys.CommandOutput = func(name string, args ...string) (string, error) {
+			t.Fatalf("unbounded CommandOutput reached: %s %v", name, args)
+			return "", nil
+		}
+		sys.CommandOutputBounded = func(_ time.Duration, name string, args ...string) (string, string, error) {
 			if name != "pwsh" {
 				t.Fatalf("unexpected command %s %v", name, args)
 			}
-			return pwsh(args)
+			// The `$PROFILE` question (profileTarget) answers the fixture's
+			// path, CRLF-terminated the way pwsh prints it; the heal invocation
+			// goes to the test's pwsh fake.
+			if len(args) == 3 && args[1] == "-Command" && args[2] == "$PROFILE" {
+				return fx.profile + "\r\n", "", nil
+			}
+			out, err := pwsh(args)
+			return out, "", err
 		}
 		var buf bytes.Buffer
 		rep := capture(&buf)
@@ -183,7 +197,7 @@ func TestCheckProfileFiles_FixRunsTheHealAndVerifiesByConsequence(t *testing.T) 
 		return buf.String(), rep
 	}
 
-	t.Run("heal rewrites the profile → FIX, invoked as pwsh -NoProfile -File <SCRIPTS_DIR>\\profile-heal.ps1", func(t *testing.T) {
+	t.Run("heal rewrites the profile → FIX, invoked as pwsh -NoProfile -File <SCRIPTS_DIR>\\profile-heal.ps1 -ProfilePath <the measured file>", func(t *testing.T) {
 		fx := setup(t, true)
 		var gotArgs []string
 		out, rep := run(t, fx, []string{"pwsh"}, func(args []string) (string, error) {
@@ -193,7 +207,9 @@ func TestCheckProfileFiles_FixRunsTheHealAndVerifiesByConsequence(t *testing.T) 
 			}
 			return "[profile-heal] rewrote profile from SSOT\n", nil
 		})
-		want := []string{"-NoProfile", "-File", fx.heal}
+		// CLI-066: the heal is told the file doctor measured — the one pwsh
+		// named — so detect and heal cannot split on a redirected Documents.
+		want := []string{"-NoProfile", "-File", fx.heal, "-ProfilePath", fx.profile}
 		if strings.Join(gotArgs, " ") != strings.Join(want, " ") {
 			t.Fatalf("heal invoked as %v, want %v", gotArgs, want)
 		}

--- a/cli/internal/doctor/checks_profile_target_test.go
+++ b/cli/internal/doctor/checks_profile_target_test.go
@@ -1,0 +1,106 @@
+package doctor
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// CLI-066 (#1364): doctor measures the file pwsh names as $PROFILE, not the
+// first of four guessed roots. The redirected-Documents box is the case the
+// CLI-064 review called out as a THEORETICAL Major: with a profile outside
+// every enumerated root, the old code measured nothing while --fix healed
+// the real file.
+func TestCheckProfileFiles_MeasuresThePwshResolvedProfile(t *testing.T) {
+	type answer struct {
+		out string
+		err error
+	}
+	cases := []struct {
+		name     string
+		onPath   []string
+		pwsh     *answer // nil: pwsh must not be asked
+		where    string  // profile location relative to home; "" for none on disk
+		wantFail int
+		wantSub  string
+	}{
+		{
+			name:     "redirected Documents: pwsh names a file outside the four roots, doctor measures it",
+			onPath:   []string{"pwsh"},
+			pwsh:     &answer{out: "{REDIRECTED}\r\n"},
+			where:    "Redirected/Docs/PowerShell/Microsoft.PowerShell_profile.ps1",
+			wantFail: 0,
+			wantSub:  "resolved by pwsh $PROFILE",
+		},
+		{
+			name:     "pwsh answers a path that does not exist yet: FAIL names that path, not four guesses",
+			onPath:   []string{"pwsh"},
+			pwsh:     &answer{out: "{REDIRECTED}\r\n"},
+			where:    "",
+			wantFail: 1,
+			wantSub:  "resolved by pwsh $PROFILE",
+		},
+		{
+			name:     "no pwsh on PATH: the enumeration answers and the row says so",
+			onPath:   nil,
+			pwsh:     nil,
+			where:    "Documents/PowerShell/Microsoft.PowerShell_profile.ps1",
+			wantFail: 0,
+			wantSub:  "enumerated, pwsh not on PATH",
+		},
+		{
+			name:     "pwsh present but fails to answer: the enumeration answers, with the reason",
+			onPath:   []string{"pwsh"},
+			pwsh:     &answer{out: "", err: errors.New("exit status 1")},
+			where:    "Documents/PowerShell/Microsoft.PowerShell_profile.ps1",
+			wantFail: 0,
+			wantSub:  "enumerated, pwsh did not answer $PROFILE (exit status 1)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			writeFile(t, filepath.Join(home, ".claude", "CLAUDE.md"), "x")
+			writeFile(t, filepath.Join(home, ".gemini", "AGY.md"), "x")
+			redirected := filepath.Join(home, "Redirected", "Docs", "PowerShell", "Microsoft.PowerShell_profile.ps1")
+			if tc.where != "" {
+				writeFile(t, filepath.Join(home, filepath.FromSlash(tc.where)), healthyProfile)
+			}
+			sys := newSys(map[string]string{"HOME": home, "USERPROFILE": home}, tc.onPath, nil)
+			sys.GOOS = "windows"
+			asked := false
+			sys.CommandOutputBounded = func(d time.Duration, name string, args ...string) (string, string, error) {
+				asked = true
+				if tc.pwsh == nil {
+					t.Fatalf("pwsh must not be asked here, got %s %v", name, args)
+				}
+				if name != "pwsh" || strings.Join(args, " ") != "-NoProfile -Command $PROFILE" {
+					t.Fatalf("unexpected question: %s %v", name, args)
+				}
+				if d != profileQueryTimeout {
+					t.Fatalf("the question must be bounded by profileQueryTimeout, got %v", d)
+				}
+				return strings.ReplaceAll(tc.pwsh.out, "{REDIRECTED}", redirected), "", tc.pwsh.err
+			}
+			var buf bytes.Buffer
+			rep := capture(&buf)
+			checkProfileFiles(sys, nil, rep, false)
+			out := buf.String()
+			if rep.Failures() != tc.wantFail {
+				t.Fatalf("failures = %d, want %d\n%s", rep.Failures(), tc.wantFail, out)
+			}
+			if !strings.Contains(out, tc.wantSub) {
+				t.Fatalf("row must say how the target was found (%q)\n%s", tc.wantSub, out)
+			}
+			if (tc.pwsh != nil) != asked {
+				t.Fatalf("pwsh asked = %v, want %v", asked, tc.pwsh != nil)
+			}
+			if tc.pwsh != nil && tc.pwsh.err == nil && !strings.Contains(out, redirected) {
+				t.Fatalf("the row must name the pwsh-resolved path\n%s", out)
+			}
+		})
+	}
+}

--- a/cli/internal/doctor/checks_profile_thresholds_test.go
+++ b/cli/internal/doctor/checks_profile_thresholds_test.go
@@ -1,0 +1,56 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// CLI-066 (#1364), Minor from the CLI-064 review: doctor and profile-heal.ps1
+// each carry the two corruption thresholds as their own literal — Go counts
+// bytes and marker occurrences, the script `-gt 1MB` and `[regex]::Matches
+// ... -gt 1`. Nothing linked them, so one could move and the other would keep
+// flagging (or clearing) a profile the heal disagrees about. This test reads
+// the script the repo ships and pins its literals beside doctor's constants:
+// change one, and this names the other.
+func TestProfileHealThresholdsMatchTheScript(t *testing.T) {
+	root := repoRootForDoctorTest(t)
+	raw, err := os.ReadFile(filepath.Join(root, "scripts", profileHealScript))
+	if err != nil {
+		t.Fatalf("the heal the doctor invokes must ship with the repo: %v", err)
+	}
+	script := string(raw)
+
+	// Size: doctor's profileMaxBytes is exactly 1 MiB, the script's `-gt 1MB`
+	// (PowerShell's 1MB is 1048576, the same power of two).
+	if profileMaxBytes != 1<<20 {
+		t.Fatalf("profileMaxBytes = %d; the script says `-gt 1MB` (1048576) — change both or neither", profileMaxBytes)
+	}
+	if !strings.Contains(script, "$state.Size -gt 1MB") {
+		t.Fatalf("%s no longer tests `$state.Size -gt 1MB`; doctor's profileMaxBytes (%d) assumes it", profileHealScript, profileMaxBytes)
+	}
+
+	// Markers: doctor flags more than one START or END; the script the same,
+	// on the same two strings.
+	for _, want := range []string{
+		"$state.StartMarkers -gt 1 -or $state.EndMarkers -gt 1",
+		"'" + profileStartMarker + "'",
+		"'" + profileEndMarker + "'",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("%s no longer contains %q; doctor's marker rule (>1 of either, on these exact strings) assumes it", profileHealScript, want)
+		}
+	}
+
+	// The parameter doctor passes exists, and the heal defaults to $PROFILE
+	// without it — the contract --fix relies on (AC3/AC4).
+	for _, want := range []string{
+		"[string]$ProfilePath = ''",
+		"$profilePath = if ($ProfilePath) { $ProfilePath } else { $PROFILE }",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("%s no longer carries %q; doctor invokes it with -ProfilePath", profileHealScript, want)
+		}
+	}
+}

--- a/scripts/profile-heal.ps1
+++ b/scripts/profile-heal.ps1
@@ -3,7 +3,10 @@
     Idempotently repair a corrupted PowerShell profile by reconstructing the
     dotfiles section from the SSOT (powershell/profile.ps1), after backing
     up the corrupted file. Companion to BUG-021 (setup-windows.ps1 fail-fast
-    preflight).
+    preflight). The rewrite keeps ONLY the dotfiles section: anything that
+    lived outside the START/END markers survives in the backup, not in the
+    healed profile. Heals this host's $PROFILE, or the file given as
+    -ProfilePath (what dotf doctor --fix passes, so it heals what it measured).
 
 .DESCRIPTION
     BUG-020 root cause: setup-windows.ps1 used to swallow -replace OOM errors
@@ -47,7 +50,12 @@
 
 [CmdletBinding()]
 param(
-    [switch]$VerboseOutput
+    [switch]$VerboseOutput,
+    # The profile to heal. Empty means this host's $PROFILE, which is what a
+    # hand invocation wants; dotf doctor --fix passes the file it measured so
+    # detect and heal cannot split on a box whose Documents folder is
+    # redirected (CLI-066, #1364).
+    [string]$ProfilePath = ''
 )
 
 Set-StrictMode -Version Latest
@@ -179,7 +187,7 @@ function Repair-Profile {
 
 # --- Main ---
 
-$profilePath = $PROFILE
+$profilePath = if ($ProfilePath) { $ProfilePath } else { $PROFILE }
 $ssotPath = Resolve-SsotProfile
 
 if (-not $ssotPath) {

--- a/specs/CLI-066-doctor-profile-target/features.json
+++ b/specs/CLI-066-doctor-profile-target/features.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "CLI-066-doctor-profile-target-f1",
+    "behavior": "AC1: with pwsh on PATH, doctor measures the file pwsh names as $PROFILE, even outside the four enumerated roots, and the row names that path",
+    "verification": "cd cli && go test ./internal/doctor/ -run 'TestCheckProfileFiles_MeasuresThePwshResolvedProfile/redirected|TestCheckProfileFiles_MeasuresThePwshResolvedProfile/pwsh_answers' -count=1",
+    "state": "verified",
+    "evidence": "TestCheckProfileFiles_MeasuresThePwshResolvedProfile: a healthy profile under <home>/Redirected/Docs/PowerShell (outside every enumerated root) passes when the fake pwsh answers its path CRLF-terminated, row says 'resolved by pwsh $PROFILE' and names the path; a pwsh answer for a file not on disk is one FAIL naming that path"
+  },
+  {
+    "id": "CLI-066-doctor-profile-target-f2",
+    "behavior": "AC2: without pwsh (or with a pwsh that does not answer) doctor falls back to the enumeration and the row says so, with the reason",
+    "verification": "cd cli && go test ./internal/doctor/ -run 'TestCheckProfileFiles_MeasuresThePwshResolvedProfile/no_pwsh|TestCheckProfileFiles_MeasuresThePwshResolvedProfile/pwsh_present_but_fails' -count=1",
+    "state": "verified",
+    "evidence": "no pwsh on PATH: pwsh is never asked, row says 'enumerated, pwsh not on PATH'; pwsh errors (exit status 1): row says 'enumerated, pwsh did not answer $PROFILE (exit status 1)'; the question is bounded by profileQueryTimeout (asserted on the seam)"
+  },
+  {
+    "id": "CLI-066-doctor-profile-target-f3",
+    "behavior": "AC3: --fix invokes pwsh -NoProfile -File <SCRIPTS_DIR>\\profile-heal.ps1 -ProfilePath <the measured file> through the bounded seam and re-measures that file; the unbounded seam is never reached",
+    "verification": "cd cli && go test ./internal/doctor/ -run 'TestCheckProfileFiles_FixRunsTheHealAndVerifiesByConsequence' -count=1",
+    "state": "verified",
+    "evidence": "the heal test's argv assertion is now [-NoProfile -File <heal> -ProfilePath <profile>]; sys.CommandOutput (unbounded) is a t.Fatalf in the harness and is never reached; the $PROFILE question is answered by the bounded fake; all five sub-cases (FIX, no-op FAIL, script absent, pwsh absent, heal error) pass"
+  },
+  {
+    "id": "CLI-066-doctor-profile-target-f4",
+    "behavior": "AC4: profile-heal.ps1 -ProfilePath heals the given file; without the parameter it targets $PROFILE as before; the script stays ASCII and analyzer-clean",
+    "verification": "bats tests/profile-heal-ps1.bats && pwsh -NoProfile -Command \"if ((Invoke-ScriptAnalyzer -Path scripts/profile-heal.ps1 -Settings .PSScriptAnalyzerSettings.psd1 -Severity Error,Warning).Count -ne 0) { exit 1 }\"",
+    "state": "verified",
+    "evidence": "bats 16/16 incl. the new 'takes -ProfilePath and defaults to $PROFILE without it'; PSScriptAnalyzer 1.25.0 on the box: 0 findings, 0 non-ASCII characters; box run: -ProfilePath against a scratch copy with two marker pairs -> 'corruption detected: marker counts (start=2, end=2) exceed 1' then 'heal complete', one pair after, backup beside it"
+  },
+  {
+    "id": "CLI-066-doctor-profile-target-f5",
+    "behavior": "AC5: a Go test reads scripts/profile-heal.ps1 and fails if its size or marker threshold literals stop matching doctor's constants, or if -ProfilePath disappears",
+    "verification": "cd cli && go test ./internal/doctor/ -run 'TestProfileHealThresholdsMatchTheScript' -count=1",
+    "state": "verified",
+    "evidence": "TestProfileHealThresholdsMatchTheScript pins '$state.Size -gt 1MB' beside profileMaxBytes == 1<<20, '$state.StartMarkers -gt 1 -or $state.EndMarkers -gt 1' and the two marker strings beside doctor's rule, and the -ProfilePath parameter with its $PROFILE default"
+  },
+  {
+    "id": "CLI-066-doctor-profile-target-f6",
+    "behavior": "AC6 (box): dotf doctor names the pwsh-resolved profile path; profile-heal.ps1 -ProfilePath heals a scratch corrupted copy while the real profile is untouched",
+    "verification": "test \"$(uname -s | cut -c1-5)\" = MINGW && dotf doctor --verbose 2>/dev/null | grep -q 'PowerShell profile exists (.*resolved by pwsh'",
+    "state": "verified",
+    "evidence": "Windows work box, 2026-08-29, binary built from this branch: dotf doctor --verbose -> '[ OK ] PowerShell profile exists (C:\\Users\\<user>\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1; resolved by pwsh $PROFILE)'; scratch heal: START markers 2 -> 1, one .corrupted-*.bak beside it; SHA256 of the real $PROFILE identical before and after"
+  }
+]

--- a/specs/CLI-066-doctor-profile-target/proposal.md
+++ b/specs/CLI-066-doctor-profile-target/proposal.md
@@ -1,0 +1,84 @@
+---
+id: "CLI-066-doctor-profile-target"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-08-29"
+issue: "mlorentedev/dotfiles#1364"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# CLI-066-doctor-profile-target
+
+> **Naming**: file lives at `<repo>/specs/CLI-066-doctor-profile-target/proposal.md`. `CLI-066-doctor-profile-target` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+`dotf doctor` (CLI-064, #1353) decides whether the PowerShell profile is
+corrupted from the file its own `findPowerShellProfile` enumerates — four
+hardcoded roots under `~\Documents` and `~\OneDrive\Documents` — while `--fix`
+runs `scripts/profile-heal.ps1`, which resolves `$PROFILE` itself and heals
+**that**. On a box whose Documents folder is redirected anywhere else (a
+corporate `User Shell Folders\Personal`, a second drive), doctor measures one
+file, or none, and the heal rewrites another: detect and heal split. Raised by
+the adversarial review of CLI-064 (Major, THEORETICAL — not reproduced;
+`specs/archive/CLI-064-doctor-profile-heal/review.md`, finding 1), with three
+Minors from the same review that this closes alongside.
+
+## What
+
+- **One source of truth for the target.** Doctor asks PowerShell for it —
+  `pwsh -NoProfile -Command '$PROFILE'` through the bounded seam
+  (`CommandOutputBounded`) — and measures that file. The four-root enumeration
+  survives only as the fallback when `pwsh` is not on PATH (then the heal could
+  not run anyway) and the row says which of the two answered.
+- **The heal takes the path it must heal.** `profile-heal.ps1` gains
+  `-ProfilePath`; doctor passes the file it measured, so `--fix` and the
+  measurement agree by construction. Run by hand without the parameter, the
+  script defaults to `$PROFILE` as before.
+- **Thresholds linked, not duplicated.** A Go test reads the script and asserts
+  its `-gt 1MB` and `-gt 1` literals beside doctor's `profileMaxBytes` and
+  marker rule, so the two cannot drift silently (Minor 1).
+- **The heal runs bounded** — `CommandOutputBounded`, like every other doctor
+  probe that shells out (Minor 2).
+- **What `--fix` does is said where it is offered:** the FAIL line and the
+  script's synopsis state that the heal rewrites the profile from the SSOT and
+  keeps everything else only in the backup it makes first (Minor 3, documented
+  rather than built: preserving an outside-marker tail is a different feature,
+  and BUG-020's profiles carried nothing worth preserving).
+
+## Out of scope
+
+- Preserving user content outside the dotfiles markers across a heal
+  (documented; a follow-up if a real profile ever carries any).
+- Windows PowerShell 5.1's `$PROFILE` (`WindowsPowerShell\`): setup deploys the
+  pwsh 7 profile; doctor measures what `pwsh` reports, as before it measured
+  the first existing candidate.
+- The PowerShell-side `doctor.ps1 -Fix` twin — retired in CLI-064.
+
+## Risks / open questions
+
+- `pwsh` present but slow to answer (`-NoProfile` avoids the profile itself;
+  measured cold start here is under 1 s). RESOLVED: bounded at 10 s; on a
+  timeout doctor falls back to the enumeration and says so in the row.
+- `$PROFILE` reported for a file that does not exist yet (fresh box, setup not
+  run). RESOLVED: that is the missing-profile FAIL doctor already emits, now
+  naming the path pwsh gave instead of four guesses.
+- A `$PROFILE` answer with a trailing newline or CRLF. RESOLVED: trimmed, and
+  the test feeds the CRLF form.
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [x] AC1 — with `pwsh` on PATH, doctor measures the file `pwsh -NoProfile -Command '$PROFILE'` names, even when it lies outside the four enumerated roots; the row names that path.
+- [x] AC2 — without `pwsh`, doctor falls back to the enumeration and the row says the target was enumerated, not resolved.
+- [x] AC3 — `--fix` invokes `pwsh -NoProfile -File <SCRIPTS_DIR>\profile-heal.ps1 -ProfilePath <the measured file>` through the bounded seam, and re-measures the same file.
+- [x] AC4 — `profile-heal.ps1 -ProfilePath <file>` heals that file and only it; without the parameter it targets `$PROFILE` as before.
+- [x] AC5 — a Go test fails if the script's size or marker threshold literals stop matching doctor's constants.
+- [x] AC6 — on the Windows work box: `dotf doctor` names the pwsh-resolved profile path in its row, and `profile-heal.ps1 -ProfilePath` against a scratch corrupted copy heals the copy while the real profile is untouched.
+
+## References
+
+- Bitácora board: #1364. Prior spec: `specs/archive/CLI-064-doctor-profile-heal/` (review finding 1 and the three Minors).
+- `cli/internal/doctor/checks_profile.go`, `scripts/profile-heal.ps1`, `tests/profile-heal-ps1.bats`.

--- a/specs/CLI-066-doctor-profile-target/tasks.md
+++ b/specs/CLI-066-doctor-profile-target/tasks.md
@@ -1,0 +1,30 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-29"
+---
+
+# Tasks - CLI-066-doctor-profile-target
+
+> TDD order. One task = one focused commit. Tick as you go. Frozen at the start of `implementing`.
+
+## Setup
+
+- [x] Branch created from main: `feat/doctor-profile-target`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+- [x] [AC1][AC2] `doctor`: `profileTarget(sys, home)` asks `pwsh -NoProfile -Command $PROFILE` through `CommandOutputBounded` (10 s), trims the answer, and falls back to `findPowerShellProfile` when pwsh is absent, fails or times out; the row names the path and says `resolved by pwsh` or `enumerated`. Tests: a profile outside the four roots found through the fake answer (CRLF-terminated); no pwsh → enumeration; pwsh errors → enumeration with the reason in the row.
+- [x] [AC3] `doctor`: `repairProfile` runs the heal through `CommandOutputBounded` (60 s) as `pwsh -NoProfile -File <heal> -ProfilePath <profile>` and re-measures `profile`; the heal test's fakes answer the `$PROFILE` query and assert the new argv; the FAIL and FIX lines say the heal rewrites from the SSOT and keeps the rest only in the backup.
+- [x] [AC4] `scripts/profile-heal.ps1`: `-ProfilePath` parameter, `$PROFILE` when absent; synopsis says so. `tests/profile-heal-ps1.bats` asserts the parameter exists and the default. ASCII only.
+- [x] [AC5] `doctor`: `TestProfileHealThresholdsMatchTheScript` reads `scripts/profile-heal.ps1` and asserts `-gt 1MB` beside `profileMaxBytes == 1<<20`, and `StartMarkers -gt 1 -or $state.EndMarkers -gt 1` beside doctor's `> 1` rule.
+- [x] [AC6] Box: `dotf doctor` names the pwsh-resolved path; `profile-heal.ps1 -ProfilePath <scratch copy with two marker pairs>` heals the copy; the real profile's hash is unchanged before/after.
+
+## Closing
+
+- [x] Every acceptance criterion from `proposal.md` is covered by at least one test (AC6 by the box transcript in `verification.md`)
+- [x] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [x] `go build ./... && go vet ./... && go test ./...`, `GOOS=windows go vet ./...`, `golangci-lint run` (pinned), PSScriptAnalyzer clean on the script, bats for the script
+- [x] No unrelated changes in the diff
+- [x] `verification.md` filled in

--- a/specs/CLI-066-doctor-profile-target/verification.md
+++ b/specs/CLI-066-doctor-profile-target/verification.md
@@ -1,0 +1,65 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-29"
+---
+
+# Verification - CLI-066-doctor-profile-target
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [x] AC1 (doctor measures the pwsh-resolved `$PROFILE`, outside the enumerated roots) -> commit `1925da6` / `TestCheckProfileFiles_MeasuresThePwshResolvedProfile` cases "redirected Documents…" and "pwsh answers a path that does not exist yet…"
+- [x] AC2 (no pwsh, or pwsh silent → enumeration, row says so) -> same test, cases "no pwsh on PATH…" and "pwsh present but fails to answer…"
+- [x] AC3 (`--fix` invokes the heal with `-ProfilePath <measured>` through the bounded seam) -> `TestCheckProfileFiles_FixRunsTheHealAndVerifiesByConsequence` (argv assertion updated; the unbounded seam is a `t.Fatalf` in the harness)
+- [x] AC4 (`profile-heal.ps1 -ProfilePath`, `$PROFILE` default, ASCII, analyzer-clean) -> `tests/profile-heal-ps1.bats` (16/16), PSScriptAnalyzer 1.25.0 0 findings, box transcript below
+- [x] AC5 (thresholds linked by test) -> `TestProfileHealThresholdsMatchTheScript`
+- [x] AC6 (box) -> transcript below, Windows work box, 2026-08-29
+
+## Test status
+
+- Test suite: `cd cli && go test ./... -count=1` -> every package `ok`, `FAIL_COUNT=0`; `go vet` clean under `GOOS=windows` and `GOOS=linux`; `golangci-lint run` (pinned 2.12.2) `0 issues`
+- `bats tests/profile-heal-ps1.bats` -> 16/16; `Invoke-ScriptAnalyzer scripts/profile-heal.ps1` -> 0 findings, 0 non-ASCII characters
+- Manual smoke test (AC6), binary built from this branch:
+
+  ```text
+  --- doctor row (dotf doctor --verbose) ---
+  [ OK ] PowerShell profile exists (C:\Users\<user>\Documents\PowerShell\Microsoft.PowerShell_profile.ps1; resolved by pwsh $PROFILE)
+  --- scratch heal via -ProfilePath ---
+  scratch START markers before: 2
+  [profile-heal] corruption detected: marker counts (start=2, end=2) exceed 1
+  [profile-heal] heal complete -- restart PowerShell or dot-source the profile
+  scratch START markers after:  1
+  backup beside scratch: 1
+  real profile untouched: True  (SHA256 before == after)
+  ```
+
+  The box's Documents is not redirected (`[Environment]::GetFolderPath('MyDocuments')` is
+  `~\Documents`), so the redirected case is proven by the Go test with a fake `$PROFILE`
+  answer outside every enumerated root; the box proves the real question-and-answer path
+  and that the heal targets the file it is given.
+- No regressions in existing test suite: yes. Doctor's default output summarises an all-OK
+  section as `(3 checks, all ok)`; the row is visible under `--verbose`, which is what f6's
+  command uses.
+
+## Decisions made during implementation
+
+- **Ask pwsh, do not guess.** The heal resolves `$PROFILE` inside pwsh, so doctor asks pwsh the same question through the bounded seam (10 s) and measures the answer. The four-root enumeration is kept only as the fallback for a box without pwsh or a pwsh that does not answer, and the row always says which of the two produced the path — a fallback that hides itself is the CLI-064 split again in a new coat.
+- **The heal is told which file.** `-ProfilePath` on the script, passed by doctor; without it the script behaves exactly as before, so a hand run needs no new knowledge. `TestProfileHealThresholdsMatchTheScript` also pins the parameter's presence, since doctor's argv depends on it.
+- **Bounded, like every other probe.** The heal runs through `CommandOutputBounded` (60 s). The test harness makes the unbounded seam a `t.Fatalf`, so a future edit cannot quietly go back.
+- **Outside-marker content is documented, not preserved.** The heal rewrites the whole file from the SSOT; the FAIL/FIX lines and the script's synopsis say that only the backup keeps what lived outside the markers. Preserving it is a different feature no real profile has asked for.
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons/`? no — the class ("detect and heal must name the same target") is CLI-064's review finding, recorded there and in this spec; nothing new was learned beyond applying it
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? no
+- [ ] New pattern candidate for `00_meta/patterns/`? no
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/CLI-066-doctor-profile-target/` -> `specs/archive/CLI-066-doctor-profile-target/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)

--- a/tests/profile-heal-ps1.bats
+++ b/tests/profile-heal-ps1.bats
@@ -126,3 +126,11 @@ setup() {
     grep -qE 'deploy_file\s+"\$DOTFILES_DIR/\.bashrc"\s+"\$HOME/\.bashrc"' "$DOTFILES_DIR/setup-linux.sh"
     grep -qE 'deploy_file\s+"\$DOTFILES_DIR/\.zshrc"\s+"\$HOME/\.zshrc"' "$DOTFILES_DIR/setup-linux.sh"
 }
+
+# CLI-066 (#1364): dotf doctor --fix passes the file it measured, so the script
+# takes -ProfilePath and defaults to this host's $PROFILE without it — detect
+# and heal agree on a box whose Documents folder is redirected.
+@test "profile-heal.ps1 takes -ProfilePath and defaults to \$PROFILE without it" {
+    grep -qF "[string]\$ProfilePath = ''" "$PS1_SCRIPT"
+    grep -qF '$profilePath = if ($ProfilePath) { $ProfilePath } else { $PROFILE }' "$PS1_SCRIPT"
+}


### PR DESCRIPTION
## Summary

`dotf doctor` decided whether the PowerShell profile was corrupted from the file its own four-root enumeration found, while `--fix` ran `profile-heal.ps1`, which resolves `$PROFILE` itself and heals **that**. On a box whose Documents folder is redirected, doctor measured one file (or none) and the heal rewrote another. Raised by CLI-064's adversarial review (Major, theoretical); this closes it and the three Minors from the same review. Spec: `specs/CLI-066-doctor-profile-target/`.

- **One source of truth for the target.** Doctor asks `pwsh -NoProfile -Command '$PROFILE'` through the bounded seam (10 s) and measures that file. The enumeration survives only as the fallback for a box without pwsh, or a pwsh that does not answer — and the row says which of the two produced the path.
- **The heal is told which file.** `profile-heal.ps1 -ProfilePath <the measured file>`; without the parameter it targets `$PROFILE` as before.
- **Thresholds linked, not duplicated.** `TestProfileHealThresholdsMatchTheScript` reads the script and pins its `-gt 1MB` / `-gt 1` literals beside doctor's constants (Minor 1).
- **The heal runs bounded** (60 s), like every other doctor probe; the test harness makes the unbounded seam a `t.Fatalf` so it cannot quietly return (Minor 2).
- **What `--fix` does is said where it is offered:** content outside the dotfiles markers survives only in the backup (Minor 3, documented rather than built).

Refs #1364 (closed by the archive PR after the independent review).

## Verification

- `go test ./...` all ok, `FAIL_COUNT=0`; `go vet` clean under `GOOS=windows` and `GOOS=linux`; `golangci-lint run` (pinned 2.12.2) 0 issues; `bats tests/profile-heal-ps1.bats` 16/16; PSScriptAnalyzer 0 findings, 0 non-ASCII.
- **Windows work box, binary from this branch:** `dotf doctor --verbose` → `[ OK ] PowerShell profile exists (…\Documents\PowerShell\Microsoft.PowerShell_profile.ps1; resolved by pwsh $PROFILE)`; `profile-heal.ps1 -ProfilePath <scratch copy with two marker pairs>` → healed (2 → 1 pairs, backup beside it) while the real profile's SHA-256 was identical before and after. Transcript in `verification.md`.
