### PR TITLE
fix(doctor): pi/opencode/copilot/yarn pin checks agree with the installer's floor policy

### DIFF
--- a/cli/internal/doctor/checks_copilot.go
+++ b/cli/internal/doctor/checks_copilot.go
@@ -3,12 +3,13 @@ package doctor
 // checkCopilot reports the GitHub Copilot CLI against its packages.json pin
 // (AI-038, #1321; ADR-036 amendment): copilot is an npm catalog tool on every
 // OS, so its version is probed once in Go (tools.ProbeVersion via semverOf)
-// and compared with the catalog pin exactly as opencode is — an exact match
-// PASSes, anything else is a drift WARN (the floor semantic belongs to
-// `dotf tools install`, which never downgrades). Absent is a SKIP: a box may
-// deliberately not carry Copilot, and setup only deploys its config when the
-// binary is on PATH. A leftover winget or scoop copy beside the npm one is
-// reported by checkShadowedCatalogTools, which reads the same catalog.
+// and compared with the catalog pin on a floor basis — `dotf tools install`'s
+// decideAction never downgrades a newer install, so doctor must agree that
+// ahead-of-pin is healthy, not drift (see matchPinFloorFrom). Absent is a
+// SKIP: a box may deliberately not carry Copilot, and setup only deploys its
+// config when the binary is on PATH. A leftover winget or scoop copy beside
+// the npm one is reported by checkShadowedCatalogTools, which reads the same
+// catalog.
 func checkCopilot(sys *System, cfg *Config, rep *Report) {
 	rep.Section("GitHub Copilot CLI")
 	if !sys.has("copilot") {
@@ -21,5 +22,5 @@ func checkCopilot(sys *System, cfg *Config, rep *Report) {
 		return
 	}
 	rep.Pass("copilot in PATH: " + ver)
-	matchPinFrom(rep, "copilot", ver, catalogPin(sys, cfg, "copilot"), "packages.json")
+	matchPinFloorFrom(rep, "copilot", ver, catalogPin(sys, cfg, "copilot"), "packages.json")
 }

--- a/cli/internal/doctor/checks_copilot_test.go
+++ b/cli/internal/doctor/checks_copilot_test.go
@@ -10,9 +10,11 @@ const catalogWithCopilot = `{"tools":[{"name":"copilot","version":"1.0.81","prof
 
 // copilot is an npm catalog tool (AI-038, #1321): the version is the first
 // semver in `copilot --version` ("GitHub Copilot CLI 1.0.80." on the Windows
-// box) compared with the packages.json pin the way opencode is (exact match
-// PASS, otherwise a drift WARN); absent is a SKIP, not a FAIL, because a box
-// may deliberately carry no Copilot.
+// box) compared with the packages.json pin on a floor basis, the way opencode
+// is (matchPinFloorFrom) — `dotf tools install`'s decideAction never downgrades
+// a newer install, so doctor must agree that ahead-of-pin is healthy, not
+// drift; absent is a SKIP, not a FAIL, because a box may deliberately carry no
+// Copilot.
 func TestCheckCopilot_PinMatchByStatus(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, filepath.Join(repo, "packages.json"), catalogWithCopilot)
@@ -24,7 +26,7 @@ func TestCheckCopilot_PinMatchByStatus(t *testing.T) {
 		needle  string
 	}{
 		{"at the pin → PASS", []string{"copilot"}, "GitHub Copilot CLI 1.0.81.\n", StatusPass, "matches packages.json"},
-		{"above the pin → WARN drift (doctor reports exact match; the floor is tools install's)", []string{"copilot"}, "GitHub Copilot CLI 1.0.90.\n", StatusWarn, "drift"},
+		{"above the pin → PASS, floor met", []string{"copilot"}, "GitHub Copilot CLI 1.0.90.\n", StatusPass, "meets the packages.json pin"},
 		{"below the pin → WARN drift", []string{"copilot"}, "GitHub Copilot CLI 1.0.78.\n", StatusWarn, "drift"},
 		{"no semver in the output → WARN, no drift line", []string{"copilot"}, "banner only\n", StatusWarn, "no semver"},
 		{"absent → SKIP naming the catalog", nil, "", StatusSkip, "dotf tools install copilot"},

--- a/cli/internal/doctor/checks_deploy.go
+++ b/cli/internal/doctor/checks_deploy.go
@@ -277,7 +277,7 @@ func checkOpenCode(sys *System, cfg *Config, rep *Report) {
 	case sys.has("opencode"):
 		ver := semverOf(sys, "opencode")
 		rep.Pass("opencode in PATH: " + ver)
-		matchPinFrom(rep, "opencode", ver, catalogPin(sys, cfg, "opencode"), "packages.json")
+		matchPinFloorFrom(rep, "opencode", ver, catalogPin(sys, cfg, "opencode"), "packages.json")
 	case isExecFile(opencodeBin):
 		// The retired curl-script channel (ADR-036) left a copy behind and
 		// nothing on PATH resolves: the rc files no longer add ~/.opencode/bin.
@@ -308,7 +308,7 @@ func checkOpenCode(sys *System, cfg *Config, rep *Report) {
 	case sys.has("pi"):
 		ver := semverOf(sys, "pi")
 		rep.Pass("pi in PATH: " + ver)
-		matchPin(rep, "pi", ver, cfg.Versions["PI_VERSION"])
+		matchPinFloor(rep, "pi", ver, cfg.Versions["PI_VERSION"])
 	case isExecFile(piLocalBin):
 		rep.Fail("pi exists at " + piLocalBin + " but not in PATH (reload shell)")
 	case piConfigured:
@@ -863,12 +863,44 @@ func matchPin(rep *Report, tool, installed, pin string) {
 
 // matchPinFrom is matchPin with the pin's source named: packages.json is the
 // SSOT for catalog tools (ADR-036), versions.conf for the rest.
+//
+// Exact match by design: for the tools that call this (golangci-lint, age),
+// nothing reconciles them toward the pin on a floor policy, so any drift —
+// ahead or behind — is worth a WARN. golangci-lint in particular needs this:
+// CI lints at the exact pinned version, so a locally-newer binary still
+// diverges from CI (BUG-071).
 func matchPinFrom(rep *Report, tool, installed, pin, source string) {
 	switch {
 	case pin == "":
 		rep.Skip(tool + " version not pinned in " + source + " — match not verified")
 	case installed == pin:
 		rep.Pass(fmt.Sprintf("%s version matches %s (%s)", tool, source, pin))
+	default:
+		rep.Warn(fmt.Sprintf("%s version drift: installed=%s pinned=%s (%s)", tool, installed, pin, source))
+	}
+}
+
+func matchPinFloor(rep *Report, tool, installed, pin string) {
+	matchPinFloorFrom(rep, tool, installed, pin, "versions.conf")
+}
+
+// matchPinFloorFrom is matchPinFrom for tools whose installer reconciles on a
+// floor policy — `dotf tools install`'s decideAction (install.go, "the pin is
+// a MINIMUM, not an exact match... an exact-match reconcile would wrongly
+// downgrade") and pi's own setup-{linux,windows} install block (REFACTOR-013).
+// Doctor must agree with the installer about what the pin means: an exact-match
+// WARN here fires every time the tool's own upstream ships a patch between two
+// pin bumps, which the installer will never revert — chasing it with a pin bump
+// is a treadmill, not a signal (observed: PI_VERSION bumped to "the version
+// actually installed" in f1c20cd, then drifted again).
+func matchPinFloorFrom(rep *Report, tool, installed, pin, source string) {
+	switch {
+	case pin == "":
+		rep.Skip(tool + " version not pinned in " + source + " — match not verified")
+	case installed == pin:
+		rep.Pass(fmt.Sprintf("%s version matches %s (%s)", tool, source, pin))
+	case atLeast(installed, pin):
+		rep.Pass(fmt.Sprintf("%s %s meets the %s pin %s", tool, installed, source, pin))
 	default:
 		rep.Warn(fmt.Sprintf("%s version drift: installed=%s pinned=%s (%s)", tool, installed, pin, source))
 	}

--- a/cli/internal/doctor/checks_opencode_version_test.go
+++ b/cli/internal/doctor/checks_opencode_version_test.go
@@ -10,6 +10,11 @@ import (
 // The opencode banner that setup-windows.ps1 parsed as the version "locked."
 // (AI-034/#1294) must not become a false drift report in doctor: the version
 // is the first semver anywhere in the output, matched against the catalog pin.
+//
+// The pin is a floor, not an exact match (matchPinFloorFrom): `dotf tools
+// install`'s decideAction never downgrades a newer install, so doctor must
+// agree that ahead-of-pin is healthy — otherwise every patch opencode ships
+// upstream between two pin bumps is a permanent false WARN.
 func TestCheckOpenCode_VersionIsTheSemverNotTheBannerToken(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, filepath.Join(repo, "packages.json"), catalogWithOpencode)
@@ -19,6 +24,7 @@ func TestCheckOpenCode_VersionIsTheSemverNotTheBannerToken(t *testing.T) {
 		{"banner line before the number", "OpenCode locked.\n1.16.2\n", "opencode version matches packages.json (1.16.2)"},
 		{"plain version", "1.16.2\n", "opencode version matches packages.json (1.16.2)"},
 		{"older version", "1.15.0\n", "opencode version drift: installed=1.15.0 pinned=1.16.2 (packages.json)"},
+		{"newer than pin", "1.17.0\n", "opencode 1.17.0 meets the packages.json pin 1.16.2"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cli/internal/doctor/checks_tools.go
+++ b/cli/internal/doctor/checks_tools.go
@@ -150,7 +150,7 @@ func checkVersionMatch(sys *System, cfg *Config, rep *Report) {
 		rep.Skip("yarn not installed (run `dotf tools install yarn`; needs Node.js on PATH)")
 	} else {
 		got, _ := sys.versionLine("yarn")
-		matchPinFrom(rep, "yarn", got, catalogPin(sys, cfg, "yarn"), "packages.json")
+		matchPinFloorFrom(rep, "yarn", got, catalogPin(sys, cfg, "yarn"), "packages.json")
 	}
 
 	checkGitWindowsFloor(sys, cfg, rep)

--- a/versions.conf
+++ b/versions.conf
@@ -13,7 +13,7 @@ BATS_VERSION=1.13.0
 AGE_VERSION=1.3.1
 EZA_VERSION=0.23.4
 ZOXIDE_VERSION=0.9.9
-PI_VERSION=0.84.3
+PI_VERSION=0.84.4
 # ShellCheck release assets are versioned (the `-stable` alias was retired after
 # v0.10, so latest/download/shellcheck-stable... now 404s). Pin the tag; setup
 # builds the URL + the tarball's internal dir name from it (prefixed with `v`).


### PR DESCRIPTION
## Summary
- `dotf tools install`'s `decideAction` (and pi's own setup block, REFACTOR-013) treat a versions.conf/packages.json pin as a MINIMUM and never downgrade a newer install. `dotf doctor`'s drift check compared with an exact match instead, so any tool that shipped a patch upstream between two pin bumps produced a permanent false WARN — installer and doctor disagreed about what the pin meant.
- Observed on `PI_VERSION`: bumped once already in f1c20cd ("the version actually installed") to chase exactly this WARN, then drifted again the moment pi shipped its next patch.
- Add `matchPinFloorFrom`/`matchPinFloor` (ahead-of-pin PASSes, behind-pin WARNs, mirroring `checkGitWindowsFloor`'s `atLeast`) and switch pi, opencode, copilot and yarn to it.
- `golangci-lint` and `age` keep the exact-match `matchPinFrom` on purpose: golangci-lint's pin is the version CI actually lints at, so drift in either direction diverges from CI (BUG-071); age has no floor-reconciling installer and no evidence it should behave differently — left untouched.
- Bumped `PI_VERSION` to 0.84.4, the version the floor policy already converged this box to.

## SDD skip rationale
55 production LOC, just over the 50-LOC gate. This is a mechanical bug fix with an obvious cause (installer and doctor using different comparison semantics for the same pin) — most of the LOC is the new function's doc comment explaining why the two semantics must agree. A spec folder would document a decision that's already fully justified in the commit message and code comments; it would not change any outcome here.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/doctor/...` (updated `checks_copilot_test.go` and `checks_opencode_version_test.go` to assert PASS-above-pin instead of WARN)
- [x] `go test ./...` (full module, green)