### PR TITLE
test(gitattributes): assert the working tree obeys the eol it declares

### DIFF
--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -270,4 +270,6 @@ tags: [lessons, index, dotfiles]
 | [249 - Two scripts writing the same logical value in two syntaxes make an equality rule OS-dependent](lesson-249-two-scripts-writing-the-same-logical-value-in-two.md) | 2026-08-31 |  |
 | [250 - Restoring a file's content is not restoring the file, and the mode is the part nobody diffs](lesson-250-restoring-a-files-content-is-not-restoring-the-file.md) | 2026-09-01 |  |
 | [251 - A guard that refuses an anticipated schema change should name its own fix, because the person who reads the refusal is the one who caused it](lesson-251-a-guard-that-refuses-an-anticipated-schema-change.md) | 2026-08-31 |  |
+| [254 - A canary that emits where nothing persists accumulates no evidence, and its silence reads as success](lesson-254-a-canary-that-emits-where-nothing-persists.md) | 2026-09-01 |  |
+| [255 - Truncation, not hostile input, is what made the collision guard load-bearing — and without it the measurement would have confirmed the opposite](lesson-255-truncation-not-hostile-input-made-the-digest-load-bearing.md) | 2026-09-01 |  |
 - [2026-08-30 Intercepting Cobra Errors without Breaking SilenceErrors](2026-08-30-cobra-silence-errors-interception.md)

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -270,8 +270,8 @@ tags: [lessons, index, dotfiles]
 | [249 - Two scripts writing the same logical value in two syntaxes make an equality rule OS-dependent](lesson-249-two-scripts-writing-the-same-logical-value-in-two.md) | 2026-08-31 |  |
 | [250 - Restoring a file's content is not restoring the file, and the mode is the part nobody diffs](lesson-250-restoring-a-files-content-is-not-restoring-the-file.md) | 2026-09-01 |  |
 | [251 - A guard that refuses an anticipated schema change should name its own fix, because the person who reads the refusal is the one who caused it](lesson-251-a-guard-that-refuses-an-anticipated-schema-change.md) | 2026-08-31 |  |
+| [252 - A git pathspec is resolved against the CWD, so the same argument means two different things and one of them is silently empty](lesson-252-a-git-pathspec-is-resolved-against-the-cwd-so-the-same.md) | 2026-09-01 |  |
 | [254 - A canary that emits where nothing persists accumulates no evidence, and its silence reads as success](lesson-254-a-canary-that-emits-where-nothing-persists.md) | 2026-09-01 |  |
 | [255 - Truncation, not hostile input, is what made the collision guard load-bearing — and without it the measurement would have confirmed the opposite](lesson-255-truncation-not-hostile-input-made-the-digest-load-bearing.md) | 2026-09-01 |  |
-| [252 - A git pathspec is resolved against the CWD, so the same argument means two different things and one of them is silently empty](lesson-252-a-git-pathspec-is-resolved-against-the-cwd-so-the-same.md) | 2026-09-01 |  |
 
 - [2026-08-30 Intercepting Cobra Errors without Breaking SilenceErrors](2026-08-30-cobra-silence-errors-interception.md)

--- a/docs/lessons/lesson-254-a-canary-that-emits-where-nothing-persists.md
+++ b/docs/lessons/lesson-254-a-canary-that-emits-where-nothing-persists.md
@@ -1,0 +1,103 @@
+# 254 - A canary that emits where nothing persists accumulates no evidence, and its silence reads as success
+
+**Date:** 2026-09-01
+**Area:** harness, orchestrator gate, verification
+
+## What happened
+
+`dotf harness gate` was bound into `~/.claude/settings.json` as a `PreToolUse`
+hook at 19:34:05 — the first time the orchestrator gate had ever run on this
+machine. The `reviewer` persona carried four skills at `enforce: warn`, the
+severity the owner chose to canary all 35 skills at before promoting any to
+`block`.
+
+The first probe dispatched a `reviewer` subagent to run one Bash command and
+looked for the gate's `[gate] warn: <skill> not consumed` lines. **Nothing
+appeared.** The obvious reading was that the payload field `agent_type` is not
+the name the gate expects, which would mean the persona resolution shipped in
+#1410 rests on a field that never arrives.
+
+That reading was wrong, and the probe could not have produced any other outcome.
+A parallel session grepped its own transcript JSONL: Claude Code records hook
+execution as entries carrying `hookCount` / `hookErrors` / `hasOutput`, and the
+entire session contained **exactly one**, of the Stop family. There is no
+`pre_tool_use_hook_summary` for any tool call. **A `PreToolUse` hook's streams on
+exit 0 are not persisted at all.** The gate emits `[gate] warn` to stderr and
+exits 0, so a warn decision was invisible however correct the field names were.
+
+The gate's other channel is durable but narrower than it looks. It writes a
+consumption ledger under `~/.local/state/dotfiles/gate/`, and only on a `Skill`
+tool call — an ordinary tool call at `warn` writes nothing. That is why the
+directory had been empty since the day the gate was written.
+
+And no persona can make a `Skill` call. `harness/capability-map.json` declares
+the neutral vocabulary `[read, search, edit, shell, web]`; **nothing maps to
+`Skill`**, so all seven personas deploy with `tools: Read, Glob, Grep, Bash`
+(plus `Edit, Write` for some). That map's own audited comment records why this is
+decisive:
+
+> claude frontmatter `tools:` — a comma-separated list of native tool names. An
+> ALLOW-LIST: a tool not named is unavailable to the agent.
+
+So at `warn` the gate produces no observable signal by any route, and the canary
+period would end with zero accumulated evidence. Verified from the other
+direction the same session: subagents with the full toolset *can* invoke a skill
+and *do* write the ledger, so the gap is precisely and only the seven persona
+capability declarations.
+
+## Why this is the lesson and not just a bug
+
+The severity ladder was designed with care — `warn` reports and allows, `block`
+refuses, an undeclared skill is neither. What nobody specified with the same rigour
+was **where the report goes**, and that turns out to decide whether the ladder
+works at all.
+
+`HARNESS-045`'s **AC4** reads *"a skill declared `enforce: warn` **emits** and does
+not block, asserted on the same path as AC3 so the two cannot collapse."* The
+non-blocking half is verifiable. The emitting half is not, through the channel it
+assumes. The AC was written against a mechanism whose observability was never
+checked.
+
+**AC3 is worse, because it would pass.** It asks that with a skill at
+`enforce: block` unconsumed, a tool call is blocked. Under `block` a persona is
+blocked on every call *and cannot reach the one action that would clear it* — the
+gate's `isSkillTool` escape ("invoking a skill is never blocked: forbidding it
+would deadlock the session") assumes an agent able to emit a call it was never
+granted. AC3 would observe a blocked call and record a pass, on a persona that is
+now permanently deadlocked. An acceptance criterion satisfied by the broken state
+is worse than a missing one.
+
+The session also spent two probes reading a silence as data, in a repository that
+has already written that mistake down twice: `dotf pr triage-queue` exiting 0 is
+not an empty queue, and a green `review-attestation` check is not a review that
+happened. Both were re-derived here at cost. **The tell is identical every time —
+a channel is consulted, it says nothing, and nothing is exactly what it says when
+it is broken and when it is fine.**
+
+## What this does not license
+
+**The gate's fail-toward-allow design is correct and is not what failed.** A field
+name it does not recognise yields an empty `AgentType`, a nil persona, and the
+pre-existing allow; a payload it cannot parse takes the same path. That is
+deliberate — a wrong guess costs enforcement and can never block a session — and
+it is why binding the gate to a live machine was safe before any of this was
+measured. The defect is not that failure is silent to the *session*; it is that
+success is silent to the *operator*.
+
+**Nor is `--debug` the answer.** It surfaces hook streams and would break this
+particular tie once, but it depends on how a human launched the session. A canary
+cannot rest on a flag someone has to remember. What the gate needs is a decision
+record that survives independently of stderr, of exit code, and of whether the
+persona holds the `Skill` tool — covering allow, warn, block, and the
+`role did not resolve` path, which today is the loudest thing the gate can say
+and is equally invisible.
+
+## Rule
+
+When you design a graduated rollout — warn now, block later — specify the
+observation channel with the same rigour as the enforcement, and **prove the
+channel persists before the canary period starts counting**. Then check every
+acceptance criterion against the failure you are guarding, not only against the
+success: an AC that the broken state satisfies is not a check. Silence in a
+channel nobody has shown to be durable is not evidence of safety, of correctness,
+or of anything at all.

--- a/docs/lessons/lesson-254-a-canary-that-emits-where-nothing-persists.md
+++ b/docs/lessons/lesson-254-a-canary-that-emits-where-nothing-persists.md
@@ -17,13 +17,29 @@ appeared.** The obvious reading was that the payload field `agent_type` is not
 the name the gate expects, which would mean the persona resolution shipped in
 #1410 rests on a field that never arrives.
 
-That reading was wrong, and the probe could not have produced any other outcome.
-A parallel session grepped its own transcript JSONL: Claude Code records hook
-execution as entries carrying `hookCount` / `hookErrors` / `hasOutput`, and the
-entire session contained **exactly one**, of the Stop family. There is no
-`pre_tool_use_hook_summary` for any tool call. **A `PreToolUse` hook's streams on
-exit 0 are not persisted at all.** The gate emits `[gate] warn` to stderr and
-exits 0, so a warn decision was invisible however correct the field names were.
+That reading was **unsupported** — the probe could not have produced any other
+outcome either way. A parallel session grepped its own transcript JSONL: Claude
+Code records hook execution as entries carrying `hookCount` / `hookErrors` /
+`hasOutput`, and every such record in the session was Stop-family;
+`stop_hook_summary` was the only hook-bearing subtype present at all, under any
+name. **A `PreToolUse` hook's streams on exit 0 are not persisted to the session
+transcript.** The gate emits `[gate] warn` to stderr and exits 0, so a warn
+decision was invisible however correct the field names were.
+
+That began as *"we looked and found no record"*, which is the weaker claim. It
+became **evidence of absence** an hour later, when a `Skill` call in that same
+session provably fired the hook — it wrote a consumption ledger entry — and still
+left no transcript record of it. The hook demonstrably ran and the transcript
+does not know.
+
+**`agent_type` remains unmeasured, and nothing here changed that.** A later probe
+established that `agent_id` arrives on subagent events and is per-invocation, but
+it did so through the ledger, and the ledger cannot speak to `agent_type`: the
+gate records a skill consumption and `return`s at `harness_gate.go:84-87`,
+*before* `loadGatePersona` is reached. Not one ledger entry has ever exercised the
+persona-resolution path. The two are sibling fields on one payload struct and are
+documented together, so it is strong inference — and inference is what it stays
+until the decision record exists.
 
 The gate's other channel is durable but narrower than it looks. It writes a
 consumption ledger under `~/.local/state/dotfiles/gate/`, and only on a `Skill`
@@ -84,9 +100,11 @@ it is why binding the gate to a live machine was safe before any of this was
 measured. The defect is not that failure is silent to the *session*; it is that
 success is silent to the *operator*.
 
-**Nor is `--debug` the answer.** It surfaces hook streams and would break this
-particular tie once, but it depends on how a human launched the session. A canary
-cannot rest on a flag someone has to remember. What the gate needs is a decision
+**Nor is `--debug` the answer.** It is *reported* to surface hook streams and
+might break this particular tie once — where those streams actually go was never
+checked, which is the honest state of it — but either way it depends on how a
+human launched the session. A canary cannot rest on a flag someone has to
+remember. What the gate needs is a decision
 record that survives independently of stderr, of exit code, and of whether the
 persona holds the `Skill` tool — covering allow, warn, block, and the
 `role did not resolve` path, which today is the loudest thing the gate can say

--- a/docs/lessons/lesson-255-truncation-not-hostile-input-made-the-digest-load-bearing.md
+++ b/docs/lessons/lesson-255-truncation-not-hostile-input-made-the-digest-load-bearing.md
@@ -19,7 +19,8 @@ The scope is `session_id + "-" + agent_id` when a subagent is acting. A session 
 is a 36-character UUID, so with the joining hyphen only **11 characters of the
 agent id survive the truncation**.
 
-Two subagents were dispatched in one session to measure whether `agent_id` is
+Two subagents were dispatched in one session, **named `gate-probe-A` and
+`gate-probe-B` by the dispatcher**, to measure whether `agent_id` is
 per-invocation or stable per persona — the check the code itself names as a
 precondition for promoting any skill to `enforce: block`. Both wrote a ledger
 entry:
@@ -46,12 +47,27 @@ alone, and the argument that carried was adversarial:
 > builder should rely on.
 
 The reviewer was right, and right for a reason neither side stated. **No hostile
-input was required.** The collision arrived on the first real measurement, from
-two ordinary auto-generated agent ids, because a fixed 48-character cap discarded
-the only part that distinguished them. The defence was accepted as a hardening
-against a rare adversarial case and turned out to be load-bearing on the normal
-path — a distinction that matters, because defences argued only on rare cases are
-the ones that get traded away under review pressure.
+input was required — but nor was the collision spontaneous, and the difference
+matters.** The dispatcher passed `name: gate-probe-A` and `name: gate-probe-B`,
+and the runtime agent id is derived from that name. The truncation then cut one
+character before the discriminator. An id left to auto-generation has a different
+shape entirely — `a` followed by sixteen hex characters — and two of those share
+an eleven-character prefix with negligible probability. **On the auto-generated
+path the digest is not load-bearing; these two prefixes differ at character two.**
+
+So the instrument shaped the finding, and the reading it produced is the one the
+naming guaranteed. Saying otherwise would make this lesson an instance of the
+error the sibling lesson is about.
+
+The true exposure is larger than the case the reviewer argued and smaller than
+"it happens by itself": **`agent_id` is caller-influenced.** A dispatcher's chosen
+name flows into a filesystem key that is then truncated, and an orchestrator
+naming agents by role produces exactly the shape that collides, because role names
+share prefixes by nature — `review-1` / `review-2`, `builder-api` / `builder-web`.
+That is not adversarial input and it is not exotic; it is the normal output of the
+naming convention any multi-agent system adopts. The #1272 reviewer argued
+character mapping (`a/b` versus `a.b`); the wider hazard is ordinary naming meeting
+a fixed-width cap, and it was never stated.
 
 **What makes this worth writing down is the shape of the failure it prevented.**
 Had the digest not been there, the second dispatch would have written to the first
@@ -77,18 +93,40 @@ into this ledger were traced back to their projects. The lesson is not "do not
 truncate" — it is that a truncated key is a *display* key, and correctness has to
 live in the part that is not truncated.
 
-**Nor does a passing measurement retire the concern.** The prefix collision is
-still there, silently, on every subagent dispatch. Anything that later reads this
-directory by prefix — a cleanup routine, a doctor check, a human running `ls
-<session>-*` — will treat two scopes as one. The collision was defused for the
-file path and nowhere else.
+**Nor does a passing measurement retire the concern.** Anything that later reads
+this directory by prefix — a cleanup routine, a doctor check, a human running
+`ls <session>-*` — will treat two scopes as one. The collision was defused for the
+file path and nowhere else, and under named dispatch it is **routine rather than
+rare**, which is a stronger reason to fix those readers than the original
+adversarial framing supplied.
+
+**One code defect surfaced alongside it and is worth naming**, because it is the
+plausible reason the truncation hazard survived review at all:
+
+```go
+func StatePath(stateDir, sessionID string) string
+```
+
+Every caller passes `ConsumptionScope()`, which is `session + "-" + agent_id` when
+a subagent is acting — never a bare session id. **The parameter name is a lie.** A
+reader checking the 48-character cap sees `sessionID`, knows a UUID is 36
+characters, and concludes the cap can never bite. It bites on every named subagent
+dispatch.
 
 ## Rule
 
-When a defence is accepted on adversarial grounds, check whether the **ordinary**
-path already triggers it; if it does, the defence is load-bearing and its
-rationale should say so, because the adversarial framing invites someone to trade
-it away later. And when a key is truncated for readability, verify the truncation
-preserves what distinguishes — otherwise the instrument fails by producing the
-very reading it was built to test for, which no amount of care in interpreting the
-result can catch.
+When a defence is accepted on adversarial grounds, check whether **your own
+callers** already produce input that triggers it — not whether an attacker could.
+If they do, the defence is load-bearing and its rationale should say so, because
+an adversarial framing invites someone to trade it away later as a rare case.
+
+When a key is truncated for readability, verify the truncation preserves what
+distinguishes, and **name the parameter after what is actually passed** — a
+truncation hazard hides behind an argument called `sessionID` that never receives
+one.
+
+And when a measurement comes back confirming what you expected, check what your
+instrument contributed to the result before you write the finding down. Here the
+collision was real, the digest genuinely saved the measurement, and the reading
+*"ordinary ids collide"* was still an artefact of the names the probe chose. A
+result the instrument guaranteed is not evidence about the world.

--- a/docs/lessons/lesson-255-truncation-not-hostile-input-made-the-digest-load-bearing.md
+++ b/docs/lessons/lesson-255-truncation-not-hostile-input-made-the-digest-load-bearing.md
@@ -1,0 +1,94 @@
+# 255 - Truncation, not hostile input, is what made the collision guard load-bearing — and without it the measurement would have confirmed the opposite
+
+**Date:** 2026-09-01
+**Area:** harness, orchestrator gate, path construction
+
+## What happened
+
+`harness.StatePath` builds the gate's per-scope consumption ledger filename. It
+maps every character outside `[A-Za-z0-9_-]` to `_`, **truncates the result to 48
+characters**, and appends the first four bytes of `sha256(scope)` as hex:
+
+```go
+if len(safe) > 48 { safe = safe[:48] }
+sum := sha256.Sum256([]byte(sessionID))
+return filepath.Join(stateDir, "gate", safe+"-"+hex.EncodeToString(sum[:4])+".json")
+```
+
+The scope is `session_id + "-" + agent_id` when a subagent is acting. A session id
+is a 36-character UUID, so with the joining hyphen only **11 characters of the
+agent id survive the truncation**.
+
+Two subagents were dispatched in one session to measure whether `agent_id` is
+per-invocation or stable per persona — the check the code itself names as a
+precondition for promoting any skill to `enforce: block`. Both wrote a ledger
+entry:
+
+```
+e4edd8fa-dc36-4cc5-bd73-5047c2e5b737-agate-probe-079740d4.json  {"skills":{"genre-picker":true}}
+e4edd8fa-dc36-4cc5-bd73-5047c2e5b737-agate-probe-8fb525a3.json  {"skills":{"research-prompt":true}}
+```
+
+The readable prefixes are **byte-identical, both exactly 48 characters**. The two
+files exist as separate files only because the digests differ. The measurement
+succeeded — the ids are distinct, per invocation — and it succeeded entirely on
+the strength of the appended hash.
+
+## Why this is the lesson and not just a bug
+
+The digest was added because a PR reviewer on #1272 objected to character-mapping
+alone, and the argument that carried was adversarial:
+
+> `a/b` and `a.b` both flatten to `a_b`, so one session's consumption record would
+> open another session's gate. Well-behaved harnesses send UUIDs and would never
+> hit it, but a session id is attacker-adjacent input that lands in a filesystem
+> path, and "it does not happen with well-behaved input" is not a property a path
+> builder should rely on.
+
+The reviewer was right, and right for a reason neither side stated. **No hostile
+input was required.** The collision arrived on the first real measurement, from
+two ordinary auto-generated agent ids, because a fixed 48-character cap discarded
+the only part that distinguished them. The defence was accepted as a hardening
+against a rare adversarial case and turned out to be load-bearing on the normal
+path — a distinction that matters, because defences argued only on rare cases are
+the ones that get traded away under review pressure.
+
+**What makes this worth writing down is the shape of the failure it prevented.**
+Had the digest not been there, the second dispatch would have written to the first
+one's file. The directory would have shown **one** entry for two dispatches, and
+the honest reading of that evidence is *"the ledger key is shared, so the second
+dispatch inherits the first's consumption"* — which is precisely the
+over-permissive failure the code documents at `gate.go:238-247` as the thing this
+measurement exists to rule out.
+
+So the missing digest would not have produced a confusing result or an obvious
+crash. It would have produced **the exact symptom of the real defect being tested
+for**, sourced from a path-construction bug instead of the harness, and we would
+have "confirmed" it and gone off to fix a harness that was behaving correctly. A
+false negative indistinguishable from the true positive is the most expensive
+possible failure of an instrument.
+
+## What this does not license
+
+**The truncation is not itself wrong and should not be removed.** Its stated
+purpose is that the directory stays diagnosable by eye, and it achieves that: the
+session id is legible in every filename, which is how the three sessions writing
+into this ledger were traced back to their projects. The lesson is not "do not
+truncate" — it is that a truncated key is a *display* key, and correctness has to
+live in the part that is not truncated.
+
+**Nor does a passing measurement retire the concern.** The prefix collision is
+still there, silently, on every subagent dispatch. Anything that later reads this
+directory by prefix — a cleanup routine, a doctor check, a human running `ls
+<session>-*` — will treat two scopes as one. The collision was defused for the
+file path and nowhere else.
+
+## Rule
+
+When a defence is accepted on adversarial grounds, check whether the **ordinary**
+path already triggers it; if it does, the defence is load-bearing and its
+rationale should say so, because the adversarial framing invites someone to trade
+it away later. And when a key is truncated for readability, verify the truncation
+preserves what distinguishes — otherwise the instrument fails by producing the
+very reading it was built to test for, which no amount of care in interpreting the
+result can catch.

--- a/tests/gitattributes-eol.bats
+++ b/tests/gitattributes-eol.bats
@@ -69,6 +69,91 @@ _extensionless_tracked_files() {
     fi
 }
 
+# The other half of this file. The two tests above ask whether a RULE EXISTS;
+# this one asks whether the WORKING TREE OBEYS IT, and nothing did before.
+#
+# Measured 2026-09-01: `scripts/obs-cli.ps1` resolved `eol: crlf` and was LF on
+# disk in the main checkout, while both worktrees had it CRLF -- and
+# `git status` reported clean in all three, because the blob round-trips
+# through `text=auto` either way. git converts at CHECKOUT, never
+# retroactively, so a file authored with LF, committed normalized, and never
+# re-checked-out keeps the wrong endings indefinitely. Two clean checkouts of
+# one commit differed byte-for-byte for three and a half months.
+#
+# It surfaced only as a `dotf doctor` deploy-dir drift FAIL whose printed
+# remedy ("run setup to refresh") could not fix it, because setup deploys from
+# the tree that is already correct. A guard that proves a rule is declared, and
+# never that it is honoured, is the reason nobody saw the cause.
+_declared_eol_files() {
+    git -C "$REPO" ls-files | git -C "$REPO" check-attr --stdin text eol
+}
+
+@test "every tracked file whose eol is declared has a working tree that obeys it" {
+    cd "$REPO" || return 1
+
+    local -A eol_of text_of
+    local line path rest attr val
+    while IFS= read -r line; do
+        path="${line%%: *}"
+        rest="${line#*: }"
+        attr="${rest%%: *}"
+        val="${rest#*: }"
+        case "$attr" in
+            eol) eol_of["$path"]="$val" ;;
+            text) text_of["$path"]="$val" ;;
+        esac
+    done < <(_declared_eol_files)
+
+    local lf=() crlf=() p
+    for p in "${!eol_of[@]}"; do
+        # `binary` (text unset) is exempt: it is never converted either way.
+        [ "${text_of[$p]:-}" = "unset" ] && continue
+        [ -f "$p" ] || continue
+        case "${eol_of[$p]}" in
+            lf)   lf+=("$p") ;;
+            crlf) crlf+=("$p") ;;
+        esac
+    done
+
+    # Same fixture-drift guard as the test above: an empty set here would pass
+    # vacuously, and an empty result reading as a finding is the failure class
+    # this whole file exists to prevent.
+    [ ${#lf[@]} -gt 0 ] && [ ${#crlf[@]} -gt 0 ] || {
+        printf 'Expected both eol=lf and eol=crlf files to be tracked; found\n' >&2
+        printf 'lf=%d crlf=%d. Either .gitattributes changed or this test is\n' "${#lf[@]}" "${#crlf[@]}" >&2
+        printf 'no longer measuring what it claims.\n' >&2
+        return 1
+    }
+
+    local bad=()
+    # An eol=lf file must carry no CR at all. -U keeps grep from stripping it.
+    local hit
+    while IFS= read -r hit; do
+        [ -n "$hit" ] && bad+=("$hit (declared lf, contains CR)")
+    done < <(printf '%s\0' "${lf[@]}" | xargs -0 grep -lU $'\r' -- 2>/dev/null)
+
+    # An eol=crlf file must carry CR. Empty files are exempt: they have no line
+    # ending to be wrong about, and flagging them would be noise.
+    for p in "${crlf[@]}"; do
+        [ -s "$p" ] || continue
+        grep -qU $'\r' -- "$p" || bad+=("$p (declared crlf, contains none)")
+    done
+
+    if [ ${#bad[@]} -ne 0 ]; then
+        printf 'Working-tree line endings disagree with .gitattributes.\n' >&2
+        printf 'git may well report these CLEAN: whether it notices depends on\n' >&2
+        printf 'its stat cache, so an untouched file that was wrong at checkout\n' >&2
+        printf 'is never re-examined. That is how scripts/obs-cli.ps1 stayed\n' >&2
+        printf 'byte-wrong from 2026-05-15 to 2026-09-01. Do not conclude from a\n' >&2
+        printf 'clean `git status` that this is a false positive -- compare the\n' >&2
+        printf 'bytes:\n' >&2
+        printf '%s\n' "${bad[@]}" | sort | while IFS= read -r f; do printf '  %s\n' "$f" >&2; done
+        printf '\nFix with: git add --renormalize <path>, or remove the file and\n' >&2
+        printf '`git checkout -- <path>` to re-convert it on the way out.\n' >&2
+        return 1
+    fi
+}
+
 @test "the five GUARD-001 hook dispatchers resolve eol=lf specifically" {
     # AC1: distinct from the class guard above -- this pins the exact value,
     # not just "something explicit", for the dispatchers whose CRLF breakage


### PR DESCRIPTION
## What

`tests/gitattributes-eol.bats` proved a **rule exists**. Nothing proved the **working tree obeys it**. This adds the missing half.

## The defect it would have caught

`scripts/obs-cli.ps1` resolves `eol: crlf` and was **LF on disk in the main checkout** while both worktrees had it CRLF — from 2026-05-15, when the attribute landed, to 2026-09-01. `git status` reported **clean in all three trees**.

git converts line endings at checkout, never retroactively. A file authored with LF, committed normalized, and never re-checked-out keeps the wrong endings indefinitely — and whether git notices depends on its stat cache, so a clean `git status` is not evidence of conformance.

It surfaced only as a `dotf doctor` deploy-dir drift FAIL whose printed remedy — *"run setup to refresh ~/.dotfiles"* — could not fix it, because setup deploys from the tree that was already correct. Two clean checkouts of one commit differed byte-for-byte and nothing in the repo could say so.

## How

Resolve `text`/`eol` for every tracked file in one `git check-attr --stdin` pass, then compare bytes: an `eol=lf` file must carry no CR; a non-empty `eol=crlf` file must carry one. Files declared `binary` are exempt — they are never converted either way. Empty files are exempt from the crlf side: they have no line ending to be wrong about.

It carries the same fixture-drift guard as the test above it. An empty set would pass vacuously, and an empty result reading as a finding is precisely the failure class this file exists to prevent.

## Verification

```
bats tests/gitattributes-eol.bats
  ok 1 every tracked extensionless file has an explicit eol (or is declared binary)
  ok 2 every tracked file whose eol is declared has a working tree that obeys it
  ok 3 the five GUARD-001 hook dispatchers resolve eol=lf specifically
```

**Proven red before green.** Converting `scripts/obs-cli.ps1` to LF:

```
not ok 2 every tracked file whose eol is declared has a working tree that obeys it
#   scripts/obs-cli.ps1 (declared crlf, contains none)
```

Restored, green again. `shellcheck -s bash` clean apart from the pre-existing SC2016 on intentional literal backticks — it did catch a real defect in the first draft (`printf '%d'` with no argument, so the fixture-drift message would have reported `lf=0 crlf=0` regardless of the true counts), fixed here.

## Also included

Two lessons from the same session's orchestrator-gate measurement, which is where this defect was found:

- **254** — a canary that emits where nothing persists accumulates no evidence, and its silence reads as success.
- **255** — truncation, not hostile input, is what made the ledger's collision digest load-bearing; without it the measurement would have confirmed the opposite of the truth.

## Scope

Tests and docs only. No production code. Related but separate: #1418 (setup deploys from the cwd while doctor compares against `DOTFILES_REPO_DIR`) — renormalizing does not fix the root mismatch and fixing the root mismatch does not renormalize.