### PR TITLE
fix(setup-windows): the skill renderer drops neutral frontmatter, so Claude Code discovers every skill again

### DIFF
--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -263,3 +263,4 @@ tags: [lessons, index, dotfiles]
 | [242 - A process nobody can watch must leave its own trace, and the redirect has to survive the parent](lesson-242-a-process-nobody-can-watch-must-leave-its-own-trace.md) | 2026-08-27 |  |
 | [243 - A guard that reads a cache reports the cache's age as the credential's health](lesson-243-a-guard-that-reads-a-cache-reports-the-cache-not-the-credential.md) | 2026-08-28 |  |
 | [244 - A sweep is bounded by what the writer recorded, not by what the store holds; and the store's name rules decide the order](lesson-244-a-sweep-is-bounded-by-what-the-writer-recorded-not-by-what-the-store-holds.md) | 2026-08-29 |  |
+| [245 - A fix applied to one of two renderers is an outage on the other OS, and nothing on the fixed side can see it](lesson-245-a-fix-to-one-of-two-renderers-is-an-outage-on-the-other-os.md) | 2026-08-29 |  |

--- a/docs/lessons/lesson-245-a-fix-to-one-of-two-renderers-is-an-outage-on-the-other-os.md
+++ b/docs/lessons/lesson-245-a-fix-to-one-of-two-renderers-is-an-outage-on-the-other-os.md
@@ -1,0 +1,48 @@
+# Lesson 245 — A fix applied to one of two renderers is an outage on the other OS, and nothing on the fixed side can see it
+
+**Date:** 2026-08-29
+**Context:** HARNESS-095 — #1080 taught `render_skill` in `scripts/compile-harness.sh` to drop `paths:` from deployed skill frontmatter, because Claude Code reads a top-level `paths:` as a *conditional* skill and holds it dormant until a matching file is touched. Its Windows twin, `Convert-SkillRecord` in `setup-windows.ps1`, never got the same rule. Measured on the Windows box 2026-08-29: 34 of 43 deployed skills invisible at session start, and the nine that survived were the nine whose records carry no `paths:` at all.
+
+## What happened
+
+`paths:` entered the skill records on 2026-08-17 (#1048). The Linux renderer was
+fixed the next day. The Windows renderer kept passing every key through, so the
+first `setup-windows.ps1` run after that date (2026-08-28 13:51) rewrote 43
+deployed skills with a key that switches each of them off. Nothing failed. The
+deploy reported success, the files were well-formed, `dotf doctor` was green,
+and the only symptom was a slash command that answered `Unknown skill: docker`.
+
+Three properties made it survive eleven days:
+
+1. **The correlation was perfect and invisible.** Availability tracked exactly
+   one frontmatter key. Every other difference between a working and a broken
+   skill — size, age, `allowed-tools`, `targets`, the generated provenance
+   block — was identical across both groups.
+2. **The fixed side cannot observe the broken one.** The bats suite that pinned
+   #1080 runs the bash renderer. No assertion in the repository read the
+   PowerShell function's output, so the twin could drift arbitrarily far while
+   CI stayed green on both OSes.
+3. **A renderer is not a script.** The rule lives in a function extracted and
+   executed by `tests/setup-windows.bats`; a source-text grep would have proved
+   only that a regex exists somewhere, not that a record survives it.
+
+## The rule
+
+When one behaviour has two implementations, the fix is not landed until both
+carry it, and the guard is not a guard until it fails on the *other* one. Two
+assertions, added together, are what closes this class:
+
+* run the twin and assert on its **output** (a fixture record with a wrapped
+  `paths:` value proves the continuation lines follow their key, which is the
+  half a per-line filter gets wrong); and
+* compare the two implementations' shared rule **textually** across files, so
+  the next edit to one of them fails loudly instead of silently deploying.
+
+## Corollary — `! grep` in the middle of a `@test` cannot fail it
+
+The first version of the behavioural guard used `! grep -qE ... "$out"`, and it
+passed against the unfixed renderer. `bash` exempts a `!`-prefixed command from
+`set -e`, so every such line before the last one in a `@test` is discarded.
+`tests/lib/refute.bash` exists for exactly this and documents the trap; loading
+it and *not* using it is the same vacuous pass. Mutation-verify every new guard:
+remove the fix, watch the guard go red. This one was green.

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -2019,6 +2019,31 @@ function Get-SkillField {
     return ''
 }
 
+# One frontmatter key line's fate, as a pure decision: $true keeps the line and
+# every continuation line under it, $false drops both. This is the twin of the
+# awk rule in render_skill (scripts/compile-harness.sh), and a bats parity test
+# compares the two allowlists textually, so an edit here that is not mirrored
+# there fails loudly instead of quietly deploying a skill the other OS drops.
+#
+# -cmatch, not -match: PowerShell's -match is case-insensitive by default, and
+# bash's grep/awk are not, so a faithful mirror needs the case-sensitive
+# operator.
+function Test-SkillFrontmatterKeyKept {
+    param([string]$Line, [string]$Kind)
+    # A command carries its name in its filename, not its frontmatter.
+    if ($Kind -eq 'command' -and $Line -cmatch '^name:') { return $false }
+    # The record (HARNESS-069) already carries its own generated_* fields,
+    # describing its relationship to the vault. Strip them here so deploy
+    # injects one fresh set, describing the deploy target's relationship to the
+    # record, instead of stacking a second set on top.
+    if ($Line -cmatch '^generated(_from|_sha)?:') { return $false }
+    # Native skill execution fields recognized by agent runtimes (Claude Code, AGY, OpenCode, Copilot)
+    if ($Line -cmatch '^(name|description|allowed-tools|when_to_use|model|effort|context|argument-hint|arguments|user-invocable|disable-model-invocation):') { return $true }
+    # Drop neutral/store-only keys (id, type, status, created, owner, paths, keywords, requires, targets, source, license, etc.)
+    # In particular, dropping `paths:` ensures Claude Code discovers skills as unconditional at session start.
+    return $false
+}
+
 # The injected generated_* fields are deliberately dual-referent, not a
 # single "where did this come from" answer (HARNESS-069): generated_from is
 # always the vault path in $SrcPath -- where a human edits, the SSOT -- while
@@ -2036,7 +2061,7 @@ function Convert-SkillRecord {
         return "<!-- generated: true; from: $SrcPath; sha256:$sha; edit the vault source + re-run setup -->`n`n" + $body.Trim()
     }
     $fm = 0
-    $keep = $true
+    $keep = $false
     $out = New-Object System.Collections.Generic.List[string]
     foreach ($line in Get-Content -LiteralPath $RecordMd) {
         if ($line -match '^---\s*$') {
@@ -2050,33 +2075,15 @@ function Convert-SkillRecord {
             continue
         }
         if ($fm -eq 1) {
-            # A frontmatter key line; anything else at this depth continues the
-            # key above it and follows that key's fate. Dropping `paths:` while
-            # keeping its indented list items would emit YAML no reader accepts,
-            # so the keep flag has to survive across lines.
+            # A key line decides its own fate and that of the continuation
+            # lines under it: dropping `paths:` while keeping its indented list
+            # items would emit YAML no reader accepts. The flag therefore
+            # survives across lines, and starts false, so anything before the
+            # first key (a comment, say) is dropped -- which is what the awk
+            # twin does with its uninitialised keep.
             if ($line -cmatch '^[a-zA-Z0-9_-]+:') {
-                if ($Kind -eq 'command' -and $line -cmatch '^name:') { $keep = $false; continue }
-                # The record (HARNESS-069) already carries its own generated_*
-                # fields, describing its relationship to the vault. Strip them
-                # here so deploy injects one fresh set, describing the deploy
-                # target's relationship to the record, instead of stacking a
-                # second set on top.
-                # -cmatch, not -match: PowerShell's -match is case-insensitive
-                # by default, and bash's grep/awk are not, so a faithful mirror
-                # needs the case-sensitive operator.
-                if ($line -cmatch '^generated(_from|_sha)?:') { $keep = $false; continue }
-                # Native skill execution fields recognized by agent runtimes (Claude Code, AGY, OpenCode, Copilot)
-                if ($line -cmatch '^(name|description|allowed-tools|when_to_use|model|effort|context|argument-hint|arguments|user-invocable|disable-model-invocation):') {
-                    $keep = $true
-                    $out.Add($line)
-                    continue
-                }
-                # Drop neutral/store-only keys (id, type, status, created, owner, paths, keywords, requires, targets, source, license, etc.)
-                # In particular, dropping `paths:` ensures Claude Code discovers skills as unconditional at session start.
-                $keep = $false
-                continue
+                $keep = Test-SkillFrontmatterKeyKept -Line $line -Kind $Kind
             }
-            # Continuation line (indented multiline value)
             if ($keep) { $out.Add($line) }
             continue
         }

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -2036,6 +2036,7 @@ function Convert-SkillRecord {
         return "<!-- generated: true; from: $SrcPath; sha256:$sha; edit the vault source + re-run setup -->`n`n" + $body.Trim()
     }
     $fm = 0
+    $keep = $true
     $out = New-Object System.Collections.Generic.List[string]
     foreach ($line in Get-Content -LiteralPath $RecordMd) {
         if ($line -match '^---\s*$') {
@@ -2048,16 +2049,37 @@ function Convert-SkillRecord {
             }
             continue
         }
-        if ($fm -eq 1 -and $Kind -eq 'command' -and $line -match '^name:') { continue }
-        # The record (HARNESS-069) already carries its own generated_* fields,
-        # describing its relationship to the vault. Strip them here so deploy
-        # injects one fresh set, describing the deploy target's relationship
-        # to the record, instead of stacking a second set on top. Mirrors
-        # render_skill's awk rule in scripts/compile-harness.sh exactly.
-        # -cmatch, not -match: PowerShell's -match is case-insensitive by
-        # default, and bash's grep/awk are not - a faithful mirror needs the
-        # case-sensitive operator.
-        if ($fm -eq 1 -and $line -cmatch '^generated(_from|_sha)?:') { continue }
+        if ($fm -eq 1) {
+            # A frontmatter key line; anything else at this depth continues the
+            # key above it and follows that key's fate. Dropping `paths:` while
+            # keeping its indented list items would emit YAML no reader accepts,
+            # so the keep flag has to survive across lines.
+            if ($line -cmatch '^[a-zA-Z0-9_-]+:') {
+                if ($Kind -eq 'command' -and $line -cmatch '^name:') { $keep = $false; continue }
+                # The record (HARNESS-069) already carries its own generated_*
+                # fields, describing its relationship to the vault. Strip them
+                # here so deploy injects one fresh set, describing the deploy
+                # target's relationship to the record, instead of stacking a
+                # second set on top.
+                # -cmatch, not -match: PowerShell's -match is case-insensitive
+                # by default, and bash's grep/awk are not, so a faithful mirror
+                # needs the case-sensitive operator.
+                if ($line -cmatch '^generated(_from|_sha)?:') { $keep = $false; continue }
+                # Native skill execution fields recognized by agent runtimes (Claude Code, AGY, OpenCode, Copilot)
+                if ($line -cmatch '^(name|description|allowed-tools|when_to_use|model|effort|context|argument-hint|arguments|user-invocable|disable-model-invocation):') {
+                    $keep = $true
+                    $out.Add($line)
+                    continue
+                }
+                # Drop neutral/store-only keys (id, type, status, created, owner, paths, keywords, requires, targets, source, license, etc.)
+                # In particular, dropping `paths:` ensures Claude Code discovers skills as unconditional at session start.
+                $keep = $false
+                continue
+            }
+            # Continuation line (indented multiline value)
+            if ($keep) { $out.Add($line) }
+            continue
+        }
         $out.Add($line)
     }
     return ($out -join "`n")

--- a/tests/copilot-native-skills-smoke.ps1
+++ b/tests/copilot-native-skills-smoke.ps1
@@ -53,6 +53,7 @@ try {
     foreach ($functionName in @(
         'Test-SkillTargetsAgent',
         'Get-SkillField',
+        'Test-SkillFrontmatterKeyKept',
         'Convert-SkillRecord',
         'Deploy-SkillRecord'
     )) {

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -395,6 +395,22 @@ setup() {
     refute_grep '\$opencodeCmdsSrc\s*=' "$PS1_SCRIPT"
 }
 
+# Runs setup-windows.ps1's skill renderer on <record>, writing the result to
+# <outfile>; sets $status/$output like any other `run`. Extracts the two
+# functions that carry the rule rather than dot-sourcing (and running) the whole
+# multi-hundred-line deploy script.
+_render_skill_record() {  # <kind> <record> <srcpath> <outfile>
+    local fn_body
+    fn_body="$(sed 's/\r$//' "$PS1_SCRIPT" \
+        | awk '/^function (Test-SkillFrontmatterKeyKept|Convert-SkillRecord) \{/,/^\}$/')"
+    [ -n "$fn_body" ]
+    run pwsh -NonInteractive -Command "
+        $fn_body
+        \$result = Convert-SkillRecord -Kind '$1' -RecordMd '$(_winpath "$2")' -SrcPath '$3'
+        Set-Content -LiteralPath '$(_winpath "$4")' -Value \$result -Encoding UTF8
+    "
+}
+
 @test "Convert-SkillRecord does not stack a second set of generated_* fields on a record that already carries its own (HARNESS-069)" {
     # A previous adversarial review of HARNESS-069 (bash side) found this bug
     # live on this exact function: it never got the strip-rule fix, so once a
@@ -413,19 +429,8 @@ setup() {
     printf -- '---\ngenerated: true\ngenerated_from: 00_meta/skills/demo/SKILL.md\ngenerated_sha: aaaaaaaaaaaaaaaa\nname: demo\ndescription: fixture skill.\n---\n\nBody.\n' \
         > "$record"
 
-    # Extract just this function's body (CRLF-stripped) so the test exercises
-    # a script excerpt rather than dot-sourcing (and running) the whole
-    # multi-hundred-line deploy script.
-    local fn_body
-    fn_body="$(sed 's/\r$//' "$PS1_SCRIPT" | awk '/^function Convert-SkillRecord \{/,/^\}$/')"
-    [ -n "$fn_body" ]
-
     local out="$scratch/out.md"
-    run pwsh -NonInteractive -Command "
-        $fn_body
-        \$result = Convert-SkillRecord -Kind 'skill' -RecordMd '$(_winpath "$record")' -SrcPath '.claude/skills/demo/SKILL.md'
-        Set-Content -LiteralPath '$(_winpath "$out")' -Value \$result -Encoding UTF8
-    "
+    _render_skill_record skill "$record" '.claude/skills/demo/SKILL.md' "$out"
     [ "$status" -eq 0 ]
 
     [ "$(grep -c '^generated:' "$out")" -eq 1 ]
@@ -451,10 +456,12 @@ setup() {
     local scratch="$BATS_TEST_TMPDIR/convert-skill-neutral"
     mkdir -p "$scratch"
     local record="$scratch/SKILL.md"
-    # `paths:` wraps onto a second line on purpose: a per-line filter drops the
-    # key and leaves the orphaned list item behind, which is broken YAML.
+    # Two shapes a per-line filter gets wrong: a `paths:` value that wraps (the
+    # orphaned list item outlives its key), and a comment before the first key
+    # (the awk twin drops it, because its keep starts unset).
     cat > "$record" <<'FIXTURE'
 ---
+# store-only metadata follows
 id: demo-skill
 type: skill
 status: active
@@ -474,21 +481,14 @@ requires: [jq]
 Body.
 FIXTURE
 
-    local fn_body
-    fn_body="$(sed 's/\r$//' "$PS1_SCRIPT" | awk '/^function Convert-SkillRecord \{/,/^\}$/')"
-    [ -n "$fn_body" ]
-
     local out="$scratch/out.md"
-    run pwsh -NonInteractive -Command "
-        $fn_body
-        \$result = Convert-SkillRecord -Kind 'skill' -RecordMd '$(_winpath "$record")' -SrcPath '.claude/skills/demo/SKILL.md'
-        Set-Content -LiteralPath '$(_winpath "$out")' -Value \$result -Encoding UTF8
-    "
+    _render_skill_record skill "$record" '.claude/skills/demo/SKILL.md' "$out"
     [ "$status" -eq 0 ]
 
-    # Neutral metadata is gone, and so is the continuation line it owned.
+    # Neutral metadata is gone, and so is every line that hung off it.
     refute_grep '^(id|type|status|created|owner|paths|keywords|requires|targets):' "$out"
     refute_grep_fixed "'**/b/**'" "$out"
+    refute_grep_fixed '# store-only metadata follows' "$out"
     # Native execution fields survive, continuation lines included.
     grep -q '^name: demo' "$out"
     grep -q '^description: fixture skill,' "$out"

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -437,6 +437,77 @@ setup() {
     grep -q '^name: demo' "$out"
 }
 
+@test "Convert-SkillRecord drops neutral/store-only keys so Claude Code discovers the skill unconditionally (#1080 parity)" {
+    # Claude Code reads a top-level `paths:` as a conditional / path-scoped
+    # skill and holds it dormant until a matching file is touched in the
+    # session, so a deployed record that keeps `paths:` disappears from the
+    # session-start roster. compile-harness.sh was fixed for that in #1080;
+    # this function is its Windows twin and was not, which took 34 of 43
+    # skills off this box (measured 2026-08-29).
+    if ! command -v pwsh >/dev/null 2>&1; then
+        skip "pwsh not available"
+    fi
+
+    local scratch="$BATS_TEST_TMPDIR/convert-skill-neutral"
+    mkdir -p "$scratch"
+    local record="$scratch/SKILL.md"
+    # `paths:` wraps onto a second line on purpose: a per-line filter drops the
+    # key and leaves the orphaned list item behind, which is broken YAML.
+    cat > "$record" <<'FIXTURE'
+---
+id: demo-skill
+type: skill
+status: active
+created: 2026-08-29
+owner: manu
+name: demo
+description: fixture skill,
+  wrapped onto a second line.
+allowed-tools: Read, Grep
+targets: [claude]
+keywords: [alpha, beta]
+paths: ['**/a/**',
+  '**/b/**']
+requires: [jq]
+---
+
+Body.
+FIXTURE
+
+    local fn_body
+    fn_body="$(sed 's/\r$//' "$PS1_SCRIPT" | awk '/^function Convert-SkillRecord \{/,/^\}$/')"
+    [ -n "$fn_body" ]
+
+    local out="$scratch/out.md"
+    run pwsh -NonInteractive -Command "
+        $fn_body
+        \$result = Convert-SkillRecord -Kind 'skill' -RecordMd '$(_winpath "$record")' -SrcPath '.claude/skills/demo/SKILL.md'
+        Set-Content -LiteralPath '$(_winpath "$out")' -Value \$result -Encoding UTF8
+    "
+    [ "$status" -eq 0 ]
+
+    # Neutral metadata is gone, and so is the continuation line it owned.
+    refute_grep '^(id|type|status|created|owner|paths|keywords|requires|targets):' "$out"
+    refute_grep_fixed "'**/b/**'" "$out"
+    # Native execution fields survive, continuation lines included.
+    grep -q '^name: demo' "$out"
+    grep -q '^description: fixture skill,' "$out"
+    grep -q '^  wrapped onto a second line.' "$out"
+    grep -q '^allowed-tools: Read, Grep' "$out"
+    grep -q '^generated_from: .claude/skills/demo/SKILL.md' "$out"
+}
+
+@test "the native-field allowlist is identical in setup-windows.ps1 and compile-harness.sh (cross-OS parity)" {
+    # Two renderers, one rule. Drift here is silent: each side keeps deploying,
+    # and only the agents on the other OS lose the skill.
+    local pat sh_list ps_list
+    pat='\(name\|description\|allowed-tools[^)]*\)'
+    sh_list=$(grep -oE "$pat" "$BATS_TEST_DIRNAME/../scripts/compile-harness.sh" | head -1)
+    ps_list=$(sed 's/\r$//' "$PS1_SCRIPT" | grep -oE "$pat" | head -1)
+    [ -n "$sh_list" ]
+    [ "$sh_list" = "$ps_list" ]
+}
+
 # --- BUG-005: Windows PowerShell 5.1 auto-reexec under pwsh ---
 # SDD-002 (PR #51) introduced Merge-ClaudeSettings which uses
 # `ConvertFrom-Json -AsHashtable` -- a parameter added in PowerShell 7.0 that


### PR DESCRIPTION
Closes #1385.

## What broke

`paths:` entered the harness skill records on 2026-08-17 (#1048). Claude Code reads a top-level `paths:` as a **conditional / path-scoped** skill and keeps it dormant until a matching file is touched in the session, so #1080 taught `render_skill` in `scripts/compile-harness.sh` to strip neutral/store-only keys at deploy time. Its Windows twin, `Convert-SkillRecord` in `setup-windows.ps1`, never got the rule.

The first `setup-windows.ps1` run after that date (2026-08-28 13:51 on this box) rewrote all 43 deployed skills with the key that switches them off. Measured 2026-08-29 — the correlation is exact, 43 of 43:

| deployed frontmatter | skills | available at session start |
|---|---|---|
| `paths:` present | 34 | 0 |
| `paths:` empty or absent | 9 | 9 |

Nothing failed while it happened: the deploy reported success, the files were well-formed YAML, `dotf doctor` was green. The only symptom was `Unknown skill: handoff`.

## The fix

`Convert-SkillRecord` now applies the same allowlist as the bash renderer, carrying a `keep` flag across continuation lines. A per-line filter would drop `paths:` and leave its wrapped list item orphaned — YAML no reader accepts, worse than the bug.

It is renderer-level, so the same deploy repairs the agy, opencode, copilot and pi skill targets, not only Claude's.

## Guards

Both mutation-verified (fix removed, guard red; fix restored, guard green):

1. **Behavioural** — the function runs on a fixture record whose `paths:` value wraps onto a second line; the output must carry no neutral key and no orphaned continuation, and must keep `name`, `description` (with its continuation) and `allowed-tools`.
2. **Parity** — the native-field allowlist must be textually identical in `setup-windows.ps1` and `scripts/compile-harness.sh`. Drift here is silent: each side keeps deploying, and only the agents on the other OS lose the skill.

The first version of guard 1 used `! grep` and **passed against the unfixed renderer** — bash exempts a `!`-prefixed command from `set -e`, so it cannot fail a `@test` from the middle of the body. `tests/lib/refute.bash` exists for that trap and is now used. That is the corollary in lesson 245.

## Verification

- `bats tests/setup-windows.bats` — 126 tests, 0 failures (3 exercise `Convert-SkillRecord`)
- full pre-commit suite green
- mutation runs recorded above

## Recovery on a live box

Re-run `setup-windows.ps1` after this merges; the skills return at the next session start.