### PR TITLE
fix(spec): the drawn reviewer is told who it is, and a foreground run that wrote nothing fails

### DIFF
--- a/cli/internal/cmd/spec.go
+++ b/cli/internal/cmd/spec.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"math/rand/v2"
 	"io"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -176,7 +176,7 @@ is the only record of how.`,
 			}
 
 			skill := spec.ReviewerSkillPath(chosen.Runner)
-			prompt := spec.ReviewPrompt(id, repoRoot, chosen.ID, skill)
+			prompt := spec.ReviewPrompt(id, repoRoot, chosen.ID, chosen.Runner, skill)
 			argv, err := spec.ReviewerCommand(chosen, prompt, timeout, repoRoot)
 			if err != nil {
 				return err
@@ -247,7 +247,18 @@ is the only record of how.`,
 			}
 
 			cmd.Printf("\n")
-			return runForeground(repoRoot, launch, transcript)
+			// A foreground run is the one case where the launcher sees how the review
+			// ENDED rather than only that it started, so the no-verdict case is
+			// reported here, with the transcript still in hand, instead of being left
+			// for whoever next tries to archive.
+			runErr := runForeground(repoRoot, launch, transcript)
+			if err := spec.VerifyReviewProduced(specDir, transcript); err != nil {
+				if runErr != nil {
+					return fmt.Errorf("%w\nthe runner also exited with: %v", err, runErr)
+				}
+				return err
+			}
+			return runErr
 		},
 	}
 

--- a/cli/internal/spec/review_launch.go
+++ b/cli/internal/spec/review_launch.go
@@ -250,14 +250,25 @@ func ResolveReviewer(entries []ReviewerEntry, want string) (ReviewerEntry, error
 // is only what the skill cannot know: which spec, which repo, and the mechanical
 // constraints that keep the review from invalidating itself.
 //
+// It states the reviewer's IDENTITY, not only the string to sign with. Measured
+// 2026-08-29 (#1383): a drawn reviewer read the pool's own "never an Anthropic
+// model" note, concluded from the doctrine that it must be Anthropic, announced
+// that some other process was the real reviewer, and refused to write a verdict
+// after a 40-minute run. The launcher knew who it had drawn the whole time.
+//
 // The canonical id is stated because `reviewer:` is self-reported and the gate
 // matches it exactly — a reviewer that writes its own name a different way gets
 // refused for a mismatch rather than for a policy breach, which wastes a whole
 // review round on a string.
-func ReviewPrompt(specID, repoRoot, reviewerID, skillPath string) string {
+func ReviewPrompt(specID, repoRoot, reviewerID, runner, skillPath string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "Perform an adversarial review of the spec `%s`.\n\n", specID)
 	fmt.Fprintf(&b, "Repo: %s\n\n", repoRoot)
+	fmt.Fprintf(&b, "You are running as `%s` (runner `%s`), drawn from harness/reviewer-pool.json\n"+
+		"for this review. That is your identity for this run, stated by the launcher that resolved\n"+
+		"it -- do not infer it from the doctrine you are about to read. The pool's exclusions were\n"+
+		"applied at draw time, so reading one and concluding you must be the wrong model to review\n"+
+		"this is a misreading: you are the model that was drawn.\n\n", reviewerID, runner)
 	fmt.Fprintf(&b, "Read and follow the skill at %s exactly — its workflow, its severity x reality\n"+
 		"classification, its test-traceability gate, its evaluator rubric, and its output format.\n"+
 		"Read that file first; it defines the whole deliverable.\n\n", skillPath)

--- a/cli/internal/spec/review_launch_test.go
+++ b/cli/internal/spec/review_launch_test.go
@@ -308,7 +308,7 @@ func TestReviewerSkillPathIsPerRunner(t *testing.T) {
 // differently is refused for a string mismatch rather than a policy breach,
 // burning a whole review round.
 func TestReviewPromptNamesTheExactReviewerIDAndProtectsContractFiles(t *testing.T) {
-	p := ReviewPrompt("AI-001-x", "/repo", "nan/deepseek-v4-flash", "/skill/SKILL.md")
+	p := ReviewPrompt("AI-001-x", "/repo", "nan/deepseek-v4-flash", "pi", "/skill/SKILL.md")
 	for _, want := range []string{
 		"AI-001-x", "/repo", "/skill/SKILL.md",
 		"`nan/deepseek-v4-flash`",
@@ -473,5 +473,35 @@ func TestReviewerCommandDoesNotGivePiAgySpecificFlags(t *testing.T) {
 		if argvIndex(argv, flag) >= 0 {
 			t.Errorf("pi must not receive agy's %s", flag)
 		}
+	}
+}
+
+// The reviewer must be TOLD who it is, not left to work it out from the
+// doctrine it reads.
+//
+// Measured 2026-08-29 (#1383), AI-042 round 4: the draw was
+// nan/deepseek-v4-flash, the transcript carries 68 assistant messages stamped
+// with that provider and model, and the run ended with "I'm an Anthropic model,
+// and this pool exists specifically to exclude Anthropic" and a refusal to write
+// the verdict. It had read the pool's own BUG-074 note and reasoned its way to an
+// identity the launcher had known since the draw. 40 minutes, 248 bash calls, no
+// review.md.
+func TestReviewPromptTellsTheReviewerWhoItIs(t *testing.T) {
+	p := ReviewPrompt("AI-042-x", "/repo", "nan/deepseek-v4-flash", "pi", "/skill/SKILL.md")
+	for _, want := range []string{
+		"You are running as `nan/deepseek-v4-flash`",
+		"(runner `pi`)",
+		"do not infer it from the doctrine",
+		"you are the model that was drawn",
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("prompt must state the identity: missing %q", want)
+		}
+	}
+
+	// Before the mechanical constraints, not buried among them: the model that
+	// refused had read most of the brief before it decided who it was.
+	if strings.Index(p, "You are running as") > strings.Index(p, "Mechanical constraints:") {
+		t.Error("the identity must come before the mechanical constraints")
 	}
 }

--- a/cli/internal/spec/review_request.go
+++ b/cli/internal/spec/review_request.go
@@ -122,3 +122,46 @@ func ReadReviewRequest(specDir string) (ReviewRequest, bool, error) {
 	}
 	return req, true, nil
 }
+
+// VerifyReviewProduced reports whether the run that has just finished left a
+// verdict, and is the launcher's own half of the guard checkReviewProvenance
+// enforces later.
+//
+// Later is the problem it fixes. The archive gate answers the same question, but
+// only when somebody next tries to archive -- which can be days on, in another
+// session, with the transcript no longer in hand. A FOREGROUND run knows the
+// answer the moment the runner exits, and every Windows run is one, because tmux
+// is Linux-only.
+//
+// Measured 2026-08-29 (#1383): AI-042 round 4 ran 40 minutes, made 248 bash calls,
+// wrote no review.md, and `dotf spec review` exited 0. A review that produced no
+// file is a failed review, not a green one.
+//
+// Detached launches are out of scope by construction: the command returns while
+// the reviewer is still running, so there is nothing yet to verify.
+func VerifyReviewProduced(specDir, transcript string) error {
+	digest := fileDigest(filepath.Join(specDir, ReviewFile))
+	if digest == "" {
+		return fmt.Errorf("the reviewer exited without writing %s -- that is a failed review, not a passing one\n"+
+			"what it did instead is in the transcript: %s\n"+
+			"re-run the review (a run ended by a turn cap, a rate limit, or a reviewer that talked itself out of the job leaves exactly this state)",
+			ReviewFile, transcript)
+	}
+
+	req, found, err := ReadReviewRequest(specDir)
+	if err != nil {
+		return err
+	}
+	if !found {
+		// No sidecar means no digest to compare against. The file exists, which
+		// is all this check can honestly assert without one.
+		return nil
+	}
+	if req.ReviewDigestBefore != "" && req.ReviewDigestBefore == digest {
+		return fmt.Errorf("%s is byte-identical to what it held before this run -- the reviewer wrote no verdict\n"+
+			"what is on disk is the PREVIOUS round's, which is not a review of this change\n"+
+			"the transcript of the run that wrote nothing: %s",
+			ReviewFile, transcript)
+	}
+	return nil
+}

--- a/cli/internal/spec/review_request_test.go
+++ b/cli/internal/spec/review_request_test.go
@@ -189,3 +189,64 @@ func TestWriteReviewRequestRecordsTheDigestOfWhatWasThere(t *testing.T) {
 		}
 	})
 }
+
+// VerifyReviewProduced is the launcher's own half of the no-verdict guard, and
+// it exists because the archive gate fires too late to help: days on, in another
+// session, with the transcript no longer in hand. Every Windows run is a
+// foreground run (tmux is Linux-only), so this is the common path there.
+func TestVerifyReviewProducedCatchesARunThatWroteNoFile(t *testing.T) {
+	dir := seedProvenanceSpec(t, "")
+	if err := WriteReviewRequest(dir, "aaaa", "nan/deepseek-v4-flash"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := VerifyReviewProduced(dir, "/transcripts/AI-042.jsonl")
+	if err == nil {
+		t.Fatal("a run that wrote no review.md must fail")
+	}
+	if !strings.Contains(err.Error(), "/transcripts/AI-042.jsonl") {
+		t.Errorf("the error must name the transcript, got %q", err)
+	}
+}
+
+// The AI-042 round 4 shape exactly: a review.md IS on disk, but it is the
+// previous round's, and a reader cannot tell it from a fresh verdict that
+// reached the same conclusion.
+func TestVerifyReviewProducedCatchesAnUnchangedVerdict(t *testing.T) {
+	dir := seedProvenanceSpec(t, provenanceReviewDoc)
+	if err := WriteReviewRequest(dir, "aaaa", "nan/deepseek-v4-flash"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := VerifyReviewProduced(dir, "/transcripts/AI-042.jsonl")
+	if err == nil {
+		t.Fatal("an unchanged review.md must fail: the reviewer wrote nothing")
+	}
+	if !strings.Contains(err.Error(), "byte-identical") {
+		t.Errorf("the error must say the file did not move, got %q", err)
+	}
+}
+
+func TestVerifyReviewProducedAcceptsAFreshVerdict(t *testing.T) {
+	dir := seedProvenanceSpec(t, provenanceReviewDoc)
+	if err := WriteReviewRequest(dir, "aaaa", "nan/deepseek-v4-flash"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ReviewFile), []byte(provenanceReviewDoc+"\nA new round.\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := VerifyReviewProduced(dir, "/transcripts/AI-042.jsonl"); err != nil {
+		t.Errorf("a verdict written during the run must pass, got %v", err)
+	}
+}
+
+// Without a sidecar there is no digest to compare against, and the check must
+// not invent one. That the file exists is all it can honestly assert -- the same
+// posture checkReviewProvenance takes for a hand-written review.
+func TestVerifyReviewProducedIsSilentWithoutASidecar(t *testing.T) {
+	dir := seedProvenanceSpec(t, provenanceReviewDoc)
+	if err := VerifyReviewProduced(dir, "/transcripts/AI-042.jsonl"); err != nil {
+		t.Errorf("no sidecar must not be an error, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #1383.

## What happened

AI-042 review round 4, measured on the Windows work box 2026-08-29. The draw was `nan/deepseek-v4-flash`; the transcript carries 68 assistant messages stamped with that provider and model. The run ended, after 248 bash calls and no `write`, with:

> I'm an Anthropic model, and this pool exists specifically to exclude Anthropic. … I will **not** write `specs/AI-042-trusted-folders-render/review.md`. … The gate-satisfying review is already running — round 4, drawn reviewer `nan/deepseek-v4-flash`.

It had read the pool's own BUG-074 note, reasoned its way to an identity, and got it wrong. 40 minutes, no verdict, archive gate unmet — and `dotf spec review` exited 0.

Two separate defects, one incident.

## 1. The prompt states the identity

The launcher has known who it drew since `DrawReviewer` returned. All it told the model was which string to put in `reviewer:`, buried among the mechanical constraints — a *formatting* instruction, which is how it was read. The prompt now opens with:

> You are running as `<id>` (runner `<runner>`), drawn from harness/reviewer-pool.json for this review. That is your identity for this run, stated by the launcher that resolved it — do not infer it from the doctrine you are about to read. The pool's exclusions were applied at draw time, so reading one and concluding you must be the wrong model to review this is a misreading: you are the model that was drawn.

A test pins that it appears *before* the mechanical constraints: the model that refused had read most of the brief before deciding who it was.

## 2. A foreground run that wrote nothing now fails

`checkReviewProvenance` already refuses a `review.md` whose digest has not moved — but at **archive** time, which can be days later, in another session, with the transcript gone. A foreground run knows when the runner exits, and **every Windows run is a foreground run**, because tmux is Linux-only.

`VerifyReviewProduced` reuses the sidecar digest the archive gate already trusts, so "wrote no verdict" has one definition rather than two. It reports:

- no `review.md` at all → names the transcript path;
- a `review.md` byte-identical to what was there at launch → says so, and says what is on disk is the previous round's.

Detached launches are untouched by construction: the command returns while the reviewer is still running, so there is nothing yet to verify. That case remains the sidecar's, checked at archive.

## Guards

Three, each mutation-verified — broken, watched fail, restored:

| Guard | Mutation | Result |
|---|---|---|
| `TestReviewPromptTellsTheReviewerWhoItIs` | identity line replaced with a bare `Signing id:` | FAIL |
| `TestVerifyReviewProducedCatchesARunThatWroteNoFile` | `VerifyReviewProduced` short-circuited to `return nil` | FAIL |
| `TestVerifyReviewProducedCatchesAnUnchangedVerdict` | same | FAIL |

Plus the two directions that must stay quiet: a verdict genuinely written during the run passes, and a spec with no sidecar is not an error (nothing to compare against — the same posture `checkReviewProvenance` takes for a hand-written review).

## Verification

- `go build ./... && go vet ./... && go test ./...` — green
- `GOOS=windows go vet ./...` — green
- `golangci-lint run ./...` on **2.12.2**, the `versions.conf` pin — 0 issues
- pre-commit suite green

Also reorders two imports in `cmd/spec.go` that `gofmt` has been flagging on `main` — pre-existing, and in the block this change already touches.

## SDD skip rationale

73 production LOC, over the 50 threshold, and deliberately without a spec folder.

- The cause is not under-specified: #1383 carries the transcript, the measured draw, the model's own words, and prescribes both halves of the fix. The issue is the spec in substance.
- The behavioural surface is one prompt paragraph, one new function and one call site; most of the 73 lines are the comment prose this repo writes around them.
- It is repair to the **review machinery itself**, which the 2026-08-19 amendment caps: cheapest honest fix, deletion over construction.
- And it would be circular. A spec must pass `dotf spec review` before `spec archive` accepts it — the exact command whose launcher is broken here, in the exact way that produced no `review.md` last time it ran.
