### PR TITLE
feat(harness): the gate resolves its persona from the payload, and doctor reports what it cannot enforce

### DIFF
--- a/cli/cmd/dotf/main.go
+++ b/cli/cmd/dotf/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	goerrors "errors"
 	"fmt"
 	"io"
 	"os"
-	goerrors "errors"
 
 	"github.com/mlorentedev/dotfiles/cli/internal/cmd"
 	"github.com/mlorentedev/dotfiles/cli/internal/errors"
@@ -19,10 +19,28 @@ func main() {
 }
 
 func run(rootCmd *cobra.Command, stderr io.Writer) int {
-	// We divert Cobra's automatic error printing to io.Discard.
-	// This prevents Cobra from printing wrapped TerminalFailure errors with "Error: context: ...",
-	// while keeping the subcommand's SilenceErrors property perfectly intact so we can read it.
-	rootCmd.SetErr(io.Discard)
+	// Suppress Cobra's AUTOMATIC error printing — its "Error: context: ..."
+	// wrapper around a TerminalFailure — while leaving the command's own stderr
+	// pointed at the real one.
+	//
+	// This was `rootCmd.SetErr(io.Discard)`, which achieved the first half by
+	// discarding EVERYTHING: `cmd.ErrOrStderr()` resolves through the root, so
+	// every deliberate diagnostic any subcommand writes went to the void.
+	// Measured on d4ea0f5: 16 call sites across 9 command files, including all
+	// four `dotf secrets` subcommands, `harness mirror`, `harness presence` — and
+	// `harness gate`, which then blocked a tool call with exit 2 and NO reason,
+	// leaving the operator no way to know which skill to invoke.
+	//
+	// SilenceErrors on the root is the mechanism Cobra provides for exactly this:
+	// ExecuteC checks the executed command's flag OR the root's before printing.
+	// The per-command flag stays readable below, so the "did this command ask for
+	// silence" branch is untouched.
+	// Forcing the flag on the root pollutes the "did this command ask for
+	// silence" read below whenever the root IS the executed command, so its
+	// original value is snapshotted and restored for that one case.
+	rootSilencedByAuthor := rootCmd.SilenceErrors
+	rootCmd.SilenceErrors = true
+	rootCmd.SetErr(stderr)
 
 	executedCmd, err := rootCmd.ExecuteC()
 	if err != nil {
@@ -32,7 +50,11 @@ func run(rootCmd *cobra.Command, stderr io.Writer) int {
 			_, _ = fmt.Fprintln(stderr, tfe.Error())
 		} else {
 			// If the specific command didn't request silence, print the error.
-			if !executedCmd.SilenceErrors {
+			silenced := executedCmd.SilenceErrors
+			if executedCmd == rootCmd {
+				silenced = rootSilencedByAuthor
+			}
+			if !silenced {
 				_, _ = fmt.Fprintf(stderr, "Error: %v\n", err)
 			}
 		}

--- a/cli/cmd/dotf/main_test.go
+++ b/cli/cmd/dotf/main_test.go
@@ -105,3 +105,66 @@ func TestRunWrappedTerminalFailure(t *testing.T) {
 		t.Errorf("expected output to not contain wrapper text, got %q", out)
 	}
 }
+
+// TestRunDoesNotDiscardDeliberateStderr is the guard for a regression that
+// silenced nine command files at once.
+//
+// `run` used to do `rootCmd.SetErr(io.Discard)` to suppress Cobra's automatic
+// "Error: ..." wrapper. But `cmd.ErrOrStderr()` resolves through the root, so it
+// discarded every diagnostic any subcommand deliberately wrote — measured on
+// d4ea0f5: 17 call sites across 9 files, all four `dotf secrets` subcommands
+// among them. The sharpest case was `dotf harness gate`, which then blocked a
+// tool call with exit 2 and NOTHING on stderr, leaving the operator no way to
+// learn which skill to invoke: an enforcement mechanism whose refusal is
+// indistinguishable from a crash.
+//
+// The two concerns share a sink, so they cannot be separated by writer. Cobra's
+// SilenceErrors is the mechanism for the first, and this pins that using it did
+// not cost the second.
+func TestRunDoesNotDiscardDeliberateStderr(t *testing.T) {
+	const diagnostic = "[cmd] a deliberate diagnostic"
+
+	rootCmd := &cobra.Command{
+		Use: "testcmd",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), diagnostic)
+			return nil
+		},
+	}
+	rootCmd.SetArgs([]string{})
+
+	var stderr bytes.Buffer
+	if code := run(rootCmd, &stderr); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(stderr.String(), diagnostic) {
+		t.Errorf("a command's deliberate stderr write was discarded; got %q.\n"+
+			"Every `dotf` subcommand that explains itself on stderr depends on this.", stderr.String())
+	}
+}
+
+// A command that writes a diagnostic AND fails must still get both out, with no
+// duplicated Cobra wrapper.
+func TestRunKeepsDiagnosticsAlongsideASilencedError(t *testing.T) {
+	rootCmd := &cobra.Command{
+		Use:           "testcmd",
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "[cmd] why it failed")
+			return fmt.Errorf("boom")
+		},
+	}
+	rootCmd.SetArgs([]string{})
+
+	var stderr bytes.Buffer
+	if code := run(rootCmd, &stderr); code == 0 {
+		t.Fatal("expected a non-zero exit")
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "[cmd] why it failed") {
+		t.Errorf("the diagnostic was discarded: %q", out)
+	}
+	if strings.Contains(out, "Error: boom") {
+		t.Errorf("a SilenceErrors command must not get Cobra's wrapper: %q", out)
+	}
+}

--- a/cli/internal/cmd/harness_gate.go
+++ b/cli/internal/cmd/harness_gate.go
@@ -72,7 +72,10 @@ Invoking a skill is never blocked: forbidding it would deadlock the session.`,
 			if stateDir == "" {
 				stateDir = defaultGateStateDir()
 			}
-			statePath := harness.StatePath(stateDir, call.SessionID)
+			// Scoped to the acting persona when the harness names one: a subagent
+			// reuses the parent session id, so keying by session alone would let one
+			// persona's skill runs satisfy another's gate.
+			statePath := harness.StatePath(stateDir, call.ConsumptionScope())
 
 			// A skill invocation is the act the gate exists to require: record
 			// it and get out of the way. Recording failures are ignored on
@@ -92,7 +95,7 @@ Invoking a skill is never blocked: forbidding it would deadlock the session.`,
 				return nil
 			}
 
-			persona := loadGatePersona(repoRoot, role)
+			persona := loadGatePersona(cmd.ErrOrStderr(), repoRoot, effectiveRole(role, call.AgentType))
 			result := harness.Decide(harness.GateInput{
 				Persona:  persona,
 				Call:     call,
@@ -123,8 +126,20 @@ Invoking a skill is never blocked: forbidding it would deadlock the session.`,
 // call in a session — that is the "normal state is red" failure, and it is worse
 // than the gate being absent, because an operator disables a noisy gate and then
 // has nothing.
-func loadGatePersona(repoRoot, role string) *harness.Persona {
+//
+// BUT A ROLE THAT WAS ASKED FOR AND DID NOT RESOLVE IS SAID OUT LOUD. Failing
+// open is the right decision and silence is not: `--role reviewr` used to exit 0
+// with no output, so a typo, a renamed record or a repo-root that resolved
+// elsewhere disabled enforcement entirely while every session reported health.
+// That is the guard-fails-open shape lesson 219 named, one level down — and it
+// is the failure this whole gate exists to prevent, committed inside the gate.
+// warn takes an io.Writer rather than reaching for os.Stderr so the message is
+// assertable; a diagnostic nothing can test is the same silence with extra steps.
+func loadGatePersona(warn io.Writer, repoRoot, role string) *harness.Persona {
 	if strings.TrimSpace(role) == "" {
+		// Not asked for: the caller declared no persona, so there is nothing to
+		// fail to find. Distinct from the case below, and NOT worth a line on
+		// every tool call.
 		return nil
 	}
 	if repoRoot == "" {
@@ -133,11 +148,30 @@ func loadGatePersona(repoRoot, role string) *harness.Persona {
 			repoRoot = filepath.Join(os.Getenv("HOME"), ".dotfiles")
 		}
 	}
-	p, err := harness.LoadPersona(filepath.Join(repoRoot, "harness", "agents", role, "AGENT.md"))
+	path := filepath.Join(repoRoot, "harness", "agents", role, "AGENT.md")
+	p, err := harness.LoadPersona(path)
 	if err != nil {
+		_, _ = fmt.Fprintf(warn, "[gate] allow: role %q did not resolve (%s): %v — ENFORCEMENT IS OFF for this call\n",
+			role, path, err)
 		return nil
 	}
 	return p
+}
+
+// effectiveRole picks the persona in scope: the operator's --role when given,
+// otherwise whatever the harness said was acting.
+//
+// THE FLAG WINS ON PURPOSE, and it is the smaller of the two jobs. The manifest
+// emits one hook for the whole harness, so a static --role in it would pin every
+// session to a single persona — which is why the flag alone left the gate inert:
+// nothing passed one, `loadGatePersona` got "", and `Decide` returned "no persona
+// in scope" for all 35 skills. The payload is the real source. The flag survives
+// as an override for testing and for a harness that reports no agent at all.
+func effectiveRole(flag, fromPayload string) string {
+	if r := strings.TrimSpace(flag); r != "" {
+		return r
+	}
+	return strings.TrimSpace(fromPayload)
 }
 
 func defaultGateStateDir() string {
@@ -159,10 +193,27 @@ func defaultGateStateDir() string {
 // agy's exact FIELD names are unverified — no agy payload has been captured — so
 // a mismatch degrades to "not understood", which allows. The gate never blocks
 // on a guess.
+// AgentType and AgentID are how the gate learns WHICH persona is acting, and
+// they are the reason no session-state mechanism was built for it. Claude
+// documents both on every hook event fired inside a subagent: `agent_type`
+// carries the dispatched agent's name (`reviewer`), `agent_id` a unique id for
+// that invocation. A MAIN-THREAD call carries NEITHER — absence means "no
+// persona in scope", which is not an error and is exactly the pre-existing
+// allow.
+//
+// DOCUMENTED, NOT YET MEASURED on this box: the gate is not live in any deployed
+// settings file here, so no real payload has been captured. The design is built
+// to make that acceptable — a wrong or renamed field yields an empty AgentType,
+// hence a nil persona, hence Allow: the behaviour before this existed. A guess
+// can therefore cost enforcement, never a blocked session. Confirm it by
+// observing `[gate] warn` lines on a real dispatch before any skill is promoted
+// to `enforce: block`.
 type commandHookPayload struct {
 	SessionID string         `json:"session_id"`
 	ToolName  string         `json:"tool_name"`
 	ToolInput map[string]any `json:"tool_input"`
+	AgentType string         `json:"agent_type"`
+	AgentID   string         `json:"agent_id"`
 }
 
 // canonicalPayload is the shape THIS REPOSITORY's own generated wrappers emit.
@@ -209,7 +260,14 @@ func normaliseToolCall(harnessName string, payload []byte) (harness.ToolCall, bo
 		if json.Unmarshal(payload, &p) != nil || p.ToolName == "" {
 			return harness.ToolCall{}, false
 		}
-		return harness.ToolCall{SessionID: p.SessionID, Tool: p.ToolName, Skill: skillArg(p.ToolName, p.ToolInput), IsSkillTool: isSkillTool(p.ToolName)}, true
+		return harness.ToolCall{
+			SessionID:   p.SessionID,
+			Tool:        p.ToolName,
+			Skill:       skillArg(p.ToolName, p.ToolInput),
+			IsSkillTool: isSkillTool(p.ToolName),
+			AgentType:   strings.TrimSpace(p.AgentType),
+			AgentID:     strings.TrimSpace(p.AgentID),
+		}, true
 	}
 }
 

--- a/cli/internal/cmd/harness_gate_test.go
+++ b/cli/internal/cmd/harness_gate_test.go
@@ -265,3 +265,28 @@ func TestConsumptionIsScopedToTheActingPersona(t *testing.T) {
 		t.Error("distinct scopes resolved to the same state file")
 	}
 }
+
+// TestConsumptionIsScopedToTheInvocationNotTheRole pins the case the previous
+// test does not reach: the SAME persona dispatched twice in one session.
+//
+// The reviewer on #1410 asked what happens if agent_id is not unique per
+// invocation. Separation there is a property of the harness's id, not of this
+// code — so what is pinned here is the contract this code owes: given distinct
+// ids, two runs of one role must not share a ledger. If the harness ever sends a
+// value stable per role, THIS test still passes and the separation is gone,
+// which is precisely why the doc comment sends that question to a measurement
+// rather than to a unit test.
+func TestConsumptionIsScopedToTheInvocationNotTheRole(t *testing.T) {
+	base := `{"tool_name":"Bash","session_id":"same-session","agent_type":"reviewer","agent_id":"%s"}`
+
+	first, ok := normaliseToolCall("claude", []byte(fmt.Sprintf(base, "agent-1")))
+	if !ok {
+		t.Fatal("payload not understood")
+	}
+	second, _ := normaliseToolCall("claude", []byte(fmt.Sprintf(base, "agent-2")))
+
+	if first.ConsumptionScope() == second.ConsumptionScope() {
+		t.Errorf("two dispatches of one role share a ledger (%q) — the second would inherit the first's consumption and go ungated",
+			first.ConsumptionScope())
+	}
+}

--- a/cli/internal/cmd/harness_gate_test.go
+++ b/cli/internal/cmd/harness_gate_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"bytes"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/mlorentedev/dotfiles/cli/internal/harness"
@@ -111,5 +114,154 @@ func TestSkillArgOnlyReadsTheSkillPrimitive(t *testing.T) {
 	}
 	if got := skillArg("Skill", map[string]any{"skill": "   "}); got != "" {
 		t.Errorf("a blank skill name must yield no skill, got %q", got)
+	}
+}
+
+// TestLoadGatePersonaSaysSoWhenARoleDoesNotResolve pins the fix for a guard that
+// failed OPEN and reported health.
+//
+// Measured on the shipped binary before the fix:
+//
+//	$ printf '{"tool_name":"Bash","session_id":"t1"}' | dotf harness gate \
+//	      --harness claude --role reviewr --repo-root .
+//	$ echo $?
+//	0
+//
+// No output at all. A typo in the role, a renamed record, or a --repo-root that
+// resolved somewhere without harness/agents disabled enforcement for the whole
+// session, and nothing anywhere said so. Allowing is the correct DECISION —
+// blocking every call on a config error is the worse failure — but silence is
+// not, because it is indistinguishable from a session with enforcement working.
+//
+// Table-driven per AGENTS.md, one row per branch of the resolution.
+func TestLoadGatePersonaSaysSoWhenARoleDoesNotResolve(t *testing.T) {
+	root := repoRootForTest(t)
+
+	for _, tc := range []struct {
+		name     string
+		role     string
+		repoRoot string
+		wantNil  bool
+		wantSaid bool
+	}{
+		{
+			name: "no role asked for is silent — nothing failed to resolve",
+			role: "", repoRoot: root, wantNil: true, wantSaid: false,
+		},
+		{
+			name: "a role that does not exist is allowed AND announced",
+			role: "reviewr", repoRoot: root, wantNil: true, wantSaid: true,
+		},
+		{
+			name: "a repo root without harness/agents is allowed AND announced",
+			role: "reviewer", repoRoot: t.TempDir(), wantNil: true, wantSaid: true,
+		},
+		{
+			name: "a role that resolves is silent",
+			role: "reviewer", repoRoot: root, wantNil: false, wantSaid: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			got := loadGatePersona(&buf, tc.repoRoot, tc.role)
+
+			if (got == nil) != tc.wantNil {
+				t.Errorf("persona nil = %v, want %v", got == nil, tc.wantNil)
+			}
+			// Always allow-shaped: this function never causes a block.
+			said := buf.Len() > 0
+			if said != tc.wantSaid {
+				t.Errorf("announced = %v, want %v (stderr=%q)", said, tc.wantSaid, buf.String())
+			}
+			if tc.wantSaid && !strings.Contains(buf.String(), "ENFORCEMENT IS OFF") {
+				t.Errorf("the message does not say enforcement is off: %q", buf.String())
+			}
+		})
+	}
+}
+
+// TestGateResolvesTheRoleFromThePayload is the fix for the reason the whole
+// binding chain decided nothing.
+//
+// MEASURED 2026-08-31, before this: the manifest emits `harness gate --harness
+// claude` with NO --role. loadGatePersona returned nil on an empty role, Decide
+// answered "no persona in scope", and every tool call was allowed regardless of
+// what any skill declared. bind, the hook, the gate and Decide were all live and
+// enforced nothing.
+//
+// Claude documents `agent_type` on every hook event fired inside a subagent, and
+// nothing on a main-thread call. So the harness already knows what the gate was
+// missing, and no session-state mechanism was needed to carry it.
+func TestGateResolvesTheRoleFromThePayload(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		flag     string
+		payload  string
+		wantRole string
+	}{
+		{
+			name:     "the payload's agent_type becomes the role",
+			payload:  `{"tool_name":"Bash","session_id":"s","agent_type":"reviewer"}`,
+			wantRole: "reviewer",
+		},
+		{
+			name:     "a main-thread call names no persona, which allows",
+			payload:  `{"tool_name":"Bash","session_id":"s"}`,
+			wantRole: "",
+		},
+		{
+			name:     "--role overrides the payload, for testing and for a silent harness",
+			flag:     "builder",
+			payload:  `{"tool_name":"Bash","session_id":"s","agent_type":"reviewer"}`,
+			wantRole: "builder",
+		},
+		{
+			name:     "--role fills in when the harness reports no agent",
+			flag:     "builder",
+			payload:  `{"tool_name":"Bash","session_id":"s"}`,
+			wantRole: "builder",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			call, ok := normaliseToolCall("claude", []byte(tc.payload))
+			if !ok {
+				t.Fatal("payload not understood")
+			}
+			if got := effectiveRole(tc.flag, call.AgentType); got != tc.wantRole {
+				t.Errorf("effectiveRole = %q, want %q", got, tc.wantRole)
+			}
+		})
+	}
+}
+
+// TestConsumptionIsScopedToTheActingPersona pins that two personas dispatched in
+// ONE session do not share a consumption ledger.
+//
+// Claude reuses the parent's session_id inside a subagent, so keying the ledger
+// by session alone would let the architect's skill runs satisfy the reviewer's
+// gate — enforcement that reports success while enforcing nothing, which is the
+// exact failure this gate exists to prevent.
+func TestConsumptionIsScopedToTheActingPersona(t *testing.T) {
+	base := `{"tool_name":"Bash","session_id":"same-session","agent_type":"%s","agent_id":"%s"}`
+
+	reviewer, ok := normaliseToolCall("claude", []byte(fmt.Sprintf(base, "reviewer", "agent-1")))
+	if !ok {
+		t.Fatal("payload not understood")
+	}
+	architect, _ := normaliseToolCall("claude", []byte(fmt.Sprintf(base, "architect", "agent-2")))
+	mainThread, _ := normaliseToolCall("claude", []byte(`{"tool_name":"Bash","session_id":"same-session"}`))
+
+	if reviewer.ConsumptionScope() == architect.ConsumptionScope() {
+		t.Errorf("two personas in one session share a ledger (%q) — one's skill runs would satisfy the other's gate",
+			reviewer.ConsumptionScope())
+	}
+	if mainThread.ConsumptionScope() != "same-session" {
+		t.Errorf("a main-thread call must fall back to the session, got %q", mainThread.ConsumptionScope())
+	}
+	// And the paths they resolve to must differ, which is what actually keeps
+	// the ledgers apart on disk.
+	dir := t.TempDir()
+	if harness.StatePath(dir, reviewer.ConsumptionScope()) == harness.StatePath(dir, architect.ConsumptionScope()) {
+		t.Error("distinct scopes resolved to the same state file")
 	}
 }

--- a/cli/internal/doctor/checks_agent_skills.go
+++ b/cli/internal/doctor/checks_agent_skills.go
@@ -1,0 +1,105 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/harness"
+)
+
+// checkAgentSkillsMigrated reports persona skills that carry no declared
+// enforcement severity, so the gate's inaction is VISIBLE rather than inferred.
+//
+// THIS CHECK EXISTED ONLY AS A PROMISE UNTIL NOW. `harness.Decide`'s
+// EnforceUnset branch says, in a comment, that such a skill "is surfaced by
+// `dotf doctor` instead" — and `UnmigratedSkills()` was written, exported and
+// unit-tested to that end. Measured 2026-08-31: NOTHING in production called it.
+// The whole binding chain (bind -> hook -> gate -> Decide) was live and decided
+// nothing for all 35 skills, and the one mechanism meant to say so did not run.
+//
+// That is precisely the failure mode this repository keeps cataloguing: a guard
+// whose absence is indistinguishable from a clean result. It matters most right
+// now, during the migration to declared severity, because this is the only
+// surface that reports how far that migration has actually got.
+//
+// It is a WARN, never a FAIL. An unmigrated skill is a known, deliberate state —
+// EnforceUnset exists so that neither enforcement nor silence is the default —
+// and failing the machine's health command over planned work would train the
+// reader to ignore it. It becomes a Pass only when every record is migrated.
+func checkAgentSkillsMigrated(cfg *Config, rep *Report) {
+	rep.Section("Persona skill enforcement")
+
+	recordDir, ok := agentRecordDir(cfg)
+	if !ok {
+		rep.Skip("no harness manifest in " + cfg.DotfilesDir + " — no persona records to check")
+		return
+	}
+	entries, err := os.ReadDir(filepath.Join(cfg.DotfilesDir, recordDir))
+	if err != nil {
+		rep.Skip("no persona records under " + recordDir)
+		return
+	}
+
+	total, unmigrated := 0, 0
+	var pending []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		path := filepath.Join(cfg.DotfilesDir, recordDir, e.Name(), "AGENT.md")
+		// LoadPersona, not readAgentFrontmatter: the latter reads single-line
+		// values only and its own docstring says it never reads `skills`. Using
+		// it here would report every record as having no skills at all — a
+		// check that passes on the broken thing.
+		p, err := harness.LoadPersona(path)
+		if err != nil {
+			rep.Warn(fmt.Sprintf("persona record %s does not parse, so its skills were not checked: %v",
+				filepath.Join(recordDir, e.Name(), "AGENT.md"), err))
+			continue
+		}
+		total += len(p.Skills)
+		if u := p.UnmigratedSkills(); len(u) > 0 {
+			unmigrated += len(u)
+			pending = append(pending, fmt.Sprintf("%s (%d: %s)", p.Name, len(u), strings.Join(u, ", ")))
+		}
+	}
+
+	switch {
+	case total == 0:
+		rep.Skip("no persona declares any skill")
+	case unmigrated == 0:
+		rep.Pass(fmt.Sprintf("every persona skill declares an enforcement severity (%d)", total))
+	default:
+		sort.Strings(pending)
+		rep.Warn(fmt.Sprintf(
+			"%d of %d persona skills carry no `enforce:` severity, so `dotf harness gate` does NOT act on them — %s",
+			unmigrated, total, strings.Join(pending, "; ")))
+	}
+}
+
+// agentRecordDir reads `agents.record_dir` from the deployed manifest, with the
+// same default the render pipeline uses. Returns false when there is no manifest
+// to read, which is a valid state (a machine that has not deployed yet) rather
+// than an error this check should diagnose.
+func agentRecordDir(cfg *Config) (string, bool) {
+	raw, err := os.ReadFile(filepath.Join(cfg.DotfilesDir, "harness", "manifest.json"))
+	if err != nil {
+		return "", false
+	}
+	var manifest struct {
+		Agents struct {
+			RecordDir string `json:"record_dir"`
+		} `json:"agents"`
+	}
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return "", false
+	}
+	if manifest.Agents.RecordDir == "" {
+		return "harness/agents", true
+	}
+	return manifest.Agents.RecordDir, true
+}

--- a/cli/internal/doctor/checks_agent_skills_test.go
+++ b/cli/internal/doctor/checks_agent_skills_test.go
@@ -1,0 +1,85 @@
+package doctor
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The check this file covers existed only as a COMMENT until 2026-08-31:
+// harness.Decide's EnforceUnset branch claimed "surfaced by `dotf doctor`", and
+// nothing in production called UnmigratedSkills. These cases pin that the claim
+// is now true, and that it stays true for the migration's whole duration —
+// during which the answer changes on every record.
+func writeSkillsFixture(t *testing.T, dir, persona, skillsBlock string) {
+	t.Helper()
+	recDir := filepath.Join(dir, "harness", "agents", persona)
+	if err := os.MkdirAll(recDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := "---\nid: agent-" + persona + "\nname: " + persona +
+		"\nkind: invocable\n" + skillsBlock + "owner: manu\n---\n\n# " + persona + "\n"
+	if err := os.WriteFile(filepath.Join(recDir, "AGENT.md"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write record: %v", err)
+	}
+	mf := filepath.Join(dir, "harness", "manifest.json")
+	if err := os.WriteFile(mf, []byte(`{"agents":{"record_dir":"harness/agents"}}`), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+func TestCheckAgentSkillsMigrated(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		skillsBlock string
+		wantLevel   string
+		wantSubstr  string
+	}{
+		{
+			name:        "the legacy inline form is a WARN naming what is not enforced",
+			skillsBlock: "skills: [audit, adversarial-review]\n",
+			wantLevel:   "warn",
+			wantSubstr:  "2 of 2 persona skills carry no `enforce:`",
+		},
+		{
+			name:        "a fully migrated record passes",
+			skillsBlock: "skills:\n  - id: audit\n    enforce: warn\n  - id: adversarial-review\n    enforce: block\n",
+			wantLevel:   "pass",
+			wantSubstr:  "every persona skill declares an enforcement severity (2)",
+		},
+		{
+			name:        "a PARTIALLY migrated record still warns, counting only the gap",
+			skillsBlock: "skills:\n  - id: audit\n    enforce: block\n  - adversarial-review\n",
+			wantLevel:   "warn",
+			wantSubstr:  "1 of 2 persona skills",
+		},
+		{
+			name:        "a record declaring no skills is skipped, not passed",
+			skillsBlock: "",
+			wantLevel:   "skip",
+			wantSubstr:  "no persona declares any skill",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeSkillsFixture(t, dir, "reviewer", tc.skillsBlock)
+
+			var buf bytes.Buffer
+			rep := NewReport(&buf, true)
+			checkAgentSkillsMigrated(&Config{DotfilesDir: dir}, rep)
+
+			text := buf.String()
+			if !strings.Contains(text, tc.wantSubstr) {
+				t.Fatalf("report does not contain %q:\n%s", tc.wantSubstr, text)
+			}
+			// The LEVEL is load-bearing, not decoration: an unmigrated skill is a
+			// known, deliberate state, so failing the machine's health command over
+			// it would train the reader to ignore the line.
+			if tc.wantLevel == "warn" && rep.Failures() != 0 {
+				t.Errorf("an unmigrated skill must WARN, never FAIL:\n%s", text)
+			}
+		})
+	}
+}

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -106,6 +106,7 @@ func Run(opts Options) (int, error) {
 		checkDeployDrift(sys, cfg, rep)
 		checkDeployManifest(sys, rep)
 		checkAgentPresence(sys, rep)
+		checkAgentSkillsMigrated(cfg, rep)
 		checkRepoDirResolves(rep)
 		checkAntigravity(sys, rep)
 		checkOrcaHook(sys, rep, opts.Fix)

--- a/cli/internal/harness/gate.go
+++ b/cli/internal/harness/gate.go
@@ -231,6 +231,20 @@ func RecordConsumed(path, skill string) error {
 // shares a ledger and the first one's skill runs silently satisfy the rest;
 // without the session fallback, a main-thread call — which carries no agent —
 // would have no ledger at all.
+//
+// SEPARATION IS ONLY AS GOOD AS AgentID'S UNIQUENESS, which is documented as a
+// per-invocation id and NOT YET MEASURED here — the same envelope as the field
+// names themselves, raised as a distinct point by the reviewer on #1410. If the
+// harness were instead to send a value stable per persona (a name, a hash of the
+// type), two dispatches of `reviewer` in one session would share this key and
+// the second would inherit the first's consumption.
+//
+// That failure is over-permissive, never over-strict: a shared ledger can only
+// skip a gate, never raise one, so it costs enforcement and cannot block a
+// session. It is checked by the same measurement that confirms the field names —
+// dispatch one persona TWICE in a session and confirm the second is gated again
+// — and that check is a precondition of promoting any skill to `enforce: block`,
+// not of this function being correct for the single-dispatch case.
 func (c ToolCall) ConsumptionScope() string {
 	if c.AgentID != "" {
 		return c.SessionID + "-" + c.AgentID

--- a/cli/internal/harness/gate.go
+++ b/cli/internal/harness/gate.go
@@ -45,6 +45,19 @@ type ToolCall struct {
 	// primitive but its argument could not be read, which is why IsSkillTool
 	// exists separately.
 	Skill string
+	// AgentType names the dispatched persona this call belongs to, when the
+	// harness says so. Empty on a main-thread call, which means "no persona in
+	// scope" and allows — never an error.
+	AgentType string
+	// AgentID scopes the consumption ledger to ONE dispatched persona.
+	//
+	// It matters because the harness reuses the parent's session id inside a
+	// subagent: keying consumption by session alone would let the parent's skill
+	// runs satisfy the reviewer's gate, and every persona dispatched in one
+	// session would share a ledger. Consumption is a claim about who has done
+	// what, so it is scoped to whoever the harness says is acting. Empty falls
+	// back to the session, which is right for a main-thread call.
+	AgentID string
 	// IsSkillTool reports that the tool is the harness's skill primitive,
 	// whether or not the skill's NAME was readable.
 	//
@@ -209,4 +222,18 @@ func RecordConsumed(path, skill string) error {
 		return err
 	}
 	return os.WriteFile(path, raw, 0o600)
+}
+
+// ConsumptionScope is the key a call's consumption ledger is stored under.
+//
+// The dispatched persona when the harness names one, the session otherwise. Both
+// are needed: without the agent scope, every persona dispatched in one session
+// shares a ledger and the first one's skill runs silently satisfy the rest;
+// without the session fallback, a main-thread call — which carries no agent —
+// would have no ledger at all.
+func (c ToolCall) ConsumptionScope() string {
+	if c.AgentID != "" {
+		return c.SessionID + "-" + c.AgentID
+	}
+	return c.SessionID
 }

--- a/specs/HARNESS-045-hook-emission/tasks.md
+++ b/specs/HARNESS-045-hook-emission/tasks.md
@@ -63,7 +63,69 @@ created: "2026-08-27"
       Mutation-checked: neutering `sameCommand` puts two copies of the mem hook
       in SessionStart.
 
-## Not done, and deliberately so
+## Done: the enabler AC3/AC4 were waiting on (2026-08-31)
+
+- [x] **The gate learns its persona from the payload.** MEASURED: the whole chain
+      — bind, hook, gate, `Decide` — was live and enforced NOTHING. The manifest
+      emits `harness gate --harness claude` with no `--role`; `loadGatePersona`
+      returned nil on an empty role; `Decide` answered *"no persona in scope"*.
+      Every tool call was allowed whatever any skill declared, on all 35 skills.
+
+      A static `--role` in the manifest could not fix it: one hook serves the
+      whole harness, so it would pin every session to one persona. Claude
+      documents `agent_type`/`agent_id` on every hook event fired inside a
+      subagent and neither on a main-thread call, so **the harness already knew
+      what the gate was missing** — no session-state mechanism, nothing to clean
+      up on a crash, no SubagentStart/Stop lifecycle. `--role` survives as an
+      override.
+
+      **Consumption is now scoped to the acting persona, not the session.** A
+      subagent reuses the parent's session id, so keying by session alone let one
+      persona's skill runs satisfy another's gate.
+
+      Verified end to end against a record declaring severity: main-thread call
+      allows; dispatched reviewer blocks with exit 2 **naming the skill to
+      invoke**; invoking it allows the next call while still warning on the
+      unconsumed `enforce: warn` skill; a second agent in the same session does
+      not inherit that consumption.
+
+      **DOCUMENTED, NOT MEASURED on this box:** the payload field names. The gate
+      is live in no deployed settings file here. The design makes that
+      acceptable — a wrong name yields no persona, hence Allow, the pre-existing
+      behaviour — so a guess costs enforcement, never a blocked session. Confirm
+      by observing `[gate] warn` on a real dispatch **before** promoting any skill
+      to `enforce: block`.
+
+- [x] **`dotf doctor` reports unmigrated skills.** The check existed only as a
+      comment: `Decide`'s EnforceUnset branch claimed "surfaced by `dotf doctor`",
+      `UnmigratedSkills()` was written and unit-tested, and **nothing in
+      production called it**. It now answers **35 of 35**. WARN, never FAIL — an
+      unmigrated skill is a deliberate state, and failing the health command over
+      planned work trains the reader to ignore the line.
+
+- [x] **A role that does not resolve is said out loud.** `--role reviewr` exited 0
+      in silence, so a typo or a renamed record disabled enforcement while every
+      session reported health. Allowing is the right decision; silence was not.
+
+- [x] **Fixed a cross-cutting regression found on the way** (`d4ea0f5`, #1404,
+      merged the same day): `rootCmd.SetErr(io.Discard)` discarded every
+      deliberate stderr write in the CLI — 17 call sites across 9 command files,
+      all four `dotf secrets` subcommands among them. The gate blocked with exit 2
+      and NO reason. Fixed via Cobra's `SilenceErrors`, which is the mechanism for
+      suppressing only the automatic wrapper; two guards added.
+
+## Still not done, and deliberately so
+
+- [ ] **Migrate the 35 skills to declared severity.** Now the only thing between
+      the machinery and real enforcement. VAULT-SIDE: the records under
+      `harness/agents/` are generated from `00_meta/agents/definitions/`, so the
+      edit lands in the vault (direct to master) and reaches the repo through
+      `compile-harness.sh --refresh`. **`check-roster-consistency.py` raises
+      `UnreadableSkills` on the mapping form by design**, so it must be updated in
+      the same movement or HARNESS-046's declared verification goes red.
+      Roll out `reviewer` first, all four skills at `enforce: warn`, observe a
+      real dispatch, and only then promote one to `block`.
+
 
 - [ ] [AC2] Presence emission. Only the Action half is built.
 - [ ] **The pi and opencode TS wrappers.** Declared in the manifest with


### PR DESCRIPTION
## What this fixes

The gate shipped in #1272 and wired into the hooks in #1407 was complete and
decided nothing. Measured on this box: **every tool call was allowed**, for two
independent reasons. This PR closes the first and makes the second visible.

### 1. The gate never learned which persona it was gating

`harness/manifest.json` emits `dotf harness gate --harness claude` with no
`--role`. With no role there is no persona, and `Decide` returns
`"no persona in scope"` → Allow. Every call, always.

The role is already in the payload: Claude documents `agent_type` on every hook
event raised inside a dispatched subagent, and omits it on the main thread —
which is exactly the distinction the gate needs. The flag still wins when
present, so nothing that passes `--role` changes behaviour.

`agent_id` is read alongside it and scopes the consumption ledger. Without it
every persona dispatched in one session shares one ledger, and the parent's
skill runs silently satisfy a reviewer's gate. `ConsumptionScope()` falls back
to the session id, which is the right key for a main-thread call.

### 2. Every persona skill is unmigrated, and nothing said so

All 35 skills are in the inline form, which carries no severity, so they parse
as `EnforceUnset` — deliberately neither enforced nor warned about.
`Decide`'s comment says such a skill "is surfaced by `dotf doctor` instead", and
`UnmigratedSkills()` was written, exported and unit-tested to that end.
**Nothing in production ever called it.** `dotf doctor` now reports
`35 of 35 persona skills carry no enforce: severity`.

It is a WARN, never a FAIL: an unmigrated skill is a known, planned state, and
failing the health command over planned work trains the reader to ignore it. It
turns into a Pass when the migration finishes.

The check uses `harness.LoadPersona`, not `readAgentFrontmatter` — the latter's
own docstring says it never reads `skills`, so using it here would have produced
a check that passes on the broken thing.

### 3. Prerequisite: stderr was being discarded wholesale

`run` set `rootCmd.SetErr(io.Discard)` to suppress Cobra's automatic
`Error: ...` wrapper around a `TerminalFailure`. But `cmd.ErrOrStderr()`
resolves through the root, so it discarded every diagnostic any subcommand
deliberately wrote — measured at `d4ea0f5`: **16 call sites across 9 command
files**, including all four `dotf secrets` subcommands, `harness mirror` and
`harness presence`.

The sharpest case is the gate itself: it blocked a tool call with exit 2 and
nothing on stderr, so its refusal was indistinguishable from a crash and the
operator had no way to learn which skill to invoke.

Cobra's `SilenceErrors` is the mechanism for the first concern without the
second. Forcing it on the root would pollute the "did this command ask for
silence" read when the root *is* the executed command, so the original value is
snapshotted and restored for that one case — the four existing tests pass
unchanged.

Also fixed: a typo'd `--role reviewr` resolved to nothing and allowed in
silence. It now says so on stderr, naming the path it tried and stating that
enforcement is off for that call.

## Verification

End-to-end against a persona record carrying declared severity:

- main thread (no `agent_type`) → allow
- dispatched `reviewer` → **exit 2**, naming the unconsumed skill on stderr
- invoking that skill → consumption recorded, subsequent calls allowed
- a second agent in the same session → does **not** inherit that consumption

```
cd cli && go build ./... && go vet ./... && GOOS=windows go vet ./... && go test ./...
golangci-lint run          # 0 issues (v2.12.2, the versions.conf pin)
bats tests/*.bats          # 1522 ok, 1 pre-existing failure (BUG-771, #1409)
```

## Declared risk

`agent_type` / `agent_id` are taken from documentation, **not measured on this
machine** — the gate is not live in any deployed settings here. The design fails
safe: a wrong field name yields no persona, which allows, which is today's
behaviour. A failure therefore costs enforcement, never a blocked session.

**No skill may be promoted to `enforce: block` before `[gate] warn` lines are
observed in a real dispatch.** That confirmation is a precondition of the
migration, not of this PR.

## Not in this PR

The skill migration itself. Persona records under `harness/agents/` are
generated from the vault, which is the SSOT, and the rollout is a canary:
`reviewer` to `enforce: warn` first, observed, and only then any promotion.
`specs/HARNESS-046/check-roster-consistency.py` raises `UnreadableSkills` on the
mapping form by design and must be updated in that same movement.

Closes part of #561.
