### PR TITLE
refactor(setup): port the shell verification layer into dotf doctor, then delete it

### DIFF
--- a/cli/internal/doctor/checks_compose.go
+++ b/cli/internal/doctor/checks_compose.go
@@ -1,0 +1,42 @@
+package doctor
+
+import "strings"
+
+// checkDockerCompose covers the one name in setup-linux.sh's check_dependencies
+// list that no doctor section, contract binary or package list mentioned:
+// docker-compose. OPS-043 deletes that shell call, so without this the tool
+// would lose its only mention.
+//
+// It probes the v2 CLI plugin first because that is the supported form —
+// compose v2 is `docker compose`, a plugin with no entry on PATH, so
+// `command -v docker-compose` (what the shell call did) reports "missing" on a
+// current install where compose works fine. Measured on msi 2026-09-02: the
+// standalone v1 binary and plugin v2.39.1 are both present, and either check
+// alone would have described that box wrongly.
+//
+// Absence is a SKIP, never a FAIL: the repo provisions compose in no installer
+// block, no versions.conf pin and no contract binary, so failing on it would red
+// a box that never asked for it — the same reasoning BUG-052 applied to
+// terraform.
+func checkDockerCompose(sys *System, rep *Report) {
+	rep.Section("Docker Compose")
+
+	if !sys.has("docker") {
+		rep.Skip("docker not on PATH — nothing for the compose plugin to attach to (see Core tools)")
+		return
+	}
+
+	if out, err := sys.CommandOutput("docker", "compose", "version"); err == nil {
+		if v := strings.TrimSpace(out); v != "" {
+			rep.Pass("compose v2 plugin: " + v)
+			return
+		}
+	}
+
+	if sys.has("docker-compose") {
+		rep.Pass("docker-compose found (legacy standalone v1; `docker compose` is the supported form)")
+		return
+	}
+
+	rep.Skip("compose not installed (optional — the repo provisions neither the plugin nor the binary)")
+}

--- a/cli/internal/doctor/checks_compose_test.go
+++ b/cli/internal/doctor/checks_compose_test.go
@@ -1,0 +1,65 @@
+package doctor
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestCheckDockerCompose pins the one tool setup's check_dependencies named that
+// doctor covered nowhere. Compose v2 ships as a `docker` CLI plugin, not a
+// binary, so a PATH test alone answers wrongly on a current install — measured
+// on msi 2026-09-02, where the v1 binary and plugin v2.39.1 are both present.
+// The repo provisions compose in no installer, versions.conf entry or contract
+// binary, so absence is a SKIP; a FAIL would red every box that never wanted it
+// (the BUG-052 reasoning that put terraform in optionalTools).
+func TestCheckDockerCompose(t *testing.T) {
+	cases := []struct {
+		name         string
+		onPath       []string
+		cmdOut       map[string]string
+		wantFailures int
+		wantSubstr   string
+	}{
+		{
+			name:       "v2 plugin present → pass naming the version",
+			onPath:     []string{"docker"},
+			cmdOut:     map[string]string{"docker compose version": "Docker Compose version v2.39.1"},
+			wantSubstr: "v2.39.1",
+		},
+		{
+			// A box still on the standalone binary: compose works, so this is
+			// not a failure, but the plugin is the supported form.
+			name:       "only the v1 binary → pass, flagged legacy",
+			onPath:     []string{"docker", "docker-compose"},
+			wantSubstr: "legacy",
+		},
+		{
+			name:       "docker present, no compose either way → skip",
+			onPath:     []string{"docker"},
+			wantSubstr: "not installed",
+		},
+		{
+			// Without docker there is nothing for a plugin to hang off; the
+			// core-tools section already reports docker itself.
+			name:       "no docker → skip without duplicating the core-tools verdict",
+			wantSubstr: "docker",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sys := newSys(nil, tc.onPath, tc.cmdOut)
+			var buf bytes.Buffer
+			rep := capture(&buf)
+			checkDockerCompose(sys, rep)
+
+			if rep.Failures() != tc.wantFailures {
+				t.Fatalf("failures = %d, want %d\n%s", rep.Failures(), tc.wantFailures, buf.String())
+			}
+			if !strings.Contains(buf.String(), tc.wantSubstr) {
+				t.Fatalf("output missing %q\n%s", tc.wantSubstr, buf.String())
+			}
+		})
+	}
+}

--- a/cli/internal/doctor/checks_home_deploy.go
+++ b/cli/internal/doctor/checks_home_deploy.go
@@ -1,0 +1,124 @@
+package doctor
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// homeDeployEntry maps one file inside the deploy dir (~/.dotfiles) to where
+// setup copies it under $HOME, and says whether the two are expected to stay
+// byte-identical.
+//
+// The map cannot reuse isManagedDeployPath: that predicate serves the repo →
+// deploy-dir leg, where a file keeps its relative path. On this leg the path
+// changes (ssh/config → .ssh/config, tmux.conf → .tmux.conf), so the mapping has
+// to be explicit — and explicit means it can drift from setup, which is what
+// TestHomeDeployMapCoversSetup exists to prevent.
+type homeDeployEntry struct {
+	// src is relative to cfg.DotfilesDir; dst is relative to $HOME.
+	src, dst string
+	// contentChecked is false for files something other than setup legitimately
+	// writes after deployment. Those are checked for existence only.
+	contentChecked bool
+	// exemptReason states the mechanism that makes contentChecked false. It is
+	// required (TestHomeDeployExemptionsAreReasoned) because the defect this
+	// spec found in setup's own NOTE was an exemption whose justification had
+	// outlived its mechanism — the comment cited a `sed -i` that the OPS-040
+	// purge removed.
+	exemptReason string
+}
+
+// homeDeployMap mirrors setup-linux.sh's `deploy_file … "$HOME/…"` call sites.
+// Adding one there without adding it here fails TestHomeDeployMapCoversSetup.
+var homeDeployMap = []homeDeployEntry{
+	{src: ".zshrc", dst: ".zshrc", exemptReason: "tool installers (opencode, bun, NVM, ggshield) append PATH/init lines post-deploy"},
+	{src: ".bashrc", dst: ".bashrc", exemptReason: "same installer appends; setup only asserts existence here too"},
+	{src: ".profile", dst: ".profile", exemptReason: "same installer appends"},
+	{src: ".gitconfig", dst: ".gitconfig", exemptReason: "every `git config --global` rewrites it; measured drifting on a converged box 2026-09-02"},
+	{src: "ssh/config", dst: ".ssh/config", contentChecked: true},
+	{src: ".zsh/aliases.zsh", dst: ".zsh/aliases.zsh", contentChecked: true},
+	{src: ".zsh/functions.zsh", dst: ".zsh/functions.zsh", contentChecked: true},
+	{src: ".zsh/functions.sh", dst: ".zsh/functions.sh", contentChecked: true},
+	{src: ".zsh/nvm.zsh", dst: ".zsh/nvm.zsh", contentChecked: true},
+	{src: "tmux.conf", dst: ".tmux.conf", contentChecked: true},
+	{src: ".inputrc", dst: ".inputrc", contentChecked: true},
+}
+
+// checkHomeDeployDrift covers the deploy-dir → $HOME leg of
+// repo → ~/.dotfiles → $HOME. Before OPS-043 no doctor section compared content
+// here: checkSymlinks and checkProfileFiles test existence, and PASS a real file
+// that has drifted. setup-linux.sh's check_deployed was the only assertion, and
+// setup-windows.ps1 never had one — so on Windows this leg was unguarded
+// outright.
+//
+// It ports check_deployed's two severities exactly, so deleting the shell calls
+// loses nothing: drifted content FAILs, and so does a symlink where a regular
+// file is expected (ADR-012 moved deployment to copy; cmp would follow the link
+// and checkSymlinks PASSes it, so nothing else catches that).
+func checkHomeDeployDrift(sys *System, cfg *Config, rep *Report) {
+	rep.Section("Deploy-dir↔$HOME drift")
+
+	// Every entry is POSIX-only, since the map is derived from setup-linux.sh.
+	// The Windows deploy targets need their own map and their own join guard —
+	// OPS-046 (#1447), deliberately out of this spec's scope.
+	if sys.GOOS == "windows" {
+		rep.Skip("POSIX-only deploy targets (Windows map tracked by #1447)")
+		return
+	}
+
+	home := sys.home()
+	deploy := cfg.DotfilesDir
+	if !isDir(deploy) {
+		rep.Skip("deploy-dir absent: " + deploy + " (run setup)")
+		return
+	}
+
+	for _, e := range homeDeployMap {
+		src := filepath.Join(deploy, filepath.FromSlash(e.src))
+		dst := filepath.Join(home, filepath.FromSlash(e.dst))
+
+		// setup guards its conditional deploys on the SOURCE existing
+		// (`[ -f "$DOTFILES_DIR/.gitconfig" ]`), so an absent source means "not
+		// provisioned on this box", never "deploy failed".
+		if !pathExists(src) {
+			rep.Skip(e.dst + " not provisioned (" + e.src + " absent from deploy-dir)")
+			continue
+		}
+		if isSymlink(dst) {
+			rep.Fail(e.dst + " is a symlink (expected a regular file since ADR-012 — re-run setup)")
+			continue
+		}
+		if !pathExists(dst) {
+			rep.Fail(e.dst + " missing at " + dst + " (run setup-linux.sh)")
+			continue
+		}
+		if !e.contentChecked {
+			rep.Pass(e.dst + " exists (content drift expected: " + e.exemptReason + ")")
+			continue
+		}
+		if filesEqual(src, dst) {
+			rep.Pass(e.dst + " matches " + e.src)
+			continue
+		}
+		rep.Fail(e.dst + " has drifted from " + src + " (edit in repo + run setup-linux.sh)")
+	}
+}
+
+// setupDeployFileCall matches `deploy_file "$DOTFILES_DIR/<src>" "$HOME/<dst>"`,
+// the only shape that deploys into $HOME. Calls targeting other roots
+// (GEMINI_HOME, the MCP master config, the hive drop-in) are a different
+// concern and are deliberately not matched.
+var setupDeployFileCall = regexp.MustCompile(`deploy_file\s+"\$DOTFILES_DIR/([^"]+)"\s+"\$HOME/([^"]+)"`)
+
+// setupHomeDeployPairs extracts src→dst from setup-linux.sh so the guard
+// compares the map against the script rather than against a second hand-written
+// list. Duplicate call sites (setup re-deploys the rc files at the tail) collapse
+// into one entry.
+func setupHomeDeployPairs(script string) map[string]string {
+	pairs := map[string]string{}
+	for _, m := range setupDeployFileCall.FindAllStringSubmatch(script, -1) {
+		pairs[strings.TrimSpace(m[1])] = strings.TrimSpace(m[2])
+	}
+	return pairs
+}

--- a/cli/internal/doctor/checks_home_deploy.go
+++ b/cli/internal/doctor/checks_home_deploy.go
@@ -75,32 +75,34 @@ func checkHomeDeployDrift(sys *System, cfg *Config, rep *Report) {
 	}
 
 	for _, e := range homeDeployMap {
-		src := filepath.Join(deploy, filepath.FromSlash(e.src))
-		dst := filepath.Join(home, filepath.FromSlash(e.dst))
+		reportHomeDeployEntry(e, deploy, home, rep)
+	}
+}
 
-		// setup guards its conditional deploys on the SOURCE existing
-		// (`[ -f "$DOTFILES_DIR/.gitconfig" ]`), so an absent source means "not
-		// provisioned on this box", never "deploy failed".
-		if !pathExists(src) {
-			rep.Skip(e.dst + " not provisioned (" + e.src + " absent from deploy-dir)")
-			continue
-		}
-		if isSymlink(dst) {
-			rep.Fail(e.dst + " is a symlink (expected a regular file since ADR-012 — re-run setup)")
-			continue
-		}
-		if !pathExists(dst) {
-			rep.Fail(e.dst + " missing at " + dst + " (run setup-linux.sh)")
-			continue
-		}
-		if !e.contentChecked {
-			rep.Pass(e.dst + " exists (content drift expected: " + e.exemptReason + ")")
-			continue
-		}
-		if filesEqual(src, dst) {
-			rep.Pass(e.dst + " matches " + e.src)
-			continue
-		}
+// reportHomeDeployEntry decides one entry's verdict. Split out to keep
+// checkHomeDeployDrift under the repository's 40-line function guideline
+// (AGENTS.md), and because the ordering of these branches is the contract:
+// unprovisioned before missing, and symlink before content, since cmp would
+// happily follow the link and report a match.
+func reportHomeDeployEntry(e homeDeployEntry, deploy, home string, rep *Report) {
+	src := filepath.Join(deploy, filepath.FromSlash(e.src))
+	dst := filepath.Join(home, filepath.FromSlash(e.dst))
+
+	switch {
+	// setup guards its conditional deploys on the SOURCE existing
+	// (`[ -f "$DOTFILES_DIR/.gitconfig" ]`), so an absent source means "not
+	// provisioned on this box", never "deploy failed".
+	case !pathExists(src):
+		rep.Skip(e.dst + " not provisioned (" + e.src + " absent from deploy-dir)")
+	case isSymlink(dst):
+		rep.Fail(e.dst + " is a symlink (expected a regular file since ADR-012 — re-run setup)")
+	case !pathExists(dst):
+		rep.Fail(e.dst + " missing at " + dst + " (run setup-linux.sh)")
+	case !e.contentChecked:
+		rep.Pass(e.dst + " exists (content drift expected: " + e.exemptReason + ")")
+	case filesEqual(src, dst):
+		rep.Pass(e.dst + " matches " + e.src)
+	default:
 		rep.Fail(e.dst + " has drifted from " + src + " (edit in repo + run setup-linux.sh)")
 	}
 }

--- a/cli/internal/doctor/checks_home_deploy_test.go
+++ b/cli/internal/doctor/checks_home_deploy_test.go
@@ -1,0 +1,177 @@
+package doctor
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCheckHomeDeployDrift drives the deploy-dir↔$HOME leg — the one no doctor
+// section covered before OPS-043, and the one setup's check_deployed was the
+// only assertion on. Each row is a branch of the contract: content drift on a
+// checked entry FAILs, the same drift on an exempt entry does not, a symlink
+// FAILs even when it resolves to identical bytes, and an unprovisioned source
+// SKIPs rather than failing (which is how setup's `[ -f "$DOTFILES_DIR/..." ]`
+// conditionals behave).
+func TestCheckHomeDeployDrift(t *testing.T) {
+	type file struct{ path, content string }
+	cases := []struct {
+		name         string
+		deployFiles  []file
+		homeFiles    []file
+		symlinks     map[string]string // $HOME rel path → deploy-dir rel path it points at
+		wantFailures int
+		wantSubstr   string
+	}{
+		{
+			name:        "checked entries agree → pass",
+			deployFiles: []file{{".zsh/functions.sh", "f()"}, {".zsh/aliases.zsh", "a=1"}},
+			homeFiles:   []file{{".zsh/functions.sh", "f()"}, {".zsh/aliases.zsh", "a=1"}},
+			wantSubstr:  "matches",
+		},
+		{
+			// The file that lives in NO doctor list today: checkSymlinks covers
+			// aliases.zsh and functions.zsh only.
+			name:         "functions.sh drift → fail naming both paths",
+			deployFiles:  []file{{".zsh/functions.sh", "new"}},
+			homeFiles:    []file{{".zsh/functions.sh", "old"}},
+			wantFailures: 1,
+			wantSubstr:   ".zsh/functions.sh",
+		},
+		{
+			name:         "tmux.conf drift → fail, and the two legs use different relative paths",
+			deployFiles:  []file{{"tmux.conf", "set -g mouse on"}},
+			homeFiles:    []file{{".tmux.conf", "set -g mouse off"}},
+			wantFailures: 1,
+			wantSubstr:   ".tmux.conf",
+		},
+		{
+			// Measured on msi 2026-09-02: the only file of the eleven observed
+			// drifting. Every `git config --global` rewrites it.
+			name:        "gitconfig drift → exempt, pass",
+			deployFiles: []file{{".gitconfig", "[user]\n\tname = repo"}},
+			homeFiles:   []file{{".gitconfig", "[user]\n\tname = local"}},
+			wantSubstr:  "exists",
+		},
+		{
+			// Installers (opencode, bun, NVM, ggshield) append PATH/init lines.
+			name:        "rc files drift → exempt, pass",
+			deployFiles: []file{{".zshrc", "base"}, {".bashrc", "base"}, {".profile", "base"}},
+			homeFiles:   []file{{".zshrc", "base\nexport PATH=x"}, {".bashrc", "base\n. bun"}, {".profile", "base\nnvm"}},
+			wantSubstr:  "exists",
+		},
+		{
+			// ADR-012 moved deployment to copy, so a symlink here is a
+			// pre-ADR-012 leftover. cmp follows it and checkSymlinks PASSes it,
+			// so this FAIL exists nowhere else in doctor.
+			name:         "symlink at $HOME → fail even when content resolves equal",
+			deployFiles:  []file{{".zsh/functions.sh", "f()"}},
+			symlinks:     map[string]string{".zsh/functions.sh": ".zsh/functions.sh"},
+			wantFailures: 1,
+			wantSubstr:   "symlink",
+		},
+		{
+			name:         "deployed source present but $HOME copy missing → fail",
+			deployFiles:  []file{{".inputrc", "set completion-ignore-case on"}},
+			wantFailures: 1,
+			wantSubstr:   "missing",
+		},
+		{
+			// setup guards .profile/.gitconfig/.bashrc on the SOURCE existing,
+			// so "not provisioned" is a skip, never a failure (R4).
+			name:        "source absent from deploy dir → skip, not fail",
+			deployFiles: []file{{".zsh/functions.sh", "f()"}},
+			homeFiles:   []file{{".zsh/functions.sh", "f()"}},
+			wantSubstr:  "not provisioned",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			deploy := filepath.Join(t.TempDir(), "deploy")
+			mkdirAll(t, deploy)
+			for _, f := range tc.deployFiles {
+				writeFile(t, filepath.Join(deploy, filepath.FromSlash(f.path)), f.content)
+			}
+			for _, f := range tc.homeFiles {
+				writeFile(t, filepath.Join(home, filepath.FromSlash(f.path)), f.content)
+			}
+			for dst, src := range tc.symlinks {
+				p := filepath.Join(home, filepath.FromSlash(dst))
+				mkdirAll(t, filepath.Dir(p))
+				if err := os.Symlink(filepath.Join(deploy, filepath.FromSlash(src)), p); err != nil {
+					t.Fatalf("symlink: %v", err)
+				}
+			}
+
+			sys := newSys(map[string]string{"HOME": home}, nil, nil)
+			cfg := &Config{DotfilesDir: deploy}
+
+			var buf bytes.Buffer
+			rep := capture(&buf)
+			checkHomeDeployDrift(sys, cfg, rep)
+
+			if rep.Failures() != tc.wantFailures {
+				t.Fatalf("failures = %d, want %d\n%s", rep.Failures(), tc.wantFailures, buf.String())
+			}
+			if !strings.Contains(buf.String(), tc.wantSubstr) {
+				t.Fatalf("output missing %q\n%s", tc.wantSubstr, buf.String())
+			}
+		})
+	}
+}
+
+// TestHomeDeployMapCoversSetup is the join guard (AC5). Nothing in the repo
+// spans setup-linux.sh and this map, which is the gap #1337 itself came through:
+// a claim about coverage that no test could refute. It reads the script from the
+// repo root the way env_test.go and prtriage_test.go already do.
+func TestHomeDeployMapCoversSetup(t *testing.T) {
+	script := filepath.Join("..", "..", "..", "setup-linux.sh")
+	b, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatalf("read %s: %v", script, err)
+	}
+
+	pairs := setupHomeDeployPairs(string(b))
+	if len(pairs) == 0 {
+		t.Fatal("no `deploy_file \"$DOTFILES_DIR/...\" \"$HOME/...\"` call sites found — the parser or the script changed shape")
+	}
+
+	covered := map[string]string{}
+	for _, e := range homeDeployMap {
+		covered[e.src] = e.dst
+	}
+	for src, dst := range pairs {
+		got, ok := covered[src]
+		if !ok {
+			t.Errorf("setup-linux.sh deploys %q to $HOME/%s but homeDeployMap has no entry — add one, or doctor stops covering it", src, dst)
+			continue
+		}
+		if got != dst {
+			t.Errorf("homeDeployMap[%q] targets $HOME/%s, setup deploys it to $HOME/%s", src, got, dst)
+		}
+	}
+	for _, e := range homeDeployMap {
+		if _, ok := pairs[e.src]; !ok {
+			t.Errorf("homeDeployMap covers %q but setup-linux.sh no longer deploys it — a stale entry outlives its mechanism (lesson 256)", e.src)
+		}
+	}
+}
+
+// TestHomeDeployExemptionsAreReasoned pins that an exemption cannot be silent:
+// every non-content-checked entry carries why. An exemption with no stated
+// mechanism is the defect R5 found in setup's own NOTE, where a `sed -i` that
+// no longer exists still justified skipping .zshrc.
+func TestHomeDeployExemptionsAreReasoned(t *testing.T) {
+	for _, e := range homeDeployMap {
+		if !e.contentChecked && strings.TrimSpace(e.exemptReason) == "" {
+			t.Errorf("homeDeployMap entry %q is exempt from the content check with no reason", e.src)
+		}
+		if e.contentChecked && e.exemptReason != "" {
+			t.Errorf("homeDeployMap entry %q is content-checked but carries an exemption reason", e.src)
+		}
+	}
+}

--- a/cli/internal/doctor/checks_setup_parity_test.go
+++ b/cli/internal/doctor/checks_setup_parity_test.go
@@ -1,0 +1,106 @@
+package doctor
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// setupShellCoverage is what setup-linux.sh's check_deployed and
+// check_dependencies asserted immediately before OPS-043 deleted them. It is a
+// deliberately FROZEN historical snapshot, not a parse: after the deletion there
+// is no line left to read, so this table IS the record of what was removed.
+//
+// blocking says whether the shell call could fail the item. check_deployed
+// log_error'd (blocking). check_dependencies only ever log_warning'd
+// (scripts/utils.sh:359-372) — it never failed, not even under set -e — so its
+// fourteen tools were advisory, and doctor need only be advisory to match.
+var setupShellCoverage = []struct {
+	name     string
+	blocking bool
+}{
+	// check_deployed — setup-linux.sh:1583-1585
+	{".zsh/aliases.zsh", true},
+	{".zsh/functions.zsh", true},
+	{".zsh/functions.sh", true},
+	// check_dependencies — setup-linux.sh:1597
+	{"git", false}, {"zsh", false}, {"eza", false}, {"direnv", false},
+	{"node", false}, {"npm", false}, {"zoxide", false}, {"docker", false},
+	{"docker-compose", false}, {"kubectl", false}, {"helm", false},
+	{"terraform", false}, {"ansible", false}, {"pip", false},
+}
+
+// TestSetupShellParity is the evidence for the deletion in setup-linux.sh, and
+// the reason this spec did not simply do what #1337 asked. Every item the two
+// shell calls covered must have an equal-or-stronger verdict in doctor.
+//
+// Measured before the port, that was false in three places, which is why the
+// port had to precede the delete: docker-compose was covered nowhere at all,
+// .zsh/functions.sh was in no doctor list, and the deploy-dir→$HOME leg had no
+// content comparison for any of the three files (checkSymlinks PASSes a drifted
+// real file).
+func TestSetupShellParity(t *testing.T) {
+	c, err := loadContract(filepath.Join("..", "..", "..", "env-contract.json"))
+	if err != nil {
+		t.Fatalf("load contract: %v", err)
+	}
+
+	core := map[string]bool{}
+	for _, tool := range coreTools {
+		core[tool] = true
+	}
+	optional := map[string]bool{}
+	for _, tool := range optionalTools {
+		optional[tool] = true
+	}
+	contractBins := contractBinaryNames(c)
+	for _, o := range c.OptionalBinaries {
+		optional[o.Name] = true
+	}
+
+	contentChecked := map[string]bool{}
+	for _, e := range homeDeployMap {
+		if e.contentChecked {
+			contentChecked[e.dst] = true
+		}
+	}
+
+	for _, item := range setupShellCoverage {
+		t.Run(item.name, func(t *testing.T) {
+			switch {
+			// The three check_deployed files: only a byte comparison is
+			// equal-or-stronger. Existence (checkSymlinks) is weaker — it
+			// PASSes exactly the drift the shell call FAILed on.
+			case item.blocking:
+				if !contentChecked[item.name] {
+					t.Fatalf("%s was byte-compared by check_deployed but has no content-checked homeDeployMap entry — deleting the shell call would lose the assertion", item.name)
+				}
+
+			// docker-compose has no PATH entry to find under compose v2; its
+			// verdict comes from checkDockerCompose probing the plugin.
+			case item.name == "docker-compose":
+				if core[item.name] || optional[item.name] {
+					t.Fatalf("docker-compose is listed as a PATH tool; compose v2 is a `docker` CLI plugin with no binary on PATH, so that answers wrongly on a current install")
+				}
+
+			// Everything else only needs to be *mentioned* somewhere doctor
+			// reports, since the shell call was advisory. coreTools is strictly
+			// stronger (FAIL); optionalTools is a SKIP, equal to the WARN it
+			// replaces — both surface the tool without failing the run.
+			default:
+				if !core[item.name] && !optional[item.name] && !contractBins[item.name] {
+					t.Fatalf("%s was reported by check_dependencies and appears in no doctor list (coreTools, optionalTools, contract binaries) — deleting the shell call would drop it entirely", item.name)
+				}
+			}
+		})
+	}
+}
+
+// TestSetupParityTableIsComplete guards the frozen table against being quietly
+// trimmed: seventeen items were deleted from setup-linux.sh, and a parity claim
+// over sixteen of them is not the claim this spec made.
+func TestSetupParityTableIsComplete(t *testing.T) {
+	const want = 17 // 3 check_deployed files + 14 check_dependencies tools
+	if got := len(setupShellCoverage); got != want {
+		t.Fatalf("setupShellCoverage has %d items, want %d — the table records what setup-linux.sh asserted at deletion time and is not editable after the fact", got, want)
+	}
+}

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -119,6 +119,7 @@ func Run(opts Options) (int, error) {
 		checkHarnessDrift(sys, cfg, rep, opts.Fix)
 		checkDeployDrift(sys, cfg, rep)
 		checkHomeDeployDrift(sys, cfg, rep)
+		checkDockerCompose(sys, rep)
 		checkDeployManifest(sys, rep)
 		checkAgentPresence(sys, rep)
 		checkAgentSkillsMigrated(cfg, rep)

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -118,6 +118,7 @@ func Run(opts Options) (int, error) {
 		checkPiExtensions(sys, cfg, rep, opts.Fix)
 		checkHarnessDrift(sys, cfg, rep, opts.Fix)
 		checkDeployDrift(sys, cfg, rep)
+		checkHomeDeployDrift(sys, cfg, rep)
 		checkDeployManifest(sys, rep)
 		checkAgentPresence(sys, rep)
 		checkAgentSkillsMigrated(cfg, rep)

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -276,5 +276,6 @@ tags: [lessons, index, dotfiles]
 | [256 - A cleanup block's own description of what it deletes is not evidence that the thing is dead](lesson-256-a-cleanup-blocks-own-description-of-what-it-deletes.md) | 2026-09-02 |  |
 | [257 - A one-time migration with no removal date is indistinguishable from live code, and two of eleven turned out not to be finished](lesson-257-a-one-time-migration-with-no-removal-date-is.md) | 2026-09-02 |  |
 | [258 - An argument passed through two independent quoting conventions is only as safe as the weaker one](lesson-258-an-argument-passed-through-two-independent-quoting-layers.md) | 2026-09-02 |  |
+| [259 - A justification outlives its mechanism as easily as a name outlives its contract, and the cleanup that taught us the first lesson left an instance of it](lesson-259-a-justification-outlives-its-mechanism.md) | 2026-09-02 |  |
 
 - [2026-08-30 Intercepting Cobra Errors without Breaking SilenceErrors](2026-08-30-cobra-silence-errors-interception.md)

--- a/docs/lessons/lesson-259-a-justification-outlives-its-mechanism.md
+++ b/docs/lessons/lesson-259-a-justification-outlives-its-mechanism.md
@@ -1,0 +1,85 @@
+# 259 - A justification outlives its mechanism as easily as a name outlives its contract, and the cleanup that taught us the first lesson left an instance of it
+
+**Date:** 2026-09-02
+**Area:** setup scripts, doctor, technical debt
+
+## What happened
+
+OPS-043 (#1337) asked to delete `check_deployed` and `check_dependencies` from
+`setup-linux.sh` as duplicates of `dotf doctor`. Measuring first found the
+premise false in five places. Two of those failures have the same shape, at
+different distances from the code.
+
+**A name outliving its contract.** The ticket read `check_deployed` and
+`checkDeployDrift` as the same check under two spellings. They are different
+legs of the same chain:
+
+| | Compares | Severity |
+|---|---|---|
+| `checkDeployDrift` (Go) | repo → `~/.dotfiles` | FAIL on drift |
+| `check_deployed` (shell) | `~/.dotfiles` → `$HOME` | FAIL on drift **and** on a symlink |
+| `checkSymlinks` (Go) | `$HOME` existence | PASS on a drifted real file |
+
+So the shell function was the *only* byte-level assertion on the second leg
+anywhere in the repo — and `setup-windows.ps1` never had it, leaving that leg
+unguarded on Windows outright. Deleting as asked would have removed coverage
+while the diff read as removing duplication.
+
+**A justification outliving its mechanism.** The NOTE explaining why `.zshrc`
+was exempt from the byte comparison said setup "may legitimately modify it (e.g.
+stripping stale gh-copilot eval lines via `sed -i`)". There is no `sed -i` left
+in the script; the only match in the whole file is inside that comment. The
+OPS-040 purge removed the mechanism a day earlier and left the sentence.
+
+That is the part worth recording. **OPS-040's entire method was lesson 256 —
+probe the target, never read the block's own comment.** It still left behind a
+comment describing a thing it had just deleted. Knowing the lesson, in writing,
+while applying it, was not enough to avoid producing another instance of it.
+
+## Why this class survives knowing about it
+
+A false comment is written by someone who was wrong. **These comments were
+true when written.** Nobody introduced an error; the world moved underneath a
+correct sentence, and the sentence has no link to the thing it describes. There
+is no moment where a careful reviewer would have caught it, because at every
+individual commit the text was accurate.
+
+Both halves are also *cheap to leave*: a stale justification still justifies
+something plausible, and a misleading name still names a real function. Nothing
+fails. The cost lands later, on a reader who takes the text as evidence — which
+is how #1337 came to be filed in the first place.
+
+## What to do instead
+
+**Put the justification next to the data it justifies, and make its absence a
+test failure.** The exemptions that used to live in a shell comment now live in
+`homeDeployMap` as a required field:
+
+```go
+{src: ".gitconfig", dst: ".gitconfig",
+    exemptReason: "every `git config --global` rewrites it; measured drifting on a converged box 2026-09-02"},
+```
+
+`TestHomeDeployExemptionsAreReasoned` fails on an exemption with an empty
+reason. That does not detect a *stale* reason — nothing can, cheaply — but it
+forces the reason to be re-read whenever the entry is touched, which is the only
+moment anyone would notice.
+
+**Guard the join, not the two sides.** Nothing in the repo spanned
+`setup-linux.sh`'s deploy calls and doctor's coverage lists, which is precisely
+the gap #1337 came through: a claim about coverage that no test could refute.
+`TestHomeDeployMapCoversSetup` parses the script and fails in both directions —
+an uncovered `deploy_file` call, *and* a map entry setup no longer deploys. The
+second direction is the one that catches this lesson's class.
+
+**When a ticket asserts duplication, compare direction and severity before
+deleting.** Two checks with similar names are duplicates only if they compare
+the same things at the same strength. Here they shared neither.
+
+## Related
+
+- #1337 — this spec; #1447 — the Windows half of the leg, still unguarded
+- Lesson 256 — a cleanup block's own description of what it deletes is not
+  evidence. This is that lesson recurring inside the work that established it.
+- Lesson 257 — the same purge; a one-time migration with no removal date
+- Lesson 232 — detect the shape that is wrong, not the shape that is right

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -129,40 +129,12 @@ function Deploy-File {
     }
 }
 
-# Test-FileDrift: assert DST matches SRC content (drift detection for healthcheck).
-# Parity with bash scripts/utils.sh check_deployed().
-#
-# Returns $true if files match, $false if drift detected.
-# Logs PASS/FAIL via Write-Host so callers can compose with their own counters.
-function Test-FileDrift {
-    param(
-        [Parameter(Mandatory)][string]$Source,
-        [Parameter(Mandatory)][string]$Destination,
-        [string]$DisplayName = ''
-    )
-    if (-not $DisplayName) { $DisplayName = Split-Path -Leaf $Destination }
-
-    if (-not (Test-Path -LiteralPath $Destination -PathType Leaf)) {
-        Write-Host "[FAIL] $DisplayName missing at $Destination (run setup-windows.ps1)" -ForegroundColor Red
-        return $false
-    }
-
-    $isReparse = (Get-Item -LiteralPath $Destination -Force).Attributes -band [IO.FileAttributes]::ReparsePoint
-    if ($isReparse) {
-        Write-Host "[FAIL] $DisplayName is a reparse-point/symlink (expected regular file)" -ForegroundColor Red
-        return $false
-    }
-
-    $srcHash = (Get-FileHash -LiteralPath $Source -Algorithm SHA256).Hash
-    $dstHash = (Get-FileHash -LiteralPath $Destination -Algorithm SHA256).Hash
-    if ($srcHash -eq $dstHash) {
-        Write-Host "[PASS] $DisplayName deployed (matches repo)" -ForegroundColor Green
-        return $true
-    }
-
-    Write-Host "[FAIL] $DisplayName has drifted from $Source (edit in repo + re-run setup)" -ForegroundColor Red
-    return $false
-}
+# Test-FileDrift was removed by OPS-043 (#1337). It was written as parity with
+# bash check_deployed for healthcheck.ps1, and CLI-018 retired that script into
+# `dotf doctor` without removing the helper -- leaving a fully implemented
+# function with zero call sites anywhere in the repo. Its behaviour now lives in
+# doctor's `Deploy-dir<->$HOME drift` section, which is cross-compiled and so
+# needs no PowerShell twin at all.
 
 # Get-ClaudeProjectKeyEncoded: the pure encoding of a working directory into
 # Claude Code's per-project key (the directory name under ~/.claude/projects) --

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -492,8 +492,12 @@ deploy_file() {
 # anywhere in the repo. It moved rather than being dropped: doctor's
 # `Deploy-dir<->$HOME drift` section carries the same two severities (content
 # drift and a symlink where ADR-012 expects a regular file) over eleven files
-# instead of three, and covers Windows, which never had this function's twin
-# wired to anything.
+# instead of three.
+#
+# It does NOT cover Windows: the map is derived from setup-linux.sh's deploy
+# calls, so every entry is POSIX-only and the section skips there. Windows never
+# had this function's twin wired to anything either, so nothing regressed -- but
+# that leg is unguarded on Windows and OPS-046 (#1447) is where it gets closed.
 
 # Checks if file exists and exits if not found
 # Input: $1 - file path, $2 - custom error message (optional)

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -352,24 +352,10 @@ check_command() {
     return 0
 }
 
-# Validates that all required commands are available
-# Input: array of command names
-# Output: error messages for missing commands, returns 0 if all found, 1 if any missing
-# Usage: check_dependencies "git" "curl" "jq"
-check_dependencies() {
-    local deps=("$@")
-    local missing=()
-
-    for dep in "${deps[@]}"; do
-        if ! check_command "$dep"; then
-            missing+=("$dep")
-        fi
-    done
-
-    if [ ${#missing[@]} -gt 0 ]; then
-        log_warning "Optional dependencies not found: ${missing[*]}. Some features may not work."
-    fi
-}
+# check_dependencies was removed by OPS-043 (#1337) along with its only call
+# site. `dotf doctor` reports every tool it named, at an equal-or-stronger
+# severity -- it only ever log_warning'd, so it never failed anything.
+# TestSetupShellParity holds the fourteen-row proof.
 
 # User confirmation functions
 
@@ -500,35 +486,14 @@ deploy_file() {
     return 1
 }
 
-# Asserts a deployed file matches its repo source (copy-deploy drift detection).
-# Pair of deploy_file: if the user edited ~/.zshrc directly instead of in the repo,
-# this surfaces it loudly instead of silently losing the edit on next setup-linux.sh run.
-# Input: $1 - repo source path, $2 - deployed target path, $3 - display name (optional)
-# Output: pass/fail log line, returns 0 if match, 1 if drift
-# Usage: check_deployed "$DOTFILES_DIR/.zshrc" "$HOME/.zshrc" ".zshrc"
-check_deployed() {
-    src="$1"
-    dst="$2"
-    name="${3:-$(basename "$dst")}"
-
-    if [[ ! -f "$dst" ]]; then
-        log_error "$name missing at $dst (run setup-linux.sh)"
-        return 1
-    fi
-
-    if [[ -L "$dst" ]]; then
-        log_error "$name is a symlink (expected regular file — run setup-linux.sh)"
-        return 1
-    fi
-
-    if cmp -s "$src" "$dst"; then
-        log_success "$name deployed (matches repo)"
-        return 0
-    fi
-
-    log_error "$name has drifted from $src (edit in repo + run setup-linux.sh)"
-    return 1
-}
+# check_deployed was removed by OPS-043 (#1337) along with its only call site.
+# It was deploy_file's pair -- the assertion that a file in $HOME still matches
+# the copy in ~/.dotfiles -- and it was the ONLY byte-level check on that leg
+# anywhere in the repo. It moved rather than being dropped: doctor's
+# `Deploy-dir<->$HOME drift` section carries the same two severities (content
+# drift and a symlink where ADR-012 expects a regular file) over eleven files
+# instead of three, and covers Windows, which never had this function's twin
+# wired to anything.
 
 # Checks if file exists and exits if not found
 # Input: $1 - file path, $2 - custom error message (optional)

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -1580,21 +1580,18 @@ fi
 # Test if files are correctly linked
 log_success "Installation completed! Verifying file links..."
 
-check_deployed "$DOTFILES_DIR/.zsh/aliases.zsh" "$HOME/.zsh/aliases.zsh" "aliases.zsh"
-check_deployed "$DOTFILES_DIR/.zsh/functions.zsh" "$HOME/.zsh/functions.zsh" "functions.zsh"
-check_deployed "$DOTFILES_DIR/.zsh/functions.sh" "$HOME/.zsh/functions.sh" "functions.sh"
-# NOTE: .zshrc intentionally NOT under strict check_deployed -- setup-linux.sh
-# may legitimately modify it (e.g. stripping stale gh-copilot eval lines via
-# sed -i). Same rationale as .bashrc: tool installers append PATH/init lines,
-# producing legitimate drift that should not abort the bootstrap.
-# NOTE: .bashrc intentionally NOT under strict check_deployed -- tool installers
-# (opencode, bun, NVM, ggshield) append PATH/init lines to ~/.bashrc post-deploy,
-# producing legitimate drift. Just verify existence.
-[ -f "$HOME/.bashrc" ] && log_success ".bashrc exists (drift expected from installers)" || log_error ".bashrc missing (run setup-linux.sh)"
+# OPS-043: the per-file byte comparison that used to live here (check_deployed
+# x3) and the 14-tool check_dependencies sweep are now `dotf doctor`'s, which
+# runs at the tail of this same script. Both moved rather than being dropped:
+# doctor's `Deploy-dir<->$HOME drift` section carries the byte comparison AND
+# check_deployed's symlink rejection, over eleven files instead of three, and
+# every one of the fourteen tools has an equal-or-stronger verdict there --
+# asserted by TestSetupShellParity, not by this comment. setup-windows.ps1 has
+# had no such block since CLI-018; this brings Linux to the same shape.
+#
+# The exemptions the deleted NOTEs recorded now live beside the data they
+# describe, in doctor's homeDeployMap, each with its own reason.
 file_exists "$HOME/.bash/bash_aliases" && log_success "bash_aliases created" || log_error "bash_aliases issue"
-
-# Check dependencies
-check_dependencies "git" "zsh" "eza" "direnv" "node" "npm" "zoxide" "docker" "docker-compose" "kubectl" "helm" "terraform" "ansible" "pip"
 
 # Deploy env-contract.json so `dotf doctor` can find it under $DOTFILES_DIR.
 if [ -f "$CURRENT_DIR/env-contract.json" ]; then

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -116,7 +116,7 @@ function Ensure-Directory {
     }
 }
 
-# SDD-007: dot-source shared deploy helpers (Deploy-File / Test-FileDrift).
+# SDD-007: dot-source shared deploy helpers (Deploy-File).
 # Same SHA256-based idempotent copy pattern previously inlined throughout this
 # script; centralizing in utils.ps1 keeps cross-OS parity with scripts/utils.sh.
 $utilsPs1Path = Join-Path $PSScriptRoot 'scripts\utils.ps1'

--- a/specs/OPS-043-setup-doctor-duplication/features.json
+++ b/specs/OPS-043-setup-doctor-duplication/features.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "OPS-043-setup-doctor-duplication-f1",
+    "behavior": "AC1 — dotf doctor FAILs on byte drift between a file deployed to $HOME and its ~/.dotfiles source, and PASSes when equal, for the three .zsh files check_deployed covered",
+    "verification": "cd cli && go test ./internal/doctor/ -run TestCheckHomeDeployDrift -v",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "OPS-043-setup-doctor-duplication-f2",
+    "behavior": "AC2 — .gitconfig/.zshrc/.bashrc/.profile are existence-only and never FAIL on content drift, and the stale sed -i clause in the setup NOTE is corrected",
+    "verification": "cd cli && go test ./internal/doctor/ -run TestCheckHomeDeployDriftExemptions -v && ! grep -n 'sed -i' ../setup-linux.sh",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "OPS-043-setup-doctor-duplication-f3",
+    "behavior": "AC3 — every one of the 14 check_dependencies tools and 3 check_deployed files has an equal-or-stronger doctor verdict, plus the docker-compose and symlink rows",
+    "verification": "cd cli && go test ./internal/doctor/ -run TestSetupShellParity -v",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "OPS-043-setup-doctor-duplication-f4",
+    "behavior": "AC4 — removing any of the six REFACTOR-002 pre-exports from setup-linux.sh fails a guard (BUG-021)",
+    "verification": "~/.local/bin/bats tests/guard-setup-preexports-present.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "OPS-043-setup-doctor-duplication-f5",
+    "behavior": "AC5 — a deploy_file call into $HOME with no homeDeployMap entry fails a guard (the R1 join)",
+    "verification": "cd cli && go test ./internal/doctor/ -run TestHomeDeployMapCoversSetup -v",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "OPS-043-setup-doctor-duplication-f6",
+    "behavior": "AC6 — setup-linux.sh no longer calls check_deployed or check_dependencies, and both layers stay green",
+    "verification": "! grep -qE '^[[:space:]]*(check_deployed|check_dependencies) ' setup-linux.sh && cd cli && go build ./... && go vet ./... && GOOS=windows go vet ./... && go test ./...",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/OPS-043-setup-doctor-duplication/features.json
+++ b/specs/OPS-043-setup-doctor-duplication/features.json
@@ -2,21 +2,21 @@
   {
     "id": "OPS-043-setup-doctor-duplication-f1",
     "behavior": "AC1 — dotf doctor FAILs on byte drift between a file deployed to $HOME and its ~/.dotfiles source, and PASSes when equal, for the three .zsh files check_deployed covered",
-    "verification": "cd cli && go test ./internal/doctor/ -run TestCheckHomeDeployDrift -v",
+    "verification": "cd cli && go test ./internal/doctor/ -run '^TestCheckHomeDeployDrift$' -v",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "OPS-043-setup-doctor-duplication-f2",
     "behavior": "AC2 — .gitconfig/.zshrc/.bashrc/.profile are existence-only and never FAIL on content drift, and the stale sed -i clause in the setup NOTE is corrected",
-    "verification": "cd cli && go test ./internal/doctor/ -run TestCheckHomeDeployDriftExemptions -v && ! grep -n 'sed -i' ../setup-linux.sh",
+    "verification": "cd cli && go test ./internal/doctor/ -run '^(TestCheckHomeDeployDrift|TestHomeDeployExemptionsAreReasoned)$' -v && ! grep -n 'sed -i' ../setup-linux.sh",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "OPS-043-setup-doctor-duplication-f3",
     "behavior": "AC3 — every one of the 14 check_dependencies tools and 3 check_deployed files has an equal-or-stronger doctor verdict, plus the docker-compose and symlink rows",
-    "verification": "cd cli && go test ./internal/doctor/ -run TestSetupShellParity -v",
+    "verification": "cd cli && go test ./internal/doctor/ -run '^TestSetupShellParity$' -v",
     "state": "pending",
     "evidence": ""
   },
@@ -30,7 +30,7 @@
   {
     "id": "OPS-043-setup-doctor-duplication-f5",
     "behavior": "AC5 — a deploy_file call into $HOME with no homeDeployMap entry fails a guard (the R1 join)",
-    "verification": "cd cli && go test ./internal/doctor/ -run TestHomeDeployMapCoversSetup -v",
+    "verification": "cd cli && go test ./internal/doctor/ -run '^TestHomeDeployMapCoversSetup$' -v",
     "state": "pending",
     "evidence": ""
   },

--- a/specs/OPS-043-setup-doctor-duplication/proposal.md
+++ b/specs/OPS-043-setup-doctor-duplication/proposal.md
@@ -1,0 +1,186 @@
+---
+id: "OPS-043-setup-doctor-duplication"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-09-02"
+issue: "mlorentedev/dotfiles#1337"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# OPS-043-setup-doctor-duplication
+
+> **Naming**: file lives at `<repo>/specs/OPS-043-setup-doctor-duplication/proposal.md`. `OPS-043-setup-doctor-duplication` is `AREA-NNN-slug`.
+
+## Why
+
+<!-- from issue #1337: OPS-043: setup duplicates dotf doctor: check_deployed/check_dependencies and six pre-exported contract vars run eleven lines before doctor covers the same -->
+
+`setup-linux.sh` ends with a shell verification layer — `check_deployed` ×3 and
+`check_dependencies` over 14 tools — eleven lines before it hands off to
+`dotf doctor`. ADR-020 makes `dotf doctor` the single post-setup diagnostic, and
+`setup-windows.ps1` already converged there (CLI-018): it carries **no**
+`check_deployed`/`check_dependencies` twin at all. Linux keeping a second
+verification surface is the drift.
+
+**But the issue's premise is false in five places, and measuring that is most of
+this spec's value.** Deleting what #1337 names would remove coverage nothing
+replaces:
+
+1. **`check_deployed` is not duplicated.** It compares the deploy dir to `$HOME`
+   (`~/.dotfiles/.zsh/aliases.zsh` vs `~/.zsh/aliases.zsh`, `cmp -s`).
+   `checkDeployDrift` (`checks_deploy.go:915`) compares the **repo** to the
+   **deploy dir**. Two different legs of `repo → ~/.dotfiles → $HOME`.
+2. **No doctor section compares bytes on the second leg.** All 40 sections were
+   enumerated. `checkSymlinks` (`checks_deploy.go:20`) and `checkProfileFiles`
+   (`checks_profile.go:45`) test *existence*; a real file that has drifted from
+   the repo reports `PASS` ("exists (not a symlink)"). So `check_deployed` is
+   today the **only** content assertion on `deploy-dir → $HOME` — and since
+   Windows never had it, that leg is **already unguarded on Windows**.
+3. **`check_dependencies` never fails.** `scripts/utils.sh:359-372` only
+   `log_warning`s. Of its 14 tools: **9** sit in doctor's `coreTools` (FAIL —
+   strictly stronger, genuine duplication), **4** (helm, terraform, ansible, pip)
+   sit in `optionalTools` (SKIP — advisory, same practical severity as the WARN
+   it replaces), and **`docker-compose` is covered nowhere** in doctor, the
+   contract, or the package lists.
+4. **`.zsh/functions.sh` is in no doctor list.** `checkSymlinks` covers
+   `aliases.zsh` and `functions.zsh` only.
+5. **The six pre-exported vars are not duplication.** `setup-linux.sh:1657-1668`
+   exports them precisely *because* the setup shell has not re-sourced the RC
+   files, so doctor would otherwise report false warnings (BUG-021, and the
+   Windows twin at `setup-windows.ps1:2185` carries the same fix). Removing them
+   reintroduces the bug they closed.
+
+So the honest shape is strangler-fig (ADR-020 §5), in this order: **port the
+missing coverage into `dotf doctor` first, then delete the shell layer.** The
+delete alone is a regression; the port alone leaves the duplication.
+
+## What
+
+After this PR:
+
+- `dotf doctor` gains a **`Deploy-dir↔$HOME drift`** section that byte-compares
+  every file setup deploys into `$HOME` against its `~/.dotfiles` source, driven
+  by an explicit deploy-dir→`$HOME` path map (the two legs have **different**
+  relative paths — `ssh/config` → `~/.ssh/config`, `tmux.conf` → `~/.tmux.conf` —
+  so `isManagedDeployPath` cannot be reused). Drift → FAIL, naming both paths and
+  the remedy. A **symlink** where a regular file is expected also FAILs, keeping
+  `check_deployed`'s severity (ADR-012 moved deployment to copy, so a symlink
+  there is a pre-ADR-012 leftover worth surfacing; `checkSymlinks` PASSes it and
+  `cmp` follows it, so nothing else would catch it).
+- **Exempt from the content comparison** (existence only), measured on msi
+  2026-09-02 rather than inherited: `.gitconfig` (**observed drifting** — every
+  `git config --global` on the box rewrites it), plus `.zshrc`, `.bashrc` and
+  `.profile`, whose exemption rests on a *named mechanism* — tool installers
+  (opencode, bun, NVM, ggshield) append PATH/init lines episodically — not on
+  drift observed today, since all three measured EQUAL. Each exemption carries
+  its reason inline; an exemption with no live mechanism is a bug (see R5).
+- `docker compose` gets a verdict where it has none today, **probed as the v2
+  CLI plugin with the standalone v1 binary as fallback**, and reported as
+  optional. The repo provisions compose nowhere (no entry in `versions.conf`,
+  `env-contract.json`, or any installer block), so a FAIL would be wrong; and a
+  bare `docker-compose`-on-PATH test would report SKIP on a modern box where
+  `docker compose` works (measured on msi: v1 binary at `/usr/local/bin` *and*
+  plugin v2.39.1 both present).
+- `setup-linux.sh` drops the three `check_deployed` calls and the
+  `check_dependencies` call; `dotf doctor` at the tail of the same script is the
+  single verification surface, matching what `setup-windows.ps1` already does.
+- A guard asserts the six REFACTOR-002 pre-exports are still there, so the next
+  reader of #1337 cannot delete them on the same false premise (BUG-021).
+
+## Out of scope
+
+- **`checkDeployDrift`** — the repo→deploy-dir leg. Untouched; it is not the
+  duplication and never was.
+- **The FAIL/SKIP policy of helm, terraform, ansible, pip** — both sides are
+  advisory today, so deleting the setup call loses no severity. BUG-052 made
+  terraform a SKIP deliberately; re-litigating it belongs to its own ticket.
+- **`docker`/`kubectl` FAIL-vs-SKIP on Windows** (BUG-052) — deliberate, and a
+  per-machine tool-role scoping in `machine.json` is a separate open idea.
+- **The six pre-exported vars** — kept, and guarded. Not a deletion candidate.
+- **`setup-windows.ps1` deletions** — nothing to delete there.
+- **Windows deploy targets.** `homeDeployMap` is derived from `setup-linux.sh`'s
+  `deploy_file` calls, and every entry in it is POSIX-only, so the new section
+  **SKIPs entirely on Windows**. The second-leg hole named in Why#2 therefore
+  **stays open on Windows** after this PR. Closing it needs a second map derived
+  from `setup-windows.ps1`'s own deploy calls plus its own join guard — filed as
+  **OPS-046 (#1447)**, blocked on this one, rather than doubling this PR's size
+  against the 300-LOC cap. The Windows exemption set also cannot be measured from
+  Linux, the same reason HIVE-118 stayed out of OPS-040.
+
+## Risks / open questions
+
+- **R1 — the path map is a new join, and nothing spans it. RESOLVED in design,
+  MUST hold in implementation.** `deploy_file` in `setup-linux.sh` is the source
+  of truth for what lands in `$HOME` (11 call sites, lines 83-1646). If the
+  doctor map hardcodes its own copy, the two drift silently the first time a file
+  is added to setup. The map must therefore ship **with a drift guard on the join
+  itself** — a test that fails when a `deploy_file "$DOTFILES_DIR/..." "$HOME/..."`
+  call has no corresponding map entry. Same idiom as
+  `tests/guard-doctrine-target-not-deleted.bats`.
+- **R2 — the exemption list is load-bearing, and deriving it from
+  `check_deployed`'s comments would have got it wrong.** Those comments only ever
+  knew about the 3 files that function checked; the map covers 11. Probing all
+  11 on msi (2026-09-02) found `.gitconfig` drifting — a file `check_deployed`
+  never watched and whose exemption no comment records. A content check that
+  omits it turns doctor red on every box with a `git config --global`.
+- **R5 — one of the inherited exemption reasons is already stale.** The NOTE at
+  `setup-linux.sh:1586-1589` justifies exempting `.zshrc` partly by "setup may
+  legitimately modify it (e.g. stripping stale gh-copilot eval lines via
+  `sed -i`)" — but **no `sed -i` remains in the script**; the only match in the
+  whole file is inside that comment. The OPS-040 purge removed the mechanism and
+  left the justification. The exemption still stands on its other half (installer
+  appends, which `.bashrc`'s NOTE names concretely), but the dead clause must be
+  corrected in this PR rather than copied into the new map — this is lesson 256
+  recurring inside the spec that cites it.
+- **R3 — ordering within the PR.** The setup deletion is only safe once the
+  doctor check is green. Both land in one PR, so this is a review property, not a
+  runtime one; the reviewer should verify the port precedes the delete in the
+  commit sequence, and that AC3's parity table is measured, not asserted.
+- **R4 — `.gitconfig` deploy is conditional** (`setup-linux.sh:96`). It may be
+  absent on a box that declined it, so its map entry must tolerate absence as
+  SKIP rather than FAIL, matching `checkDeployDrift`'s both-sides-present rule.
+
+## Acceptance criteria
+
+- [ ] **AC1** — `dotf doctor` FAILs when a file deployed to `$HOME` differs
+      byte-for-byte from its `~/.dotfiles` source, and PASSes when equal, for at
+      minimum `.zsh/aliases.zsh`, `.zsh/functions.zsh`, `.zsh/functions.sh`.
+      Today all three report PASS under drift.
+- [ ] **AC2** — the exempt set (`.gitconfig`, `.zshrc`, `.bashrc`, `.profile`) is
+      checked for existence only and never FAILs on content drift; every other
+      map entry is content-checked. The `.zshrc` NOTE's stale `sed -i` clause is
+      corrected in the same PR (R5).
+- [ ] **AC3** — every tool and file covered by the deleted `check_deployed` ×3 and
+      `check_dependencies` calls has an **equal-or-stronger** verdict in
+      `dotf doctor`, demonstrated by a table-driven test enumerating all 14 tools
+      and 3 files with their before/after severity. Three rows are decided here
+      rather than left to the implementer: **`docker compose`** → optional,
+      plugin-probed (the repo provisions it nowhere, so FAIL is wrong);
+      **helm/terraform/ansible/pip** → doctor's SKIP is severity-equal to the
+      shell's WARN, both advisory; **a symlink at `$HOME`** → FAIL, preserving
+      `check_deployed`'s rejection that nothing else in doctor catches.
+- [ ] **AC4** — a test fails if any of the six REFACTOR-002 pre-exports
+      (`SCRIPTS_DIR`, `GEMINI_HOME`, `AGY_HOME`, `COPILOT_HOME`, `OPENCODE_HOME`,
+      `DOTFILES_REPO_DIR`) is removed from `setup-linux.sh` (BUG-021 guard).
+- [ ] **AC5** — a Go test fails if a `deploy_file … "$HOME/…"` call in
+      `setup-linux.sh` has no entry in `homeDeployMap` (R1 join guard). It lives
+      in Go, not bats, because the map is Go: one parser, and it breaks in
+      `go test` where the map changes. Reading a repo file from a Go test is an
+      established path here (`env_test.go:77`, `prtriage_test.go:134`,
+      `repoRootForTest` in `cmd/`).
+- [ ] **AC6** — `setup-linux.sh` no longer calls `check_deployed` or
+      `check_dependencies`; `GOOS=windows go vet ./...` and the full Go + bats
+      suites pass.
+
+## References
+
+- Bitácora board: `mlorentedev/dotfiles#1337`
+- `docs/adr/adr-020-tooling-cli-go-convergence.md` — §5 strangler-fig on contact;
+  ADR-021/CLI-012 retired the `doctor.sh`/`healthcheck.sh` twins into `dotf doctor`.
+- BUG-021 (the pre-export fix), BUG-052 (terraform SKIP, Windows docker/kubectl).
+- `docs/lessons.md` 256 — probe the target, never read the block's own comment.
+  This spec is that lesson recurring: #1337 asserts duplication from **names**
+  (`check_deployed` ≈ `checkDeployDrift`) without comparing direction or severity.
+- Sibling precedent: `specs/archive/OPS-040-dead-migration-purge/` — same class of
+  ticket, same class of false premise, same method (classify, then probe).

--- a/specs/OPS-043-setup-doctor-duplication/tasks.md
+++ b/specs/OPS-043-setup-doctor-duplication/tasks.md
@@ -1,0 +1,63 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-09-02"
+---
+
+# Tasks - OPS-043-setup-doctor-duplication
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers:**
+> - `[P]` — no dependency on another unchecked task; safe to run in parallel.
+> - `[AC<n>]` — helps satisfy acceptance criterion #`<n>` from `proposal.md`.
+>
+> **Ordering is load-bearing here (R3).** Every task under "Port" must be green
+> before the single task under "Delete" runs. The reverse order opens the
+> coverage hole this spec exists to avoid — on Windows it is already open.
+
+## Setup
+
+- [x] Branch created from main: `chore/ops-043-setup-doctor-duplication`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions" (R1 resolved by design: explicit map + join guard; R2 exemption list explicit; R3 ordering enforced below; R4 absence → SKIP)
+
+## Implementation
+
+### Port (must all be green before the Delete section)
+
+- [ ] [P] [AC1] Failing test: `checkHomeDeployDrift` FAILs when `~/.zsh/functions.sh` differs from `~/.dotfiles/.zsh/functions.sh`, PASSes when equal. Table-driven over the three `.zsh` files, through the `System` seam.
+- [ ] [AC1] Add `homeDeployMap` — the explicit deploy-dir→`$HOME` path map — and `checkHomeDeployDrift` in `cli/internal/doctor/checks_deploy.go`. New section `Deploy-dir↔$HOME drift`. Both-sides-present rule mirrors `checkDeployDrift` (R4: absent either side → SKIP, never FAIL).
+- [ ] [AC1] Failing test: a symlink at `$HOME` FAILs even when it resolves to an identical file (`cmp` follows it; `checkSymlinks` PASSes it). Then implement — this is `check_deployed`'s severity that nothing else in doctor carries.
+- [ ] [AC2] Failing test: the four exempt entries (`.gitconfig`, `.zshrc`, `.bashrc`, `.profile`) report PASS with drifted content; every other entry FAILs. Then encode the exemption in `homeDeployMap` as an explicit `contentChecked: false`, each with its own measured reason (R2 — `.gitconfig` observed drifting on msi; the three RC files on the installer-append mechanism).
+- [ ] [AC2] Correct the stale clause in the `setup-linux.sh:1586-1589` NOTE: no `sed -i` remains in the script (R5). One-line comment fix, in this PR, not a follow-up.
+- [ ] [P] [AC3] Failing test: `docker compose` reports a verdict, probed as the v2 CLI plugin (`docker compose version`) with the standalone v1 binary as fallback, reported optional. Then implement. Do **not** add the bare string to `coreTools` — the repo provisions compose nowhere, so a FAIL is wrong; and a PATH test alone SKIPs on a box where the plugin works.
+- [ ] [AC3] Table-driven parity test enumerating all 14 `check_dependencies` tools and the 3 `check_deployed` files, asserting each has an equal-or-stronger doctor verdict than the shell call it replaces, plus the symlink row. This test is the evidence for the delete, not a description of it.
+- [ ] [P] [AC5] Guard test (Go, not bats): every `deploy_file … "$HOME/…"` call site in `setup-linux.sh` has a `homeDeployMap` entry. Read the script from the repo root the way `env_test.go:77` and `prtriage_test.go:134` already do.
+- [ ] [P] [AC4] Guard test (bats): the six REFACTOR-002 pre-exports are present in `setup-linux.sh`. Comment names BUG-021 and #1337 so the next reader sees why they are not deletable.
+
+### Delete (only after every Port task is ticked)
+
+- [ ] [AC6] Remove the three `check_deployed` calls (`setup-linux.sh:1583-1585`) and the `check_dependencies` call (`:1597`). Leave the two NOTE comments' rationale where it now belongs — in `homeDeployMap`. Do **not** touch lines 1657-1668 (the pre-exports) or `checkDeployDrift`.
+
+### Cleanup
+
+- [ ] Are `check_deployed` / `check_dependencies` still called anywhere? Grep repo-wide (`scripts/`, `tests/`, both setup scripts) before deleting the function bodies from `scripts/utils.sh` — the lesson from OPS-040 is that things look inert until the grep widens. If unreferenced, delete the bodies and their tests too; if referenced, leave them and say where.
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [ ] `cd cli && go build ./... && go vet ./... && go test ./...` green
+- [ ] `GOOS=windows go vet ./...` green (the Windows leg compiles the same tree)
+- [ ] `golangci-lint run` with the pinned version from `versions.conf` (BUG-071)
+- [ ] `~/.local/bin/shellcheck setup-linux.sh` + `~/.local/bin/bats tests/*.bats` green
+- [ ] Setup LOC re-measured and recorded in `verification.md` (baseline 3991)
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+See sibling `features.json`. Pass-state gating: the agent cannot write
+`"state": "passing"` — only the harness, after running `verification` and
+capturing exit 0, may set that terminal state.

--- a/specs/OPS-043-setup-doctor-duplication/tasks.md
+++ b/specs/OPS-043-setup-doctor-duplication/tasks.md
@@ -25,23 +25,23 @@ created: "2026-09-02"
 
 ### Port (must all be green before the Delete section)
 
-- [ ] [P] [AC1] Failing test: `checkHomeDeployDrift` FAILs when `~/.zsh/functions.sh` differs from `~/.dotfiles/.zsh/functions.sh`, PASSes when equal. Table-driven over the three `.zsh` files, through the `System` seam.
-- [ ] [AC1] Add `homeDeployMap` — the explicit deploy-dir→`$HOME` path map — and `checkHomeDeployDrift` in `cli/internal/doctor/checks_deploy.go`. New section `Deploy-dir↔$HOME drift`. Both-sides-present rule mirrors `checkDeployDrift` (R4: absent either side → SKIP, never FAIL).
-- [ ] [AC1] Failing test: a symlink at `$HOME` FAILs even when it resolves to an identical file (`cmp` follows it; `checkSymlinks` PASSes it). Then implement — this is `check_deployed`'s severity that nothing else in doctor carries.
-- [ ] [AC2] Failing test: the four exempt entries (`.gitconfig`, `.zshrc`, `.bashrc`, `.profile`) report PASS with drifted content; every other entry FAILs. Then encode the exemption in `homeDeployMap` as an explicit `contentChecked: false`, each with its own measured reason (R2 — `.gitconfig` observed drifting on msi; the three RC files on the installer-append mechanism).
-- [ ] [AC2] Correct the stale clause in the `setup-linux.sh:1586-1589` NOTE: no `sed -i` remains in the script (R5). One-line comment fix, in this PR, not a follow-up.
-- [ ] [P] [AC3] Failing test: `docker compose` reports a verdict, probed as the v2 CLI plugin (`docker compose version`) with the standalone v1 binary as fallback, reported optional. Then implement. Do **not** add the bare string to `coreTools` — the repo provisions compose nowhere, so a FAIL is wrong; and a PATH test alone SKIPs on a box where the plugin works.
-- [ ] [AC3] Table-driven parity test enumerating all 14 `check_dependencies` tools and the 3 `check_deployed` files, asserting each has an equal-or-stronger doctor verdict than the shell call it replaces, plus the symlink row. This test is the evidence for the delete, not a description of it.
-- [ ] [P] [AC5] Guard test (Go, not bats): every `deploy_file … "$HOME/…"` call site in `setup-linux.sh` has a `homeDeployMap` entry. Read the script from the repo root the way `env_test.go:77` and `prtriage_test.go:134` already do.
-- [ ] [P] [AC4] Guard test (bats): the six REFACTOR-002 pre-exports are present in `setup-linux.sh`. Comment names BUG-021 and #1337 so the next reader sees why they are not deletable.
+- [x] [P] [AC1] Failing test: `checkHomeDeployDrift` FAILs when `~/.zsh/functions.sh` differs from `~/.dotfiles/.zsh/functions.sh`, PASSes when equal. Table-driven over the three `.zsh` files, through the `System` seam.
+- [x] [AC1] Add `homeDeployMap` — the explicit deploy-dir→`$HOME` path map — and `checkHomeDeployDrift` in `cli/internal/doctor/checks_deploy.go`. New section `Deploy-dir↔$HOME drift`. Both-sides-present rule mirrors `checkDeployDrift` (R4: absent either side → SKIP, never FAIL).
+- [x] [AC1] Failing test: a symlink at `$HOME` FAILs even when it resolves to an identical file (`cmp` follows it; `checkSymlinks` PASSes it). Then implement — this is `check_deployed`'s severity that nothing else in doctor carries.
+- [x] [AC2] Failing test: the four exempt entries (`.gitconfig`, `.zshrc`, `.bashrc`, `.profile`) report PASS with drifted content; every other entry FAILs. Then encode the exemption in `homeDeployMap` as an explicit `contentChecked: false`, each with its own measured reason (R2 — `.gitconfig` observed drifting on msi; the three RC files on the installer-append mechanism).
+- [x] [AC2] Correct the stale clause in the `setup-linux.sh:1586-1589` NOTE: no `sed -i` remains in the script (R5). One-line comment fix, in this PR, not a follow-up.
+- [x] [P] [AC3] Failing test: `docker compose` reports a verdict, probed as the v2 CLI plugin (`docker compose version`) with the standalone v1 binary as fallback, reported optional. Then implement. Do **not** add the bare string to `coreTools` — the repo provisions compose nowhere, so a FAIL is wrong; and a PATH test alone SKIPs on a box where the plugin works.
+- [x] [AC3] Table-driven parity test enumerating all 14 `check_dependencies` tools and the 3 `check_deployed` files, asserting each has an equal-or-stronger doctor verdict than the shell call it replaces, plus the symlink row. This test is the evidence for the delete, not a description of it.
+- [x] [P] [AC5] Guard test (Go, not bats): every `deploy_file … "$HOME/…"` call site in `setup-linux.sh` has a `homeDeployMap` entry. Read the script from the repo root the way `env_test.go:77` and `prtriage_test.go:134` already do.
+- [x] [P] [AC4] Guard test (bats): the six REFACTOR-002 pre-exports are present in `setup-linux.sh`. Comment names BUG-021 and #1337 so the next reader sees why they are not deletable.
 
 ### Delete (only after every Port task is ticked)
 
-- [ ] [AC6] Remove the three `check_deployed` calls (`setup-linux.sh:1583-1585`) and the `check_dependencies` call (`:1597`). Leave the two NOTE comments' rationale where it now belongs — in `homeDeployMap`. Do **not** touch lines 1657-1668 (the pre-exports) or `checkDeployDrift`.
+- [x] [AC6] Remove the three `check_deployed` calls (`setup-linux.sh:1583-1585`) and the `check_dependencies` call (`:1597`). Leave the two NOTE comments' rationale where it now belongs — in `homeDeployMap`. Do **not** touch lines 1657-1668 (the pre-exports) or `checkDeployDrift`.
 
 ### Cleanup
 
-- [ ] Are `check_deployed` / `check_dependencies` still called anywhere? Grep repo-wide (`scripts/`, `tests/`, both setup scripts) before deleting the function bodies from `scripts/utils.sh` — the lesson from OPS-040 is that things look inert until the grep widens. If unreferenced, delete the bodies and their tests too; if referenced, leave them and say where.
+- [x] Are `check_deployed` / `check_dependencies` still called anywhere? Grep repo-wide (`scripts/`, `tests/`, both setup scripts) before deleting the function bodies from `scripts/utils.sh` — the lesson from OPS-040 is that things look inert until the grep widens. If unreferenced, delete the bodies and their tests too; if referenced, leave them and say where.
 
 ## Closing
 

--- a/specs/OPS-043-setup-doctor-duplication/verification.md
+++ b/specs/OPS-043-setup-doctor-duplication/verification.md
@@ -49,7 +49,40 @@ created: "2026-09-02"
 - **Mutation test** (the parity claim is not vacuous): flipping
   `.zsh/functions.sh` to `contentChecked: false` turns `TestSetupShellParity`
   red with "…would lose the assertion". Reverted; `git diff` clean afterwards.
+- **Mutation test** (the ordering guard is not vacuous): moving
+  `export GEMINI_HOME=` below the `dotf doctor` handoff turns the guard red
+  naming that variable. Reverted; `git diff` clean afterwards.
+- **The join guard runs in CI, not only locally.** `TestHomeDeployMapCoversSetup`
+  reads `../../../setup-linux.sh`; `.github/workflows/cli.yml` sets
+  `working-directory: cli` over a full `actions/checkout@v7` (not sparse), and
+  both `test (ubuntu-latest)` and `test (windows-latest)` passed — so the guard
+  is exercised on both runners. Checked because a guard that only resolves on
+  the author's machine is lesson 160's class.
 - No regressions: yes.
+
+## Review disposition (commit `563ede1`)
+
+CodeRabbit produced **both** shapes on this PR — a *"Reviews paused"* notice and
+a real review with four findings. All four verified against the code before
+applying; all four were real.
+
+| Finding | Verdict | Disposition |
+|---|---|---|
+| AC2's verification command names a test that does not exist | **CONFIRMED** — `go test -run <missing>` exits 0, measured | Applied: names the two real tests; every `-run` anchored |
+| `scripts/utils.sh` comment claims the replacement "covers Windows" | **CONFIRMED** — the section skips Windows | Applied: corrected, names #1447 |
+| Ordering guard samples one variable on Linux, matches any mention on Windows | **CONFIRMED** — reproduced the reviewer's exact failing input | Applied: all six on both scripts, assignment-matched, mutation-tested |
+| `checkHomeDeployDrift` is 48 lines, over the 40-line guideline | **CONFIRMED** — measured | Applied: split; both functions now 22 |
+
+Its *Linked Issues* pre-merge check warned that keeping the six pre-exports
+contradicts #1337. That is the ticket being wrong rather than the PR — it is
+Why#5 of this proposal — but the reviewer is right that the issue itself still
+said "delete them", so #1337 was updated with the measurement instead of the
+warning being waved off.
+
+**The first finding is the one worth recording.** It is a verification command
+that could not fail, inside a spec whose own evidence section argues that a
+parity claim must be mutation-tested. The mutation testing was applied to the
+assertions and not to the commands that invoke them.
 
 ## Decisions made during implementation
 

--- a/specs/OPS-043-setup-doctor-duplication/verification.md
+++ b/specs/OPS-043-setup-doctor-duplication/verification.md
@@ -7,36 +7,101 @@ created: "2026-09-02"
 
 ## Evidence
 
-Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
-
-- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+- [x] **AC1** (byte drift on the deploy-dir→`$HOME` leg FAILs; symlink FAILs) →
+      commit `7482384`, `TestCheckHomeDeployDrift` in
+      `cli/internal/doctor/checks_home_deploy_test.go`. Eight rows: content
+      agreement, drift on `.zsh/functions.sh` (the file in no doctor list before
+      this), drift on `tmux.conf` (the entry whose relative path differs between
+      the two legs), the symlink case, and the missing/unprovisioned branches.
+- [x] **AC2** (exempt set is existence-only; stale `sed -i` clause corrected) →
+      commit `7482384` for the exemptions plus
+      `TestHomeDeployExemptionsAreReasoned`, which fails on an exemption with no
+      stated mechanism; commit `c61d607` removed the NOTE carrying the dead
+      clause. `grep -n 'sed -i' setup-linux.sh` now returns nothing.
+- [x] **AC3** (equal-or-stronger parity for all 17 items) → commit `69dc2da`,
+      `TestSetupShellParity` (17 subtests, all pass) + `TestCheckDockerCompose`
+      (4 rows).
+- [x] **AC4** (six REFACTOR-002 pre-exports guarded) → commit `69dc2da`,
+      `tests/guard-setup-preexports-present.bats`, 3 tests. Covers both setup
+      scripts and asserts the exports still precede the `dotf doctor` handoff.
+- [x] **AC5** (join guard on the map ↔ setup script) → commit `7482384`,
+      `TestHomeDeployMapCoversSetup`. Fails in both directions: an uncovered
+      `deploy_file` call, and a map entry setup no longer deploys.
+- [x] **AC6** (shell calls gone, both layers green) → commit `c61d607`. See
+      Test status below.
 
 ## Test status
 
-- Test suite: `<command> -> <output / coverage %>`
-- Manual smoke test: what was exercised, what was observed
-- No regressions in existing test suite: yes / no (if no, document)
+- `cd cli && go build ./... && go vet ./... && GOOS=windows go vet ./...` → clean.
+- `cd cli && go test ./...` → all packages ok, no FAIL lines.
+- `golangci-lint run` with the pinned 2.12.2 (matches `versions.conf`, BUG-071
+  checked before running) → **0 issues**.
+- `~/.local/bin/bats tests/*.bats` → **1534 tests, exit 0**, run against the tree
+  with the deletion already applied.
+- `shellcheck --severity=error setup-linux.sh scripts/utils.sh` → clean (CI's
+  severity; at default severity the repo is non-clean on `main` too, verified by
+  stashing — this change adds nothing new).
+- `bash -n` and `zsh -n` on `setup-linux.sh` → both clean.
+- **Smoke test on msi:** `dotf doctor` built from this branch reports
+  `[Deploy-dir↔$HOME drift] (11 checks, all ok)` on a converged box — including
+  `.gitconfig`, which genuinely differs from its deploy-dir copy and passes via
+  its exemption rather than by accident.
+- **Mutation test** (the parity claim is not vacuous): flipping
+  `.zsh/functions.sh` to `contentChecked: false` turns `TestSetupShellParity`
+  red with "…would lose the assertion". Reverted; `git diff` clean afterwards.
+- No regressions: yes.
 
 ## Decisions made during implementation
 
-Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
-
--
--
+- **The ticket's premise was false in five places, and the fix order is the whole
+  finding.** `check_deployed` and `checkDeployDrift` cover *different legs* of
+  `repo → ~/.dotfiles → $HOME`; no doctor section byte-compared the second leg
+  (all 40 enumerated); `check_dependencies` only ever `log_warning`d;
+  `.zsh/functions.sh` was in no doctor list; and the six pre-exports are BUG-021's
+  fix, not duplication. Doing what #1337 asked, in the order it asked, removes
+  coverage rather than duplication.
+- **`isManagedDeployPath` was not reusable.** The second leg renames
+  (`ssh/config` → `.ssh/config`, `tmux.conf` → `.tmux.conf`), so the map is
+  explicit — and explicit means it can drift, which is why AC5 guards the join
+  itself. Nothing in the repo spanned a setup script and a doctor list before.
+- **Compose is probed as a plugin, not a PATH entry.** `command -v
+  docker-compose` — what the shell call did — reports missing on a current
+  install where `docker compose` works. Measured on msi: v1 binary *and* plugin
+  v2.39.1 both present, so either probe alone describes the box wrongly.
+- **Absence of compose is SKIP, not FAIL**, because the repo provisions it in no
+  installer, pin or contract binary. Same reasoning BUG-052 applied to terraform.
+- **The exemption list was measured, not inherited.** Deriving it from
+  `check_deployed`'s comments would have missed `.gitconfig`, the only one of the
+  eleven files actually observed drifting, since that function never watched it.
+- **`Test-FileDrift` was already dead.** Written as PowerShell parity with
+  `check_deployed` for `healthcheck.ps1`; CLI-018 retired that script and left
+  the helper with zero call sites. Deleted as part of the same pair.
+- **Windows does not get the check.** Every map entry is POSIX-only, so the
+  section SKIPs there and the leg stays unguarded — stated as an explicit
+  non-goal and filed as **OPS-046 (#1447)** rather than silently implied.
+- Setup scripts 3991 → 3988 lines; the shell layer as a whole (`*.sh` + `*.ps1`)
+  is **net −66**. The setup-script figure moves little because the deleted calls
+  were replaced by comments recording where the behaviour went — which is what
+  would have prevented #1337 being filed against them.
 
 ## Promotion candidates
 
-Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
-
-- [ ] Lesson for the repo's `docs/lessons/`? <yes / no - one line of what>
-- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
-- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+- [x] Lesson for the repo's `docs/lessons/`? **yes** — a justification can outlive
+      its mechanism exactly as a name outlives its contract: the `sed -i` clause
+      was true when written, and OPS-040's purge (whose own method was "probe the
+      target, never read the block's comment") removed the mechanism and left the
+      comment. Lesson 256 violated by the change that established it.
+- [ ] ADR-worthy decision? **no** — ADR-020 §5 already governs strangler-fig on
+      contact; this is an application of it, not a new decision.
+- [ ] New pattern candidate for `00_meta/patterns/`? **no** — the finding is
+      about this repo's own comments and tickets; not yet observed in a second
+      project.
 
 ## Archive checklist
 
 - [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Independent adversarial review PASS recorded in `review.md` (reviewer must
+      not be the implementer)
 - [ ] Folder moved: `specs/OPS-043-setup-doctor-duplication/` -> `specs/archive/OPS-043-setup-doctor-duplication/`
-- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
-- [ ] Promotions above executed (if any)
+- [ ] Bitácora board ticket #1337 closed with PR link (ADR-018)
+- [ ] Lesson above written to `docs/lessons.md`

--- a/specs/OPS-043-setup-doctor-duplication/verification.md
+++ b/specs/OPS-043-setup-doctor-duplication/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-09-02"
+---
+
+# Verification - OPS-043-setup-doctor-duplication
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons/`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/OPS-043-setup-doctor-duplication/` -> `specs/archive/OPS-043-setup-doctor-duplication/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)

--- a/tests/guard-setup-preexports-present.bats
+++ b/tests/guard-setup-preexports-present.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# GUARD (OPS-043): the REFACTOR-002 path vars must stay pre-exported in both
+# setup scripts, immediately before each hands off to `dotf doctor`.
+#
+# WHAT THIS GUARDS AGAINST
+# ------------------------
+# Issue #1337 asked for these six exports to be deleted, describing them as
+# duplication because "doctor covers the same" a few lines later. They are not
+# duplication. They exist because the shell running setup has not re-sourced
+# .zshrc/.bashrc, so the values the deployed rc files WILL set on the next login
+# are not in the current environment. Without the pre-export, doctor reads the
+# stale environment and reports contract-variable warnings on every fresh setup
+# — which is BUG-021, closed by adding these lines, and mirrored into
+# setup-windows.ps1 for the same reason.
+#
+# Deleting them therefore does not remove a redundant check; it reopens a fixed
+# bug in a way that looks green in code review and only shows up as noise on the
+# next clean box. OPS-043 deleted the two shell verification calls that WERE
+# duplication (check_deployed, check_dependencies) and deliberately kept these,
+# so this guard records the distinction where the next reader of #1337 will hit
+# it.
+#
+# WHY BOTH SCRIPTS
+# ----------------
+# The Windows twin carries the same fix at setup-windows.ps1:2185. A guard that
+# only knew about Linux would let the regression back in on the platform where
+# it is harder to notice.
+
+setup() {
+    DOTFILES_DIR="$BATS_TEST_DIRNAME/.."
+}
+
+# The six vars, as named in env-contract.json. AGY_HOME is the SSOT spelling;
+# it lives inside GEMINI_HOME for backwards compat with gemini-cli.
+preexported_vars() {
+    printf '%s\n' SCRIPTS_DIR GEMINI_HOME AGY_HOME COPILOT_HOME OPENCODE_HOME DOTFILES_REPO_DIR
+}
+
+@test "setup-linux.sh pre-exports every REFACTOR-002 path var (BUG-021)" {
+    script="$DOTFILES_DIR/setup-linux.sh"
+    [ -f "$script" ]
+
+    missing=""
+    while IFS= read -r var; do
+        if ! grep -qE "^export ${var}=" "$script"; then
+            missing="$missing $var"
+        fi
+    done <<EOF
+$(preexported_vars)
+EOF
+
+    if [ -n "$missing" ]; then
+        printf 'setup-linux.sh is missing pre-exports for:%s\n' "$missing" >&2
+        printf 'These are not duplication of dotf doctor -- see BUG-021 and #1337.\n' >&2
+        return 1
+    fi
+}
+
+@test "setup-windows.ps1 pre-exports every REFACTOR-002 path var (BUG-021)" {
+    script="$DOTFILES_DIR/setup-windows.ps1"
+    [ -f "$script" ]
+
+    missing=""
+    while IFS= read -r var; do
+        # PowerShell spells it $env:NAME = ... ; accept any assignment form.
+        if ! grep -qE "env:${var}" "$script"; then
+            missing="$missing $var"
+        fi
+    done <<EOF
+$(preexported_vars)
+EOF
+
+    if [ -n "$missing" ]; then
+        printf 'setup-windows.ps1 is missing pre-exports for:%s\n' "$missing" >&2
+        printf 'These mirror the Linux BUG-021 fix -- see #1337.\n' >&2
+        return 1
+    fi
+}
+
+@test "the pre-exports still precede the dotf doctor handoff in setup-linux.sh" {
+    script="$DOTFILES_DIR/setup-linux.sh"
+
+    # The exports are only useful if doctor runs AFTER them in the same shell.
+    # Reordering them below the handoff would leave the lines present and the
+    # bug reopened, which a presence-only guard would call green.
+    last_export=$(grep -nE '^export DOTFILES_REPO_DIR=' "$script" | tail -1 | cut -d: -f1)
+    doctor_call=$(grep -nE '^\s*dotf doctor' "$script" | tail -1 | cut -d: -f1)
+
+    [ -n "$last_export" ]
+    [ -n "$doctor_call" ]
+    [ "$last_export" -lt "$doctor_call" ]
+}

--- a/tests/guard-setup-preexports-present.bats
+++ b/tests/guard-setup-preexports-present.bats
@@ -77,16 +77,54 @@ EOF
     fi
 }
 
-@test "the pre-exports still precede the dotf doctor handoff in setup-linux.sh" {
+@test "every pre-export precedes the dotf doctor handoff in setup-linux.sh" {
     script="$DOTFILES_DIR/setup-linux.sh"
 
     # The exports are only useful if doctor runs AFTER them in the same shell.
-    # Reordering them below the handoff would leave the lines present and the
-    # bug reopened, which a presence-only guard would call green.
-    last_export=$(grep -nE '^export DOTFILES_REPO_DIR=' "$script" | tail -1 | cut -d: -f1)
-    doctor_call=$(grep -nE '^\s*dotf doctor' "$script" | tail -1 | cut -d: -f1)
-
-    [ -n "$last_export" ]
+    # Reordering ONE of them below the handoff leaves every line present and the
+    # bug reopened for that variable, which a presence-only guard calls green --
+    # and so does an ordering guard that samples a single variable.
+    doctor_call=$(grep -nE '^[[:space:]]*dotf doctor' "$script" | tail -1 | cut -d: -f1)
     [ -n "$doctor_call" ]
-    [ "$last_export" -lt "$doctor_call" ]
+
+    late=""
+    while IFS= read -r var; do
+        line=$(grep -nE "^export ${var}=" "$script" | tail -1 | cut -d: -f1)
+        if [ -z "$line" ] || [ "$line" -gt "$doctor_call" ]; then
+            late="$late $var"
+        fi
+    done <<EOF
+$(preexported_vars)
+EOF
+
+    if [ -n "$late" ]; then
+        printf 'these pre-exports do not precede the dotf doctor call (line %s):%s\n' "$doctor_call" "$late" >&2
+        return 1
+    fi
+}
+
+@test "every pre-export precedes the dotf doctor handoff in setup-windows.ps1" {
+    script="$DOTFILES_DIR/setup-windows.ps1"
+
+    # The Windows twin has the same ordering requirement and the same failure
+    # mode. Matching the ASSIGNMENT (`$env:VAR =`) rather than any mention of
+    # the name: GEMINI_HOME appears on the AGY_HOME line too, so a bare name
+    # match would read the wrong line number.
+    doctor_call=$(grep -nE '^[[:space:]]*& dotf doctor' "$script" | tail -1 | cut -d: -f1)
+    [ -n "$doctor_call" ]
+
+    late=""
+    while IFS= read -r var; do
+        line=$(grep -nE "\\\$env:${var}[[:space:]]*=" "$script" | tail -1 | cut -d: -f1)
+        if [ -z "$line" ] || [ "$line" -gt "$doctor_call" ]; then
+            late="$late $var"
+        fi
+    done <<EOF
+$(preexported_vars)
+EOF
+
+    if [ -n "$late" ]; then
+        printf 'these pre-exports do not precede the & dotf doctor call (line %s):%s\n' "$doctor_call" "$late" >&2
+        return 1
+    fi
 }

--- a/tests/iac-deploy.bats
+++ b/tests/iac-deploy.bats
@@ -78,32 +78,16 @@ teardown() {
     [ -f "$nested" ]
 }
 
-# --- check_deployed ---
-
-@test "check_deployed: matching content returns 0 (success)" {
-    deploy_file "$SRC" "$DST"
-    run check_deployed "$SRC" "$DST" "test-file"
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"deployed (matches repo)"* ]]
-}
-
-@test "check_deployed: missing target returns 1 (drift)" {
-    run check_deployed "$SRC" "$TEST_TMPDIR/never-deployed" "test-file"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"missing"* ]]
-}
-
-@test "check_deployed: symlinked target returns 1 (legacy-strategy drift)" {
-    ln -sf "$SRC" "$DST"
-    run check_deployed "$SRC" "$DST" "test-file"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"symlink"* ]]
-}
-
-@test "check_deployed: drift between repo and home returns 1" {
-    deploy_file "$SRC" "$DST"
-    echo "user-edited-in-home" > "$DST"
-    run check_deployed "$SRC" "$DST" "test-file"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"drifted"* ]]
-}
+# --- check_deployed: removed by OPS-043 (#1337) ---
+#
+# The four cases that lived here were ported one-for-one into
+# TestCheckHomeDeployDrift in cli/internal/doctor/checks_home_deploy_test.go,
+# which is where the behaviour now lives:
+#
+#   matching content returns 0        -> "checked entries agree -> pass"
+#   missing target returns 1          -> "deployed source present but $HOME copy missing -> fail"
+#   symlinked target returns 1        -> "symlink at $HOME -> fail even when content resolves equal"
+#   drift repo vs home returns 1      -> "functions.sh drift -> fail naming both paths"
+#
+# deploy_file's own tests stay above: the deployer was not migrated, only its
+# assertion pair.


### PR DESCRIPTION
Refs #1337 — the issue stays open until the spec archives, which is a separate PR after an independent adversarial review (same shape as OPS-040: #1433 → review → #1440 closed #1333).

Spec: `specs/OPS-043-setup-doctor-duplication/`

## The ticket's premise was false in five places

#1337 asked to delete `check_deployed` and `check_dependencies` from `setup-linux.sh` as duplicates of `dotf doctor`. Measured first:

1. **`check_deployed` is not duplicated.** It compares the deploy dir to `$HOME`; `checkDeployDrift` compares the **repo** to the **deploy dir**. Different legs of `repo → ~/.dotfiles → $HOME`.
2. **No doctor section byte-compared the second leg.** All 40 enumerated. `checkSymlinks` and `checkProfileFiles` test existence, and PASS a real file that has drifted. `setup-windows.ps1` never had the shell check, so that leg was **unguarded on Windows outright**.
3. **`check_dependencies` never fails** — it only `log_warning`s. Of its 14 tools: 9 stricter in doctor, 4 equally advisory, and `docker-compose` covered **nowhere** (not doctor, not `env-contract.json`, not any package list).
4. **`.zsh/functions.sh` was in no doctor list.**
5. **The six pre-exported path vars are BUG-021's fix**, not duplication — the setup shell has not re-sourced the rc files, so without them doctor reports false warnings on every fresh box.

So the order matters: **port first, then delete.** Done as the ticket asked, this removes coverage while the diff reads as removing duplication.

## What this does

- **New doctor section `Deploy-dir↔$HOME drift`** — byte-compares 11 files (was 3) and rejects a symlink where ADR-012 expects a regular file, the severity `checkSymlinks` does not carry. Driven by an explicit `homeDeployMap`, because this leg renames (`ssh/config` → `.ssh/config`, `tmux.conf` → `.tmux.conf`) and `isManagedDeployPath` cannot be reused.
- **`docker compose` gets a verdict**, probed as the v2 CLI plugin with the v1 binary as fallback. `command -v docker-compose` — what the shell call did — reports missing on a current install where compose works; measured on msi, both are present. Absence is SKIP: the repo provisions compose nowhere, so FAIL would red a box that never wanted it (BUG-052's reasoning for terraform).
- **Deletes** the 3 `check_deployed` calls, the `check_dependencies` call, both function bodies (no other caller repo-wide), their bats tests, and `Test-FileDrift` in `scripts/utils.ps1` — dead since CLI-018 retired `healthcheck.ps1`, with zero call sites.
- **Keeps and guards** the six pre-exports, in both scripts, asserting they still precede the `dotf doctor` handoff.

## Three guards, because the gap was structural

- `TestSetupShellParity` — all 17 items the shell calls covered, each asserted equal-or-stronger in doctor. **Mutation-tested**: flipping `.zsh/functions.sh` to existence-only turns it red.
- `TestHomeDeployMapCoversSetup` — the join guard. Nothing spanned `setup-linux.sh` and doctor's lists before, which is the gap #1337 came through. Fails in both directions.
- `TestHomeDeployExemptionsAreReasoned` — an exemption with no stated mechanism fails. See below for why.

## Two corrections found along the way

- The NOTE exempting `.zshrc` cited a `sed -i` that **no longer exists** — OPS-040's purge removed the mechanism and left the justification. Corrected here; written up as lesson 259, since OPS-040's own method was lesson 256 ("probe the target, don't read the comment") and it still produced an instance.
- The exemption list was **measured, not inherited**: deriving it from `check_deployed`'s comments would have missed `.gitconfig`, the only one of the 11 files actually observed drifting.

## Not in scope

- **Windows deploy targets.** Every map entry is POSIX-only, so the section SKIPs there and the leg stays unguarded. Filed as **OPS-046 (#1447)**, blocked on this — stated as an explicit non-goal in the proposal rather than implied.
- `checkDeployDrift`, the FAIL/SKIP policy of helm/terraform/ansible/pip (both sides advisory today), and `docker`/`kubectl` on Windows (BUG-052).

## Verification

- `go build` + `go vet` + `GOOS=windows go vet` clean; `go test ./...` all ok.
- `golangci-lint run` at the pinned **2.12.2** (matches `versions.conf`, BUG-071): **0 issues**.
- `bats tests/*.bats`: **1534 tests, exit 0**, run against the tree with the deletion applied.
- `shellcheck --severity=error` clean; `bash -n` and `zsh -n` clean.
- **On msi:** `dotf doctor` from this branch reports `[Deploy-dir↔$HOME drift] (11 checks, all ok)` — including `.gitconfig`, which genuinely differs and passes via its exemption.

Production diff +198/−96 (net +102), under the 300-LOC cap. Shell layer net **−66**.
