### PR TITLE
chore(setup): delete the migrations that are dead, keep the two that are not

### DIFF
--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -273,5 +273,7 @@ tags: [lessons, index, dotfiles]
 | [252 - A git pathspec is resolved against the CWD, so the same argument means two different things and one of them is silently empty](lesson-252-a-git-pathspec-is-resolved-against-the-cwd-so-the-same.md) | 2026-09-01 |  |
 | [254 - A canary that emits where nothing persists accumulates no evidence, and its silence reads as success](lesson-254-a-canary-that-emits-where-nothing-persists.md) | 2026-09-01 |  |
 | [255 - Truncation, not hostile input, is what made the collision guard load-bearing — and without it the measurement would have confirmed the opposite](lesson-255-truncation-not-hostile-input-made-the-digest-load-bearing.md) | 2026-09-01 |  |
+| [256 - A cleanup block's own description of what it deletes is not evidence that the thing is dead](lesson-256-a-cleanup-blocks-own-description-of-what-it-deletes.md) | 2026-09-02 |  |
+| [257 - A one-time migration with no removal date is indistinguishable from live code, and two of eleven turned out not to be finished](lesson-257-a-one-time-migration-with-no-removal-date-is.md) | 2026-09-02 |  |
 
 - [2026-08-30 Intercepting Cobra Errors without Breaking SilenceErrors](2026-08-30-cobra-silence-errors-interception.md)

--- a/docs/lessons/lesson-256-a-cleanup-blocks-own-description-of-what-it-deletes.md
+++ b/docs/lessons/lesson-256-a-cleanup-blocks-own-description-of-what-it-deletes.md
@@ -1,0 +1,100 @@
+# 256 - A cleanup block's own description of what it deletes is not evidence that the thing is dead
+
+**Date:** 2026-09-02
+**Area:** setup scripts, harness, guards
+
+## What happened
+
+OPS-040 (#1333) set out to delete ~200 lines of one-time migrations from both
+setup scripts. One of them looked like the easiest deletion in the batch:
+
+```sh
+# SDD-007 one-time migration: gemini-cli -> agy. Remove the legacy
+# ~/.gemini/GEMINI.md identity file so it doesn't linger as an orphan
+# pointing to the retired binary. Safe to repeat (no-op if absent).
+if [ -f "$GEMINI_HOME/GEMINI.md" ]; then
+    rm -f "$GEMINI_HOME/GEMINI.md"
+    log_info "Removed legacy GEMINI.md (SDD-007 migration: agy replaces gemini-cli)"
+fi
+```
+
+Self-describing, dated, obviously finished. Classified "harmless cleanup" from
+reading it, and deleted.
+
+Then the targets were probed on the machine, as a formality:
+
+```
+$ stat -c '%y %s' ~/.gemini/GEMINI.md
+2026-09-01 19:34:11  12029 bytes
+```
+
+Not an orphan. **12 KB of harness-generated cross-agent doctrine**, carrying a
+`sha256:` provenance marker, written the previous evening.
+
+`harness/manifest.json` declares it, with the reason spelled out:
+
+> `.gemini/GEMINI.md` — *"Antigravity reads global rules from
+> `~/.gemini/GEMINI.md` and caps EACH rules file at 12000 characters… The file is
+> shared with Gemini CLI, so injection is **append-and-replace-in-place, never an
+> overwrite**."*
+
+And `tests/compile-harness.bats` asserts precisely that a user's own rules
+written into that file survive a deploy.
+
+So both setup scripts had been `rm -f`-ing a live doctrine deploy target on every
+run, while the manifest promised users their content in it would be preserved.
+`tests/setup-windows.bats` held a test asserting the removal happened, which is
+how it stayed green.
+
+## Why nothing caught it
+
+Only ordering hid the conflict. Setup deleted the file early; the single
+`compile-harness.sh --deploy` call near the end rewrote it. The destruction was
+invisible as long as nothing changed — a run that stopped in between, a skipped
+deploy, or a reordering would have silently dropped whatever the user had put
+around the generated region.
+
+Two artefacts agreed with each other and were both wrong: the block's comment
+("legacy orphan pointing to the retired binary") and the test that pinned it
+("Without explicit cleanup the orphan GEMINI.md lingers"). The comment was
+written when it was true — before the harness claimed the path — and neither was
+re-checked when the manifest started deploying there. **The description aged; the
+code did not.**
+
+## What to do instead
+
+**Probe the target before deleting the cleanup.** Not to decide whether the
+deletion is safe — a `rm -f` of an absent file is safe either way — but to find
+out what the block is actually pointed at. One `stat` was the entire difference
+between "harmless cleanup, deleted" and "live doctrine target, this is a bug".
+
+Concretely, for any block that removes a path:
+
+1. Look at the path on a real machine. Present is a question, not an answer.
+2. Ask who *writes* it, not only who reads it. Here the writer was
+   `compile-harness.sh`, a subsystem the setup script never mentions.
+3. Check whether it is declared anywhere as an output. A manifest, a deploy
+   manifest, an SSOT — a file that is someone's declared target cannot also be
+   someone else's orphan.
+
+## Guard
+
+`tests/guard-doctrine-target-not-deleted.bats` resolves `.doctrine.deploy[]`
+from `harness/manifest.json` and refuses any removal command naming a declared
+target in either setup script.
+
+It reads the manifest rather than naming `GEMINI.md`, so a target declared later
+is covered the day it is declared. Verified fail-first: red against the pre-fix
+scripts at `setup-linux.sh:503`, green after. It SKIPs with its reason when the
+manifest yields no targets, per C15 — a check that cannot answer must not pass.
+
+## Related
+
+- #1333 — the purge this was found inside
+- #1431 — the other block in the same batch that had never converged, for a
+  different reason: it asserts against a proxy (`settings.json`) instead of the
+  end-state, so a platform change moved the file out from under it
+- Lesson 247 — a pointer into a deletable location keeps every check green until
+  the deletion
+- Lesson 252 — the dangerous constructs are the ones that return an answer that
+  reads as a finding

--- a/docs/lessons/lesson-257-a-one-time-migration-with-no-removal-date-is.md
+++ b/docs/lessons/lesson-257-a-one-time-migration-with-no-removal-date-is.md
@@ -1,0 +1,83 @@
+# 257 - A one-time migration with no removal date is indistinguishable from live code, and two of eleven turned out not to be finished
+
+**Date:** 2026-09-02
+**Area:** setup scripts, technical debt
+
+## What happened
+
+Both setup scripts had accumulated eleven blocks written to converge existing
+machines off some retired arrangement. None recorded when it could be removed.
+#1333 proposed the obvious cleanup: delete them, they are done.
+
+They were not all done. Classifying each block by **what breaks on a machine that
+never runs it** — rather than by what its comment says — split them three ways:
+
+| | Count | |
+|---|---|---|
+| Dead: skipping costs nothing on any machine | 7 | deleted |
+| Correcting, probed converged on the only OS they run on | 2 | deleted |
+| Correcting, unverifiable or actively broken | 2 | **kept** |
+
+The two that stayed are the point:
+
+- **HIVE-118** (stale `uvx hive-vault` MCP entry) is correcting and has a Windows
+  twin. Skipping it leaves the `hive` MCP pinned to a retired definition that the
+  surrounding skip-if-present loop will then never replace. Probed clean on
+  Linux; the Windows box cannot be probed from here, so it stays.
+- **MEM-002** (claude-mem retirement) **had never worked**. It strips a
+  `settings.json` key Claude Code stopped writing; the registry moved to
+  `plugins/known_marketplaces.json`, which no code in the repo mentions. The
+  `rm -rf` runs, the marketplace re-clones on the next session, forever. Filed as
+  #1431.
+
+A twelfth block, the `GEMINI.md` removal, turned out to be deleting a live
+harness deploy target — lesson 256.
+
+So of eleven "finished one-time migrations", **one had never functioned, one
+could not be shown to have converged, and one was actively destroying a file the
+harness deploys.** The ticket's framing — delete ~200 lines of finished work —
+would have shipped all three outcomes as a cleanup.
+
+## Why the missing expiry is the root cause
+
+Without a removal date, every reader has to re-derive convergence from scratch,
+and the cheapest derivation is reading the comment — which is exactly the step
+that fails (lesson 256). The blocks are also *cheap to keep*: each is a guarded
+no-op on a converged machine, so nothing ever pressures anyone to check. They
+accrete until someone opens a debt ticket, at which point the accumulated
+verification cost lands in one PR, on someone with no memory of why any of them
+was written.
+
+An expiry converts an unbounded question ("has every machine that will ever run
+this already run it?") into a bounded one ("has the date passed?").
+
+## What to do instead
+
+**When you write a one-time migration, write when it dies.** A comment is
+enough; the mechanism is the discipline, not the tooling:
+
+```sh
+# EXPIRES: 2026-12-01 (OPS-040) - converge machines off X; delete after this
+# date once `dotf doctor` reports no machine still needing it.
+```
+
+Two things make the date honest rather than decorative:
+
+- **Name what "converged" means, checkable from a machine.** "Delete after
+  2026-12-01" is a guess; "delete once `crontab -l` shows no matching line on
+  every box" is a probe someone can actually run — and running it is what caught
+  MEM-002.
+- **Classify by skip-cost when you write it, not when you delete it.** "Skipping
+  this leaves harmless cruft" and "skipping this leaves the MCP entry broken" are
+  different lifetimes, and only the author knows which one it is.
+
+Deliberately not built here: a `# EXPIRES:` CI check. The convention costs a
+comment; enforcing it is construction, and the repo caps meta-work while opened
+tickets outnumber closed ones. Proposed to the owner as a decision instead.
+
+## Related
+
+- #1333 — this purge; #1431 — the block that never converged
+- Lesson 256 — the block's own description of what it deletes is not evidence
+- Lesson 247 — a pointer into a deletable location keeps every check green until
+  the deletion, and then the cleanup gets blamed

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -279,22 +279,6 @@ else
     log_warning "scripts/install-dotf.sh not found; skipping dotf install"
 fi
 
-# Deploy-time secret for the agy MCP config: agy does NOT expand env vars inside
-# JSON, so OPENROUTER_API_KEY must be baked into mcp_config.json at deploy. The
-# agy block below reads it from the environment; fetch it via the `dotf secrets`
-# facade (ADR-028) now that dotf + the registry/store are deployed above, into
-# THIS one-shot setup process only -- never the user's interactive shell (that
-# export was retired in #581). opencode/pi `{env:NAN_API_KEY}` is resolved
-# independently by `dotf secrets render` at deploy time (and opencode/pi's own
-# runtime resolver as fallback), which age-decrypt directly.
-if command -v dotf >/dev/null 2>&1; then
-    if ! OPENROUTER_API_KEY="$(dotf secrets show OPENROUTER_API_KEY 2>&1)"; then
-        log_warning "dotf secrets show OPENROUTER_API_KEY failed: $OPENROUTER_API_KEY"
-        OPENROUTER_API_KEY=""
-    fi
-    export OPENROUTER_API_KEY
-fi
-
 # Catalog tools (CLI-029): download + checksum-verify the declarative packages.json
 # tools (currently sops) into ~/.local/bin via dotf — the same deterministic pattern
 # as install_dotf, driven by data instead of a per-OS install block. Best-effort:
@@ -387,14 +371,13 @@ fi
 log_info "Setting up Antigravity CLI configuration..."
 export GEMINI_HOME="$HOME/.gemini"
 export AGY_APP_DATA="$GEMINI_HOME/antigravity-cli"
-# NOTE: ANTIGRAVITY_ENDPOINT / CLOUDCODE_URL kept for backward compat. Empirical
-# finding (cli log 2026-05-25): agy 1.0.2 issues `loadCodeAssist` and
-# `fetchAvailableModels` calls to `daily-cloudcode-pa.googleapis.com` regardless
-# of these env vars — appears to be hardcoded metadata-plane routing. The chat
-# completion itself goes through a separate gRPC channel whose endpoint is not
-# clearly env-overridable. Setting these has no observed effect on routing.
-export ANTIGRAVITY_ENDPOINT="https://cloudcode-pa.googleapis.com"
-export CLOUDCODE_URL="https://cloudcode-pa.googleapis.com"
+# ANTIGRAVITY_ENDPOINT / CLOUDCODE_URL were exported here until OPS-040, kept
+# "for backward compat" against an empirical finding that already said they did
+# nothing (cli log 2026-05-25): agy 1.0.2 issues `loadCodeAssist` and
+# `fetchAvailableModels` to `daily-cloudcode-pa.googleapis.com` regardless of
+# them — hardcoded metadata-plane routing — and the chat completion goes through
+# a separate gRPC channel whose endpoint is not env-overridable. Two exports
+# whose own comment recorded that they had no observed effect.
 
 ensure_directory "$GEMINI_HOME"
 ensure_directory "$GEMINI_HOME/config"
@@ -479,12 +462,6 @@ fi
 [ -d "$CURRENT_DIR/.antigravitycli.bak" ] && rm -rf "$CURRENT_DIR/.antigravitycli.bak"
 rm -f "$GEMINI_HOME/config/.migrated" 2>/dev/null
 
-# SDD-007 one-time migration: drop orphan master at the pre-SDD-007 path
-# (~/.gemini/mcp_config.json). Canonical path is now ~/.gemini/config/mcp_config.json.
-if [ -f "$GEMINI_HOME/mcp_config.json" ] && [ ! -L "$GEMINI_HOME/mcp_config.json" ]; then
-    log_info "Removing orphan master from pre-SDD-007 path: $GEMINI_HOME/mcp_config.json"
-    rm -f "$GEMINI_HOME/mcp_config.json"
-fi
 # Drop the old AGY_APP_DATA symlink/copy of mcp_config.json (replaced by canonical path)
 [ -e "$AGY_APP_DATA/mcp_config.json" ] && rm -f "$AGY_APP_DATA/mcp_config.json"
 
@@ -495,14 +472,6 @@ fi
 # skill's targets[]. The single --deploy call near the end of this script does
 # this for every agent at once; no per-agent skill loop here.
 ensure_directory "$HOME/.gemini/skills"
-
-# SDD-007 one-time migration: gemini-cli -> agy. Remove the legacy
-# ~/.gemini/GEMINI.md identity file so it doesn't linger as an orphan
-# pointing to the retired binary. Safe to repeat (no-op if absent).
-if [ -f "$GEMINI_HOME/GEMINI.md" ]; then
-    rm -f "$GEMINI_HOME/GEMINI.md"
-    log_info "Removed legacy GEMINI.md (SDD-007 migration: agy replaces gemini-cli)"
-fi
 
 # Force copy master files (Neural Hive Protocol)
 rm -f "$GEMINI_HOME/AGY.md"
@@ -589,9 +558,6 @@ for _claude_src in "$CURRENT_DIR/ai/claude/"*; do
     cp -rf "$_claude_src" "$HOME/.claude/" 2>/dev/null || true
 done
 unset _claude_src
-# CLI-014: init-project.sh was retired (repo scaffolding is now `dotf init`).
-# Remove any copy a prior setup left in ~/.claude so it doesn't linger as an orphan.
-rm -f "$HOME/.claude/init-project.sh"
 # Claude skills are deployed from the vault skill records by
 # `compile-harness.sh --deploy` (SDD-008): each committed record under
 # harness/skills/ is rendered (with provenance) to ~/.claude/skills/<n>/,
@@ -637,14 +603,6 @@ if ! command -v poetry >/dev/null 2>&1; then
     fi
 else
     log_info "poetry already installed"
-fi
-
-# Create convenience symlinks for versioned-only binaries
-PYTHON_DIR=$(ls -d "$HOME/Applications"/python-* 2>/dev/null | sort -V | tail -1) || true
-if [ -n "$PYTHON_DIR" ] && [ -d "$PYTHON_DIR/bin" ] && [ ! -e "$PYTHON_DIR/bin/python" ]; then
-    log_info "Creating python symlink..."
-    ln -s python3 "$PYTHON_DIR/bin/python"
-    log_success "python -> python3 symlink created"
 fi
 
 # Claude Code (primary AI coding agent — see ADR-009)
@@ -974,15 +932,9 @@ fi
 # packages.json); this block only deploys config when the binary is on PATH.
 # Verification string set by AI-013 (pointer-style copilot-instructions.md).
 #
-# Cleanup (idempotent): the previous setup added 'eval "$(gh copilot alias -- bash)"'
-# to .zshrc/.bashrc. That subcommand does not exist in the new standalone CLI, so
-# the line errors silently on every shell startup. Strip it if present.
-for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
-    if [ -f "$rc" ] && grep -qF 'eval "$(gh copilot alias -- bash)"' "$rc"; then
-        sed -i '/eval "$(gh copilot alias -- bash)"/d' "$rc"
-        log_info "Removed stale gh-copilot eval line from $rc"
-    fi
-done
+# A loop stripping a stale 'eval "$(gh copilot alias -- bash)"' line from
+# .zshrc/.bashrc lived here until OPS-040. Probed absent from both files on the
+# only OS it ran on before removal.
 
 if command -v copilot >/dev/null 2>&1; then
     log_info "GitHub Copilot CLI detected, deploying configuration..."
@@ -1209,13 +1161,9 @@ if command -v hive >/dev/null 2>&1 && [ -n "$hive_ver" ] \
             systemctl --user daemon-reload >/dev/null 2>&1 || true
             if systemctl --user enable --now hive-upgrade.timer >/dev/null 2>&1; then
                 log_success "Enabled hive-upgrade.timer (every 15 min, systemd --user)"
-                # Single owner: retire the legacy manual cron now the timer owns
-                # the upgrade policy (only after a successful enable).
-                if crontab -l 2>/dev/null | grep -q 'uv tool upgrade hive-vault'; then
-                    if crontab -l 2>/dev/null | grep -v 'uv tool upgrade hive-vault' | crontab -; then
-                        log_info "Removed legacy 'uv tool upgrade hive-vault' cron (timer is now the single owner)"
-                    fi
-                fi
+                # A removal of the legacy 'uv tool upgrade hive-vault' crontab
+                # line ran here until OPS-040, retiring it once the timer owned
+                # upgrade policy. Probed absent from `crontab -l` before removal.
             else
                 log_warning "hive-upgrade.timer enable failed (non-fatal; setup still upgrades hive each run)"
             fi

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -686,21 +686,6 @@ if (Test-Path -LiteralPath $registrySource) {
     Write-Warn "secrets/registry.yaml not found at $registrySource"
 }
 
-# Deploy-time secret for the agy MCP config: agy does NOT expand env vars inside
-# JSON, so OPENROUTER_API_KEY must be baked into mcp_config.json at deploy. The
-# agy block below reads it from $env; fetch it via the `dotf secrets` facade
-# (ADR-028) now that dotf + the registry/store are in place, into THIS one-shot
-# setup process only -- never the user's session (that export was retired in
-# #581). opencode/pi {env:NAN_API_KEY} is resolved independently by
-# `dotf secrets render` at deploy time (and their own runtime resolver as fallback).
-if (Get-Command dotf -ErrorAction SilentlyContinue) {
-    $env:OPENROUTER_API_KEY = (& dotf secrets show OPENROUTER_API_KEY 2>&1 | Out-String).Trim()
-    if ($LASTEXITCODE -ne 0) {
-        Write-Warn "dotf secrets show OPENROUTER_API_KEY failed: $env:OPENROUTER_API_KEY"
-        $env:OPENROUTER_API_KEY = ""
-    }
-}
-
 # Catalog tools (CLI-029): download + checksum-verify the declarative packages.json
 # tools (currently sops) into ~/.local/bin via dotf - the same deterministic pattern
 # as Install-Dotf, driven by data instead of a per-OS winget loop. Best-effort: an
@@ -1061,29 +1046,12 @@ if (-not $poetryCmd) {
     Write-Info "poetry already installed"
 }
 
-# Install Bun (JS runtime used by some Claude Code plugin workers for bun:sqlite)
-$bunCmd = Get-Command bun -ErrorAction SilentlyContinue
-if (-not $bunCmd) {
-    Write-Info "Installing Bun..."
-    try {
-        $bunInstaller = Join-Path $env:TEMP "bun-install.ps1"
-        Invoke-RestMethod https://bun.sh/install.ps1 -OutFile $bunInstaller
-        & (Get-Process -Id $PID).Path -NoProfile -ExecutionPolicy Bypass -File $bunInstaller 2>$null
-        Remove-Item -Path $bunInstaller -Force -ErrorAction SilentlyContinue
-        # Refresh PATH for current session
-        $env:PATH = "$env:USERPROFILE\.bun\bin;$env:PATH"
-        $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
-        if ($bunCmd) {
-            Write-Success "Bun installed"
-        } else {
-            Write-Warn "Bun installation failed"
-        }
-    } catch {
-        Write-Warn "Failed to install Bun: $_"
-    }
-} else {
-    Write-Info "Bun already installed"
-}
+# Bun was installed here until OPS-040, for "some Claude Code plugin workers for
+# bun:sqlite" -- the conversation-memory plugin worker MEM-002 retired on
+# 2026-06-23. No code in this repository invokes bun, bunx or bun run, so setup
+# no longer installs a runtime nothing here uses. The shell rc files keep their
+# BUN_INSTALL PATH export: a bun the user installed themselves stays reachable,
+# setup just stops providing one.
 
 # What the rest of setup will see. The npm-driven pi block below skips silently
 # when npm is missing (obsidian and yarn moved to packages.json, OPS-042); naming the state here
@@ -1395,12 +1363,13 @@ Ensure-Directory "$GeminiHome\prompts"
 $AgyAppData = Join-Path $GeminiHome "antigravity-cli"
 Ensure-Directory $AgyAppData
 
-# Force production endpoint
-[Environment]::SetEnvironmentVariable("ANTIGRAVITY_ENDPOINT", "https://cloudcode-pa.googleapis.com", "User")
-[Environment]::SetEnvironmentVariable("CLOUDCODE_URL", "https://cloudcode-pa.googleapis.com", "User")
+# agy reads GEMINI_DIR; set it for this session and persist it for later ones.
+# ANTIGRAVITY_ENDPOINT / CLOUDCODE_URL were set here too until OPS-040. They had
+# no observed effect on routing -- agy issues its metadata-plane calls to a
+# hardcoded host regardless -- so setup no longer sets them. Values a previous
+# run persisted to the user environment stay behind, inert; scrubbing them would
+# mean adding the kind of one-time migration OPS-040 exists to remove.
 [Environment]::SetEnvironmentVariable("GEMINI_DIR", "$GeminiHome", "User")
-$env:ANTIGRAVITY_ENDPOINT = "https://cloudcode-pa.googleapis.com"
-$env:CLOUDCODE_URL = "https://cloudcode-pa.googleapis.com"
 $env:GEMINI_DIR = "$GeminiHome"
 
 # 1. agy settings.json is a `dotf deploy` entry (ai/deploy.json `agy-settings`,
@@ -1486,15 +1455,6 @@ $projAgyCli = Join-Path $DotfilesDir ".antigravitycli"
 $projAgyBak = Join-Path $DotfilesDir ".antigravitycli.bak"
 if (Test-Path $projAgyCli) { Remove-Item -Recurse -Force $projAgyCli -ErrorAction SilentlyContinue }
 if (Test-Path $projAgyBak) { Remove-Item -Recurse -Force $projAgyBak -ErrorAction SilentlyContinue }
-
-# SDD-007 one-time migration: gemini-cli -> agy. Remove the legacy
-# ~/.gemini/GEMINI.md identity file so it doesn't linger as an orphan
-# pointing to the retired binary. Safe to repeat (no-op if absent).
-$geminiMdLegacy = Join-Path $GeminiHome 'GEMINI.md'
-if (Test-Path $geminiMdLegacy) {
-    Remove-Item -LiteralPath $geminiMdLegacy -Force -ErrorAction SilentlyContinue
-    Write-Info "Removed legacy GEMINI.md (SDD-007 migration: agy replaces gemini-cli)"
-}
 
 # Deploy AGY.md (Neural Hive Protocol pointer to AGENTS.md). Linux-parity.
 $agyMdSource = Join-Path $DotfilesDir 'ai\agy\AGY.md'
@@ -1684,7 +1644,11 @@ Write-Info "Deploying scripts..."
 
 # CLI-020: the init .ps1 were retired (repo scaffolding is now `dotf init`).
 # Remove any copy a prior setup left in ~/scripts or ~/.claude so they don't
-# linger as orphans (mirrors setup-linux.sh's init-project.sh cleanup, CLI-014).
+# linger as orphans. The Linux twin (CLI-014, one `rm -f` of init-project.sh)
+# was deleted by OPS-040 after probing its target absent on msi; this one stays
+# because the WIN-013 note below records leftovers of exactly this kind measured
+# still present on a real Windows box on 2026-08-27, and that box cannot be
+# probed from the Linux session that would delete it.
 foreach ($initOrphan in @(
         "$ScriptsDir\init-project.ps1", "$ClaudeHome\init-project.ps1",
         "$ScriptsDir\init-repo-agents.ps1", "$ClaudeHome\init-repo-agents.ps1",

--- a/specs/OPS-040-dead-migration-purge/features.json
+++ b/specs/OPS-040-dead-migration-purge/features.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "OPS-040-dead-migration-purge-f1",
+    "behavior": "Neither setup script resolves a deploy-time secret for agy; the OPENROUTER_API_KEY export is gone from both",
+    "verification": "bats tests/setup-windows.bats -f 'neither setup resolves a deploy-time secret'",
+    "state": "verified",
+    "evidence": "bats: ok 1 parity: neither setup resolves a deploy-time secret for agy [#587, OPS-040]"
+  },
+  {
+    "id": "OPS-040-dead-migration-purge-f2",
+    "behavior": "Blocks 2-7 are absent from both setup scripts (endpoint exports, pre-SDD-007 mcp_config, legacy GEMINI.md, init-project.sh orphan, python symlink, Bun installer)",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && for p in 'export ANTIGRAVITY_ENDPOINT=' 'export CLOUDCODE_URL=' 'SetEnvironmentVariable(\"ANTIGRAVITY_ENDPOINT\"' 'SetEnvironmentVariable(\"CLOUDCODE_URL\"' 'Removing orphan master from pre-SDD-007 path' 'Removed legacy GEMINI.md' 'rm -f \"$HOME/.claude/init-project.sh\"' 'Creating python symlink' '-OutFile $bunInstaller'; do if grep -qF -- \"$p\" setup-linux.sh setup-windows.ps1; then echo \"STILL PRESENT: $p\"; exit 1; fi; done; echo OK",
+    "state": "verified",
+    "evidence": "loop over the nine executable forms -> OK (no match in either script)"
+  },
+  {
+    "id": "OPS-040-dead-migration-purge-f3",
+    "behavior": "Blocks 8 and 9 are absent from setup-linux.sh (gh-copilot alias strip, legacy hive-vault crontab removal)",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && for p in 'Removed stale gh-copilot eval line from' 'grep -v '\\''uv tool upgrade hive-vault'\\'' | crontab -'; do if grep -qF -- \"$p\" setup-linux.sh; then echo \"STILL PRESENT: $p\"; exit 1; fi; done; echo OK",
+    "state": "verified",
+    "evidence": "loop over the two executable forms -> OK (no match in setup-linux.sh)"
+  },
+  {
+    "id": "OPS-040-dead-migration-purge-f4",
+    "behavior": "The HIVE-118 and MEM-002 blocks are untouched relative to main, and the shell rc BUN_INSTALL exports are retained",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && bats tests/guard-no-claude-mem.bats && grep -qF 'HIVE-118: migrate a stale' setup-linux.sh && grep -qF 'BUN_INSTALL' .zshrc && grep -qF 'BUN_INSTALL' .bashrc && echo OK",
+    "state": "verified",
+    "evidence": "guard-no-claude-mem.bats 3/3 ok incl. 'the MEM-002 cleanup block IS present in both setup scripts'; HIVE-118 comment and both rc BUN_INSTALL exports present"
+  },
+  {
+    "id": "OPS-040-dead-migration-purge-f5",
+    "behavior": "secrets-show-callsites reports a SKIP naming its reason when no call site exists, rather than a vacuous pass",
+    "verification": "bats tests/secrets-show-callsites.bats | grep -q '# skip no .dotf secrets show'",
+    "state": "verified",
+    "evidence": "ok 1 ... # skip no 'dotf secrets show <id>' call sites in the tree - nothing to resolve (the shell/ps1 sweep found none)"
+  },
+  {
+    "id": "OPS-040-dead-migration-purge-f6",
+    "behavior": "The full bats suite shows no failure beyond the seven that are already red on main, and setup-linux.sh stays shellcheck-clean at warning severity",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && bash -n setup-linux.sh && shellcheck -S warning setup-linux.sh && bats tests/*.bats",
+    "state": "verified",
+    "evidence": "bash -n clean; shellcheck -S warning clean (info findings 19 on main -> 16 here); bats tests/*.bats ok=1526 not_ok=7 skipped=76, and all 7 are red on clean main (6 install-dotf fixture leakage + BUG-771/#1409)"
+  },
+  {
+    "id": "OPS-040-dead-migration-purge-f7",
+    "behavior": "A guard refuses any removal in either setup script naming a file the harness manifest declares a doctrine deploy target, resolving the list from the manifest",
+    "verification": "bats tests/guard-doctrine-target-not-deleted.bats",
+    "state": "verified",
+    "evidence": "bats 2/2 ok; fail-first proven red against main's scripts at setup-linux.sh:503"
+  },
+  {
+    "id": "OPS-040-dead-migration-purge-f8",
+    "behavior": "Both lessons are written and indexed",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && test -f docs/lessons/lesson-256-a-cleanup-blocks-own-description-of-what-it-deletes.md && test -f docs/lessons/lesson-257-a-one-time-migration-with-no-removal-date-is.md && grep -q 'lesson-256' docs/lessons/_index.md && grep -q 'lesson-257' docs/lessons/_index.md && echo OK",
+    "state": "verified",
+    "evidence": "both lesson files present and indexed in docs/lessons/_index.md"
+  }
+]

--- a/specs/OPS-040-dead-migration-purge/proposal.md
+++ b/specs/OPS-040-dead-migration-purge/proposal.md
@@ -29,7 +29,7 @@ Nine blocks leave both setup scripts. Two stay, each for a stated reason. After 
 | # | Block | Location | Why it is dead |
 |---|---|---|---|
 | 1 | `OPENROUTER_API_KEY` deploy-time export | `setup-linux.sh:282-296`, `setup-windows.ps1:690-701` | Fetched for the agy `mcp_config` cascade that CLI-042 AC8 removed. Zero readers remain: the only other repo mentions are two comments recording that the cascade is gone, and the interactive `opencode`/`pi` wrappers in `.bashrc:113-114` / `powershell/profile.ps1:297-298` resolve it independently through `dotf secrets run`. Removing it stops a decryption on every setup run. |
-| 2 | `ANTIGRAVITY_ENDPOINT` / `CLOUDCODE_URL` exports | `setup-linux.sh:390-397`, `setup-windows.ps1:1413-1418` | The block's own comment records the empirical finding: *"Setting these has no observed effect on routing"* — agy routes to a hardcoded metadata plane regardless. |
+| 2 | `ANTIGRAVITY_ENDPOINT` / `CLOUDCODE_URL` exports | `setup-linux.sh:390-397`, `setup-windows.ps1:1413-1418` | Dead **within setup**, which is all these lines reached. See the note below — they are not dead repo-wide, and nothing about the user's environment changes. |
 | 3 | SDD-007 orphan `mcp_config.json` removal | `setup-linux.sh:482-489` | Deletes a file at the pre-SDD-007 path. agy reads the canonical path; the orphan is inert. |
 | 4 | SDD-007 legacy `GEMINI.md` removal | `setup-linux.sh:500-505`, `setup-windows.ps1:1490-1497` | **Not dead — actively wrong. See below.** |
 | 5 | CLI-014 orphan `init-project.sh` removal | `setup-linux.sh:592-594` | Deletes a script retired in favour of `dotf init`. Nothing invokes it. |
@@ -49,6 +49,16 @@ Nine blocks leave both setup scripts. Two stay, each for a stated reason. After 
 |---|---|---|---|
 | 10 | HIVE-118 stale `uvx hive-vault` MCP entry | `setup-linux.sh:1073-1082`, `setup-windows.ps1:563` | Correcting, and it has a Windows twin. Skipping it leaves the `hive` MCP entry pinned to the retired `uvx` definition, and because the surrounding loop is skip-if-present, the current `hive client` definition is never re-added. Probed absent on msi; **the Windows box cannot be probed from here**, so it is deferred to the batched Windows session rather than deleted on one OS's evidence. |
 | 11 | MEM-002 claude-mem retirement | `setup-linux.sh:1305-1337`, `setup-windows.ps1:894-935` | **It has never worked.** Filed as #1431. Untouched here — the whole block, not part of it. |
+
+### Block 2 is dead inside setup only, and `.zshrc` is where the value actually comes from
+
+Stated carefully, because a first pass got it wrong by grepping only the two setup scripts. `ANTIGRAVITY_ENDPOINT` / `CLOUDCODE_URL` have three homes, and only one of them is deleted here:
+
+- **`setup-linux.sh` / `setup-windows.ps1`** — an `export` into the setup process. Nothing later in either script reads it; on Linux it cannot outlive the process. **Deleted.** On Windows the same block also wrote them to the user environment, which is the part that leaves values behind (see Out of scope).
+- **`.zshrc:42-43`** — the live source. Every interactive zsh exports them, which is why they are set in a running shell despite setup having no lasting effect. **Untouched**, and `tests/antigravity.bats:84` still pins it. (`.bashrc` does not export them — a parity gap that predates this change and is not in scope.)
+- **`cli/internal/doctor/checks_deploy.go:801`** — `dotf doctor` reads the variable, but as `sys.env("ANTIGRAVITY_ENDPOINT", "https://cloudcode-pa.googleapis.com")`, i.e. **defaulting to production when unset**, inside a section that SKIPs entirely when `agy` is not on PATH. So the check passes identically before and after.
+
+The block's own comment — *"Setting these has no observed effect on routing"* — is a statement about **agy's behaviour**, not about whether anything reads the variables. Something does. The deletion is still right, and it is a no-op for both the user's shell and `dotf doctor`; the reason is narrower than "these are inert".
 
 ### Block 4 is a defect, and removing it is the fix
 

--- a/specs/OPS-040-dead-migration-purge/proposal.md
+++ b/specs/OPS-040-dead-migration-purge/proposal.md
@@ -1,0 +1,95 @@
+---
+id: "OPS-040-dead-migration-purge"
+type: spec
+status: verifying # draft | implementing | verifying | archived
+created: "2026-09-01"
+issue: "mlorentedev/dotfiles#1333"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# OPS-040-dead-migration-purge
+
+> **Naming**: file lives at `<repo>/specs/OPS-040-dead-migration-purge/proposal.md`. `OPS-040-dead-migration-purge` is `AREA-NNN-slug`.
+
+## Why
+
+<!-- from issue #1333: OPS-040: dead-migration purge in both setups - converge-old-machines code with no expiry, plus a secret decrypted for nothing on every run -->
+
+Both setup scripts carry one-time migration blocks written to converge machines off a retired arrangement, none of which records when it may be removed. They accumulate: every reader must work out whether a block is still load-bearing, and the answer is not in the code. One of them decrypts a credential on every run for a consumer that no longer exists.
+
+The ticket proposes deleting roughly 200 lines as finished work. **Measurement does not support that framing, and this spec exists to replace it with a per-block one.** A block is safe to delete only when skipping it costs nothing on an unconverged machine, so each was classified by what breaks if it never runs, and the conditions the correcting ones test were probed on this box. Three of the four correcting blocks are converged on Linux. The fourth has never worked at all.
+
+## What
+
+Nine blocks leave both setup scripts. Two stay, each for a stated reason. After this change, `setup-linux.sh` and `setup-windows.ps1` no longer decrypt a credential nobody reads, no longer install a runtime for a retired consumer, and no longer carry cleanup for paths that stopped existing.
+
+**Deleted — dead code (skipping costs nothing on any machine, converged or not):**
+
+| # | Block | Location | Why it is dead |
+|---|---|---|---|
+| 1 | `OPENROUTER_API_KEY` deploy-time export | `setup-linux.sh:282-296`, `setup-windows.ps1:690-701` | Fetched for the agy `mcp_config` cascade that CLI-042 AC8 removed. Zero readers remain: the only other repo mentions are two comments recording that the cascade is gone, and the interactive `opencode`/`pi` wrappers in `.bashrc:113-114` / `powershell/profile.ps1:297-298` resolve it independently through `dotf secrets run`. Removing it stops a decryption on every setup run. |
+| 2 | `ANTIGRAVITY_ENDPOINT` / `CLOUDCODE_URL` exports | `setup-linux.sh:390-397`, `setup-windows.ps1:1413-1418` | The block's own comment records the empirical finding: *"Setting these has no observed effect on routing"* — agy routes to a hardcoded metadata plane regardless. |
+| 3 | SDD-007 orphan `mcp_config.json` removal | `setup-linux.sh:482-489` | Deletes a file at the pre-SDD-007 path. agy reads the canonical path; the orphan is inert. |
+| 4 | SDD-007 legacy `GEMINI.md` removal | `setup-linux.sh:500-505`, `setup-windows.ps1:1490-1497` | **Not dead — actively wrong. See below.** |
+| 5 | CLI-014 orphan `init-project.sh` removal | `setup-linux.sh:592-594` | Deletes a script retired in favour of `dotf init`. Nothing invokes it. |
+| 6 | `python` → `python3` convenience symlink | `setup-linux.sh:642-648` | Not a migration — a symlink inside `~/Applications/python-*/bin`. Nothing in either script installs to `~/Applications` any more, so the glob matches nothing and the block has been a no-op since that install path was dropped. |
+| 7 | Bun installer | `setup-windows.ps1:1064-1086` | Installed for *"some Claude Code plugin workers for bun:sqlite"* — the claude-mem worker, retired 2026-06-23. No repo code invokes `bun`, `bunx` or `bun run`. |
+
+**Deleted — correcting, and probed converged on the only OS that runs them:**
+
+| # | Block | Location | Probe result |
+|---|---|---|---|
+| 8 | gh-copilot stale `eval` line strip | `setup-linux.sh:977-984` | Strips `eval "$(gh copilot alias -- bash)"`, which errors on every shell startup when present. Absent from both `~/.zshrc` and `~/.bashrc` on msi. Linux-only; no Windows twin. |
+| 9 | Legacy `uv tool upgrade hive-vault` cron removal | `setup-linux.sh:1212-1219` | Retires the manual cron now `hive-upgrade.timer` owns upgrade policy. Absent from `crontab -l` on msi. Linux-only by construction (crontab). |
+
+**Kept, with the reason stated in the code:**
+
+| # | Block | Location | Why it stays |
+|---|---|---|---|
+| 10 | HIVE-118 stale `uvx hive-vault` MCP entry | `setup-linux.sh:1073-1082`, `setup-windows.ps1:563` | Correcting, and it has a Windows twin. Skipping it leaves the `hive` MCP entry pinned to the retired `uvx` definition, and because the surrounding loop is skip-if-present, the current `hive client` definition is never re-added. Probed absent on msi; **the Windows box cannot be probed from here**, so it is deferred to the batched Windows session rather than deleted on one OS's evidence. |
+| 11 | MEM-002 claude-mem retirement | `setup-linux.sh:1305-1337`, `setup-windows.ps1:894-935` | **It has never worked.** Filed as #1431. Untouched here — the whole block, not part of it. |
+
+### Block 4 is a defect, and removing it is the fix
+
+Probing the deleted blocks' targets on msi turned up `~/.gemini/GEMINI.md` **present, 12029 bytes, generated doctrine with a harness `sha256:` marker**. It is not an orphan of the retired `gemini-cli`. `harness/manifest.json:151` declares it as agy's live doctrine deploy target, and records why: *"Antigravity reads global rules from `~/.gemini/GEMINI.md`… The file is shared with Gemini CLI, so injection is append-and-replace-in-place, never an overwrite."* `tests/compile-harness.bats:808-814` asserts precisely that a user's own rules in that file survive a deploy.
+
+Both setup scripts `rm -f`'d it on every run, describing it as a legacy orphan. A file cannot be both a deploy target with an append-in-place contract and something setup deletes. Only ordering hid the conflict — setup removed it early, `compile-harness.sh --deploy` rewrote it near the end — so the destruction was invisible unless a run stopped in between, the deploy was skipped, or the order changed. The append-in-place contract exists to protect user content in that file, and the `rm -f` defeated it on every single run.
+
+So block 4 is deleted as a **fix**, and it carries a guard: `tests/guard-doctrine-target-not-deleted.bats` reads `.doctrine.deploy[]` from the manifest and refuses any removal naming a declared target in either setup script. It reads the manifest rather than hardcoding `GEMINI.md` so a target declared later is covered the day it is declared. Verified fail-first: red against `main`'s scripts at `setup-linux.sh:503`, green on this tree.
+
+**Shell rc `BUN_INSTALL` exports are also kept** (`.zshrc:130-135`, `.bashrc:152-154`), which the ticket lists for deletion. `bun` is installed on msi at `~/.bun/bin/bun`; deleting the `PATH` export removes a working binary from the user's interactive shell for no benefit. "Zero consumers in the repo" is not "zero consumers on the machine". Setup stops *installing* bun; the shell keeps *finding* the one that is there.
+
+## Out of scope
+
+- **MEM-002 (#1431).** Measured during this spec: `~/.claude/plugins/marketplaces/thedotmack` is a live clone of `thedotmack/claude-mem` re-fetched an hour before measurement, because Claude Code moved the marketplace registry to `~/.claude/plugins/known_marketplaces.json` (`autoUpdate: true`) while the block still strips `settings.json`'s `extraKnownMarketplaces` key — which no longer exists. The `rm -rf` runs, Claude re-clones, forever. Fixing it means choosing between a `claude plugin marketplace remove` subcommand that may or may not exist and hand-editing a state file this repo has never touched, plus a Windows leg. That is new behaviour, unverified on either OS, and it does not belong in a PR whose thesis is "delete code proven dead".
+- **HIVE-118**, deferred to the Windows session for the reason in the table above.
+- **A `# EXPIRES:` convention or a CI check enforcing it.** The lesson is written; the machinery is not built. Proposed to the owner in the PR body as a decision, not landed unasked — and adding an expiry-less migration inside the PR whose lesson is "migrations carry an expiry" would refute itself.
+- **Scrubbing the Windows registry values** that `ANTIGRAVITY_ENDPOINT` / `CLOUDCODE_URL` persisted. Removing them needs a new one-time migration, which is the thing this spec is deleting. They linger inert — "no observed effect" is the block's own measurement. Same owner decision as above.
+- **#1337** (OPS-043, the duplicated doctor checks). Separate concern, separate PR.
+
+## Risks / open questions
+
+- **Convergence is probed on one machine, not proven on both.** msi is clean for every correcting block deleted here, and both are Linux-only surfaces (`~/.zshrc`/`~/.bashrc`, `crontab`), so msi is the only machine they could ever have run on. Every cross-platform block deleted is dead code, whose deletion is safe on an unconverged machine by definition. RESOLVED by that split: nothing deleted here depends on the Windows box having converged.
+- **`secrets-show-callsites.bats` goes vacuous.** Blocks 1 removes the only two real `dotf secrets show` call sites (`setup-linux.sh:291`, `setup-windows.ps1:697`); the four remaining grep hits are log strings and prose. Its loop would then iterate an empty list and report a pass having checked nothing. RESOLVED: the guard learns to SKIP with its reason when it finds no call sites, per C15 — a check that cannot answer must not pass.
+- **`tests/setup-windows.bats:993` pins the Bun installer** alongside the uv installer (both must run in a child pwsh, TEST-003). RESOLVED: narrow the assertion to uv; the invariant it protects is about child-pwsh execution, not about Bun specifically.
+- **Unknown breakage in the other marker-referencing suites** (`setup-linux.bats`, `iac-deploy.bats`, `antigravity.bats`). Not resolvable by reading; resolved empirically by running bats after the deletion and fixing only what breaks.
+
+## Acceptance criteria
+
+- [ ] AC1 — Neither setup script contains a `dotf secrets show OPENROUTER_API_KEY` call site, and no repository code exports `OPENROUTER_API_KEY` into the setup process.
+- [ ] AC2 — Blocks 2 through 7 are absent from both setup scripts: no `ANTIGRAVITY_ENDPOINT`/`CLOUDCODE_URL` export, no pre-SDD-007 `mcp_config.json` or legacy `GEMINI.md` removal, no `init-project.sh` orphan removal, no `~/Applications` python symlink, no Bun installer.
+- [ ] AC3 — Blocks 8 and 9 are absent from `setup-linux.sh`: no `gh copilot alias` strip loop, no `uv tool upgrade hive-vault` crontab removal.
+- [ ] AC4 — The HIVE-118 and MEM-002 blocks are byte-identical to `main` in both scripts, and `.zshrc`/`.bashrc` retain their `BUN_INSTALL` exports.
+- [ ] AC5 — `secrets-show-callsites.bats` reports a SKIP naming the reason when no `dotf secrets show` call site exists, rather than a pass, and still fails on a call site referencing an unknown registry id.
+- [ ] AC6 — `bats tests/*.bats` passes under both bash and zsh, and `bash -n` / `shellcheck` are clean on `setup-linux.sh`; PSScriptAnalyzer is clean on `setup-windows.ps1`.
+- [ ] AC7 — `tests/guard-doctrine-target-not-deleted.bats` fails when either setup script contains a removal naming a file declared in `harness/manifest.json` `.doctrine.deploy[]`, resolves its target list from that manifest rather than a hardcoded name, and SKIPs with a reason when the manifest yields no targets.
+- [ ] AC8 — `docs/lessons/` records the lessons this turned up: that a one-time migration without a removal date is indistinguishable from live code; that a cleanup block's own description of what it deletes is not evidence (block 4 called a live deploy target a legacy orphan); and that MEM-002 asserted against a proxy rather than the end-state — the same class archived spec `BUG-014-claude-mem-marketplace-register` had already recorded one cycle earlier.
+
+## References
+
+- Bitácora board: mlorentedev/dotfiles#1333.
+- Spun out of this spec: #1431 (MEM-002 never converged), and the deferred HIVE-118 Windows leg.
+- Sibling debt ticket, deliberately not folded in: #1337 (OPS-043).
+- Source audit: scripts-parity audit F3, `10_projects/dotfiles/research/2026-08-27-windows-drive-audit-plan.md` (knowledge vault).
+- Prior art on the proxy-vs-end-state failure: `specs/archive/BUG-014-claude-mem-marketplace-register/`.

--- a/specs/OPS-040-dead-migration-purge/tasks.md
+++ b/specs/OPS-040-dead-migration-purge/tasks.md
@@ -1,0 +1,55 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-09-01"
+---
+
+# Tasks - OPS-040-dead-migration-purge
+
+> TDD order. One task = one focused commit. Tick as you go.
+>
+> **Inline markers**: `[P]` safe in parallel · `[AC<n>]` satisfies that criterion.
+
+## Setup
+
+- [x] Branch created from main: `chore/ops-040-dead-migration-purge`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Classify before deleting
+
+- [x] Enumerate every block by its issue-ID marker, not by the audit's line numbers — they had drifted (MEM-002 L1342→L1305, GEMINI.md L478→L500)
+- [x] Classify each by **skip-cost on an unconverged machine**: dead / correcting-and-probed / correcting-and-unverifiable
+- [x] Probe the correcting blocks' conditions on msi (`~/.zshrc`, `~/.bashrc`, `claude mcp get hive`, `crontab -l`, the claude-mem dirs and settings key)
+- [x] Probe the *targets* of every cleanup block being deleted — this is the step that caught blocks 4 and 11
+
+## Implementation
+
+- [x] [AC1] Delete the `OPENROUTER_API_KEY` deploy-time export from both scripts
+- [x] [AC2] Delete blocks 2–7: endpoint exports (both), pre-SDD-007 `mcp_config` orphan, legacy `GEMINI.md` (both), `init-project.sh` orphan, python symlink, Bun installer
+- [x] [AC3] Delete blocks 8–9 from `setup-linux.sh`: gh-copilot alias strip, legacy hive-vault crontab removal
+- [x] [AC4] Leave HIVE-118 and MEM-002 whole; leave the rc `BUN_INSTALL` exports alone
+- [x] [AC7] Write `tests/guard-doctrine-target-not-deleted.bats` and prove it fail-first against `main`'s scripts **before** relying on it
+- [x] [AC5] Teach `secrets-show-callsites.bats` to SKIP with its reason instead of passing on an empty sweep (C15)
+- [x] Retire the seven tests that pinned deleted blocks, each replaced by a comment saying what was removed and on what evidence — never by an assertion that the deletion happened
+- [x] [AC6] `bash -n`, `shellcheck`, full `bats tests/*.bats`, baselined against clean `main`
+- [x] [AC8] Write lessons 256 and 257 and index them
+
+## Spun out rather than absorbed
+
+- [x] #1431 — MEM-002 never converged (strips a `settings.json` key Claude Code stopped writing)
+- [x] HIVE-118 deferred to the batched Windows session, named in `proposal.md`
+- [x] `# EXPIRES:` convention proposed to the owner in the PR body, not built
+
+## Closing
+
+- [x] Every acceptance criterion is covered by at least one executable check
+- [x] Every criterion has a `features.json` entry with a non-vacuous verification command, each one **executed**, not asserted
+- [x] No unrelated changes in the diff
+- [x] `verification.md` filled in with evidence
+- [ ] PR opened referencing this spec folder
+- [ ] Independent adversarial review passed (required before archive)
+- [ ] Spec archived and #1333 closed in the archiving PR
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` following [[pattern-feature-list-as-primitive]].

--- a/specs/OPS-040-dead-migration-purge/verification.md
+++ b/specs/OPS-040-dead-migration-purge/verification.md
@@ -1,0 +1,72 @@
+---
+tags: [spec, verification, templates]
+created: "2026-09-01"
+---
+
+# Verification - OPS-040-dead-migration-purge
+
+## Evidence
+
+Every command below was executed on this branch; nothing here is asserted from reading.
+
+- [x] AC1 — no deploy-time secret fetch in either script → `bats tests/setup-windows.bats -f 'neither setup resolves a deploy-time secret'` → `ok 1`
+- [x] AC2 — blocks 2–7 absent → loop over the nine executable forms (`export ANTIGRAVITY_ENDPOINT=`, `SetEnvironmentVariable("CLOUDCODE_URL"`, `Removing orphan master from pre-SDD-007 path`, `Removed legacy GEMINI.md`, `rm -f "$HOME/.claude/init-project.sh"`, `Creating python symlink`, `-OutFile $bunInstaller`, …) → `OK`
+- [x] AC3 — blocks 8–9 absent from `setup-linux.sh` → same shape → `OK`
+- [x] AC4 — HIVE-118 and MEM-002 intact, rc exports intact → `bats tests/guard-no-claude-mem.bats` 3/3 `ok`, including *"the MEM-002 cleanup block IS present in both setup scripts (anti-regression)"*
+- [x] AC5 — C15 skip → `ok 1 … # skip no 'dotf secrets show <id>' call sites in the tree — nothing to resolve (the shell/ps1 sweep found none)`
+- [x] AC6 — `bash -n` clean; `shellcheck -S warning` clean; `bats tests/*.bats` → **ok=1526 not_ok=7 skipped=76**
+- [x] AC7 — `bats tests/guard-doctrine-target-not-deleted.bats` 2/2 `ok`
+- [x] AC8 — lessons 256 and 257 written and indexed
+
+### The seven bats failures are pre-existing
+
+Baselined by running the same files on a clean `main` worktree at `3a11d97`:
+
+| Test | On this branch | On clean `main` |
+|---|---|---|
+| 6 × `tests/install-dotf.bats` | red | **red** — reads the ambient PATH `dotf`, and `install_dotf` refuses to overwrite a `dev` source build |
+| `BUG-771: copilot native skills are not deployed…` | red | **red** (`tests/skills-pipeline.bats`, 22 ok / 1 not ok) |
+
+Both are fixture-isolation defects tracked at #1409, independently observed by the session working `feat/persona-skill-enforcement`. The suite went 14 red → 7 red on this branch; the seven that remain are the baseline, not a regression.
+
+### Fail-first proof for the new guard
+
+Ran `tests/guard-doctrine-target-not-deleted.bats` against a scratch tree holding `main`'s setup scripts plus the shipped manifest:
+
+```
+not ok 1 guard: no setup script deletes a harness doctrine deploy target
+# expected NOT to find /(rm[[:space:]]+-[rf]+|Remove-Item)[^|;]*GEMINI.md/ in .../setup-linux.sh, but it is there:
+# 503:    rm -f "$GEMINI_HOME/GEMINI.md"
+```
+
+Green on this tree. The guard fails for the right reason, at the right line.
+
+### Shellcheck
+
+`shellcheck -f gcc setup-linux.sh` → **16 findings**, against **19** on `main`. All are `info` (SC1091 / SC2015 / SC2016) and all pre-existing; `-S warning` is silent. No finding is introduced by this change.
+
+### LOC
+
+`setup-linux.sh` 1738 → 1686, `setup-windows.ps1` 2341 → 2301. **4079 → 3987, −92 net**, against 150 raw deletions — the difference is the comments left behind saying what was removed and on what evidence.
+
+## Decisions made during implementation
+
+- **The ticket's framing was wrong and is replaced, not executed.** "Delete ~200 lines of finished migrations" became a per-block classification by skip-cost. Of eleven blocks, one had never worked (#1431), one cannot be shown converged on Windows (HIVE-118), and one was destroying a live harness deploy target on every run (block 4).
+- **Block 4's deletion is a bug fix and carries a guard.** `harness/manifest.json` declares `.gemini/GEMINI.md` as agy's doctrine target with an append-in-place contract; both setups `rm -f`'d it, and a bats test pinned that behaviour. Only ordering hid the loss.
+- **MEM-002 excluded whole, not partially.** Its fix needs a `claude plugin marketplace remove` that may not exist, a state file the repo has never touched, and a Windows leg. Coupling unverified new behaviour to a deletion PR would make both harder to review.
+- **The rc `BUN_INSTALL` exports stay**, against the ticket. `bun` is installed on msi at `~/.bun/bin/bun`; deleting the PATH export removes a working binary from the user's shell. Zero consumers *in the repo* is not zero consumers *on the machine*.
+- **Retired tests are replaced by comments, never by absence-assertions.** Pinning a deletion is not an invariant.
+- **No `# EXPIRES:` CI check.** The convention is written into lesson 257; enforcing it is construction, and adding an expiry-less migration inside this PR would refute its own lesson. Owner decision, raised in the PR body.
+
+## Promotion candidates
+
+- [x] Lesson for `docs/lessons/` — **two**: 256 (a cleanup block's description of what it deletes is not evidence) and 257 (a migration with no removal date is indistinguishable from live code).
+- [ ] ADR-worthy? No. Nothing here changes a structural decision.
+- [ ] New pattern for `00_meta/patterns/`? Candidate: "classify a cleanup by skip-cost, then probe its target" — hold until a second instance appears.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved to `specs/archive/OPS-040-dead-migration-purge/`
+- [ ] Independent adversarial review passed (`dotf spec review OPS-040-dead-migration-purge`) — the reviewer must not be the implementer
+- [ ] #1333 closed by the archiving PR (ADR-018)

--- a/specs/OPS-040-dead-migration-purge/verification.md
+++ b/specs/OPS-040-dead-migration-purge/verification.md
@@ -29,6 +29,20 @@ Baselined by running the same files on a clean `main` worktree at `3a11d97`:
 
 Both are fixture-isolation defects tracked at #1409, independently observed by the session working `feat/persona-skill-enforcement`. The suite went 14 red → 7 red on this branch; the seven that remain are the baseline, not a regression.
 
+### Where the endpoint variables actually live (repo-wide sweep)
+
+The first pass grepped only the two setup scripts and called block 2 inert. A repo-wide sweep corrected that:
+
+```
+.zshrc:42-43                          export ANTIGRAVITY_ENDPOINT / CLOUDCODE_URL   ← the live source, untouched
+tests/antigravity.bats:84             pins that .zshrc export                        ← untouched, still green
+cli/internal/doctor/checks_deploy.go:801
+                                      sys.env("ANTIGRAVITY_ENDPOINT", "https://cloudcode-pa.googleapis.com")
+.bashrc                               (no export — pre-existing parity gap, not in scope)
+```
+
+`dotf doctor` defaults to production when the variable is unset, inside a section that SKIPs when `agy` is absent, so the check reads identically before and after this change. `.zshrc` continues to export both, so a running shell is unaffected. **The deletion is a no-op outside the setup process**, which is the correct scope for it — but the reason is narrower than "these are inert", and the spec now says so.
+
 ### Fail-first proof for the new guard
 
 Ran `tests/guard-doctrine-target-not-deleted.bats` against a scratch tree holding `main`'s setup scripts plus the shipped manifest:

--- a/tests/guard-doctrine-target-not-deleted.bats
+++ b/tests/guard-doctrine-target-not-deleted.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# GUARD (OPS-040): no setup script may delete a file the harness manifest
+# declares as a doctrine deploy target.
+#
+# WHAT THIS CAUGHT
+# ----------------
+# `harness/manifest.json` .doctrine.deploy declares `.gemini/GEMINI.md` as agy's
+# rules file, and records why the injection is append-and-replace-in-place:
+# Antigravity reads global rules from it, the file is shared with Gemini CLI, and
+# a user's own rules around the generated region are meant to survive a deploy.
+# `tests/compile-harness.bats` asserts exactly that survival.
+#
+# Both setup scripts nevertheless carried an SDD-007 block that `rm -f`'d that
+# same path on every run, describing it as "a legacy orphan pointing to the
+# retired binary". The description was wrong — the manifest says agy reads it —
+# and the two behaviours were in direct conflict. Only ordering hid it: setup
+# deleted the file early and `compile-harness.sh --deploy` rewrote it near the
+# end, so the loss was invisible unless a run stopped in between, or the deploy
+# was skipped, or anything moved. Measured 2026-09-02 on msi: 12029 bytes of
+# generated doctrine present at the path setup deletes.
+#
+# The pairing is the bug. A file cannot be both a deploy target and a thing
+# setup removes, and the append-in-place contract exists precisely so that user
+# content in it is not destroyed.
+#
+# WHY IT READS THE MANIFEST
+# -------------------------
+# Hardcoding GEMINI.md would only re-catch this one instance. The manifest is
+# the SSOT for which files carry doctrine, so a target added later is covered
+# the day it is declared, with no edit here.
+
+setup() {
+    DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+    load 'lib/refute'
+}
+
+# A removal naming the target's basename anywhere in a setup script. Deliberately
+# broader than the exact path: the scripts reach these files through several
+# spellings ($GEMINI_HOME, $HOME/.gemini, Join-Path $GeminiHome), and a guard
+# that only knew one of them would be bypassed by the next one. Basenames here
+# are distinctive enough that a match is a real hit, not a coincidence.
+REMOVAL_ERE='(rm[[:space:]]+-[rf]+|Remove-Item)[^|;]*'
+
+@test "guard: no setup script deletes a harness doctrine deploy target" {
+    local manifest="$DOTFILES_DIR/harness/manifest.json"
+    [ -f "$manifest" ] || skip "harness/manifest.json not found — cannot resolve doctrine targets"
+    command -v jq >/dev/null 2>&1 || skip "jq not available — cannot read the manifest"
+
+    local targets
+    targets="$(jq -r '.doctrine.deploy[]?.file // empty' "$manifest")"
+
+    # C15: a check that cannot answer must say so, not pass. An empty target list
+    # would make every assertion below vacuous, and a vacuous pass here is
+    # indistinguishable from "no setup script deletes a doctrine target".
+    if [ -z "$targets" ]; then
+        skip "manifest declares no .doctrine.deploy targets — nothing to assert"
+    fi
+
+    local file base script
+    while IFS= read -r file; do
+        [ -n "$file" ] || continue
+        base="${file##*/}"
+        for script in setup-linux.sh setup-windows.ps1; do
+            [ -f "$DOTFILES_DIR/$script" ] || continue
+            refute_grep "${REMOVAL_ERE}${base}" "$DOTFILES_DIR/$script"
+        done
+    done <<EOF
+$targets
+EOF
+}
+
+# The guard above is only worth its lines if the manifest reaches it. This pins
+# that the query resolves to real targets on the shipped manifest, so a schema
+# move (.doctrine.deploy renamed, say) surfaces as a red test rather than as the
+# guard quietly skipping forever.
+@test "guard: the shipped manifest resolves at least one doctrine deploy target" {
+    local manifest="$DOTFILES_DIR/harness/manifest.json"
+    [ -f "$manifest" ] || skip "harness/manifest.json not found"
+    command -v jq >/dev/null 2>&1 || skip "jq not available"
+
+    run jq -r '[.doctrine.deploy[]?.file] | length' "$manifest"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}

--- a/tests/hive-upgrade-timer.bats
+++ b/tests/hive-upgrade-timer.bats
@@ -60,17 +60,16 @@ setup() {
     [ "$enable_line" -gt "$gate_line" ]
 }
 
-# SSOT cleanup: once the timer is the owner, the legacy manual cron must go.
-@test "setup-linux.sh removes the legacy uv tool upgrade hive-vault cron" {
-    grep -qF "grep -v 'uv tool upgrade hive-vault' | crontab -" "$DOTFILES_DIR/setup-linux.sh"
-}
-
-# The cron strip must be guarded (only remove when a matching line exists) and
-# only run after a successful timer enable -- an old-hive machine that skips the
-# gate keeps its cron so it is never left with no upgrade owner.
-@test "setup-linux.sh cron strip is guarded on the line existing" {
-    grep -qF "crontab -l 2>/dev/null | grep -q 'uv tool upgrade hive-vault'" "$DOTFILES_DIR/setup-linux.sh"
-}
+# Two tests pinning the legacy-cron strip lived here until OPS-040: that setup
+# removed a `uv tool upgrade hive-vault` crontab line once the timer owned
+# upgrade policy, and that the removal was guarded on the line existing. The
+# block they pinned is gone -- probed absent from `crontab -l` on msi, which is
+# the only OS it could ever have run on, crontab being the mechanism.
+#
+# Nothing replaces them. Asserting the ABSENCE of the strip would pin a deletion
+# rather than an invariant, and the invariant that mattered -- the timer is the
+# single upgrade owner -- is already covered by the enable/version-gate tests
+# above and the non-fatal test below.
 
 @test "setup-linux.sh timer install is non-fatal (warns, never hard-exits)" {
     grep -qF 'hive-upgrade.timer enable failed (non-fatal' "$DOTFILES_DIR/setup-linux.sh"

--- a/tests/secrets-show-callsites.bats
+++ b/tests/secrets-show-callsites.bats
@@ -14,6 +14,17 @@ setup() {
     cd "$DOTFILES_DIR"
     ids=$(grep -rhoE "dotf secrets show [A-Za-z0-9_-]+" --include='*.sh' --include='*.ps1' . \
         | awk '{print $NF}' | sort -u)
+
+    # C15: a check that cannot answer must SKIP saying why, never pass. OPS-040
+    # removed the last two call sites (the OPENROUTER_API_KEY export both setup
+    # scripts ran for a consumer CLI-042 AC8 had already deleted), so this loop
+    # now iterates an empty list. A pass in that state would be indistinguishable
+    # from "every call site checks out" and would stay green through the
+    # reintroduction of a typo'd one, which is the entire failure #698 describes.
+    if [ -z "$ids" ]; then
+        skip "no 'dotf secrets show <id>' call sites in the tree — nothing to resolve (the shell/ps1 sweep found none)"
+    fi
+
     missing=""
     for id in $ids; do
         grep -qE "^[[:space:]]*-[[:space:]]*id:[[:space:]]*${id}([[:space:]]|#|\$)" secrets/registry.yaml \

--- a/tests/setup-linux.bats
+++ b/tests/setup-linux.bats
@@ -71,13 +71,17 @@ setup() {
     grep -qF 'secrets/registry.yaml' "$DOTFILES_DIR/setup-linux.sh"
 }
 
-@test "setup-linux.sh resolves the agy deploy-time secret via dotf, not the load-secrets twin [#587]" {
-    # agy's OPENROUTER_API_KEY is fetched via dotf (opencode/pi materialize via
-    # `dotf secrets render` over the registry, and their own runtime resolver).
-    grep -qF 'dotf secrets show OPENROUTER_API_KEY' "$DOTFILES_DIR/setup-linux.sh"
-    # the eager-source + the old secrets_show twin API are gone
+@test "setup-linux.sh carries neither load-secrets twin, and fetches no deploy-time secret [#587, OPS-040]" {
+    # #587 migrated agy's OPENROUTER_API_KEY off the load-secrets eager
+    # dot-source onto `dotf secrets show`. OPS-040 removed the fetch entirely:
+    # the agy mcp_config cascade that consumed it was deleted by CLI-042 AC8, so
+    # setup was decrypting a credential on every run for nobody. What survives
+    # from #587 is the half that still binds -- neither retired twin API may come
+    # back -- plus the stronger statement that no deploy-time secret is resolved
+    # here at all.
     refute_grep 'load-secrets\.sh" >/dev/null 2>&1' "$DOTFILES_DIR/setup-linux.sh"
     refute_grep_fixed 'secrets_show ' "$DOTFILES_DIR/setup-linux.sh"
+    refute_grep_fixed 'dotf secrets show OPENROUTER_API_KEY' "$DOTFILES_DIR/setup-linux.sh"
 }
 
 @test "setup-linux.sh installs gh if missing" {

--- a/tests/setup-windows.bats
+++ b/tests/setup-windows.bats
@@ -74,18 +74,22 @@ setup() {
     grep -qF "PSObject.Properties['prerequisite_command']" "$PS1_SCRIPT"
 }
 
-@test "setup-windows.ps1 does NOT eager-source load-secrets; resolves the agy secret via dotf [#587]" {
-    # Migrated off the load-secrets eager dot-source (ADR-028). agy's
-    # OPENROUTER_API_KEY is baked into mcp_config.json via `dotf secrets show`
-    # after Install-Dotf, before the agy block (opencode/pi self-resolve).
+@test "setup-windows.ps1 does NOT eager-source load-secrets, and fetches no deploy-time secret [#587, OPS-040]" {
+    # Migrated off the load-secrets eager dot-source by #587 (ADR-028), then
+    # OPS-040 removed the `dotf secrets show` fetch itself: the agy mcp_config
+    # cascade that consumed OPENROUTER_API_KEY was deleted by CLI-042 AC8, so
+    # the decryption ran on every setup for no reader.
     refute_grep '\. \$loadSecretsDeployed' "$PS1_SCRIPT"
     refute_grep_fixed 'Eager-load secrets' "$PS1_SCRIPT"
-    grep -qF 'dotf secrets show OPENROUTER_API_KEY' "$PS1_SCRIPT"
+    refute_grep_fixed 'dotf secrets show OPENROUTER_API_KEY' "$PS1_SCRIPT"
 }
 
-@test "parity: both setups resolve the agy deploy-time secret via dotf secrets show [#587]" {
+@test "parity: neither setup resolves a deploy-time secret for agy [#587, OPS-040]" {
+    # The parity statement inverted with the behaviour: both scripts fetched it,
+    # now neither does. Kept as parity rather than deleted, because the failure
+    # this catches is one OS reintroducing the fetch alone.
     for s in "$PS1_SCRIPT" "$DOTFILES_DIR/setup-linux.sh"; do
-        grep -qF 'dotf secrets show OPENROUTER_API_KEY' "$s"
+        refute_grep_fixed 'dotf secrets show OPENROUTER_API_KEY' "$s"
     done
 }
 
@@ -115,12 +119,17 @@ setup() {
     grep -qF 'age identity key not found' "$DOTFILES_DIR/setup-linux.sh"
 }
 
-@test "setup-windows.ps1 removes legacy GEMINI.md (SDD-007 migration)" {
-    # Pre-SDD-007 setups deployed ~/.gemini/GEMINI.md. After agy replaced
-    # gemini-cli, AGY.md is the new identity file. Without explicit cleanup the
-    # orphan GEMINI.md lingers and confuses any tool that picks up either file.
-    grep -qF 'Removed legacy GEMINI.md' "$PS1_SCRIPT"
-}
+# A test asserting that setup-windows.ps1 REMOVES ~/.gemini/GEMINI.md stood here
+# until OPS-040, on the premise that the file was a pre-SDD-007 orphan. The
+# premise was false: harness/manifest.json declares .gemini/GEMINI.md as agy's
+# live doctrine deploy target -- "Antigravity reads global rules from
+# ~/.gemini/GEMINI.md", injected append-and-replace-in-place so a user's own
+# rules survive. Both setups deleted it on every run, and this test held that
+# behaviour in place. Measured on msi 2026-09-02: 12029 bytes of generated
+# doctrine at the path setup deleted.
+#
+# The inverse invariant now lives in tests/guard-doctrine-target-not-deleted.bats,
+# which resolves its targets from the manifest instead of naming this one file.
 
 @test "setup-windows.ps1 sets up GitHub Copilot CLI" {
     grep -q 'Setting up GitHub Copilot CLI' "$PS1_SCRIPT"
@@ -990,14 +999,18 @@ FIXTURE
     grep -qE '^function Sync-SessionPath' "$BATS_TEST_DIRNAME/../scripts/utils.ps1"
 }
 
-@test "setup-windows.ps1 runs the uv and Bun installers in a child pwsh, never in its own session (TEST-003)" {
+@test "setup-windows.ps1 runs downloaded installers in a child pwsh, never in its own session (TEST-003)" {
     # A downloaded installer executed in-session can rewrite the process
     # environment for the rest of setup; the runner lost npm after these two.
+    #
+    # It named uv AND Bun until OPS-040 deleted the Bun installer (it existed for
+    # the claude-mem worker, retired 2026-06-23, and nothing in the repo invokes
+    # bun). Per the note above at "Guards assert the invariant, never the
+    # population": the invariant is child-pwsh execution, not which installers
+    # happen to exist, so this asserts the surviving one rather than counting
+    # them. Any installer added later inherits the rule, not this test's silence.
     grep -qF -- '-File $uvInstaller' "$PS1_SCRIPT"
-    grep -qF -- '-File $bunInstaller' "$PS1_SCRIPT"
     run grep -F '& $uvInstaller' "$PS1_SCRIPT"
-    [ "$status" -ne 0 ]
-    run grep -F '& $bunInstaller' "$PS1_SCRIPT"
     [ "$status" -ne 0 ]
 }
 


### PR DESCRIPTION
## Summary

#1333 asked for ~200 lines of finished one-time migrations to be deleted from both setup scripts. **The framing did not survive measurement**, so this PR replaces it with a per-block one: each block classified by *what breaks on a machine that never runs it*, and the conditions the correcting ones test probed on msi.

Of eleven blocks: **7 dead**, **2 correcting and probed converged**, **2 kept** — one that cannot be verified from this OS, and one that **has never worked**. Plus one deletion that turned out to be a bug fix.

`setup-linux.sh` + `setup-windows.ps1`: **4079 → 3987 LOC**.

## The block that was destroying a live file

`harness/manifest.json` declares `.gemini/GEMINI.md` as agy's doctrine deploy target, and says why:

> *"Antigravity reads global rules from `~/.gemini/GEMINI.md`… The file is shared with Gemini CLI, so injection is **append-and-replace-in-place, never an overwrite**."*

Both setup scripts `rm -f`'d that exact path on every run, calling it *"a legacy orphan pointing to the retired binary"*, and `tests/setup-windows.bats` held a test asserting the removal happened. Measured on msi: **12029 bytes of harness-generated doctrine** carrying a `sha256:` marker, written the previous evening.

Only ordering hid it — setup deleted it early, `compile-harness.sh --deploy` rewrote it near the end. A run that stopped in between, a skipped deploy, or a reorder would have silently dropped whatever the user had written around the generated region, which is the exact thing the append-in-place contract exists to protect (and which `tests/compile-harness.bats` asserts).

Guarded: `tests/guard-doctrine-target-not-deleted.bats` resolves `.doctrine.deploy[]` from the manifest and refuses any removal naming a declared target in either script. It reads the manifest rather than hardcoding `GEMINI.md`, so a target declared later is covered the day it is declared. **Fail-first proven** — red against `main`'s scripts at `setup-linux.sh:503`, green here.

## What was deleted, and why each is safe

**Dead on any machine, converged or not** — skipping costs nothing by construction:

| Block | Why dead |
|---|---|
| `OPENROUTER_API_KEY` deploy-time export (both) | Its agy `mcp_config` cascade was removed by CLI-042 AC8. Zero readers; the interactive `opencode`/`pi` wrappers resolve it independently via `dotf secrets run`. **Setup was decrypting a credential on every run for nobody.** |
| `ANTIGRAVITY_ENDPOINT` / `CLOUDCODE_URL` (both) | The block's own comment: *"Setting these has no observed effect on routing."* |
| pre-SDD-007 `mcp_config.json` orphan removal | agy reads the canonical path. |
| `init-project.sh` orphan removal | Retired for `dotf init`; nothing invokes it. |
| python → python3 symlink | Not a migration. Its `~/Applications/python-*` glob has matched nothing since that install path was dropped. |
| Bun installer (Windows) | Installed for *"Claude Code plugin workers for bun:sqlite"* — the worker MEM-002 retired 2026-06-23. No repo code invokes `bun`/`bunx`/`bun run`. |

**Correcting, probed converged on the only OS they run on** (both are Linux-only by mechanism — rc files, crontab — so msi is the only machine they could ever have run on):

| Block | Probe |
|---|---|
| gh-copilot stale `eval` strip | absent from `~/.zshrc` **and** `~/.bashrc` |
| legacy `uv tool upgrade hive-vault` cron removal | absent from `crontab -l` |

## What was kept, deliberately

- **HIVE-118** — correcting, with a Windows twin. Skipping it leaves the `hive` MCP pinned to the retired `uvx` definition, which the surrounding skip-if-present loop then never replaces. Probed clean on Linux; **the Windows box cannot be probed from here**, so it is deferred to the batched Windows session rather than deleted on one OS's evidence.
- **MEM-002 → #1431.** It has never converged. It strips `settings.json`'s `extraKnownMarketplaces.thedotmack`; Claude Code moved the registry to `~/.claude/plugins/known_marketplaces.json`, which **no code in this repo mentions**, and the entry carries `autoUpdate: true`. So the `rm -rf` runs and the retired marketplace re-clones on the next session — `lastUpdated` was one hour before measurement. Left **whole**, not partially touched: its fix needs a `claude plugin marketplace remove` subcommand that may not exist, a state file this repo has never touched, and a Windows leg. Unverified new behaviour does not belong in a PR whose thesis is "delete code proven dead".
- **The rc `BUN_INSTALL` exports**, against the ticket. `bun` **is** installed on msi at `~/.bun/bin/bun`; deleting the PATH export removes a working binary from the user's interactive shell for no benefit. Zero consumers *in the repo* is not zero consumers *on the machine*. Setup stops installing bun; the shell keeps finding the one that is there.

## Test changes

- `secrets-show-callsites.bats` would have gone **vacuous** — the deleted export held the last two `dotf secrets show` call sites, so its loop would iterate an empty list and pass having checked nothing. It now SKIPs with its reason, per C15.
- Seven tests pinned deleted blocks. Each is retired with a comment recording what went and on what evidence — **never replaced by an assertion that the deletion happened**, which would pin a deletion rather than an invariant.
- `setup-windows.bats` TEST-003 narrowed from "uv and Bun installers" to the surviving one, following that file's own note: *"Guards assert the invariant, never the population."*

## Verification

Every `features.json` verification command was **executed**, not asserted; all 8 criteria `verified` with evidence in `verification.md`.

```
bats tests/*.bats        ok=1526  not_ok=7  skipped=76      (14 red before this PR's test fixes)
bash -n setup-linux.sh   clean
shellcheck               16 info findings, vs 19 on main; -S warning silent
```

**The 7 remaining failures are pre-existing**, baselined by running the same files on a clean `main` worktree at `3a11d97`: 6 × `install-dotf.bats` (reads the ambient PATH `dotf`; `install_dotf` refuses to overwrite a `dev` source build) and `BUG-771` in `skills-pipeline.bats`. Both are the fixture-isolation class tracked at **#1409**, independently observed by the session working `feat/persona-skill-enforcement`.

PSScriptAnalyzer could not run locally (no `pwsh` on this box; those bats cases skip) — the Windows leg is CI's.

## Owner decision requested

Lesson 257 records the convention `# EXPIRES: <date> (<ticket>)` on every one-time migration, naming a *checkable* convergence condition rather than a guessed date. **The CI check enforcing it is deliberately not built** — that is construction, and adding an expiry-less migration inside the PR whose lesson is "migrations carry an expiry" would refute itself. Say the word and it becomes a ticket.

Same question for the Windows registry values `ANTIGRAVITY_ENDPOINT`/`CLOUDCODE_URL` persisted by earlier runs: they linger inert (*"no observed effect"* is the block's own measurement) and scrubbing them means adding exactly the kind of migration this PR removes.

## Not in scope

- **#1337** (OPS-043, duplicated doctor checks) — separate concern, separate PR.
- HIVE-118's Windows leg, and #1431.

## Lessons

- **256** — a cleanup block's own description of what it deletes is not evidence that the thing is dead.
- **257** — a one-time migration with no removal date is indistinguishable from live code, and two of eleven turned out not to be finished.

## References

- Refs #1333 — spec stays `verifying`; it archives in a follow-up PR after an independent adversarial review, which closes the issue then (Discipline Gate step 7).
- Refs #1431 — spun out of this work.
