### PR TITLE
fix(memlink): quote mklink's arguments for cmd.exe's own tokenizer, not Go's argv escaping

### DIFF
--- a/cli/internal/memlink/memlink.go
+++ b/cli/internal/memlink/memlink.go
@@ -15,7 +15,6 @@ package memlink
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -181,18 +180,9 @@ func slugify(s string, keepSlash bool) string {
 
 // createLink makes a directory link from target to src: a junction on Windows
 // (no privilege required, unlike os.Symlink there) and a symlink on POSIX.
-func createLink(src, target string) error {
-	if runtime.GOOS == "windows" {
-		// `mklink /J <link> <existing-target>` is a cmd builtin, so it runs via
-		// `cmd /c`. Args are passed as argv elements (not concatenated into a shell
-		// string); os/exec quotes any with spaces. Both paths are CLI-resolved
-		// vault/.claude locations, not user input — no shell-metachar surface.
-		// (A path component containing a bare cmd delimiter such as a comma is a
-		// known narrow gap — see HARNESS follow-up; spaces already round-trip.)
-		return exec.Command("cmd", "/c", "mklink", "/J", target, src).Run()
-	}
-	return os.Symlink(src, target)
-}
+// Implemented per-OS in memlink_windows.go / memlink_unix.go (HARNESS-050):
+// the Windows junction needs cmd.exe-specific quoting os/exec's ordinary argv
+// escaping does not provide, which pulled it out of this shared file.
 
 // linkNoun is the OS-accurate word for the created link, used in the message.
 func linkNoun() string {

--- a/cli/internal/memlink/memlink_test.go
+++ b/cli/internal/memlink/memlink_test.go
@@ -196,3 +196,36 @@ func TestEnsure(t *testing.T) {
 		}
 	})
 }
+
+// --- createLink: path components containing a cmd.exe word delimiter -------
+
+// On Windows, mklink runs through cmd.exe's own tokenizer (createLink's
+// Windows implementation, memlink_windows.go), which treats a bare comma,
+// semicolon or equals sign as a word separator outside quotes — unlike Go's
+// ordinary argv escaping, which only quotes on space/tab/quote and so let
+// these through unquoted (HARNESS-050, #575). On POSIX this exercises
+// os.Symlink, which never had the defect; the table still documents the
+// contract and catches a regression on either OS.
+func TestCreateLink_CmdDelimiterPaths(t *testing.T) {
+	for _, name := range []string{
+		"comma,here", "semi;colon", "paren(here)", "equals=here", "space here",
+	} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			src := filepath.Join(root, "src "+name)
+			writeFile(t, filepath.Join(src, "MEMORY.md"), "content")
+			target := filepath.Join(root, "link "+name)
+
+			if err := createLink(src, target); err != nil {
+				t.Fatalf("createLink(%q, %q): %v", src, target, err)
+			}
+			got, err := os.ReadFile(filepath.Join(target, "MEMORY.md"))
+			if err != nil {
+				t.Fatalf("link did not read through: %v", err)
+			}
+			if string(got) != "content" {
+				t.Errorf("read %q through link, want %q", got, "content")
+			}
+		})
+	}
+}

--- a/cli/internal/memlink/memlink_unix.go
+++ b/cli/internal/memlink/memlink_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package memlink
+
+import "os"
+
+// createLink makes a POSIX symlink. No cmd.exe-style tokenizer sits between
+// the caller and the syscall here, so no quoting dance is needed — see
+// memlink_windows.go for the Windows counterpart and why it needs one.
+func createLink(src, target string) error {
+	return os.Symlink(src, target)
+}

--- a/cli/internal/memlink/memlink_windows.go
+++ b/cli/internal/memlink/memlink_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package memlink
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// quoteArg wraps s in double quotes for cmd.exe's own tokenizer. NTFS forbids
+// a literal '"' in a path component, so no embedded-quote escaping is needed.
+func quoteArg(s string) string { return `"` + s + `"` }
+
+// createLink makes a directory junction via the cmd.exe builtin `mklink /J`.
+//
+// mklink is a cmd.exe builtin, not a separate executable, so there is no
+// second argv-parsing layer downstream of cmd — only cmd's own tokenizer ever
+// sees the paths. That tokenizer treats a bare comma, semicolon, equals sign
+// (and, unquoted, a space) as a word separator. Go's automatic argv-to-
+// command-line escaping (exec.Command's ordinary argument passing) follows a
+// different convention entirely — the C-runtime/CommandLineToArgvW one, which
+// only quotes an argument containing a space, tab or embedded quote — so a
+// path with a bare comma passed as a normal argv element reached cmd.exe
+// unquoted, cmd split it into extra words, and mklink failed "the syntax of
+// the command is incorrect" (HARNESS-050, #575). Spaces happened to round-
+// trip only because the C-runtime convention quotes on space too, coincidence
+// masking the real defect.
+//
+// The fix bypasses that automatic escaping entirely via SysProcAttr.CmdLine
+// (Go uses this string verbatim as the process's full command line) and
+// quotes both paths for cmd's tokenizer directly: `cmd /s /c "mklink /J
+// "<link>" "<src>""`. The /S switch is what makes this work — it tells cmd to
+// strip only the outermost quote pair from its command tail and hand the
+// still-quoted `mklink /J "..." "..."` straight to the builtin's own argument
+// scanner, rather than cmd's default behavior of treating a single quoted
+// tail as one opaque token. Verified empirically against comma, semicolon,
+// paren, equals and space path components.
+func createLink(src, target string) error {
+	cmdline := `cmd /s /c "mklink /J ` + quoteArg(target) + ` ` + quoteArg(src) + `"`
+	cmd := exec.Command("cmd")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: cmdline}
+	return cmd.Run()
+}


### PR DESCRIPTION
## Summary
Closes #575 (HARNESS-050).

- `createLink`'s Windows branch passed the link/source paths as ordinary argv elements to `cmd /c mklink /J`. Go's automatic argv-to-command-line escaping only quotes on space/tab/quote (the C-runtime/CommandLineToArgvW convention) — but `mklink` is a cmd.exe builtin with no separate-process argv layer downstream, so only cmd's own tokenizer ever parses the paths, and it treats a bare comma, semicolon or equals sign as a word separator outside quotes. A path containing one of those split into extra words and `mklink` failed "the syntax of the command is incorrect" — silently, since `Ensure`'s caller swallows the error by contract.
- Split `createLink` into `memlink_windows.go` / `memlink_unix.go` (the build-tag convention already used by `secrets/bwserve_*.go`, `agent/lock_*.go`). The Windows implementation builds the exact command line by hand via `SysProcAttr.CmdLine`, bypassing Go's escaping, and quotes both paths for cmd's tokenizer with `cmd /s /c "mklink /J "<link>" "<src>""` — the `/S` switch is what makes cmd hand the still-quoted tail to `mklink`'s own argument scanner instead of treating it as one opaque token.
- Verified empirically against a real `cmd.exe` on this box (throwaway probe) before landing this shape — comma, semicolon, paren, equals and space path components all work — then locked down with a table test exercising `createLink` directly through all five.

## SDD skip rationale
71 production LOC, just over the 50-LOC gate — most of it is the Windows implementation's doc comment, which carries genuinely non-obvious reasoning (two independent, differently-scoped quoting layers: Go's argv escaping vs. cmd.exe's own tokenizer, and why `/S` is what makes the fix work) that a future reader will need. The fix itself, its cause, and the proposed shape were already fully specified in issue #575 before this PR; a spec folder would restate that, not add a decision.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/memlink/...` — new `TestCreateLink_CmdDelimiterPaths` (comma, semicolon, paren, equals, space), verified passing live on a real Windows box
- [x] `go test ./...` (full module, 22 packages, green)