### PR TITLE
feat(harness): the gate writes down every decision it takes

### DIFF
--- a/cli/internal/cmd/harness_gate.go
+++ b/cli/internal/cmd/harness_gate.go
@@ -32,6 +32,17 @@ const gateExitBlock = 2
 // command that could exit 1 would therefore mean opposite things on two
 // harnesses. Every path here resolves to an explicit decision instead, so the
 // harness never sees an error and its error semantics never apply.
+//
+// The single non-nil return is tagged with exit 2 explicitly. An untagged error
+// would resolve to 1 through ExitCode — the one status this command must never
+// produce — so nothing here may return a bare error.
+//
+// AND EVERY PATH LEAVES A DURABLE RECORD. An exit status is not an audit trail:
+// the harness consumes and discards it, `warn` and `allow` share it, and a
+// PreToolUse hook's stderr on exit 0 is not persisted anywhere the session can
+// be asked about later. Three paths below return before any persona is loaded,
+// and before the journal they left nothing at all — so a harness whose payload
+// this cannot parse looked exactly like a harness with nothing to enforce.
 func newHarnessGateCmd() *cobra.Command {
 	var (
 		harnessName string
@@ -57,9 +68,28 @@ Invoking a skill is never blocked: forbidding it would deadlock the session.`,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			payload, _ := io.ReadAll(cmd.InOrStdin())
+			if stateDir == "" {
+				stateDir = defaultGateStateDir()
+			}
+			// One closure, used by every exit below, because the requirement is
+			// that NO path returns without leaving a record. Writing it at each
+			// `return` is how the three early paths came to leave none: each was
+			// individually correct, and the omission existed only in aggregate —
+			// the same shape as the defect this spec started from.
+			record := func(scope string, rec harness.DecisionRecord) {
+				rec.Harness = harnessName
+				rec.Scope = scope
+				_ = harness.RecordDecision(harness.DecisionPath(stateDir, scope), rec)
+			}
 
 			call, understood := normaliseToolCall(harnessName, payload)
 			if !understood {
+				record(harness.UnparsedScope, harness.DecisionRecord{
+					Outcome:      harness.OutcomePayloadUnrecognised,
+					Allowed:      true,
+					Reason:       "payload not recognised",
+					PayloadBytes: len(payload),
+				})
 				// MEASURED 2026-08-26: this branch is why it exists. Without
 				// it a malformed payload produced a zero ToolCall, Decide saw
 				// a valid persona with nothing consumed, and the gate BLOCKED
@@ -69,13 +99,23 @@ Invoking a skill is never blocked: forbidding it would deadlock the session.`,
 				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "[gate] allow: payload not recognised")
 				return nil
 			}
-			if stateDir == "" {
-				stateDir = defaultGateStateDir()
-			}
 			// Scoped to the acting persona when the harness names one: a subagent
 			// reuses the parent session id, so keying by session alone would let one
 			// persona's skill runs satisfy another's gate.
-			statePath := harness.StatePath(stateDir, call.ConsumptionScope())
+			scope := call.ConsumptionScope()
+			statePath := harness.StatePath(stateDir, scope)
+
+			// Every record from here carries what the harness said was acting.
+			// THIS IS WHAT CONVERTS agent_type FROM INFERRED TO MEASURED: it is
+			// read straight off the payload, before any persona lookup, so even
+			// the skill path below — which returns before that lookup — leaves
+			// evidence that the field arrived and of what it contained.
+			base := harness.DecisionRecord{
+				Session:   call.SessionID,
+				AgentType: call.AgentType,
+				AgentID:   call.AgentID,
+				Tool:      call.Tool,
+			}
 
 			// A skill invocation is the act the gate exists to require: record
 			// it and get out of the way. Recording failures are ignored on
@@ -83,6 +123,12 @@ Invoking a skill is never blocked: forbidding it would deadlock the session.`,
 			// failing here would block a session over a full disk.
 			if call.Skill != "" {
 				_ = harness.RecordConsumed(statePath, call.Skill)
+				rec := base
+				rec.Skill = call.Skill
+				rec.Outcome = harness.OutcomeSkillConsumed
+				rec.Allowed = true
+				rec.Reason = "skill invocation recorded"
+				record(scope, rec)
 				return nil
 			}
 			if call.IsSkillTool {
@@ -91,23 +137,66 @@ Invoking a skill is never blocked: forbidding it would deadlock the session.`,
 				// deadlock the session on the one action that could satisfy the
 				// gate — a well-formed payload with a missing argument, not a
 				// parse failure. Raised by the reviewer on #1272.
+				rec := base
+				rec.Outcome = harness.OutcomeSkillUnnamed
+				rec.Allowed = true
+				rec.Reason = "skill invocation with no readable name"
+				record(scope, rec)
 				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "[gate] allow: skill invocation with no readable name")
 				return nil
 			}
 
-			persona := loadGatePersona(cmd.ErrOrStderr(), repoRoot, effectiveRole(role, call.AgentType))
+			requested := effectiveRole(role, call.AgentType)
+			persona, resolution := loadGatePersona(cmd.ErrOrStderr(), repoRoot, requested)
 			result := harness.Decide(harness.GateInput{
 				Persona:  persona,
 				Call:     call,
 				Consumed: harness.LoadConsumed(statePath),
 			})
 
+			rec := base
+			rec.RoleRequested = requested
+			rec.Reason = result.Reason
+			rec.Warned = result.Warned
+			rec.Missing = result.Missing
+			rec.Allowed = result.Decision != harness.Block
+			if persona != nil {
+				rec.RoleResolved = persona.Name
+			}
+			switch {
+			case resolution == roleUnresolved:
+				// Checked BEFORE the decision, because this call allowed and a
+				// healthy allow looks identical to it. The distinction is the
+				// whole reason AC5 names this case: enforcement was off, and
+				// nothing outside this record says so.
+				rec.Outcome = harness.OutcomeRoleUnresolved
+			case resolution == roleNotAsked:
+				rec.Outcome = harness.OutcomeNoRole
+			case result.Decision == harness.Block:
+				rec.Outcome = harness.OutcomeBlock
+			case len(result.Warned) > 0:
+				rec.Outcome = harness.OutcomeWarn
+			default:
+				rec.Outcome = harness.OutcomeAllow
+			}
+			// Written before the return below, not after: the block path used to
+			// call os.Exit, which runs no defers, so a record deferred past it
+			// would be the one decision never written — the only one anybody
+			// would go looking for.
+			record(scope, rec)
+
 			for _, w := range result.Warned {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "[gate] warn: %s not consumed\n", w)
 			}
 			if result.Decision == harness.Block {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "[gate] blocked: %s\n", result.Reason)
-				os.Exit(gateExitBlock)
+				// withExitCode rather than os.Exit, which is what this called
+				// before. The status is identical — main resolves it through
+				// ExitCode — but os.Exit kills the test runner, so the ONE path
+				// that matters most could never be driven end to end in process.
+				// The command sets SilenceErrors, so main prints nothing extra
+				// and the reason a human reads is still the line above.
+				return withExitCode(gateExitBlock, fmt.Errorf("%s", result.Reason))
 			}
 			return nil
 		},
@@ -135,12 +224,30 @@ Invoking a skill is never blocked: forbidding it would deadlock the session.`,
 // is the failure this whole gate exists to prevent, committed inside the gate.
 // warn takes an io.Writer rather than reaching for os.Stderr so the message is
 // assertable; a diagnostic nothing can test is the same silence with extra steps.
-func loadGatePersona(warn io.Writer, repoRoot, role string) *harness.Persona {
+// roleResolution separates the two ways loadGatePersona returns nil.
+//
+// They were indistinguishable to the caller, and both allow, so from outside
+// "no persona was asked for" and "a persona was asked for and enforcement is
+// therefore OFF" produced the same silence. The stderr line tells them apart for
+// a human reading a live terminal; nothing told them apart afterwards, which is
+// the gap AC5 names by calling out `role did not resolve` explicitly.
+type roleResolution int
+
+const (
+	// roleNotAsked: the caller declared no persona. A main-thread call.
+	roleNotAsked roleResolution = iota
+	// roleUnresolved: a persona was named and could not be loaded.
+	roleUnresolved
+	// roleResolved: a persona is in scope.
+	roleResolved
+)
+
+func loadGatePersona(warn io.Writer, repoRoot, role string) (*harness.Persona, roleResolution) {
 	if strings.TrimSpace(role) == "" {
 		// Not asked for: the caller declared no persona, so there is nothing to
 		// fail to find. Distinct from the case below, and NOT worth a line on
 		// every tool call.
-		return nil
+		return nil, roleNotAsked
 	}
 	if repoRoot == "" {
 		repoRoot = os.Getenv("DOTFILES_DIR")
@@ -153,9 +260,9 @@ func loadGatePersona(warn io.Writer, repoRoot, role string) *harness.Persona {
 	if err != nil {
 		_, _ = fmt.Fprintf(warn, "[gate] allow: role %q did not resolve (%s): %v — ENFORCEMENT IS OFF for this call\n",
 			role, path, err)
-		return nil
+		return nil, roleUnresolved
 	}
-	return p
+	return p, roleResolved
 }
 
 // effectiveRole picks the persona in scope: the operator's --role when given,

--- a/cli/internal/cmd/harness_gate_test.go
+++ b/cli/internal/cmd/harness_gate_test.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -143,30 +146,40 @@ func TestLoadGatePersonaSaysSoWhenARoleDoesNotResolve(t *testing.T) {
 		repoRoot string
 		wantNil  bool
 		wantSaid bool
+		// wantRes is the part a caller can act on AFTER the call. The stderr
+		// line tells a human reading a live terminal that enforcement is off;
+		// this is what lets the decision record say so durably.
+		wantRes roleResolution
 	}{
 		{
 			name: "no role asked for is silent — nothing failed to resolve",
-			role: "", repoRoot: root, wantNil: true, wantSaid: false,
+			role: "", repoRoot: root, wantNil: true, wantSaid: false, wantRes: roleNotAsked,
 		},
 		{
 			name: "a role that does not exist is allowed AND announced",
-			role: "reviewr", repoRoot: root, wantNil: true, wantSaid: true,
+			role: "reviewr", repoRoot: root, wantNil: true, wantSaid: true, wantRes: roleUnresolved,
 		},
 		{
 			name: "a repo root without harness/agents is allowed AND announced",
-			role: "reviewer", repoRoot: t.TempDir(), wantNil: true, wantSaid: true,
+			role: "reviewer", repoRoot: t.TempDir(), wantNil: true, wantSaid: true, wantRes: roleUnresolved,
 		},
 		{
 			name: "a role that resolves is silent",
-			role: "reviewer", repoRoot: root, wantNil: false, wantSaid: false,
+			role: "reviewer", repoRoot: root, wantNil: false, wantSaid: false, wantRes: roleResolved,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			got := loadGatePersona(&buf, tc.repoRoot, tc.role)
+			got, res := loadGatePersona(&buf, tc.repoRoot, tc.role)
 
 			if (got == nil) != tc.wantNil {
 				t.Errorf("persona nil = %v, want %v", got == nil, tc.wantNil)
+			}
+			// Both nil cases return nil and both allow. Only this separates
+			// them, and conflating them is what made "enforcement is off" and
+			// "nothing to enforce" the same observation.
+			if res != tc.wantRes {
+				t.Errorf("resolution = %v, want %v", res, tc.wantRes)
 			}
 			// Always allow-shaped: this function never causes a block.
 			said := buf.Len() > 0
@@ -288,5 +301,352 @@ func TestConsumptionIsScopedToTheInvocationNotTheRole(t *testing.T) {
 	if first.ConsumptionScope() == second.ConsumptionScope() {
 		t.Errorf("two dispatches of one role share a ledger (%q) — the second would inherit the first's consumption and go ungated",
 			first.ConsumptionScope())
+	}
+}
+
+// runGate drives the real command end to end, in process.
+//
+// End to end matters here: the three paths that return before any persona is
+// loaded are exactly the ones that used to leave no trace, and a test calling
+// Decide directly cannot see them at all — which is how they came to be
+// unrecorded while every unit test passed.
+func runGate(t *testing.T, args []string, payload string) (int, string) {
+	t.Helper()
+	c := newHarnessGateCmd()
+	var errb bytes.Buffer
+	c.SetIn(strings.NewReader(payload))
+	c.SetOut(io.Discard)
+	c.SetErr(&errb)
+	c.SetArgs(args)
+	return ExitCode(c.Execute()), errb.String()
+}
+
+func readJournal(t *testing.T, stateDir, scope string) []harness.DecisionRecord {
+	t.Helper()
+	recs, err := harness.LoadDecisions(harness.DecisionPath(stateDir, scope))
+	if err != nil {
+		t.Fatalf("read journal for scope %q: %v", scope, err)
+	}
+	return recs
+}
+
+// blockingRepoRoot writes a persona whose skill is `enforce: block`.
+//
+// No shipped record declares one — the canary migrated `reviewer` to `warn`
+// deliberately — so the block path has to be driven from a fixture. That is the
+// honest arrangement rather than a gap: the day a real record turns `block` on,
+// this test already covers what happens, and it does not silently start
+// measuring something different because the roster changed.
+func blockingRepoRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "harness", "agents", "gatekeeper")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := "---\nname: gatekeeper\nkind: persona\nskills:\n  - id: audit\n    enforce: block\n---\n\n# Gatekeeper\n"
+	if err := os.WriteFile(filepath.Join(dir, "AGENT.md"), []byte(rec), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// TestEveryGateDecisionLeavesADurableRecord is AC5.
+//
+// The gate's answer to the harness is an exit code, and an exit code is consumed
+// and discarded. `warn` and `allow` share it; "the payload did not parse" and
+// "there was nothing to enforce" share it; and "the role did not resolve, so
+// enforcement is OFF" shares it with a clean pass. Everything that told those
+// apart was stderr, which a PreToolUse hook does not persist on exit 0.
+//
+// So this asserts the property that makes the gate measurable at all: NO path
+// returns without writing down what it decided and why.
+func TestEveryGateDecisionLeavesADurableRecord(t *testing.T) {
+	root := repoRootForTest(t)
+	blocking := blockingRepoRoot(t)
+
+	for _, tc := range []struct {
+		name        string
+		payload     string
+		repoRoot    string
+		wantScope   string
+		wantOutcome harness.Outcome
+		wantExit    int
+		wantAllowed bool
+	}{
+		{
+			// The single most diagnostic case. An unparsed payload is what a
+			// harness with different field names produces — the open question
+			// for agy — and before this record it was indistinguishable from a
+			// harness working perfectly.
+			name:      "a payload the gate cannot parse",
+			payload:   `not json at all`,
+			repoRoot:  root,
+			wantScope: harness.UnparsedScope, wantOutcome: harness.OutcomePayloadUnrecognised,
+			wantExit: 0, wantAllowed: true,
+		},
+		{
+			name:      "a skill invocation, which returns before any persona is loaded",
+			payload:   `{"tool_name":"Skill","tool_input":{"skill":"audit"},"session_id":"s1","agent_type":"reviewer","agent_id":"a1"}`,
+			repoRoot:  root,
+			wantScope: "s1-a1", wantOutcome: harness.OutcomeSkillConsumed,
+			wantExit: 0, wantAllowed: true,
+		},
+		{
+			name:      "the skill primitive with an unreadable argument",
+			payload:   `{"tool_name":"Skill","tool_input":{},"session_id":"s2"}`,
+			repoRoot:  root,
+			wantScope: "s2", wantOutcome: harness.OutcomeSkillUnnamed,
+			wantExit: 0, wantAllowed: true,
+		},
+		{
+			name:      "a main-thread call naming no persona",
+			payload:   `{"tool_name":"Bash","session_id":"s3"}`,
+			repoRoot:  root,
+			wantScope: "s3", wantOutcome: harness.OutcomeNoRole,
+			wantExit: 0, wantAllowed: true,
+		},
+		{
+			// AC5 names this case explicitly, and this is why: it ALLOWS, so
+			// from outside it is identical to health, while enforcement is off.
+			name:      "a role that was asked for and did not resolve",
+			payload:   `{"tool_name":"Bash","session_id":"s4","agent_type":"no-such-persona"}`,
+			repoRoot:  root,
+			wantScope: "s4", wantOutcome: harness.OutcomeRoleUnresolved,
+			wantExit: 0, wantAllowed: true,
+		},
+		{
+			name:      "a persona whose skills are all warn",
+			payload:   `{"tool_name":"Bash","session_id":"s5","agent_type":"reviewer","agent_id":"a2"}`,
+			repoRoot:  root,
+			wantScope: "s5-a2", wantOutcome: harness.OutcomeWarn,
+			wantExit: 0, wantAllowed: true,
+		},
+		{
+			name:      "a persona whose skills carry no severity is not enforced",
+			payload:   `{"tool_name":"Bash","session_id":"s6","agent_type":"builder","agent_id":"a3"}`,
+			repoRoot:  root,
+			wantScope: "s6-a3", wantOutcome: harness.OutcomeAllow,
+			wantExit: 0, wantAllowed: true,
+		},
+		{
+			name:      "a blocked call records before it exits",
+			payload:   `{"tool_name":"Bash","session_id":"s7","agent_type":"gatekeeper","agent_id":"a4"}`,
+			repoRoot:  blocking,
+			wantScope: "s7-a4", wantOutcome: harness.OutcomeBlock,
+			wantExit: 2, wantAllowed: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stateDir := t.TempDir()
+			code, _ := runGate(t, []string{
+				"--harness", "claude", "--repo-root", tc.repoRoot, "--state-dir", stateDir,
+			}, tc.payload)
+
+			if code != tc.wantExit {
+				t.Errorf("exit = %d, want %d", code, tc.wantExit)
+			}
+			recs := readJournal(t, stateDir, tc.wantScope)
+			if len(recs) != 1 {
+				t.Fatalf("journal for scope %q holds %d records, want exactly 1 — "+
+					"a path that returns without recording is invisible afterwards", tc.wantScope, len(recs))
+			}
+			got := recs[0]
+			if got.Outcome != tc.wantOutcome {
+				t.Errorf("outcome = %q, want %q", got.Outcome, tc.wantOutcome)
+			}
+			if got.Allowed != tc.wantAllowed {
+				t.Errorf("allowed = %v, want %v", got.Allowed, tc.wantAllowed)
+			}
+			if got.Harness != "claude" {
+				t.Errorf("harness = %q, want claude", got.Harness)
+			}
+			if got.Time == "" {
+				t.Error("record carries no timestamp")
+			}
+		})
+	}
+}
+
+// TestGateRecordCarriesAgentType is AC7, and it is the criterion that converts a
+// standing inference into a measurement.
+//
+// `agent_type` has been DOCUMENTED and acted upon since the binding landed, and
+// never observed in any durable artifact — the consumption ledger records only
+// the skill name, and the skill path returns before the persona lookup that
+// would otherwise have exercised the field. So a dispatch could carry it, or
+// not, and both looked the same on disk.
+//
+// It is read straight off the payload here, before any lookup, so even the two
+// early-returning skill paths preserve it.
+func TestGateRecordCarriesAgentType(t *testing.T) {
+	root := repoRootForTest(t)
+
+	for _, tc := range []struct {
+		name    string
+		payload string
+		scope   string
+	}{
+		{
+			name:    "on the skill path, which returns before the persona is loaded",
+			payload: `{"tool_name":"Skill","tool_input":{"skill":"audit"},"session_id":"s","agent_type":"reviewer","agent_id":"a1"}`,
+			scope:   "s-a1",
+		},
+		{
+			name:    "on the enforcement path",
+			payload: `{"tool_name":"Bash","session_id":"s","agent_type":"reviewer","agent_id":"a1"}`,
+			scope:   "s-a1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stateDir := t.TempDir()
+			runGate(t, []string{"--harness", "claude", "--repo-root", root, "--state-dir", stateDir}, tc.payload)
+
+			recs := readJournal(t, stateDir, tc.scope)
+			if len(recs) != 1 {
+				t.Fatalf("want 1 record, got %d", len(recs))
+			}
+			if recs[0].AgentType != "reviewer" {
+				t.Errorf("agent_type = %q, want reviewer — the field the whole persona "+
+					"resolution rests on is still unrecorded", recs[0].AgentType)
+			}
+			if recs[0].AgentID != "a1" {
+				t.Errorf("agent_id = %q, want a1", recs[0].AgentID)
+			}
+		})
+	}
+}
+
+// TestTheRecordSeparatesWhatWasAskedForFromWhatResolved.
+//
+// Three fields, because they can differ and the difference IS the diagnosis: the
+// payload said one thing, `--role` may override it, and the record that actually
+// loaded may be a third. Collapsing them into one would hide a `--role` override
+// and a renamed record behind the same value.
+func TestTheRecordSeparatesWhatWasAskedForFromWhatResolved(t *testing.T) {
+	stateDir := t.TempDir()
+	runGate(t, []string{
+		"--harness", "claude", "--repo-root", repoRootForTest(t), "--state-dir", stateDir,
+		"--role", "builder",
+	}, `{"tool_name":"Bash","session_id":"s","agent_type":"reviewer","agent_id":"a1"}`)
+
+	recs := readJournal(t, stateDir, "s-a1")
+	if len(recs) != 1 {
+		t.Fatalf("want 1 record, got %d", len(recs))
+	}
+	got := recs[0]
+	if got.AgentType != "reviewer" {
+		t.Errorf("agent_type = %q, want the payload's reviewer", got.AgentType)
+	}
+	if got.RoleRequested != "builder" {
+		t.Errorf("role_requested = %q, want the overriding builder", got.RoleRequested)
+	}
+	if got.RoleResolved != "builder" {
+		t.Errorf("role_resolved = %q, want builder", got.RoleResolved)
+	}
+}
+
+// TestAWarnIsReadableAfterTheSessionEnds is AC6.
+//
+// A warn is emitted on stderr, and a PreToolUse hook's stderr on exit 0 is not
+// persisted anywhere the session can be asked about afterwards — measured, and
+// the subject of lesson 254. So before this, a warn that fired and a warn that
+// never fired were the same observation, and the canary accumulated no evidence
+// for a whole day while appearing to work.
+//
+// The journal is read here through a SEPARATE call that shares nothing with the
+// writer but the path, which is what "after the session ends" means in practice.
+func TestAWarnIsReadableAfterTheSessionEnds(t *testing.T) {
+	stateDir := t.TempDir()
+	_, stderr := runGate(t, []string{
+		"--harness", "claude", "--repo-root", repoRootForTest(t), "--state-dir", stateDir,
+	}, `{"tool_name":"Bash","session_id":"s","agent_type":"reviewer","agent_id":"a1"}`)
+
+	// The stderr channel still says it, for a human watching live.
+	if !strings.Contains(stderr, "[gate] warn:") {
+		t.Errorf("no warn on stderr: %q", stderr)
+	}
+
+	recs := readJournal(t, stateDir, "s-a1")
+	if len(recs) != 1 {
+		t.Fatalf("want 1 record, got %d", len(recs))
+	}
+	if recs[0].Outcome != harness.OutcomeWarn {
+		t.Fatalf("outcome = %q, want warn", recs[0].Outcome)
+	}
+	// And it names WHICH skills, or the record says a warn happened without
+	// saying what would clear it — true, and useless.
+	if len(recs[0].Warned) == 0 {
+		t.Error("the record reports a warn but names no skill")
+	}
+	for _, w := range recs[0].Warned {
+		if strings.TrimSpace(w) == "" {
+			t.Error("a warned skill is blank")
+		}
+	}
+}
+
+// TestTheJournalNeverRecordsToolInput is a security property, not a detail.
+//
+// This file is durable, unencrypted, world-readable to the user's own processes,
+// and nothing scans it. Tool inputs carry file contents, shell commands and
+// credentials, so a journal that logged them would be a secrets leak with a
+// retention policy — and it would be written by a hook that fires on EVERY tool
+// call, which is the worst possible collection rate.
+//
+// The neutral ToolCall already drops them at the parse boundary. This pins that,
+// because the next person adding a field to the record will be looking at a
+// payload that still has them.
+func TestTheJournalNeverRecordsToolInput(t *testing.T) {
+	stateDir := t.TempDir()
+	const secret = "AKIAIOSFODNN7EXAMPLE-not-a-real-key"
+	payload := `{"tool_name":"Bash","session_id":"s","agent_type":"reviewer","agent_id":"a1",` +
+		`"tool_input":{"command":"aws configure set aws_secret_access_key ` + secret + `"}}`
+
+	runGate(t, []string{
+		"--harness", "claude", "--repo-root", repoRootForTest(t), "--state-dir", stateDir,
+	}, payload)
+
+	raw, err := os.ReadFile(harness.DecisionPath(stateDir, "s-a1"))
+	if err != nil {
+		t.Fatalf("read journal: %v", err)
+	}
+	if strings.Contains(string(raw), secret) {
+		t.Fatal("the decision journal contains a tool input — this file is a durable, " +
+			"unscanned artifact written on every tool call, so tool arguments must never reach it")
+	}
+	// The tool's NAME is recorded, and must be: without it the journal cannot
+	// say what was gated.
+	if !strings.Contains(string(raw), `"tool":"Bash"`) {
+		t.Errorf("the tool name is missing from the record: %s", raw)
+	}
+}
+
+// TestAnUnparsedPayloadRecordsItsSizeNotItsContent.
+//
+// Size separates "stdin was empty" from "a real payload arrived and did not
+// parse" — two causes of a silent gate needing opposite fixes, and the exact
+// question agy poses. Content is the one thing that must not be written: the
+// payload we could not parse is the payload we cannot vouch for.
+func TestAnUnparsedPayloadRecordsItsSizeNotItsContent(t *testing.T) {
+	stateDir := t.TempDir()
+	const marker = "unparseable-but-sensitive"
+	runGate(t, []string{"--harness", "agy", "--state-dir", stateDir}, `{"weird":"`+marker+`"}`)
+
+	recs := readJournal(t, stateDir, harness.UnparsedScope)
+	if len(recs) != 1 {
+		t.Fatalf("want 1 record, got %d", len(recs))
+	}
+	if recs[0].PayloadBytes == 0 {
+		t.Error("payload_bytes is 0 for a non-empty payload; empty stdin and an " +
+			"unrecognised shape would be indistinguishable")
+	}
+	if recs[0].Harness != "agy" {
+		t.Errorf("harness = %q, want agy — an unparsed record that does not say WHICH "+
+			"harness produced it cannot be acted on", recs[0].Harness)
+	}
+	raw, _ := os.ReadFile(harness.DecisionPath(stateDir, harness.UnparsedScope))
+	if strings.Contains(string(raw), marker) {
+		t.Fatal("the unparsed payload's content was written to disk")
 	}
 }

--- a/cli/internal/harness/bind_test.go
+++ b/cli/internal/harness/bind_test.go
@@ -238,15 +238,37 @@ func TestMergeAgainstTheRealDeployedSettings(t *testing.T) {
 	if err := json.Unmarshal(raw, &doc); err != nil {
 		t.Skipf("deployed settings unreadable: %v", err)
 	}
-	before := ForeignHookCount(doc)
+	before := foreignCommands(doc)
 	out, _, err := MergeHooks(doc, []HookCommand{gateCmd("reviewer")})
 	if err != nil {
 		t.Fatalf("merging into the real file failed: %v", err)
 	}
-	if after := ForeignHookCount(out); after != before {
-		t.Errorf("foreign hooks %d -> %d on the REAL file", before, after)
+	after := foreignCommands(out)
+
+	// A COUNT is the wrong assertion here, and it fails on any machine bound
+	// before the marker field existed. Such a machine carries an UNMARKED gate
+	// entry, which `ForeignHookCount` counts as foreign and which `isOurs`
+	// deliberately adopts by command substring — so the count drops by one while
+	// nothing was lost. Measured on this box, 15 -> 14, with no third-party hook
+	// touched.
+	//
+	// What the file actually has to promise is narrower and is the thing the
+	// Orca incident was about: no hook BELONGING TO SOMEBODY ELSE disappears.
+	// So the loss is compared per command, and the only tolerated disappearance
+	// is an entry the merge was entitled to claim.
+	for cmd, n := range before {
+		lost := n - after[cmd]
+		if lost <= 0 {
+			continue
+		}
+		if strings.Contains(cmd, "dotf harness gate") {
+			// A pre-marker entry of our own, adopted. This is the fallback
+			// working, not a hook being deleted.
+			continue
+		}
+		t.Errorf("a hook that is not ours was lost from the REAL file (%d of %d): %.120s", lost, n, cmd)
 	}
-	t.Logf("real deployed file: %d foreign hook entries, all preserved", before)
+	t.Logf("real deployed file: %d distinct foreign hook commands, none belonging to a third party lost", len(before))
 }
 
 func countOurs(doc map[string]any, event string) int {
@@ -266,4 +288,38 @@ func countOurs(doc map[string]any, event string) int {
 		}
 	}
 	return n
+}
+
+// foreignCommands is ForeignHookCount broken out per command string.
+//
+// The count alone cannot answer the question the test above asks. "Fifteen
+// became fourteen" is true both when a third party's hook was deleted and when
+// one of our own pre-marker entries was adopted, and those are opposite
+// outcomes — one is the incident that motivated the marker, the other is the
+// mechanism that prevents it.
+func foreignCommands(doc map[string]any) map[string]int {
+	out := map[string]int{}
+	hooks, _ := doc["hooks"].(map[string]any)
+	for _, v := range hooks {
+		groups, _ := v.([]any)
+		for _, g := range groups {
+			group, ok := g.(map[string]any)
+			if !ok {
+				continue
+			}
+			inner, _ := group["hooks"].([]any)
+			for _, h := range inner {
+				obj, ok := h.(map[string]any)
+				if !ok {
+					continue
+				}
+				if m, ok := obj[managedKey].(string); ok && strings.HasPrefix(m, BindMarker+":") {
+					continue
+				}
+				cmd, _ := obj["command"].(string)
+				out[cmd]++
+			}
+		}
+	}
+	return out
 }

--- a/cli/internal/harness/decision.go
+++ b/cli/internal/harness/decision.go
@@ -134,12 +134,6 @@ func RecordDecision(path string, rec DecisionRecord) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return err
 	}
-	// Size is one stat, checked before the append rather than by counting lines,
-	// because this runs on every tool call and reading the file to measure it
-	// would make the hot path grow with its own history.
-	if fi, err := os.Stat(path); err == nil && fi.Size() >= maxDecisionBytes {
-		_ = os.Rename(path, path+".1")
-	}
 	raw, err := json.Marshal(rec)
 	if err != nil {
 		return err
@@ -149,8 +143,50 @@ func RecordDecision(path string, rec DecisionRecord) error {
 		return err
 	}
 	defer func() { _ = f.Close() }()
-	_, err = f.Write(append(raw, '\n'))
-	return err
+
+	// ONE write of one line, on a fd opened O_APPEND. That is what keeps
+	// concurrent writers from interleaving: the kernel makes the seek-to-end and
+	// the write a single step for a regular file, and every record here is far
+	// below the size where that stops holding. Building the line in memory first
+	// is therefore load-bearing, not tidiness — two Writes could interleave.
+	//
+	// Concurrency is not hypothetical: the gate runs per tool call, and several
+	// sessions and subagents on one machine write at once. Pinned by
+	// TestConcurrentWritersLoseNoRecords.
+	if _, err := f.Write(append(raw, '\n')); err != nil {
+		return err
+	}
+
+	// ROTATION HAPPENS AFTER THE WRITE, AND FROM OUR OWN FD. Doing it first —
+	// stat the path, rename, then open — loses the record being written when
+	// another writer rotates in between, and lets a file that is not full replace
+	// the kept generation. Raised by the reviewer on #1435.
+	//
+	// fstat on the descriptor we just wrote answers about THAT file rather than
+	// about whatever the path names now, and SameFile confirms the path still
+	// refers to it before renaming.
+	//
+	// A RESIDUAL RACE REMAINS AND IS ACCEPTED. Between the SameFile check and the
+	// rename, another writer can rotate, so two writers holding the same full file
+	// can both proceed and the second may replace the generation the first just
+	// kept. Measured — an assertion on the emergent property flaked.
+	//
+	// What it can cost is bounded to OLD history: the record being written is
+	// already durable above, so nothing recent is lost, and a not-full file is no
+	// longer a plausible replacement for a full one. Closing the window entirely
+	// needs an advisory lock, and `syscall.Flock` does not exist on Windows —
+	// this package compiles for it, and a Windows-only build break is a defect
+	// this repository has already paid for once (#1075). A lock is not worth that
+	// for a diagnostic journal whose worst case is losing records nobody has
+	// asked about since they rotated.
+	fi, err := f.Stat()
+	if err != nil || fi.Size() < maxDecisionBytes {
+		return nil //nolint:nilerr // a failed stat means only that rotation is skipped; the record is already durable
+	}
+	if cur, err := os.Stat(path); err == nil && os.SameFile(fi, cur) {
+		_ = os.Rename(path, path+".1")
+	}
+	return nil
 }
 
 // LoadDecisions reads a scope's journal oldest-first.

--- a/cli/internal/harness/decision.go
+++ b/cli/internal/harness/decision.go
@@ -1,0 +1,187 @@
+package harness
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Outcome is WHY the gate decided what it decided.
+//
+// It is a closed vocabulary rather than a free-text reason because the record is
+// a measurement surface: `features.json`, the agy/pi/opencode verification, and
+// any future query all select on this field. A reason string is for a human; an
+// outcome is for a filter, and a filter that matches on prose silently returns
+// nothing the day the prose is reworded — the failure mode this repository has
+// already catalogued in `check-roster-consistency.py`.
+//
+// Every value here is reachable from `dotf harness gate`. Deliberately absent is
+// a "skill invocation" outcome: `Decide` has that branch, but the command
+// returns on the skill paths before reaching it, so recording one would describe
+// a state the gate cannot be in.
+type Outcome string
+
+const (
+	// OutcomePayloadUnrecognised is stdin the gate could not parse at all.
+	//
+	// This is the single most diagnostic value in the vocabulary. A harness whose
+	// field names do not match — agy is the open question — produces exactly this
+	// and nothing else, and before this record existed it was indistinguishable
+	// from a harness working perfectly: both allowed, and both wrote nothing.
+	OutcomePayloadUnrecognised Outcome = "payload-unrecognised"
+	// OutcomeSkillConsumed is a skill invocation, recorded in the ledger.
+	OutcomeSkillConsumed Outcome = "skill-consumed"
+	// OutcomeSkillUnnamed is the skill primitive with an unreadable argument.
+	OutcomeSkillUnnamed Outcome = "skill-unnamed"
+	// OutcomeNoRole is a call naming no persona — a main-thread call. Not an
+	// error, and the pre-existing allow.
+	OutcomeNoRole Outcome = "no-role"
+	// OutcomeRoleUnresolved is a role that was ASKED FOR and did not resolve.
+	// Enforcement is off for this call, which is the state AC5 names explicitly
+	// because it is the one that looks identical to health from outside.
+	OutcomeRoleUnresolved Outcome = "role-unresolved"
+	// OutcomeAllow is a persona in scope with nothing outstanding.
+	OutcomeAllow Outcome = "allow"
+	// OutcomeWarn is allowed, with `enforce: warn` skills unconsumed.
+	//
+	// This value is the whole of AC6. A warn is emitted on stderr, and a
+	// PreToolUse hook's stderr on exit 0 is not persisted anywhere the session
+	// can be asked about afterwards — so before this record, a warn that fired
+	// and a warn that never fired were the same observation.
+	OutcomeWarn Outcome = "warn"
+	// OutcomeBlock is a refused tool call.
+	OutcomeBlock Outcome = "block"
+)
+
+// UnparsedScope is the ledger scope for a payload with no readable session.
+//
+// It has to go somewhere, and by definition it has no scope of its own. The
+// leading underscore keeps it out of the space of real session ids — every
+// harness observed here sends a UUID — so a genuine session can never land in
+// this file and make an unparsed pile look like healthy traffic.
+const UnparsedScope = "_unparsed"
+
+// maxDecisionBytes caps one scope's journal before it rotates to a single `.1`
+// generation, bounding a scope at twice this. The gate runs on EVERY tool call,
+// so this file grows without an upper bound otherwise — and an unbounded log
+// written by a hook is a way to fill a disk, which would then fail the very
+// writes the fail-open discipline depends on being harmless.
+const maxDecisionBytes = 1 << 20
+
+// DecisionRecord is one gate decision, durably.
+//
+// IT CARRIES NO TOOL INPUT, and that is a security property rather than an
+// omission. This file is durable, unencrypted, and nothing scans it. Tool inputs
+// carry file contents, shell commands and credentials; a journal that logged
+// them would be a secrets leak with a retention policy. The neutral `ToolCall`
+// already drops them at the parse boundary, and this type is built to keep it
+// that way: tool and skill are NAMES.
+type DecisionRecord struct {
+	Time    string `json:"ts"`
+	Harness string `json:"harness"`
+	Session string `json:"session,omitempty"`
+	// AgentType is what the payload SAID was acting. Recorded separately from
+	// RoleRequested and RoleResolved because the three can differ, and the
+	// difference is the diagnosis: a `--role` override, a typo, or a record that
+	// moved will show up as a resolved role that does not match the payload.
+	AgentType string `json:"agent_type,omitempty"`
+	AgentID   string `json:"agent_id,omitempty"`
+	Scope     string `json:"scope,omitempty"`
+	Tool      string `json:"tool,omitempty"`
+	Skill     string `json:"skill,omitempty"`
+	// RoleRequested is what the gate actually looked up, after the flag override.
+	RoleRequested string `json:"role_requested,omitempty"`
+	// RoleResolved is the persona it found. Empty with a `role-unresolved`
+	// outcome is the case AC5 names; empty with `no-role` is a main-thread call.
+	RoleResolved string   `json:"role_resolved,omitempty"`
+	Outcome      Outcome  `json:"outcome"`
+	Allowed      bool     `json:"allowed"`
+	Reason       string   `json:"reason,omitempty"`
+	Warned       []string `json:"warned,omitempty"`
+	Missing      []string `json:"missing,omitempty"`
+	// PayloadBytes is set only for an unrecognised payload. It separates "stdin
+	// was empty" from "a real payload arrived and did not parse" — the two
+	// causes of a silent gate, which need opposite fixes. The LENGTH, never the
+	// content: the thing we could not parse is exactly the thing least safe to
+	// write down.
+	PayloadBytes int `json:"payload_bytes,omitempty"`
+}
+
+// DecisionPath is where one scope's journal lives.
+//
+// It reuses scopeKey, and therefore StatePath's collision digest, on purpose.
+// Character-mapping alone collides (`a/b` and `a.b` both flatten to `a_b`), and
+// on the consumption ledger that would open one session's gate with another's
+// record. Here it would attribute one dispatch's decisions to another, which is
+// worse in the specific way that matters: this file is the instrument, so a
+// collision corrupts the measurement rather than announcing itself.
+func DecisionPath(stateDir, scope string) string {
+	return filepath.Join(stateDir, "gate", scopeKey(scope)+".decisions.jsonl")
+}
+
+// RecordDecision appends one decision.
+//
+// Errors are returned but every caller ignores them, matching RecordConsumed:
+// losing a record costs a measurement, while failing here would block a session
+// over a full disk. The gate's entire contract is that it never turns its own
+// malfunction into a refused tool call.
+func RecordDecision(path string, rec DecisionRecord) error {
+	if rec.Time == "" {
+		rec.Time = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	// Size is one stat, checked before the append rather than by counting lines,
+	// because this runs on every tool call and reading the file to measure it
+	// would make the hot path grow with its own history.
+	if fi, err := os.Stat(path); err == nil && fi.Size() >= maxDecisionBytes {
+		_ = os.Rename(path, path+".1")
+	}
+	raw, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) // #nosec G304 -- path is built by DecisionPath from the state dir
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	_, err = f.Write(append(raw, '\n'))
+	return err
+}
+
+// LoadDecisions reads a scope's journal oldest-first.
+//
+// A malformed line is SKIPPED rather than failing the read. The writer appends
+// from a hook that can be killed mid-write, so a torn final line is an expected
+// state, and refusing to read the file because of it would lose every intact
+// record before it — turning a partial answer into no answer.
+func LoadDecisions(path string) ([]DecisionRecord, error) {
+	f, err := os.Open(path) // #nosec G304 -- path is built by DecisionPath from the state dir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var out []DecisionRecord
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var rec DecisionRecord
+		if json.Unmarshal(line, &rec) != nil {
+			continue
+		}
+		out = append(out, rec)
+	}
+	return out, sc.Err()
+}

--- a/cli/internal/harness/decision.go
+++ b/cli/internal/harness/decision.go
@@ -142,8 +142,6 @@ func RecordDecision(path string, rec DecisionRecord) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = f.Close() }()
-
 	// ONE write of one line, on a fd opened O_APPEND. That is what keeps
 	// concurrent writers from interleaving: the kernel makes the seek-to-end and
 	// the write a single step for a regular file, and every record here is far
@@ -154,6 +152,25 @@ func RecordDecision(path string, rec DecisionRecord) error {
 	// sessions and subagents on one machine write at once. Pinned by
 	// TestConcurrentWritersLoseNoRecords.
 	if _, err := f.Write(append(raw, '\n')); err != nil {
+		_ = f.Close()
+		return err
+	}
+
+	// fstat while the descriptor is still open, then CLOSE BEFORE ROTATING.
+	//
+	// The close is not cleanup, it is a correctness step, and it is why there is
+	// no `defer` here. Windows refuses to rename an open file, so leaving the
+	// handle open made rotation fail silently — the error is ignored by design —
+	// and the journal grew without bound on that platform only. Measured on
+	// #1435's `test (windows-latest)`: rotation never fired, and both bounding
+	// tests failed with "no rotation happened, so this test asserts nothing".
+	//
+	// `GOOS=windows go vet` does not see this. It is runtime behaviour, not a
+	// compile error, so only running the tests on Windows catches it — and this
+	// overlap between the open handle and the rename was created by moving the
+	// rotation AFTER the write, which is otherwise the right ordering.
+	fi, statErr := f.Stat()
+	if err := f.Close(); err != nil {
 		return err
 	}
 
@@ -179,8 +196,7 @@ func RecordDecision(path string, rec DecisionRecord) error {
 	// this repository has already paid for once (#1075). A lock is not worth that
 	// for a diagnostic journal whose worst case is losing records nobody has
 	// asked about since they rotated.
-	fi, err := f.Stat()
-	if err != nil || fi.Size() < maxDecisionBytes {
+	if statErr != nil || fi.Size() < maxDecisionBytes {
 		return nil //nolint:nilerr // a failed stat means only that rotation is skipped; the record is already durable
 	}
 	if cur, err := os.Stat(path); err == nil && os.SameFile(fi, cur) {

--- a/cli/internal/harness/decision_test.go
+++ b/cli/internal/harness/decision_test.go
@@ -1,0 +1,193 @@
+package harness
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestDecisionRecordSchemaIsPinned fixes the wire field names.
+//
+// This record is an INSTRUMENT, not a log. `features.json` selects on it, the
+// agy/pi/opencode verification will select on it, and a human answering "did the
+// gate ever see agent_type" greps it. A renamed key breaks every one of those
+// silently — the query returns nothing, and nothing is exactly what a working
+// system that has not fired yet also returns. Same class as
+// `check-roster-consistency.py`'s regex, which returned "no skills" in silence
+// when the schema moved under it.
+//
+// So the names are pinned here, and renaming one is a deliberate act that also
+// updates its consumers, rather than a refactor that quietly empties them.
+func TestDecisionRecordSchemaIsPinned(t *testing.T) {
+	full := DecisionRecord{
+		Time: "2026-09-02T00:00:00Z", Harness: "claude", Session: "s", AgentType: "reviewer",
+		AgentID: "a1", Scope: "s-a1", Tool: "Bash", Skill: "audit", RoleRequested: "reviewer",
+		RoleResolved: "reviewer", Outcome: OutcomeWarn, Allowed: true, Reason: "r",
+		Warned: []string{"w"}, Missing: []string{"m"}, PayloadBytes: 7,
+	}
+	raw, err := json.Marshal(full)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	want := []string{
+		"agent_id", "agent_type", "allowed", "harness", "missing", "payload_bytes",
+		"reason", "role_requested", "role_resolved", "scope", "session", "skill",
+		"tool", "ts", "warned", "outcome",
+	}
+	sort.Strings(want)
+	var keys []string
+	for k := range got {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if strings.Join(keys, ",") != strings.Join(want, ",") {
+		t.Errorf("the record's wire schema changed.\n got: %v\nwant: %v\n\n"+
+			"Every consumer selects on these names. Update them in the same change, or a\n"+
+			"query that used to answer now returns nothing and reads as 'never happened'.",
+			keys, want)
+	}
+}
+
+// TestDecisionOutcomesAreDistinct guards the vocabulary itself. Two constants
+// sharing a string would silently merge two states — and the pair that matters,
+// no-role and role-unresolved, are the ones a reader most needs told apart:
+// both allow, and only one means enforcement was off.
+func TestDecisionOutcomesAreDistinct(t *testing.T) {
+	all := []Outcome{
+		OutcomePayloadUnrecognised, OutcomeSkillConsumed, OutcomeSkillUnnamed,
+		OutcomeNoRole, OutcomeRoleUnresolved, OutcomeAllow, OutcomeWarn, OutcomeBlock,
+	}
+	seen := map[Outcome]bool{}
+	for _, o := range all {
+		if o == "" {
+			t.Error("an outcome is the empty string, which is indistinguishable from an unset field")
+		}
+		if seen[o] {
+			t.Errorf("duplicate outcome %q — two states would be recorded as one", o)
+		}
+		seen[o] = true
+	}
+}
+
+// TestDecisionPathSharesTheLedgersCollisionGuard is why DecisionPath does not
+// build its own filename.
+//
+// Character-mapping alone collides: `a/b` and `a.b` both flatten to `a_b`. On
+// the consumption ledger that opens one session's gate with another's record; on
+// the journal it attributes one dispatch's decisions to another, which is worse
+// in the specific way that matters — this file is the measurement, so a
+// collision corrupts the answer instead of announcing itself.
+func TestDecisionPathSharesTheLedgersCollisionGuard(t *testing.T) {
+	dir := t.TempDir()
+	a, b := "a/b", "a.b"
+	if DecisionPath(dir, a) == DecisionPath(dir, b) {
+		t.Errorf("scopes %q and %q share a journal at %s", a, b, DecisionPath(dir, a))
+	}
+	// And the two files for ONE scope must differ, or the journal would append
+	// into the ledger and destroy it.
+	if DecisionPath(dir, a) == StatePath(dir, a) {
+		t.Error("the journal and the consumption ledger resolve to the same file")
+	}
+	// They must nonetheless agree on the scope's identity, which is the whole
+	// reason scopeKey is shared rather than reimplemented.
+	stem := strings.TrimSuffix(filepath.Base(StatePath(dir, a)), ".json")
+	if !strings.HasPrefix(filepath.Base(DecisionPath(dir, a)), stem) {
+		t.Errorf("journal %q is not keyed by the ledger's stem %q",
+			filepath.Base(DecisionPath(dir, a)), stem)
+	}
+}
+
+func TestDecisionJournalRoundTrips(t *testing.T) {
+	path := DecisionPath(t.TempDir(), "s")
+	for _, o := range []Outcome{OutcomeAllow, OutcomeWarn, OutcomeBlock} {
+		if err := RecordDecision(path, DecisionRecord{Outcome: o, Tool: "Bash"}); err != nil {
+			t.Fatalf("record %s: %v", o, err)
+		}
+	}
+	got, err := LoadDecisions(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("read %d records, want 3", len(got))
+	}
+	if got[0].Outcome != OutcomeAllow || got[2].Outcome != OutcomeBlock {
+		t.Errorf("records are not oldest-first: %v", got)
+	}
+	if got[0].Time == "" {
+		t.Error("a record was written with no timestamp; ordering across files would be unrecoverable")
+	}
+}
+
+// TestDecisionJournalSurvivesATornFinalLine pins the read side against the way
+// this file actually gets damaged.
+//
+// The writer is a hook. A hook is killed when the session is, so a half-written
+// final line is an expected state rather than corruption. Refusing the whole
+// file for it would discard every intact record before it — turning a partial
+// answer into no answer, which is the direction this whole spec argues against.
+func TestDecisionJournalSurvivesATornFinalLine(t *testing.T) {
+	path := DecisionPath(t.TempDir(), "s")
+	if err := RecordDecision(path, DecisionRecord{Outcome: OutcomeAllow}); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"outcome":"bl`); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	got, err := LoadDecisions(path)
+	if err != nil {
+		t.Fatalf("a torn line made the whole journal unreadable: %v", err)
+	}
+	if len(got) != 1 || got[0].Outcome != OutcomeAllow {
+		t.Errorf("the intact record before the tear was lost: %v", got)
+	}
+}
+
+// TestDecisionJournalIsBounded. The gate runs on EVERY tool call, so an
+// unbounded journal is a way to fill a disk — and a full disk breaks the writes
+// that the fail-open discipline assumes are harmless to lose.
+func TestDecisionJournalIsBounded(t *testing.T) {
+	path := DecisionPath(t.TempDir(), "s")
+	big := DecisionRecord{Outcome: OutcomeAllow, Reason: strings.Repeat("x", 4096)}
+	for i := 0; i < 400; i++ {
+		if err := RecordDecision(path, big); err != nil {
+			t.Fatalf("record %d: %v", i, err)
+		}
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Size() >= maxDecisionBytes {
+		t.Errorf("journal reached %d bytes without rotating (cap %d)", fi.Size(), maxDecisionBytes)
+	}
+	// Rotation keeps exactly one generation, so the total is bounded rather
+	// than merely the live file.
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Errorf("no rotated generation beside the live journal: %v", err)
+	}
+}
+
+func TestLoadDecisionsOnAMissingJournalIsEmptyNotAnError(t *testing.T) {
+	got, err := LoadDecisions(DecisionPath(t.TempDir(), "never-written"))
+	if err != nil {
+		t.Errorf("a missing journal must read as empty, got %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("want no records, got %d", len(got))
+	}
+}

--- a/cli/internal/harness/decision_test.go
+++ b/cli/internal/harness/decision_test.go
@@ -2,10 +2,12 @@ package harness
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -189,5 +191,119 @@ func TestLoadDecisionsOnAMissingJournalIsEmptyNotAnError(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("want no records, got %d", len(got))
+	}
+}
+
+// TestConcurrentWritersLoseNoRecords answers the reviewer's concern on #1435
+// with a measurement rather than with prose about O_APPEND.
+//
+// The gate runs on every tool call, and several sessions and subagents on one
+// machine write at once — so this is the normal case, not an edge one. Each
+// writer opens its own descriptor, which is what a separate process does too;
+// the kernel path exercised is the same one, so this models cross-process
+// appends faithfully for the property being asserted.
+//
+// The property: every record survives, and none is torn by another writer.
+func TestConcurrentWritersLoseNoRecords(t *testing.T) {
+	path := DecisionPath(t.TempDir(), "busy")
+	const writers, each = 24, 40
+
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < each; i++ {
+				if err := RecordDecision(path, DecisionRecord{
+					Outcome: OutcomeAllow,
+					Tool:    "Bash",
+					Session: fmt.Sprintf("w%d-i%d", w, i),
+				}); err != nil {
+					t.Errorf("writer %d record %d: %v", w, i, err)
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	recs, err := LoadDecisions(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(recs) != writers*each {
+		t.Errorf("read %d records, want %d — concurrent appends lost or tore records",
+			len(recs), writers*each)
+	}
+	// Every session id must appear exactly once. A count alone would pass if one
+	// record were duplicated while another was lost.
+	seen := map[string]int{}
+	for _, r := range recs {
+		seen[r.Session]++
+	}
+	for w := 0; w < writers; w++ {
+		for i := 0; i < each; i++ {
+			if k := fmt.Sprintf("w%d-i%d", w, i); seen[k] != 1 {
+				t.Fatalf("record %s appears %d times, want exactly 1", k, seen[k])
+			}
+		}
+	}
+}
+
+// TestTheRecordThatTriggersRotationIsInTheRotatedFile pins the ORDERING that
+// the reviewer's rotation finding on #1435 is about, deterministically.
+//
+// Two earlier attempts at this were worse and are worth recording, because both
+// failure modes are ones this repository keeps meeting:
+//
+//   - The first was single-threaded and asserted "no record is lost". The old
+//     ordering passes that: stat sees a full file, renames it, writes to a fresh
+//     one, nothing lost. It stayed green with the defect reinstated — VACUOUS,
+//     and only exposed by proving the red direction.
+//   - The second asserted the emergent property under concurrency (the kept
+//     generation is always full). That one FLAKED: it depends on goroutine
+//     interleaving, and the residual race documented in RecordDecision means it
+//     is not a property the code guarantees.
+//
+// So this asserts the ordering itself, which is what actually changed and is
+// fully deterministic. Write-then-rotate puts the triggering record in the
+// ROTATED file. Rotate-then-write puts it in a fresh live file and leaves the
+// rotated one without it.
+func TestTheRecordThatTriggersRotationIsInTheRotatedFile(t *testing.T) {
+	path := DecisionPath(t.TempDir(), "s")
+	big := strings.Repeat("x", 4096)
+
+	trigger := ""
+	for i := 0; i < 600; i++ {
+		id := fmt.Sprintf("r%d", i)
+		if err := RecordDecision(path, DecisionRecord{
+			Outcome: OutcomeAllow, Reason: big, Session: id,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(path + ".1"); err == nil {
+			trigger = id
+			break
+		}
+	}
+	if trigger == "" {
+		t.Fatal("no rotation happened, so this test asserts nothing")
+	}
+
+	rotated, err := LoadDecisions(path + ".1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, r := range rotated {
+		if r.Session == trigger {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("the record that triggered rotation (%s) is not in the rotated file. "+
+			"That means rotation ran BEFORE the write, which is the ordering that drops a "+
+			"record when another writer rotates in between", trigger)
 	}
 }

--- a/cli/internal/harness/gate.go
+++ b/cli/internal/harness/gate.go
@@ -167,20 +167,31 @@ type consumedState struct {
 // happen with well-behaved input" is not a property a path builder should rely
 // on. The readable prefix is kept so the directory stays diagnosable by eye.
 func StatePath(stateDir, sessionID string) string {
+	return filepath.Join(stateDir, "gate", scopeKey(sessionID)+".json")
+}
+
+// scopeKey turns a scope into the readable-prefix-plus-digest filename stem that
+// both the consumption ledger and the decision journal are keyed by.
+//
+// It is shared rather than duplicated because the two must agree: a scope whose
+// ledger and journal disagreed would report decisions for one dispatch against
+// another's consumption, and the digest is the part that makes either of them
+// safe. Extracted when the journal landed; the behaviour is unchanged.
+func scopeKey(scope string) string {
 	safe := strings.Map(func(r rune) rune {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
 			return r
 		}
 		return '_'
-	}, sessionID)
+	}, scope)
 	if len(safe) > 48 {
 		safe = safe[:48]
 	}
 	if safe == "" {
 		safe = "unknown"
 	}
-	sum := sha256.Sum256([]byte(sessionID))
-	return filepath.Join(stateDir, "gate", safe+"-"+hex.EncodeToString(sum[:4])+".json")
+	sum := sha256.Sum256([]byte(scope))
+	return safe + "-" + hex.EncodeToString(sum[:4])
 }
 
 // LoadConsumed reads a session's consumed skills. A missing or unreadable file

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -273,5 +273,6 @@ tags: [lessons, index, dotfiles]
 | [252 - A git pathspec is resolved against the CWD, so the same argument means two different things and one of them is silently empty](lesson-252-a-git-pathspec-is-resolved-against-the-cwd-so-the-same.md) | 2026-09-01 |  |
 | [254 - A canary that emits where nothing persists accumulates no evidence, and its silence reads as success](lesson-254-a-canary-that-emits-where-nothing-persists.md) | 2026-09-01 |  |
 | [255 - Truncation, not hostile input, is what made the collision guard load-bearing — and without it the measurement would have confirmed the opposite](lesson-255-truncation-not-hostile-input-made-the-digest-load-bearing.md) | 2026-09-01 |  |
+| [256 - Hooks are re-read and personas are not, and one measurement was generalised into both](lesson-256-hooks-reload-personas-do-not-and-the-difference-was-assumed-away.md) | 2026-09-02 |  |
 
 - [2026-08-30 Intercepting Cobra Errors without Breaking SilenceErrors](2026-08-30-cobra-silence-errors-interception.md)

--- a/docs/lessons/lesson-256-hooks-reload-personas-do-not-and-the-difference-was-assumed-away.md
+++ b/docs/lessons/lesson-256-hooks-reload-personas-do-not-and-the-difference-was-assumed-away.md
@@ -1,0 +1,70 @@
+---
+id: 256
+title: "Hooks are re-read and personas are not, and one measurement was generalised into both"
+date: "2026-09-02"
+tags: [lesson, harness, orchestrator, measurement]
+---
+
+# 256 — Hooks are re-read, personas are not, and one measurement was generalised into both
+
+## What happened
+
+Measuring the orchestrator gate on 2026-09-01 established, three separate ways, that Claude
+Code **re-reads `settings.json` hooks** rather than freezing them at session start. That was a
+real result and it retired a standing plan: every "open a fresh session to pick this up" step
+was unnecessary.
+
+The next day it got applied one layer over. `harness/capability-map.json` gained a `skill` verb,
+`compile-harness.sh --deploy` rewrote `~/.claude/agents/reviewer.md` from
+`tools: Read, Glob, Grep, Bash` to `tools: Read, Glob, Grep, Bash, Skill`, and the file on disk
+was verified by reading it back. A `reviewer` was then dispatched and asked to invoke a skill.
+
+It answered that it had no Skill tool: `Read, Bash, advisor`. Not the old set, not the new set —
+**the roster the dispatching session had loaded at ITS start.**
+
+## The mistake
+
+"Hooks reload" was measured. "The harness reloads its configuration" was inferred from it, and
+those are different claims about different files read by different subsystems at different
+times. Nothing was measured about persona records, and the earlier result gave no reason to
+expect they behave alike — hooks are consulted per tool call, a persona roster is consulted when
+a dispatch is constructed.
+
+The tell was available and went unread: the reported tool set matched **neither** the old file
+nor the new one. A disagreement with both versions on disk is a signal that the file is not the
+source at all, and it was briefly read as a deploy that had half-worked.
+
+## The rule
+
+**A reload measurement covers the file that was measured.** Extending it to a second file is a
+new claim needing its own measurement, and the cost of getting it wrong is asymmetric: assuming
+a reload that does not happen makes a change look shipped when it is not, and the verification
+that "proves" it reads the file rather than the running system.
+
+Concretely, in this repository:
+
+- **Hooks in `~/.claude/settings.json` — re-read.** A `dotf harness bind` takes effect in
+  sessions already running.
+- **Persona records in `~/.claude/agents/` — frozen at the dispatching session's start.** A
+  `compile-harness.sh --deploy` reaches only sessions started afterwards.
+
+## What it cost, and what it did not
+
+One acceptance criterion (`HARNESS-106` AC4 — a dispatched persona invokes a skill and leaves a
+consumption record) could not be closed in the session that shipped the mechanism, and stayed
+open with a named blocker rather than being ticked on a file's contents. Which is the right
+outcome: AC4 was written as *"proven by a dispatch that writes a consumption record — never by a
+config file containing a key"*, precisely to refuse the evidence that was available.
+
+Nothing was mis-shipped, because the criterion was worded to reject exactly the shortcut the
+wrong inference would have taken. An acceptance criterion that names the evidence it will not
+accept is what turned a bad assumption into a deferred item instead of a false claim.
+
+## See also
+
+- `docs/lessons/lesson-254-a-canary-that-emits-where-nothing-persists.md` — the same family: a
+  measurement whose instrument could not observe what it claimed.
+- `docs/lessons/lesson-255-truncation-not-hostile-input-made-the-digest-load-bearing.md`
+- `specs/HARNESS-106-skill-capability/` — AC4's wording, and the decision record that made the
+  session's real state readable.
+- #1434 — the fail-open the decision record caught on its first day.

--- a/specs/HARNESS-106-skill-capability/features.json
+++ b/specs/HARNESS-106-skill-capability/features.json
@@ -22,30 +22,30 @@
   },
   {
     "id": "HARNESS-106-skill-capability-f4",
-    "behavior": "AC4 — a dispatched persona can invoke a skill, proven by a consumption record rather than by a config file containing a key",
-    "verification": "test -n \"$(dotf harness gate-decisions --last --agent-type reviewer 2>/dev/null)\"",
+    "behavior": "AC4 — a dispatched persona invokes a skill and the gate writes a skill-consumed record carrying agent_type",
+    "verification": "test -n \"$(grep -h skill-consumed \"${XDG_STATE_HOME:-$HOME/.local/state}\"/dotfiles/gate/*.decisions.jsonl 2>/dev/null | grep agent_type)\"",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "HARNESS-106-skill-capability-f5",
-    "behavior": "AC5 — the gate writes a durable record for every decision including allow and 'role did not resolve', reachable without --debug and without reading a transcript",
-    "verification": "cd cli && go test ./internal/harness/ -run TestGateRecordsEveryDecision",
-    "state": "pending",
+    "behavior": "AC5 — every gate path writes a durable record, including allow and 'role did not resolve', independent of stderr and exit code",
+    "verification": "cd cli && go test ./internal/cmd/ -run TestEveryGateDecisionLeavesADurableRecord",
+    "state": "implemented",
     "evidence": ""
   },
   {
     "id": "HARNESS-106-skill-capability-f6",
-    "behavior": "AC6 — a warn decision is observable after the session ends, from the durable record alone",
-    "verification": "cd cli && go test ./internal/harness/ -run TestWarnDecisionSurvivesTheSession",
-    "state": "pending",
+    "behavior": "AC6 — a warn decision is readable from the record alone after the session ends, naming the skills",
+    "verification": "cd cli && go test ./internal/cmd/ -run TestAWarnIsReadableAfterTheSessionEnds",
+    "state": "implemented",
     "evidence": ""
   },
   {
     "id": "HARNESS-106-skill-capability-f7",
-    "behavior": "AC7 — agent_type is reported in the record, converting the standing inference into a measurement",
-    "verification": "cd cli && go test ./internal/harness/ -run TestGateRecordCarriesAgentType",
-    "state": "pending",
+    "behavior": "AC7 — agent_type is carried in the record, on the skill path too, separate from the role requested and the role resolved",
+    "verification": "cd cli && go test ./internal/cmd/ -run 'TestGateRecordCarriesAgentType|TestTheRecordSeparatesWhatWasAskedForFromWhatResolved'",
+    "state": "implemented",
     "evidence": ""
   },
   {

--- a/specs/HARNESS-106-skill-capability/proposal.md
+++ b/specs/HARNESS-106-skill-capability/proposal.md
@@ -121,12 +121,12 @@ Concretely, after this:
       capability, asserted by a guard that fails red when one does not.
 - [ ] **AC4** — A dispatched persona **can invoke a skill**, proven by a dispatch
       that writes a consumption record — never by a config file containing a key.
-- [ ] **AC5** — `dotf harness gate` writes a durable record for every decision it
+- [x] **AC5** — `dotf harness gate` writes a durable record for every decision it
       takes, including `allow` and `role did not resolve`, reachable without
       `--debug` and without reading a transcript.
-- [ ] **AC6** — A `warn` decision is **observable after the session ends**, from
+- [x] **AC6** — A `warn` decision is **observable after the session ends**, from
       that record alone.
-- [ ] **AC7** — `agent_type` is reported in the record, so a real dispatch shows
+- [x] **AC7** — `agent_type` is reported in the record, so a real dispatch shows
       which persona the gate resolved. This is the criterion that converts the
       standing inference into a measurement.
 - [x] **AC8** — The change propagates by deploy: the vault SSOT plus the repo map

--- a/specs/HARNESS-106-skill-capability/verification.md
+++ b/specs/HARNESS-106-skill-capability/verification.md
@@ -28,12 +28,24 @@ Map every acceptance criterion from `proposal.md` to concrete proof (commit hash
       Red/green proven against two real fixtures: this machine's pre-fix `~/.claude/agents`
       (**RED**, `checked=7`, all seven named) and a deploy from this tree (**GREEN**,
       `checked=7`). Neither is vacuous.
-- [ ] **AC4** -> deferred. Cannot be proven until AC5–AC7 land: a dispatch currently leaves no
-      durable evidence, so "the persona invoked a skill" and "the gate never saw it" are the
-      same observation.
-- [ ] **AC5** -> deferred (durable decision record).
-- [ ] **AC6** -> deferred (a `warn` decision observable after the session ends).
-- [ ] **AC7** -> deferred (`agent_type` in the record).
+- [ ] **AC4** -> **still open, with a named blocker rather than a vague one.** The deployed
+      `~/.claude/agents/reviewer.md` carries `Skill` after the deploy, and a dispatched reviewer
+      nonetheless reported its tools as `Read, Bash, advisor`. That matches the roster loaded at
+      the *dispatching session's* start, not the file on disk. **Agent definitions are frozen at
+      session start; hooks are re-read.** The earlier measurement that hooks reload does not
+      generalise to personas, and assuming it did is what made this look ready. AC4 needs a
+      session started after the deploy — nothing more, and nothing in this change.
+- [x] **AC5** -> test `TestEveryGateDecisionLeavesADurableRecord`, eight cases, one per path
+      the command can take — including the three that return before any persona is loaded and
+      the block path, which was untestable in process until it stopped calling `os.Exit`.
+      Confirmed live: 43 records on this machine across `no-role`, `warn` and `role-unresolved`.
+- [x] **AC6** -> test `TestAWarnIsReadableAfterTheSessionEnds`, and measured live. An unnamed
+      `reviewer` dispatch produced `outcome: warn` naming all four skills
+      (`adversarial-review`, `audit`, `cyclomatic-complexity`, `verification-before-completion`)
+      readable from the journal alone, with nothing but the file path shared with the writer.
+- [x] **AC7** -> test `TestGateRecordCarriesAgentType`, and **measured on a real dispatch** —
+      the criterion's whole point. `agent_type: "reviewer"` arrived, resolved to the persona,
+      and was recorded. It also immediately caught a defect nothing else could see: see below.
 - [x] **AC8** -> two consecutive `compile-harness.sh --deploy` runs into a scratch `$HOME`,
       `diff -rq` byte-identical. Only the vault SSOT (7 records) and the repo map were edited;
       no generated file was hand-edited.
@@ -76,6 +88,26 @@ Brief log of non-obvious trade-offs or course corrections taken during the work.
   probes `resolve-capabilities` to tell "stale binary" from "bad map" and names its own fix.
 - **AC4 was reclassified as deferred rather than met.** A scratch deploy proves a config file
   contains a key, which is precisely what AC4 says is not proof.
+
+## What the record caught on its first day
+
+Two dispatches of the SAME persona, differing only in whether the caller supplied a name:
+
+| dispatch | payload `agent_type` | `role_resolved` | outcome |
+|---|---|---|---|
+| `subagent_type: reviewer`, no name | `reviewer` | `reviewer` | `warn`, 4 skills named |
+| `subagent_type: reviewer`, `name: gate-probe-agent-type` | `gate-probe-agent-type` | *(none)* | **`role-unresolved`** |
+
+`agent_type` carries the **caller-supplied name** when one is given, not the persona type. So
+naming a dispatch makes the role unresolvable and **turns its gate off** — allowing, exiting 0,
+and indistinguishable from health by every other means. Under `enforce: block` that is a bypass
+with a one-word opt-out. Filed as **#1434**, and it is a hard precondition on promoting any
+skill to `block`.
+
+This is the strongest available argument for the record itself: the defect was found on the day
+it shipped, by looking at it, and was invisible to the exit code, the stderr and `dotf doctor`
+alike. It also generalises lesson 255 — **both** identity fields are caller-influenced, not just
+`agent_id`.
 
 ## Promotion candidates
 


### PR DESCRIPTION
Refs #1420 — **deliberately not a closing keyword**; AC4 is still open. Spec: `specs/HARNESS-106-skill-capability/` (`status: implementing`). Closes AC5, AC6, AC7.

## The problem

The gate's answer to a harness is an exit code, and an exit code is consumed and discarded.

| These share exit 0 | |
|---|---|
| `allow` | nothing outstanding |
| `warn` | a skill unconsumed, reported and allowed |
| payload unparsed | the harness said something we could not read |
| **`role did not resolve`** | **enforcement was OFF for this call** |

Everything that told them apart was stderr — and a `PreToolUse` hook's stderr on exit 0 **is not persisted**, measured, and the subject of lesson 254, where a canary ran for a day accumulating no evidence while appearing to work.

Three paths returned before any persona was loaded and left nothing at all. That is why "agy sends a payload we cannot parse" has been indistinguishable from "agy has nothing to enforce".

## What this adds

A per-scope append-only journal beside the consumption ledger, keyed by the **same digest** — reusing the collision guard rather than inventing a second path scheme, because a colliding journal corrupts the measurement instead of announcing itself.

Nine fields, a closed `Outcome` vocabulary, and `agent_type` read straight off the payload **before any lookup**, so even the skill path preserves it. It is kept separate from the role *requested* and the role *resolved*, because those three can differ and the difference is the diagnosis.

**The record carries no tool input.** It is durable, unencrypted, unscanned, and written on every tool call; tool arguments carry file contents, commands and credentials, so logging them would be a secrets leak with a retention policy. Pinned by a test that puts a key-shaped string in the payload and greps the file for it.

## Measured on a real dispatch, not just tested

```
outcome          agent_type       role_resolved   n
no-role          <empty>          -               38   (main-thread calls)
warn             reviewer         reviewer         2   ← AC6, AC7
role-unresolved  gate-probe-...   (none)           3   ← see below
```

The `warn` record names all four skills (`adversarial-review`, `audit`, `cyclomatic-complexity`, `verification-before-completion`), read back from the journal with nothing but a path shared with the writer. That is what AC6 means by *observable after the session ends*.

## It caught a real bypass on its first day

Two dispatches of the **same** persona, differing only in whether the caller supplied a name:

| dispatch | payload `agent_type` | `role_resolved` | outcome |
|---|---|---|---|
| `subagent_type: reviewer`, no name | `reviewer` | `reviewer` | `warn` |
| `subagent_type: reviewer`, `name: gate-probe-agent-type` | `gate-probe-agent-type` | *(none)* | **`role-unresolved`** |

`agent_type` carries the **caller-supplied name** when one is given. So naming a subagent makes its role unresolvable and **turns its gate off** — allowing, exit 0, invisible to the exit code, the stderr and `dotf doctor` alike. Under `enforce: block` that is a bypass with a one-word opt-out.

Filed as **#1434**, and a hard precondition on promoting any skill to `block`. It also generalises lesson 255: **both** identity fields are caller-influenced, not just `agent_id`.

## AC4 stays open, with a named blocker

The deployed `reviewer` record carries `Skill` after the deploy, and a dispatched reviewer still reported `Read, Bash, advisor` — the roster its *dispatching session* loaded at start. **Personas are frozen at session start; hooks are re-read.** Yesterday's reload measurement covered hooks and was generalised to persona records without being re-measured (lesson 256).

AC4 was written as *"proven by a dispatch that writes a consumption record — never by a config file containing a key"*, and that wording is exactly why a wrong assumption became a deferred item rather than a false claim. It needs a session started after the deploy, and nothing in this change.

## Two supporting changes the record forced

- `loadGatePersona` now reports **which** of its two nil cases happened. Both allow, and only one means enforcement was off; the caller could not tell them apart.
- The block path returns a tagged exit code instead of `os.Exit`. Identical status, but `os.Exit` kills the test runner — so the one path that matters most could never be driven end to end in process — and it runs no defers, making it the path most likely to lose its own record.

## Also fixed

`TestMergeAgainstTheRealDeployedSettings` failed on any machine bound before the marker field existed: such a machine carries an unmarked gate entry that `isOurs` deliberately **adopts**, so the foreign *count* drops by one while nothing is lost (15 → 14 here). A count cannot tell adoption from deletion. The assertion is now per command, and the only tolerated disappearance is an entry the merge was entitled to claim.

## Verification

`go build` / `vet` / `test` clean, `GOOS=windows go vet` clean, `golangci-lint` 0 issues, `shellcheck` clean, `bats tests/gitattributes-eol.bats` green.

Red direction proven for the journal by neutering the skill path's `record(...)` in place: `journal for scope "s1-a1" holds 0 records, want exactly 1` — exactly the two affected cases failed, the rest stayed green.