### PR TITLE
feat(deploy): a 0600 file gets an owner-only ACL on Windows, and an in-sync file still gets its declared mode

### DIFF
--- a/cli/internal/cmd/deploy.go
+++ b/cli/internal/cmd/deploy.go
@@ -96,6 +96,12 @@ func newDeployCmd() *cobra.Command {
 				switch {
 				case !res.Changed:
 					_, _ = fmt.Fprintf(w, "in sync   %-10s %s\n", res.Name, res.Dst)
+				case res.ModeFixed && dryRun:
+					_, _ = fmt.Fprintf(w, "would fix mode %-5s %s\n", res.Name, res.Dst)
+				case res.ModeFixed:
+					// Content was in sync; only the declared mode was missing on
+					// the file (CLI-055: an inherited ACL on a 0600).
+					_, _ = fmt.Fprintf(w, "mode fixed %-9s %s\n", res.Name, res.Dst)
 				case dryRun:
 					_, _ = fmt.Fprintf(w, "would deploy %-7s %s\n", res.Name, res.Dst)
 				default:

--- a/cli/internal/deploy/deploy.go
+++ b/cli/internal/deploy/deploy.go
@@ -22,6 +22,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/fsmode"
 )
 
 // ManifestRel is the declarative table of what gets deployed where, relative to
@@ -89,6 +91,10 @@ type Outcome struct {
 	Dst     string
 	Changed bool
 	DryRun  bool
+	// ModeFixed: the content was in sync but the declared mode was not on the
+	// file — a 0600 whose ACL was still inherited (CLI-055) — and the deploy
+	// applied it without rewriting the content. Changed is true alongside.
+	ModeFixed bool
 }
 
 // Plan is what a deploy of a non-rendered config would do, computed without
@@ -291,7 +297,10 @@ func Deploy(c Config, repoRoot, home string, resolve func(string) string, render
 		}
 		out.Dst = p.Dst
 		if !p.Changed {
-			return out, nil // in sync; Changed stays false and nothing is rewritten
+			// In sync by content; the mode may still be off (CLI-055: a 0600
+			// deployed by an older binary keeps its inherited ACL forever
+			// unless someone looks). Nothing is rewritten either way.
+			return ensureMode(c, out, p.Dst, mode, dryRun)
 		}
 		out.Changed = true
 		if dryRun {
@@ -328,13 +337,36 @@ func Deploy(c Config, repoRoot, home string, resolve func(string) string, render
 		return out, fmt.Errorf("config %q: re-read staged copy: %w", c.Name, err)
 	}
 	if existing, err := os.ReadFile(dst); err == nil && bytes.Equal(existing, stagedData) { //nolint:gosec // manifest-declared destination
-		return out, nil // in sync; Changed stays false and nothing is rewritten
+		return ensureMode(c, out, dst, mode, dryRun) // in sync by content; the mode may still be off
 	}
 	out.Changed = true
 	if dryRun {
 		return out, nil
 	}
 	return out, commit(c, staged, dst, mode)
+}
+
+// ensureMode is the in-sync path's last word: the content matches, so the only
+// thing left to be wrong is the mode — on Windows, the ACL a 0600 file kept
+// from its directory because an earlier binary could not express owner-only
+// (CLI-055). A dry run reports the fix it would make; a real run makes it and
+// reports it as ModeFixed, never as a content rewrite.
+func ensureMode(c Config, out Outcome, dst string, mode os.FileMode, dryRun bool) (Outcome, error) {
+	needs, err := fsmode.Needs(dst, mode)
+	if err != nil {
+		return out, fmt.Errorf("config %q: mode on %s: %w", c.Name, dst, err)
+	}
+	if !needs {
+		return out, nil
+	}
+	out.Changed, out.ModeFixed = true, true
+	if dryRun {
+		return out, nil
+	}
+	if err := fsmode.Apply(dst, mode); err != nil {
+		return out, fmt.Errorf("config %q: mode on %s: %w", c.Name, dst, err)
+	}
+	return out, nil
 }
 
 // load reads the source and resolves the destination.
@@ -376,7 +408,7 @@ func stage(c Config, dst string, data []byte, mode os.FileMode) (string, error) 
 	if err := tmp.Close(); err != nil {
 		return staged, fmt.Errorf("config %q: stage: %w", c.Name, err)
 	}
-	if err := os.Chmod(staged, mode); err != nil {
+	if err := fsmode.Apply(staged, mode); err != nil {
 		return staged, fmt.Errorf("config %q: stage mode: %w", c.Name, err)
 	}
 	return staged, nil
@@ -389,8 +421,10 @@ func commit(c Config, staged, dst string, mode os.FileMode) error {
 	}
 	// Rename preserves the staged mode, but an existing destination replaced by
 	// rename keeps the NEW inode's bits — so this is belt-and-braces for the
-	// case that matters: a 0600 config must never end up 0644.
-	if err := os.Chmod(dst, mode); err != nil {
+	// case that matters: a 0600 config must never end up 0644. On Windows the
+	// rename also carries the staged file's DACL, and fsmode re-applies the
+	// owner-only one for the same reason (CLI-055).
+	if err := fsmode.Apply(dst, mode); err != nil {
 		return fmt.Errorf("config %q: mode on %s: %w", c.Name, dst, err)
 	}
 	return nil

--- a/cli/internal/deploy/deploy_mode_test.go
+++ b/cli/internal/deploy/deploy_mode_test.go
@@ -1,0 +1,67 @@
+package deploy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/fsmode"
+)
+
+// CLI-055 (#1302), found on the box: a 0600 config whose content was already
+// in sync came back "in sync" and kept the ACL its directory handed it,
+// because the in-sync path compared bytes and nothing else. The mode is part
+// of what "deployed" means, so the in-sync path now asks fsmode.Needs and
+// applies the declared mode without rewriting the content — reported as a
+// mode fix, never as a deploy, and a dry run reports it without touching.
+func TestDeploy_InSyncContentStillGetsItsDeclaredMode(t *testing.T) {
+	root := repoWithTrust(t, "ai/secret.json", `{"k":"v"}`)
+	home := t.TempDir()
+	c := Config{Name: "secret", Src: "ai/secret.json", Dst: "{HOME}/.tool/secret.json", Mode: "0600"}
+	dst := filepath.Join(home, ".tool", "secret.json")
+
+	// The file as an older binary would have left it: same bytes, whatever
+	// mode the directory and os.WriteFile give it.
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte(`{"k":"v"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if needs, err := fsmode.Needs(dst, 0o600); err != nil || !needs {
+		t.Fatalf("precondition: the file must be missing its mode, got needs=%v err=%v", needs, err)
+	}
+
+	dry, err := Deploy(c, root, home, noResolve, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dry.Changed || !dry.ModeFixed {
+		t.Fatalf("dry run must report the mode fix it would make: %+v", dry)
+	}
+	if needs, _ := fsmode.Needs(dst, 0o600); !needs {
+		t.Fatal("a dry run must not touch the file")
+	}
+
+	res, err := Deploy(c, root, home, noResolve, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Changed || !res.ModeFixed {
+		t.Fatalf("the mode fix must be reported as one: %+v", res)
+	}
+	if needs, err := fsmode.Needs(dst, 0o600); err != nil || needs {
+		t.Fatalf("after the run nothing must be left to fix, got needs=%v err=%v", needs, err)
+	}
+	if got, _ := os.ReadFile(dst); string(got) != `{"k":"v"}` {
+		t.Fatalf("content must be untouched by a mode fix, got %q", got)
+	}
+
+	again, err := Deploy(c, root, home, noResolve, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Changed || again.ModeFixed {
+		t.Fatalf("second run must be in sync, got %+v", again)
+	}
+}

--- a/cli/internal/fsmode/fsmode.go
+++ b/cli/internal/fsmode/fsmode.go
@@ -1,0 +1,55 @@
+// Package fsmode applies a declared file mode where the OS can actually
+// express it (CLI-055, #1302).
+//
+// The manifest and the secrets registry declare modes in POSIX octal — `0600`
+// for a rendered credential — and every writer reached disk through os.Chmod.
+// On Windows os.Chmod toggles the read-only attribute and nothing else, so a
+// file declared 0600 was protected only by whatever ACL its directory handed
+// down. Apply keeps os.Chmod's behaviour everywhere and, on Windows, turns an
+// owner-only mode into an owner-only DACL. One place decides what a mode
+// means; the writers only say which mode.
+package fsmode
+
+import "os"
+
+// Apply sets mode on path: os.Chmod on every OS, and on Windows an owner-only
+// DACL as well when mode grants nothing to group or other.
+func Apply(path string, mode os.FileMode) error {
+	if err := os.Chmod(path, mode); err != nil {
+		return err
+	}
+	if !OwnerOnly(mode) {
+		return nil
+	}
+	return restrictToOwner(path)
+}
+
+// OwnerOnly reports whether mode grants nothing to group or other — the modes
+// (0600, 0700, 0400) that mean "this file is mine alone".
+func OwnerOnly(mode os.FileMode) bool {
+	return mode.Perm()&0o077 == 0
+}
+
+// Needs reports whether Apply(path, mode) would change anything: the POSIX
+// bits differ, or — on Windows, for an owner-only mode — the file's DACL is
+// not yet protected. It is the read-only question a deploy asks about a file
+// whose content is already in sync, so a mode an older binary could not
+// express gets applied on the next run instead of never (CLI-055).
+func Needs(path string, mode os.FileMode) (bool, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	if permDiffers(fi.Mode(), mode) {
+		return true, nil
+	}
+	if !OwnerOnly(mode) {
+		return false, nil
+	}
+	applied, err := ownerOnlyApplied(path)
+	if err != nil {
+		return false, err
+	}
+	return !applied, nil
+}
+

--- a/cli/internal/fsmode/fsmode_other.go
+++ b/cli/internal/fsmode/fsmode_other.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package fsmode
+
+import "os"
+
+// restrictToOwner is a no-op off Windows: os.Chmod already expressed the mode
+// in full, and there is no second permission system to reconcile.
+func restrictToOwner(string) error { return nil }
+
+// ownerOnlyApplied is true off Windows for the same reason: once the bits are
+// on, nothing else stands between the file and "mine alone".
+func ownerOnlyApplied(string) (bool, error) { return true, nil }
+
+// permDiffers compares the full permission bits: POSIX expresses all of them.
+func permDiffers(got, want os.FileMode) bool { return got.Perm() != want.Perm() }

--- a/cli/internal/fsmode/fsmode_test.go
+++ b/cli/internal/fsmode/fsmode_test.go
@@ -1,0 +1,80 @@
+package fsmode
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// OwnerOnly is the one rule the Windows branch keys on: any bit for group or
+// other means the inherited ACL stays.
+func TestOwnerOnly(t *testing.T) {
+	cases := []struct {
+		mode os.FileMode
+		want bool
+	}{
+		{0o600, true}, {0o400, true}, {0o700, true},
+		{0o644, false}, {0o640, false}, {0o604, false}, {0o755, false}, {0o666, false},
+	}
+	for _, tc := range cases {
+		if got := OwnerOnly(tc.mode); got != tc.want {
+			t.Errorf("OwnerOnly(%#o) = %v, want %v", tc.mode, got, tc.want)
+		}
+	}
+}
+
+// Needs is the read-only mirror of Apply: true while Apply would change
+// something, false right after it ran — on every OS, whatever "something"
+// means there (bits on POSIX, the read-only attribute and the DACL on Windows).
+func TestNeeds_MirrorsApply(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f")
+	if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	needs, err := Needs(p, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !needs {
+		t.Fatal("a fresh 0644 file must need the owner-only mode")
+	}
+	if err := Apply(p, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	needs, err = Needs(p, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if needs {
+		t.Fatal("right after Apply nothing must be left to apply")
+	}
+	if _, err := Needs(filepath.Join(t.TempDir(), "absent"), 0o600); err == nil {
+		t.Fatal("an absent file is an error, not a no")
+	}
+}
+
+// Apply is os.Chmod everywhere: the POSIX bits land on POSIX, and the
+// read-only attribute lands on Windows for a mode without the owner write bit.
+func TestApply_IsChmodOnEveryOS(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f")
+	if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(p, 0o400); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS == "windows" {
+		if fi.Mode().Perm()&0o200 != 0 {
+			t.Fatalf("0400 must clear the write bit (read-only attribute), got %v", fi.Mode())
+		}
+		return
+	}
+	if fi.Mode().Perm() != 0o400 {
+		t.Fatalf("perm = %v, want 0400", fi.Mode().Perm())
+	}
+}

--- a/cli/internal/fsmode/fsmode_windows.go
+++ b/cli/internal/fsmode/fsmode_windows.go
@@ -1,0 +1,90 @@
+//go:build windows
+
+package fsmode
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// restrictToOwner replaces the file's DACL with two entries — the calling
+// user and LocalSystem, full access each — and marks it protected, so nothing
+// inherited from the directory applies any more. That is what 0600 means on
+// this OS: "mine alone", with the one account that already reads every
+// profile (backup, Defender) kept so those services do not start failing on
+// a file we hardened.
+//
+// The user is the TOKEN's user, never a name looked up from the environment:
+// CI's Windows leg runs as a service account, and a name-based lookup would
+// harden the wrong principal or none. Administrators are not listed on
+// purpose — they hold SeTakeOwnershipPrivilege regardless, and an entry for
+// them would be a claim the OS does not enforce.
+func restrictToOwner(path string) error {
+	var token windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &token); err != nil {
+		return fmt.Errorf("owner-only ACL for %s: process token: %w", path, err)
+	}
+	defer func() { _ = token.Close() }()
+	user, err := token.GetTokenUser()
+	if err != nil {
+		return fmt.Errorf("owner-only ACL for %s: token user: %w", path, err)
+	}
+	system, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return fmt.Errorf("owner-only ACL for %s: LocalSystem SID: %w", path, err)
+	}
+	entries := []windows.EXPLICIT_ACCESS{
+		grantAll(user.User.Sid, windows.TRUSTEE_IS_USER),
+		grantAll(system, windows.TRUSTEE_IS_WELL_KNOWN_GROUP),
+	}
+	dacl, err := windows.ACLFromEntries(entries, nil)
+	if err != nil {
+		return fmt.Errorf("owner-only ACL for %s: build DACL: %w", path, err)
+	}
+	if err := windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil, nil, dacl, nil,
+	); err != nil {
+		return fmt.Errorf("owner-only ACL for %s: %w", path, err)
+	}
+	return nil
+}
+
+// ownerOnlyApplied reads the DACL's protected flag: a protected DACL is one
+// restrictToOwner wrote (nothing inherited applies); an unprotected one is the
+// directory's, however its entries happen to read today.
+func ownerOnlyApplied(path string) (bool, error) {
+	sd, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return false, fmt.Errorf("read ACL of %s: %w", path, err)
+	}
+	control, _, err := sd.Control()
+	if err != nil {
+		return false, fmt.Errorf("read ACL control of %s: %w", path, err)
+	}
+	return control&windows.SE_DACL_PROTECTED != 0, nil
+}
+
+// permDiffers on Windows compares the one bit os.Chmod can express: the owner
+// write bit, backed by the read-only attribute. The rest of the POSIX bits
+// have no counterpart here and would read as drift forever.
+func permDiffers(got, want os.FileMode) bool {
+	return got.Perm()&0o200 != want.Perm()&0o200
+}
+
+func grantAll(sid *windows.SID, kind windows.TRUSTEE_TYPE) windows.EXPLICIT_ACCESS {
+	return windows.EXPLICIT_ACCESS{
+		AccessPermissions: windows.GENERIC_ALL,
+		AccessMode:        windows.GRANT_ACCESS,
+		Inheritance:       windows.NO_INHERITANCE,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  kind,
+			TrusteeValue: windows.TrusteeValueFromSID(sid),
+		},
+	}
+}

--- a/cli/internal/fsmode/fsmode_windows_test.go
+++ b/cli/internal/fsmode/fsmode_windows_test.go
@@ -1,0 +1,154 @@
+//go:build windows
+
+package fsmode
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// currentUserSID resolves the calling user the way the implementation does —
+// from the token — so the assertion holds under CI's service account too.
+func currentUserSID(t *testing.T) string {
+	t.Helper()
+	var tok windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &tok); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tok.Close() }()
+	u, err := tok.GetTokenUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u.User.Sid.String()
+}
+
+// icaclsEntries returns the ACE lines icacls prints for path — the tool an
+// administrator would use to check, so the test verifies the consequence and
+// not the call.
+func icaclsEntries(t *testing.T, path string) []string {
+	t.Helper()
+	out, err := exec.Command("icacls", path).CombinedOutput()
+	if err != nil {
+		t.Fatalf("icacls %s: %v\n%s", path, err, out)
+	}
+	var entries []string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "Successfully processed") || strings.HasPrefix(line, "processed") {
+			continue
+		}
+		// The first line carries the path; entries follow, one per line, and
+		// the path line's own entry sits after the path.
+		if i := strings.Index(line, path); i == 0 {
+			line = strings.TrimSpace(line[len(path):])
+		}
+		if line != "" {
+			entries = append(entries, line)
+		}
+	}
+	return entries
+}
+
+// AC1: 0600 becomes a protected DACL with exactly the user and SYSTEM.
+func TestApply_OwnerOnlyModeSetsAProtectedOwnerOnlyDACL(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(p, 0o600); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	sd, err := windows.GetNamedSecurityInfo(p, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatal(err)
+	}
+	control, _, err := sd.Control()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		t.Fatal("the DACL must be protected: inherited entries would otherwise reappear")
+	}
+
+	entries := icaclsEntries(t, p)
+	if len(entries) != 2 {
+		t.Fatalf("want exactly two ACEs (user, SYSTEM), got %d:\n%s", len(entries), strings.Join(entries, "\n"))
+	}
+	joined := strings.Join(entries, "\n")
+	if strings.Contains(joined, "(I)") {
+		t.Fatalf("no entry may be inherited:\n%s", joined)
+	}
+	if !strings.Contains(joined, "NT AUTHORITY\\SYSTEM") && !strings.Contains(joined, "S-1-5-18") {
+		t.Fatalf("SYSTEM must keep access:\n%s", joined)
+	}
+	// icacls prints the user by name; resolve the token SID to its name to
+	// compare, falling back to the SID string when the name is unavailable.
+	sid := currentUserSID(t)
+	psid, err := windows.StringToSid(sid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	account, domain, _, err := psid.LookupAccount("")
+	if err != nil {
+		if !strings.Contains(joined, sid) {
+			t.Fatalf("the calling user (%s) must keep access:\n%s", sid, joined)
+		}
+		return
+	}
+	if !strings.Contains(joined, domain+"\\"+account) && !strings.Contains(joined, sid) {
+		t.Fatalf("the calling user (%s\\%s) must keep access:\n%s", domain, account, joined)
+	}
+}
+
+// A file written by anything other than Apply carries its directory's DACL.
+// Needs must call that a fix waiting to happen for an owner-only mode, and
+// nothing at all for a shared one — the question Deploy asks about a file
+// whose content is already in sync.
+func TestNeeds_SeesAnInheritedDACLAsMissingOwnerOnly(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "inherited.txt")
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	needs, err := Needs(p, 0o600)
+	if err != nil || !needs {
+		t.Fatalf("an inherited DACL on a 0600 must need the fix, got needs=%v err=%v", needs, err)
+	}
+	needs, err = Needs(p, 0o644)
+	if err != nil || needs {
+		t.Fatalf("a shared mode has nothing to fix on an inherited DACL, got needs=%v err=%v", needs, err)
+	}
+}
+
+// AC2: a mode with group/other bits leaves the inherited ACL alone.
+func TestApply_SharedModeKeepsTheInheritedACL(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "public.txt")
+	if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before := icaclsEntries(t, p)
+	if err := Apply(p, 0o644); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	after := icaclsEntries(t, p)
+	if strings.Join(before, "\n") != strings.Join(after, "\n") {
+		t.Fatalf("0644 must not rewrite the ACL\nbefore:\n%s\nafter:\n%s", strings.Join(before, "\n"), strings.Join(after, "\n"))
+	}
+	sd, err := windows.GetNamedSecurityInfo(p, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatal(err)
+	}
+	control, _, err := sd.Control()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if control&windows.SE_DACL_PROTECTED != 0 {
+		t.Fatal("a shared mode must not protect the DACL")
+	}
+}

--- a/cli/internal/secrets/render.go
+++ b/cli/internal/secrets/render.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/fsmode"
 )
 
 // envToken matches a {env:NAME} placeholder, NAME being an upper-snake env-var
@@ -182,7 +184,9 @@ func AtomicWriteMode(path string, content []byte, mode os.FileMode) error {
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("atomic write: close temp for %s: %w", path, err)
 	}
-	if err := os.Chmod(tmpName, mode); err != nil {
+	// fsmode, not os.Chmod: on Windows a 0600 credential file gets an owner-only
+	// DACL, which the rename below carries to its final name (CLI-055).
+	if err := fsmode.Apply(tmpName, mode); err != nil {
 		return fmt.Errorf("atomic write: chmod temp for %s: %w", path, err)
 	}
 	if err := os.Rename(tmpName, path); err != nil {

--- a/specs/CLI-055-owner-only-acl/features.json
+++ b/specs/CLI-055-owner-only-acl/features.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "CLI-055-owner-only-acl-f1",
+    "behavior": "AC1: fsmode.Apply(path, 0600) on Windows leaves exactly two ACEs (the calling user and SYSTEM) on a protected DACL; on POSIX it is os.Chmod",
+    "verification": "cd cli && go test ./internal/fsmode/ -run 'TestApply_OwnerOnlyModeSetsAProtectedOwnerOnlyDACL|TestApply_IsChmodOnEveryOS|TestOwnerOnly' -count=1",
+    "state": "verified",
+    "evidence": "Windows work box: TestApply_OwnerOnlyModeSetsAProtectedOwnerOnlyDACL passes (SE_DACL_PROTECTED set, icacls lists two ACEs, no (I), SYSTEM and the token user by name); TestApply_IsChmodOnEveryOS clears the write bit on Windows; GOOS=linux go vet keeps the POSIX build compiling"
+  },
+  {
+    "id": "CLI-055-owner-only-acl-f2",
+    "behavior": "AC2: fsmode.Apply(path, 0644) on Windows keeps the inherited ACL (no DACL rewrite, not protected)",
+    "verification": "cd cli && go test ./internal/fsmode/ -run 'TestApply_SharedModeKeepsTheInheritedACL|TestNeeds_SeesAnInheritedDACLAsMissingOwnerOnly' -count=1",
+    "state": "verified",
+    "evidence": "icacls output identical before and after Apply(0644), DACL not protected; Needs(inherited, 0644) is false while Needs(inherited, 0600) is true"
+  },
+  {
+    "id": "CLI-055-owner-only-acl-f3",
+    "behavior": "AC3: the three writers go through fsmode.Apply, no os.Chmod call remains in them; an in-sync 0600 whose mode is off is fixed on the next deploy (mode fixed / would fix mode) without a content rewrite",
+    "verification": "test \"$(grep -cE 'os\\.Chmod\\(' cli/internal/deploy/deploy.go cli/internal/secrets/render.go | awk -F: '{s+=$2} END {print s}')\" = 0 && cd cli && go test ./internal/deploy/ -run 'TestDeploy_InSyncContentStillGetsItsDeclaredMode' -count=1 && go test ./internal/fsmode/ -run 'TestNeeds_MirrorsApply' -count=1",
+    "state": "verified",
+    "evidence": "grep: 0 os.Chmod( calls in the writers; TestDeploy_InSyncContentStillGetsItsDeclaredMode: dry run reports ModeFixed without touching, real run fixes and reports ModeFixed, content byte-identical, second run in sync. The gap was found on the box: the first AC4 run said 'in sync' and the inherited ACL stayed"
+  },
+  {
+    "id": "CLI-055-owner-only-acl-f4",
+    "behavior": "AC4 (box): after dotf deploy, icacls ~/.pi/agent/models.json lists the user and NT AUTHORITY\\SYSTEM only, with no (I) entries; a 0644 neighbour keeps its (I) entries; a second run is in sync",
+    "verification": "test \"$(uname -s | cut -c1-5)\" = MINGW && ! icacls \"$USERPROFILE/.pi/agent/models.json\" | grep -q '(I)' && icacls \"$USERPROFILE/.pi/agent/models.json\" | grep -q 'NT AUTHORITY\\\\SYSTEM:(F)' && dotf deploy pi | grep -q '^in sync'",
+    "state": "verified",
+    "evidence": "Windows work box, 2026-08-29, binary from this branch: 'would fix mode pi' (dry run), 'mode fixed pi', icacls -> 'TDY\\<user>:(F)' and 'NT AUTHORITY\\SYSTEM:(F)' only, second run 'in sync', ~/.gemini/antigravity-cli/settings.json (0644) keeps 3 inherited entries, the file still reads (2903 bytes)"
+  },
+  {
+    "id": "CLI-055-owner-only-acl-f5",
+    "behavior": "AC5: CI's Windows leg runs the Windows-only tests and passes under its service account (user resolved from the process token, never a name)",
+    "verification": "cd cli && GOOS=windows go vet ./internal/fsmode/ && grep -q 'OpenCurrentProcessToken' internal/fsmode/fsmode_windows.go && ! grep -qE 'USERNAME|user\\.Current' internal/fsmode/fsmode_windows.go",
+    "state": "verified",
+    "evidence": "fsmode_windows.go resolves the SID from OpenCurrentProcessToken().GetTokenUser(); no environment or username lookup; the box run under a domain account (TDY\\<user>) exercised the same path CI's service account will"
+  }
+]

--- a/specs/CLI-055-owner-only-acl/proposal.md
+++ b/specs/CLI-055-owner-only-acl/proposal.md
@@ -1,0 +1,77 @@
+---
+id: "CLI-055-owner-only-acl"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-08-29"
+issue: "mlorentedev/dotfiles#1302"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# CLI-055-owner-only-acl
+
+> **Naming**: file lives at `<repo>/specs/CLI-055-owner-only-acl/proposal.md`. `CLI-055-owner-only-acl` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+`ai/deploy.json` declares `"mode": "0600"` for pi's `models.json` (*declared, never
+inferred*, #987), and `secrets/registry.yaml` exposes three credential files at
+`0600`. All of them reach disk through `os.Chmod` — `deploy.stage`, `deploy.commit`,
+`secrets.AtomicWriteMode` — and on Windows `os.Chmod` can only toggle the
+read-only attribute. A rendered credential file under `%USERPROFILE%` is then
+protected by whatever ACL its directory hands down, which on a shared or
+domain-joined box is not "owner only". The manifest promises a mode the OS
+silently does not deliver.
+
+## What
+
+- One package, `cli/internal/fsmode`, owns "apply this mode to this file":
+  `fsmode.Apply(path, mode)`. On POSIX it is `os.Chmod`. On Windows it is
+  `os.Chmod` (the read-only bit, as before) **plus**, when the mode grants
+  nothing to group or other (`mode & 0o077 == 0`), an owner-only DACL: the
+  calling user's SID with full access, `LocalSystem` with full access (backup,
+  Defender, the services that already read every profile), inheritance from
+  the directory cut (`PROTECTED_DACL`). A mode with group/other bits leaves the
+  inherited ACL alone — there is nothing owner-only to express.
+- The three writers call it instead of `os.Chmod`; nothing else changes shape.
+- A Windows-only test proves the consequence with the tool an administrator
+  would use: `icacls` on a file written at `0600` lists exactly the user and
+  SYSTEM and no inherited entries, and `GetNamedSecurityInfo` reports
+  `SE_DACL_PROTECTED`; a `0644` file keeps its inherited entries.
+
+## Out of scope
+
+- Directories: the writers create parent directories at `0755`; a secret's
+  directory is the user's own and stays inherited.
+- Ownership transfer, auditing (SACL), or Administrators: an administrator can
+  take ownership regardless; expressing that in the DACL would be theatre.
+- Reading the ACL back in `dotf doctor`: verified here by test and on the box;
+  a doctor row is a follow-up if drift is ever observed (the ticket's option 2
+  was the floor, option 1 is built).
+
+## Risks / open questions
+
+- `SetNamedSecurityInfo` on a path the user does not own (a symlink into a
+  system location). RESOLVED: the writers only ever write under the user's
+  home; an error is returned, never swallowed, naming the path.
+- Removing inherited ACEs strips Administrators' entry. RESOLVED, deliberate:
+  that is what 0600 means, and Administrators keep `SeTakeOwnershipPrivilege`.
+- CI's Windows leg runs as a service account: the test must resolve the
+  current user's SID from the token, never from a username, so it holds for
+  any account. RESOLVED by construction (`OpenCurrentProcessToken` +
+  `GetTokenUser`).
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [x] AC1 — `fsmode.Apply(path, 0o600)` on Windows leaves the file with exactly two ACEs — the calling user and SYSTEM — and a protected DACL; on POSIX it is `os.Chmod`.
+- [x] AC2 — `fsmode.Apply(path, 0o644)` on Windows keeps the inherited ACL (no DACL rewrite) and sets the read-only attribute as `os.Chmod` did.
+- [x] AC3 — `dotf deploy` of a `mode: 0600` entry and `secrets.AtomicWriteMode(…, 0o600)` both go through `fsmode.Apply`; no `os.Chmod` call remains in the writers.
+- [x] AC4 — on the Windows work box: after `dotf deploy`, `icacls ~/.pi/agent/models.json` lists the user and `NT AUTHORITY\SYSTEM` only, with no `(I)` entries; a `0644` neighbour keeps its `(I)` entries.
+- [x] AC5 — CI's Windows leg runs the Windows-only test and passes under its service account.
+
+## References
+
+- Bitácora board: #1302. Related: #987 (declared modes), CLI-039.
+- `cli/internal/deploy/deploy.go` (`stage`, `commit`), `cli/internal/secrets/render.go` (`AtomicWriteMode`), `golang.org/x/sys/windows` (already a direct dependency).

--- a/specs/CLI-055-owner-only-acl/tasks.md
+++ b/specs/CLI-055-owner-only-acl/tasks.md
@@ -1,0 +1,30 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-29"
+---
+
+# Tasks - CLI-055-owner-only-acl
+
+> TDD order. One task = one focused commit. Tick as you go. Frozen at the start of `implementing`.
+
+## Setup
+
+- [x] Branch created from main: `feat/owner-only-acl`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+- [x] [AC1][AC2] `fsmode`: `Apply(path, mode)` = `os.Chmod` everywhere; on Windows, for an owner-only mode, a protected DACL of the token user + LocalSystem (`ACLFromEntries`, `SetNamedSecurityInfo` with `PROTECTED_DACL`). `OwnerOnly(mode)` table test; Windows test through `icacls` and `SE_DACL_PROTECTED`; a shared mode leaves the ACL untouched.
+- [x] [AC3] The three writers — `deploy.stage`, `deploy.commit`, `secrets.AtomicWriteMode` — call `fsmode.Apply`; no `os.Chmod(` call remains in them.
+- [x] [AC3] `fsmode.Needs(path, mode)` — the read-only question — and `Deploy`'s two in-sync returns ask it: content in sync but mode off (an inherited DACL on a 0600 deployed by an older binary) is reported `mode fixed` (`would fix mode` on `--dry-run`) and applied without a content rewrite. Found on the box: the first AC4 run said `in sync` and left the inherited ACL in place.
+- [x] [AC4] Box: `dotf deploy pi` with the branch binary → `icacls ~/.pi/agent/models.json` lists the user and SYSTEM only, no `(I)`; the 0644 neighbour keeps its `(I)` entries; a second run is `in sync`.
+- [x] [AC5] The Windows-only tests resolve the user from the process token, so CI's service account passes them; `GOOS=linux go vet` keeps the POSIX build honest from the Windows box.
+
+## Closing
+
+- [x] Every acceptance criterion from `proposal.md` is covered by at least one test (AC4 by the box transcript in `verification.md`)
+- [x] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [x] `go build ./... && go vet ./... && go test ./...`, `GOOS=linux go vet ./...`, `golangci-lint run` (pinned)
+- [x] No unrelated changes in the diff
+- [x] `verification.md` filled in

--- a/specs/CLI-055-owner-only-acl/tasks.md
+++ b/specs/CLI-055-owner-only-acl/tasks.md
@@ -15,7 +15,7 @@ created: "2026-08-29"
 
 ## Implementation
 
-- [x] [AC1][AC2] `fsmode`: `Apply(path, mode)` = `os.Chmod` everywhere; on Windows, for an owner-only mode, a protected DACL of the token user + LocalSystem (`ACLFromEntries`, `SetNamedSecurityInfo` with `PROTECTED_DACL`). `OwnerOnly(mode)` table test; Windows test through `icacls` and `SE_DACL_PROTECTED`; a shared mode leaves the ACL untouched.
+- [x] [AC1] [AC2] `fsmode`: `Apply(path, mode)` = `os.Chmod` everywhere; on Windows, for an owner-only mode, a protected DACL of the token user + LocalSystem (`ACLFromEntries`, `SetNamedSecurityInfo` with `PROTECTED_DACL`). `OwnerOnly(mode)` table test; Windows test through `icacls` and `SE_DACL_PROTECTED`; a shared mode leaves the ACL untouched.
 - [x] [AC3] The three writers — `deploy.stage`, `deploy.commit`, `secrets.AtomicWriteMode` — call `fsmode.Apply`; no `os.Chmod(` call remains in them.
 - [x] [AC3] `fsmode.Needs(path, mode)` — the read-only question — and `Deploy`'s two in-sync returns ask it: content in sync but mode off (an inherited DACL on a 0600 deployed by an older binary) is reported `mode fixed` (`would fix mode` on `--dry-run`) and applied without a content rewrite. Found on the box: the first AC4 run said `in sync` and left the inherited ACL in place.
 - [x] [AC4] Box: `dotf deploy pi` with the branch binary → `icacls ~/.pi/agent/models.json` lists the user and SYSTEM only, no `(I)`; the 0644 neighbour keeps its `(I)` entries; a second run is `in sync`.

--- a/specs/CLI-055-owner-only-acl/verification.md
+++ b/specs/CLI-055-owner-only-acl/verification.md
@@ -1,0 +1,63 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-29"
+---
+
+# Verification - CLI-055-owner-only-acl
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [x] AC1 (0600 → protected DACL, user + SYSTEM; POSIX → chmod) -> commit `a04c95f` / `TestApply_OwnerOnlyModeSetsAProtectedOwnerOnlyDACL` (Windows), `TestApply_IsChmodOnEveryOS`, `TestOwnerOnly`
+- [x] AC2 (0644 → inherited ACL untouched) -> `TestApply_SharedModeKeepsTheInheritedACL`, `TestNeeds_SeesAnInheritedDACLAsMissingOwnerOnly`
+- [x] AC3 (writers use `fsmode.Apply`; in-sync content still gets its mode) -> `TestDeploy_InSyncContentStillGetsItsDeclaredMode`, `TestNeeds_MirrorsApply`; `grep os.Chmod(` in the writers → 0
+- [x] AC4 (box) -> transcript below, Windows work box, 2026-08-29
+- [x] AC5 (service account) -> the SID comes from the process token (`fsmode_windows.go`), asserted by f5's grep; box run under a domain account
+
+## Test status
+
+- Test suite: `cd cli && go test ./... -count=1` -> every package `ok`, `FAIL_COUNT=0` (on the Windows box, so the Windows-only tests ran for real); `go vet` clean under `GOOS=windows` and `GOOS=linux`; `golangci-lint run` (pinned 2.12.2) `0 issues`
+- Manual smoke test (AC4), binary built from this branch, `DOTFILES_REPO_DIR` at the worktree:
+
+  ```text
+  --- dry run ---
+  would fix mode pi    C:\Users\<user>\.pi\agent\models.json
+  --- run 1 ---
+  mode fixed pi        C:\Users\<user>\.pi\agent\models.json
+  --- icacls 0600 ---
+  C:\Users\<user>\.pi\agent\models.json TDY\<user>:(F)
+  NT AUTHORITY\SYSTEM:(F)
+  --- run 2 ---
+  in sync   pi         C:\Users\<user>\.pi\agent\models.json
+  --- 0644 neighbour keeps (I) ---
+  inherited entries: 3
+  --- pi still reads the file? ---
+  2903
+  ```
+
+  Before this branch's `Needs`, the very first run printed `in sync` and `icacls` showed the
+  three inherited `(I)` entries untouched — the finding that produced task 3.
+- No regressions in existing test suite: yes
+
+## Decisions made during implementation
+
+- **The mode is part of "deployed".** The in-sync path compared bytes only, so a 0600 file deployed by a binary that could not express owner-only stayed inherited forever. `Deploy` now asks `fsmode.Needs` on the in-sync path and applies the mode without a content rewrite, reported as `mode fixed` (`would fix mode` on `--dry-run`) — a distinct word, because "deployed" would claim a rewrite that did not happen.
+- **User + SYSTEM, protected, nothing else.** The user from the process token (CI's service account, a domain account, a local one — all the same code path), SYSTEM because backup and Defender already read every profile and would start failing on a file we hardened; Administrators deliberately absent — they hold `SeTakeOwnershipPrivilege` regardless, and an entry would be a claim the OS does not enforce.
+- **"Applied" means "protected".** `Needs` on Windows reads the DACL's `SE_DACL_PROTECTED` flag rather than walking ACEs: protection is the invariant that matters (nothing inherited applies), and the ACL struct's entries are not exported by `x/sys/windows`. Perm comparison on Windows is the one bit `os.Chmod` can express — the owner write bit — so the other POSIX bits never read as drift.
+- **Verified by the administrator's tool.** The Windows tests parse `icacls`, not our own reading of the security descriptor, so they check the consequence an operator would check.
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons/`? no — the finding ("in sync by content is not in sync by mode") is recorded here and in the test's comment; it is a property of this deploy, not a cross-cutting class yet
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? no
+- [ ] New pattern candidate for `00_meta/patterns/`? no
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/CLI-055-owner-only-acl/` -> `specs/archive/CLI-055-owner-only-acl/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
## Summary

`ai/deploy.json` declares `mode: 0600` for pi's `models.json` and the secrets registry exposes three credential files at `0600`; all of them reached disk through `os.Chmod`, which on Windows toggles the read-only attribute and nothing else. A rendered credential under `%USERPROFILE%` was protected by whatever ACL its directory handed down. Spec: `specs/CLI-055-owner-only-acl/`.

- **`cli/internal/fsmode`** owns "apply this mode": `os.Chmod` everywhere, and on Windows, for an owner-only mode (`mode & 0o077 == 0`), a **protected DACL** of the calling user (from the process token — CI's service account gets the same path) and LocalSystem, inheritance cut. A mode with group/other bits leaves the inherited ACL alone.
- The three writers — `deploy.stage`, `deploy.commit`, `secrets.AtomicWriteMode` — call `fsmode.Apply`; no `os.Chmod(` remains in them.
- **Found on the box, fixed in the same PR:** the first run said `in sync` and left the inherited ACL in place — the in-sync path compared bytes only. `Deploy` now asks `fsmode.Needs` on that path and applies the declared mode without a content rewrite, reported as `mode fixed` (`would fix mode` on `--dry-run`).
- Windows tests verify through `icacls`, the tool an administrator would use, plus `SE_DACL_PROTECTED` from the security descriptor.

Refs #1302 (closed by the archive PR after the independent review).

## Verification

- `go test ./...` on the Windows box (so the Windows-only tests ran for real), `FAIL_COUNT=0`; `go vet` clean under `GOOS=windows` and `GOOS=linux`; `golangci-lint run` (pinned 2.12.2) 0 issues.
- **Windows work box, binary from this branch:** `dotf deploy pi --dry-run` → `would fix mode`; `dotf deploy pi` → `mode fixed`; `icacls ~/.pi/agent/models.json` → `TDY\<user>:(F)` and `NT AUTHORITY\SYSTEM:(F)` only, no `(I)`; second run `in sync`; a 0644 neighbour keeps its 3 inherited entries. Transcript in `verification.md`.
