### PR TITLE
feat(doctor): print a Next steps block for FAILs that carry a remedy command

### DIFF
--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -1,9 +1,12 @@
 package doctor
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"strings"
 )
 
 // Options configures a doctor run. System and StartDir are injection seams for
@@ -48,7 +51,18 @@ func Run(opts Options) (int, error) {
 		return 2, err
 	}
 
-	rep := NewReport(out, opts.Verbose)
+	// Tee the report into a transcript so Summary() can be followed by a
+	// curated Next-steps block (below) without changing Report's shape: it
+	// streams messages straight to out and keeps no record of them (CLI-070,
+	// #1442 — setup's own "Next steps" never named the FAIL doctor had just
+	// printed, e.g. `bw login`, so the reader had to go find it in the
+	// scroll). Color detection must run on the real out, not the tee:
+	// io.MultiWriter is never an *os.File, so isColorEnabled would otherwise
+	// report false on every run.
+	color := isColorEnabled(out)
+	var transcript bytes.Buffer
+	rep := NewReport(io.MultiWriter(out, &transcript), opts.Verbose)
+	rep.SetColor(color)
 	mode := "check"
 	switch {
 	case opts.Quick:
@@ -114,7 +128,45 @@ func Run(opts Options) (int, error) {
 	}
 
 	rep.Summary()
+	if steps := nextSteps(transcript.String()); len(steps) > 0 {
+		_, _ = fmt.Fprintln(out, "\nNext steps:")
+		for _, step := range steps {
+			_, _ = fmt.Fprintf(out, "  %s\n", step)
+		}
+	}
 	return rep.ExitCode(), nil
+}
+
+// failRemedyRe pulls the backtick-quoted command out of a FAIL line's remedy
+// clause. Matched against the handful of verbs FAIL messages actually use to
+// introduce one (surveyed across the package: run/re-run cover the large
+// majority, recover with/upgrade with the rest) — not every backtick span,
+// which would also catch a diagnostic reference like `bw status` that names
+// what was checked, not what to do about it.
+var failRemedyRe = regexp.MustCompile("(?:run|re-run|recover with|upgrade with) `([^`]+)`")
+
+// nextSteps scans a rendered report transcript for FAIL lines carrying a
+// remedy command and returns each one once, in first-seen order. Free text,
+// not a structured field on Report: Report streams a message to its writer
+// and keeps no record of it, and giving every check a machine-readable hint
+// would be a much larger change than one FAIL in the middle of a 30+ section
+// sweep (Bitwarden reach) actually needs surfaced at the end.
+func nextSteps(transcript string) []string {
+	seen := map[string]bool{}
+	var steps []string
+	for _, line := range strings.Split(transcript, "\n") {
+		if !strings.Contains(line, "[FAIL]") {
+			continue
+		}
+		for _, m := range failRemedyRe.FindAllStringSubmatch(line, -1) {
+			cmd := m[1]
+			if !seen[cmd] {
+				seen[cmd] = true
+				steps = append(steps, cmd)
+			}
+		}
+	}
+	return steps
 }
 
 // loadContractSection resolves + parses the contract, reporting its own status

--- a/cli/internal/doctor/doctor_test.go
+++ b/cli/internal/doctor/doctor_test.go
@@ -41,6 +41,22 @@ func TestNextSteps_NoFailNoBlock(t *testing.T) {
 	}
 }
 
+// nextSteps must still find the [FAIL] tag and the remedy on a real terminal
+// run, where Report wraps each tag in ANSI color codes (coloredTag) rather
+// than printing it plain. The color codes surround the whole "[FAIL]" literal
+// — ansiRed + "[FAIL]" + ansiReset — they never land inside it, so the
+// substring search survives; this pins that down against a real color-tagged
+// line rather than asserting it from the source (PR review flagged this as a
+// theoretical risk: #1443 review comment).
+func TestNextSteps_SurvivesColoredTag(t *testing.T) {
+	line := "  " + coloredTag[StatusFail] + " Bitwarden session is gone — run `bw login`"
+	got := nextSteps(line)
+	want := []string{"bw login"}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Errorf("got %q, want %q (line: %q)", got, want, line)
+	}
+}
+
 // End-to-end: a real Run() with a FAIL that carries `bw login` renders the
 // Next-steps block after Results:, and a clean run renders neither.
 func TestRun_NextStepsBlock(t *testing.T) {

--- a/cli/internal/doctor/doctor_test.go
+++ b/cli/internal/doctor/doctor_test.go
@@ -1,0 +1,85 @@
+package doctor
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// nextSteps must find the remedy in a FAIL line regardless of which of the
+// package's few remedy verbs introduces it, must ignore a diagnostic backtick
+// span that names what was checked rather than what to run, must never pick
+// up a WARN's remedy (Next steps is for what is actually blocking, i.e. what
+// drives the non-zero exit), and must dedupe a command repeated across
+// sections.
+func TestNextSteps(t *testing.T) {
+	transcript := strings.Join([]string{
+		"  [FAIL] Bitwarden session is gone (`bw status`: unauthenticated) — run `bw login`, not `bw unlock`",
+		"  [FAIL] git 2.54.0 is below the git-for-windows floor 2.55.0 — upgrade with `winget upgrade Git.Git`",
+		"  [WARN] git 2.54.0 is below the git-for-windows floor 2.55.0 — upgrade with `winget upgrade Git.Git`",
+		"  [FAIL] env-contract.json unreadable — contract checks skipped",
+		"  [FAIL] dispatcher not found — run `dotf tools install`",
+		"  [FAIL] core.hooksPath unset — run `dotf tools install`",
+	}, "\n")
+
+	got := nextSteps(transcript)
+	want := []string{"bw login", "winget upgrade Git.Git", "dotf tools install"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d steps %q, want %d %q", len(got), got, len(want), want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("step %d: got %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestNextSteps_NoFailNoBlock(t *testing.T) {
+	if got := nextSteps("  [WARN] upgrade with `winget upgrade Git.Git`\n  [FAIL] no default available (required)"); len(got) != 0 {
+		t.Errorf("want no steps when no FAIL line carries a remedy, got %q", got)
+	}
+}
+
+// End-to-end: a real Run() with a FAIL that carries `bw login` renders the
+// Next-steps block after Results:, and a clean run renders neither.
+func TestRun_NextStepsBlock(t *testing.T) {
+	home := t.TempDir()
+	dotfiles := filepath.Join(home, ".dotfiles")
+	writeFile(t, filepath.Join(dotfiles, "env-contract.json"),
+		`{"env_vars":[],"required_path_entries":{"linux":[]},"required_binaries":[],"optional_binaries":[]}`)
+	writeFile(t, filepath.Join(dotfiles, "versions.conf"), "GO_VERSION=1.26.0\n")
+	env := map[string]string{"HOME": home, "DOTFILES_DIR": dotfiles}
+
+	t.Run("FAIL with a remedy surfaces it after Results", func(t *testing.T) {
+		// Nothing on PATH: opencode missing is one of the FAILs this fixture
+		// produces, with a `run \`...\`` remedy — no extra fixture (a populated
+		// secrets registry, a real Bitwarden session) needed to exercise the
+		// wiring end to end.
+		sys := newSys(env, nil, nil)
+		var buf bytes.Buffer
+		if _, err := Run(Options{Out: &buf, System: sys, StartDir: home, Verbose: true}); err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+		out := buf.String()
+		results := strings.Index(out, "Results:")
+		next := strings.Index(out, "Next steps:")
+		if results == -1 || next == -1 || next < results {
+			t.Fatalf("want Next steps: after Results: in\n%s", out)
+		}
+		if !strings.Contains(out, "  dotf tools install opencode\n") {
+			t.Errorf("want the opencode install remedy listed\n%s", out)
+		}
+	})
+
+	t.Run("quick mode with no FAIL prints no block", func(t *testing.T) {
+		sys := newSys(env, nil, nil)
+		var buf bytes.Buffer
+		if _, err := Run(Options{Out: &buf, System: sys, StartDir: home, Verbose: true, Quick: true}); err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+		if strings.Contains(buf.String(), "Next steps:") {
+			t.Errorf("want no Next steps: block on a clean run\n%s", buf.String())
+		}
+	})
+}

--- a/specs/CLI-070-doctor-next-steps/features.json
+++ b/specs/CLI-070-doctor-next-steps/features.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": "CLI-070-doctor-next-steps-f1",
+    "behavior": "AC1: a FAIL line with a run/re-run/recover-with/upgrade-with remedy prints a Next steps: block after Results: listing the command",
+    "verification": "cd cli && go test ./internal/doctor/... -run 'TestNextSteps$|TestRun_NextStepsBlock'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-070-doctor-next-steps-f2",
+    "behavior": "AC2: a WARN line with the same remedy pattern does not produce a Next-steps entry",
+    "verification": "cd cli && go test ./internal/doctor/... -run TestNextSteps$",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-070-doctor-next-steps-f3",
+    "behavior": "AC3: a diagnostic-only backtick span on a FAIL line (not introduced by one of the four verbs) is not mistaken for a remedy",
+    "verification": "cd cli && go test ./internal/doctor/... -run TestNextSteps$",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-070-doctor-next-steps-f4",
+    "behavior": "AC4: the same command repeated across FAIL lines is listed once",
+    "verification": "cd cli && go test ./internal/doctor/... -run TestNextSteps$",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-070-doctor-next-steps-f5",
+    "behavior": "AC5: a clean run (no FAIL) prints no Next steps: block",
+    "verification": "cd cli && go test ./internal/doctor/... -run TestNextSteps_NoFailNoBlock",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-070-doctor-next-steps-f6",
+    "behavior": "AC6: --quick mode is covered by the same logic with no special-casing",
+    "verification": "cd cli && go test ./internal/doctor/... -run TestRun_NextStepsBlock",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-070-doctor-next-steps-f7",
+    "behavior": "AC7: tee-ing the report writer into a transcript buffer does not disable ANSI color on a real terminal run",
+    "verification": "cd cli && go test ./internal/doctor/...",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CLI-070-doctor-next-steps/proposal.md
+++ b/specs/CLI-070-doctor-next-steps/proposal.md
@@ -1,0 +1,48 @@
+---
+id: "CLI-070-doctor-next-steps"
+type: spec
+status: verifying # draft | implementing | verifying | archived
+created: "2026-09-02"
+issue: "mlorentedev/dotfiles#1442"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# CLI-070-doctor-next-steps
+
+> **Naming**: file lives at `<repo>/specs/CLI-070-doctor-next-steps/proposal.md`. `CLI-070-doctor-next-steps` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+A setup run that ends with `dotf doctor` exiting non-zero hands the operator the scrolled check list and nothing else. Both `setup-windows.ps1` and `setup-linux.sh` print a hardcoded "Next steps" block at the very end of every run, unrelated to whatever doctor actually found. Observed live on 2026-09-02: after converging a stale Windows checkout, doctor FAILed with `Bitwarden session is gone ... run \`bw login\`` — a one-line fix already spelled out in the FAIL message — but the run's final output said nothing about it; the remedy was buried under ~40 other check lines the operator had to scroll back through.
+
+## What
+
+After `Results:`, `dotf doctor` prints a `Next steps:` block listing the remedy command from every FAIL line whose message names one (`run`, `re-run`, `recover with`, or `upgrade with` followed by a backtick-quoted command — the convention 34 of the ~38 backtick-carrying FAIL/WARN messages in the package already follow). Each command is listed once, in first-seen order. A run with no such FAIL prints no block — unchanged output shape from today.
+
+## Out of scope
+
+- Changing `Report`'s message API (no severity/hint field added to `Fail()`/`Warn()`) — the block is built by scanning the already-rendered transcript, not by adding structured data to every one of the package's ~100 `Fail()` call sites.
+- WARN remedies. Next steps is about what is actually driving the non-zero exit; a WARN is advisory by the package's own contract (`Status` doc comment in `report.go`) and stays visible in the check list itself.
+- A FAIL whose remedy is phrased without one of the four verbs above (e.g. prose that doesn't say "run"). That is a message-authoring convention gap, not something this feature's parser chases; fixing individual messages to use the convention is a separate, unbounded cleanup.
+- Rewriting either setup script's own hardcoded "Next steps" block. Both still print their generic first-run orientation (restart the shell, `project-init ...`) below doctor's output; this feature is additive, not a replacement, since removing them was never proposed or reviewed as part of this issue.
+
+## Risks / open questions
+
+- **Coupling to message wording.** The extraction is a regex over free text, so a FAIL message that's reworded to drop its remedy verb silently stops appearing in Next steps with no compile-time signal. Accepted: the alternative (a structured hint field on every check) is a much larger change for a benefit — catching a wording regression at compile time — that a doctor-package code reviewer already catches by eye, since the message and the regex live in the same package.
+- **Severity depends on check internals the feature doesn't control.** `checkBitwardenReach` downgrades its unauthenticated-session message from FAIL to WARN when zero registry secrets are bw-backed (`live == 0`). On a machine with bw-backed secrets it's a FAIL and appears in Next steps; on one with none, it's a WARN and correctly does not. This is intentional (severity should scale with actual impact) and not a defect of this feature, but it means "does bw login show up in Next steps" is not a fixed answer — noted so a reviewer doesn't read it as a gap.
+
+## Acceptance criteria
+
+- [x] AC1: `dotf doctor` output whose transcript contains a `[FAIL]` line matching `(run|re-run|recover with|upgrade with) \`<cmd>\`` prints a `Next steps:` block after `Results:` listing `<cmd>`.
+- [x] AC2: A `[WARN]` line carrying the same pattern does NOT produce a Next-steps entry.
+- [x] AC3: A `[FAIL]` line with a backtick span that is not introduced by one of the four verbs (e.g. a line that only *references* a command, like `` `bw status`: unauthenticated ``) does NOT produce a spurious entry from that span.
+- [x] AC4: The same command appearing in more than one FAIL line is listed once.
+- [x] AC5: A clean run (no FAIL) prints no `Next steps:` block — output byte-identical in shape to today for that case.
+- [x] AC6: `--quick` mode is covered by the same logic with no special-casing (it already skips every section that could produce a FAIL doctor would want surfaced here; the wiring sits after `Summary()` regardless of mode).
+- [x] AC7: Color output (`isColorEnabled`) is unaffected — tee-ing the report writer into a transcript buffer must not turn off ANSI color on a real terminal run.
+
+## References
+
+- Bitácora board: the GitHub issue / Project item tracking this spec (see the `issue:` frontmatter field)
+- Related: `PI_VERSION` / pin-floor fix landed separately as its own PR (#1441) — split out because it was an independent, obvious-cause bug fix bundled with this feature in the same investigation session; kept apart per AGENTS.md's Discipline Gate ("was this one change or two").

--- a/specs/CLI-070-doctor-next-steps/tasks.md
+++ b/specs/CLI-070-doctor-next-steps/tasks.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-09-02"
+---
+
+# Tasks - CLI-070-doctor-next-steps
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers** (optional, additive — borrowed from `github/spec-kit`, adapt-not-adopt per #141):
+> - `[P]` — this task has **no dependency on another unchecked task**, so it is safe to run in parallel (fan out to a `Workflow`, or just batch). TDD chains (test → implement → refactor of the *same* behavior) are sequential and must NOT carry `[P]`; independent behaviors can.
+> - `[AC<n>]` — this task helps satisfy **acceptance criterion #`<n>`** from `proposal.md`. Lets `/spec check` map coverage deterministically; omit it and the check falls back to semantic judgment.
+
+## Setup
+
+- [x] Branch created from main: `feat/doctor-next-steps`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+- [x] [AC1][AC2][AC3][AC4] Write `TestNextSteps` (table of FAIL/WARN lines covering the run/re-run/recover-with/upgrade-with verbs, a diagnostic-only backtick span, and a duplicate command) and `TestNextSteps_NoFailNoBlock`
+- [x] [AC1][AC2][AC3][AC4] Implement `nextSteps()` + `failRemedyRe` in `doctor.go` to make them pass
+- [x] [AC5][AC6] Write `TestRun_NextStepsBlock` (FAIL-with-remedy end to end via `Run()`, and a quick-mode clean run producing no block)
+- [x] [AC5][AC6][AC7] Wire `nextSteps()` into `Run()` after `rep.Summary()`; tee `Report`'s writer into a transcript buffer, computing `isColorEnabled` from the real `out` before wrapping it (AC7 — a `MultiWriter` is never an `*os.File`, so color detection must run first)
+- [x] Full existing suite re-run (`go test ./internal/doctor/...`, `go test ./...`) — no regressions
+
+## Closing
+
+- [x] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [x] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [x] Type checks pass (`go build ./...`, `go vet ./...`)
+- [ ] Lint passes (`golangci-lint run` — not run locally; pin drift on this box, CI is authoritative)
+- [x] No unrelated changes in the diff (no scope creep) — pin-floor fix split out to PR #1441
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.

--- a/specs/CLI-070-doctor-next-steps/verification.md
+++ b/specs/CLI-070-doctor-next-steps/verification.md
@@ -1,0 +1,49 @@
+---
+tags: [spec, verification, templates]
+created: "2026-09-02"
+---
+
+# Verification - CLI-070-doctor-next-steps
+
+## Evidence
+
+- [x] AC1 -> test `TestNextSteps` (multi-verb case) + `TestRun_NextStepsBlock/FAIL_with_a_remedy_surfaces_it_after_Results`
+- [x] AC2 -> test `TestNextSteps` (WARN line asserted absent from the result)
+- [x] AC3 -> test `TestNextSteps` (`` `bw status`: unauthenticated `` diagnostic span asserted not captured)
+- [x] AC4 -> test `TestNextSteps` (`dotf tools install` repeated across two FAIL lines, asserted listed once)
+- [x] AC5 -> test `TestNextSteps_NoFailNoBlock` + `TestRun_NextStepsBlock/quick_mode_with_no_FAIL_prints_no_block`
+- [x] AC6 -> test `TestRun_NextStepsBlock/quick_mode_with_no_FAIL_prints_no_block` (Quick: true, no special-casing in the implementation)
+- [x] AC7 -> `go test ./internal/doctor/...` full pass (no test disables color explicitly; live smoke test below shows color-capable terminal output unaffected)
+
+## Test status
+
+- Test suite: `cd cli && go test ./...` -> all 22 packages ok, no regressions (full module, not just the doctor package)
+- Manual smoke test: built `dotf` from this branch's tree (`go build -o dotf.exe ./cmd/dotf`) and ran `dotf doctor` live on a real Windows box with an unauthenticated Bitwarden session. Output ended:
+  ```
+  Results: 121 passed, 3 failed, 10 warned, 32 skipped
+
+  Next steps:
+    bw login
+    export BW_SESSION=$(bw login --raw) && bw sync
+  ```
+  Both lines are the `checkBitwardenReach` FAIL's two remedies (`run \`bw login\`` and `recover with \`export BW_SESSION=...\``), deduplicated and printed once each in first-seen order — the exact behavior AC1/AC4 assert, now also observed outside the test suite.
+- No regressions in existing test suite: yes
+
+## Decisions made during implementation
+
+- Split what was originally one investigation into two PRs: the pin-floor semantics fix (#1441, independent, obvious-cause, shipped under `skip-sdd`) and this feature. Bundled together they were 108 production LOC pushing an unrelated bug fix through a spec process it didn't need and diluting this feature's own spec.
+- Chose to extract remedies by scanning the *rendered transcript* for verb+backtick patterns rather than adding a structured hint field to `Report.Fail()`. Considered and rejected the structured-field approach: it would touch on the order of 100 call sites across the package for a benefit (compile-time-checked hints) that a doctor-package reviewer already gets for free, since the regex and the messages it reads live in the same package and get reviewed together.
+- Scoped strictly to FAIL lines, not WARN. `checkGitWindowsFloor`'s WARN carries a real remedy (`upgrade with \`winget upgrade Git.Git\``) that is NOT surfaced in Next steps under this design — deliberate, per `Report`'s own contract that only FAIL drives the non-zero exit Next steps exists to explain.
+
+## Promotion candidates
+
+- [ ] Lesson for the repo's `docs/lessons/`? no
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? no — additive, within the existing doctor architecture
+- [ ] New pattern candidate for `00_meta/patterns/`? no — single-repo concern
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/CLI-070-doctor-next-steps/` -> `specs/archive/CLI-070-doctor-next-steps/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)

--- a/specs/CLI-070-doctor-next-steps/verification.md
+++ b/specs/CLI-070-doctor-next-steps/verification.md
@@ -31,6 +31,7 @@ created: "2026-09-02"
 
 ## Decisions made during implementation
 
+- PR review (pr-agent) flagged the `[FAIL]` substring match as a theoretical risk under ANSI color, hypothesizing the tag could be split by escape codes. Verified false: `coloredTag[StatusFail]` wraps the whole `"[FAIL]"` literal from the outside (`ansiRed + "[FAIL]" + ansiReset`), never splits it. Added `TestNextSteps_SurvivesColoredTag` to pin this down with evidence rather than leave it as an unresolved comment.
 - Split what was originally one investigation into two PRs: the pin-floor semantics fix (#1441, independent, obvious-cause, shipped under `skip-sdd`) and this feature. Bundled together they were 108 production LOC pushing an unrelated bug fix through a spec process it didn't need and diluting this feature's own spec.
 - Chose to extract remedies by scanning the *rendered transcript* for verb+backtick patterns rather than adding a structured hint field to `Report.Fail()`. Considered and rejected the structured-field approach: it would touch on the order of 100 call sites across the package for a benefit (compile-time-checked hints) that a doctor-package reviewer already gets for free, since the regex and the messages it reads live in the same package and get reviewed together.
 - Scoped strictly to FAIL lines, not WARN. `checkGitWindowsFloor`'s WARN carries a real remedy (`upgrade with \`winget upgrade Git.Git\``) that is NOT surfaced in Next steps under this design — deliberate, per `Report`'s own contract that only FAIL drives the non-zero exit Next steps exists to explain.


### PR DESCRIPTION
## Summary
- Every setup run ends with `dotf doctor`'s scrolled check list, then setup's own hardcoded "Next steps" (restart the shell, `project-init ...`) — unrelated to whatever doctor actually found.
- Observed live this session: doctor FAILed with an unauthenticated Bitwarden session and its exact remedy (`run \`bw login\``) already in the message, and nothing at the end of the run said so; the operator had to find it by scrolling back through ~40 other check lines.
- `dotf doctor` now scans its own rendered transcript for FAIL lines carrying a `run`/`re-run`/`recover with`/`upgrade with` + backtick-quoted remedy and prints them once each, in first-seen order, as a `Next steps:` block after `Results:`.
- WARNs are excluded by design — Next steps is about what actually drives the non-zero exit, matching `Report`'s own PASS/FAIL/WARN/SKIP contract.
- Extraction reads the already-rendered text rather than adding a hint field to `Report.Fail()` across the package's ~100 call sites — `Report`'s shape is unchanged.
- Color detection runs on the real writer before it's teed into the transcript buffer, so ANSI output on a real terminal is unaffected (`io.MultiWriter` is never an `*os.File`).

## Not included
- Either setup script's own hardcoded "Next steps" block — untouched, still prints below doctor's output. Removing/rewriting it wasn't reviewed as part of this issue; this feature is additive.
- A FAIL message reworded without one of the four remedy verbs won't be picked up. That's a message-authoring convention gap (34 of ~38 backtick-carrying messages already follow it), not a parser gap this PR chases.
- The pin-floor semantics fix from the same investigation session shipped separately as #1441 — independent, obvious-cause bug fix; bundling it here would have diluted this feature's own spec.

## Spec
`specs/CLI-070-doctor-next-steps/` (issue #1442). Proposal, tasks and verification filled from the investigation that motivated this — see `verification.md` for the acceptance-criteria-to-test mapping and the live smoke-test output.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/doctor/...` — new `doctor_test.go` (`TestNextSteps`, `TestNextSteps_NoFailNoBlock`, `TestRun_NextStepsBlock`)
- [x] `go test ./...` (full module, 22 packages, green)
- [x] Built `dotf` from this branch and ran `dotf doctor` live on a real Windows box with an unauthenticated Bitwarden session:
  ```
  Results: 121 passed, 3 failed, 10 warned, 32 skipped

  Next steps:
    bw login
    export BW_SESSION=$(bw login --raw) && bw sync
  ```