### PR TITLE
fix(prtriage): give the fetch path a seam, then move it off GraphQL

### DIFF
--- a/cli/internal/mem/session_start_triage_test.go
+++ b/cli/internal/mem/session_start_triage_test.go
@@ -42,7 +42,7 @@ func TestTriageQueueSection(t *testing.T) {
 	// If this section swallowed the error, the brief would restore exactly the
 	// blind spot the exit contract was written to close.
 	t.Run("a failure is reported, never rendered as empty", func(t *testing.T) {
-		got := triageQueue("", errors.New("gh pr list: exit status 4"))
+		got := triageQueue("", errors.New("gh api pulls: exit status 4"))
 		if got == "" {
 			t.Fatal("a queue that could not be computed must not be silent")
 		}

--- a/cli/internal/prtriage/fetch.go
+++ b/cli/internal/prtriage/fetch.go
@@ -5,23 +5,59 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"sync"
 	"time"
 )
 
-// ghPR mirrors what `gh pr list --json` returns. It is deliberately separate
-// from PR: the vendor's shape is a boundary concern, and pinning the domain to
-// it would make every test carry gh's nesting for no benefit.
-type ghPR struct {
-	Number   int    `json:"number"`
-	Title    string `json:"title"`
-	URL      string `json:"url"`
-	Comments []struct {
-		Author struct {
-			Login string `json:"login"`
-		} `json:"author"`
-		Body      string    `json:"body"`
-		CreatedAt time.Time `json:"createdAt"`
-	} `json:"comments"`
+// ghRunner runs a `gh` subcommand and returns its stdout.
+//
+// It is the seam CLI-071 introduced, and introducing it was the point of that
+// change rather than a means to it. Before it, FetchWithRegistry called
+// exec.CommandContext directly, so the fetch path could not be reached from a
+// test — and the path that had actually been observed failing in production
+// (#1454) was therefore the only one in this package with no coverage.
+type ghRunner func(ctx context.Context, args ...string) ([]byte, error)
+
+func execGH(ctx context.Context, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, "gh", args...).Output()
+}
+
+const (
+	// prLimit and commentLimit are page sizes AND boundary alarms. REST
+	// paginates where the old GraphQL query did not, so a full page means
+	// "there may be more" and this package refuses rather than answering from
+	// part of the data.
+	prLimit      = 100
+	commentLimit = 100
+
+	// commentFanout bounds the per-pull-request calls. The session-start probe
+	// runs on every session start under a five-second budget (see the caller in
+	// cmd/mem.go), and REST needs one call per pull request where GraphQL
+	// needed none — so these must overlap. Unbounded would be its own failure
+	// mode: a burst against a rate limit is what this change is escaping.
+	commentFanout = 8
+)
+
+// restPR is one item of `GET /repos/{owner}/{repo}/pulls`.
+//
+// Note `html_url`: the GraphQL shape this replaced called the same field `url`,
+// and a silent zero value there would have produced a queue whose entries point
+// nowhere rather than an error.
+type restPR struct {
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	HTMLURL string `json:"html_url"`
+}
+
+// restComment is one item of `GET /repos/{owner}/{repo}/issues/{n}/comments`.
+// Pull request conversation comments are issue comments; this is the same set
+// the previous `gh pr list --json comments` returned.
+type restComment struct {
+	User struct {
+		Login string `json:"login"`
+	} `json:"user"`
+	Body      string    `json:"body"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // Fetch asks GitHub for the open pull requests and returns the ones whose
@@ -34,7 +70,7 @@ type ghPR struct {
 // conversion to drift.
 //
 // An empty repo means "the current repository", matching gh's own default. The
-// context bounds the gh call: this runs on the session-start path, where an
+// context bounds the calls: this runs on the session-start path, where an
 // unreachable API must cost a bounded wait and a visible message rather than a
 // hung shell.
 //
@@ -52,42 +88,107 @@ func Fetch(ctx context.Context, repo, registryPath string) ([]Status, error) {
 // FetchWithRegistry asks GitHub for open PRs using a pre-loaded Registry,
 // avoiding redundant disk reads when the caller already has the registry.
 func FetchWithRegistry(ctx context.Context, repo string, reg Registry) ([]Status, error) {
-	args := []string{"pr", "list", "--state", "open", "--limit", fmt.Sprintf("%d", prLimit),
-		"--json", "number,title,url,comments"}
-	if repo != "" {
-		args = append(args, "--repo", repo)
-	}
-	out, err := exec.CommandContext(ctx, "gh", args...).Output()
-	if err != nil {
-		return nil, fmt.Errorf("gh pr list: %w", err)
-	}
-	return parseWire(out, reg)
+	return fetchWith(ctx, execGH, repo, reg)
 }
 
-const prLimit = 100
+// fetchWith is FetchWithRegistry with the GitHub access injected.
+//
+// It speaks REST and only REST. The previous implementation used
+// `gh pr list --json …`, a GraphQL query that returned pull requests with their
+// comments nested in one response; REST has no such nesting, so the join lives
+// here as a bounded fan-out. That cost buys independence from the GraphQL
+// bucket, which refused every list and write for a stretch on 2026-09-02 while
+// REST served the same data throughout.
+func fetchWith(ctx context.Context, run ghRunner, repo string, reg Registry) ([]Status, error) {
+	base := repoBase(repo)
 
-func parseWire(out []byte, reg Registry) ([]Status, error) {
-	var wire []ghPR
+	out, err := run(ctx, "api", fmt.Sprintf("%s/pulls?state=open&per_page=%d", base, prLimit))
+	if err != nil {
+		return nil, fmt.Errorf("gh api pulls: %w", err)
+	}
+	var wire []restPR
 	if err := json.Unmarshal(out, &wire); err != nil {
-		return nil, fmt.Errorf("parse gh output: %w", err)
+		return nil, fmt.Errorf("parse open pull requests: %w", err)
 	}
-
 	if len(wire) >= prLimit {
-		return nil, fmt.Errorf("gh pr list returned %d open PRs (hit boundary limit); queue may be truncated — investigate with gh pr list", prLimit)
+		return nil, fmt.Errorf("GitHub returned %d open pull requests (a full page); the queue may be truncated — page through with `gh api %s/pulls --paginate`", prLimit, base)
 	}
 
-	prs := make([]PR, 0, len(wire))
-	for _, w := range wire {
-		p := PR{Number: w.Number, Title: w.Title, URL: w.URL}
-		for _, cm := range w.Comments {
-			p.Comments = append(p.Comments, Comment{
-				Author: cm.Author.Login, Body: cm.Body, CreatedAt: cm.CreatedAt,
-			})
+	prs := make([]PR, len(wire))
+	errs := make([]error, len(wire))
+	sem := make(chan struct{}, commentFanout)
+	var wg sync.WaitGroup
+
+	for i, w := range wire {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				errs[i] = ctx.Err()
+				return
+			}
+			comments, err := fetchComments(ctx, run, base, w.Number)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			prs[i] = PR{Number: w.Number, Title: w.Title, URL: w.HTMLURL, Comments: comments}
+		}()
+	}
+	wg.Wait()
+
+	// One unreadable pull request poisons the whole answer. A PR whose comments
+	// could not be read is not a PR with no comments, and reporting the rest as
+	// a complete queue is exactly the "cannot compute reads as nothing pending"
+	// failure this package refuses.
+	for _, err := range errs {
+		if err != nil {
+			return nil, err
 		}
-		prs = append(prs, p)
 	}
 
 	return Queue(prs, reg), nil
+}
+
+// fetchComments reads one pull request's conversation.
+func fetchComments(ctx context.Context, run ghRunner, base string, number int) ([]Comment, error) {
+	out, err := run(ctx, "api", fmt.Sprintf("%s/issues/%d/comments?per_page=%d", base, number, commentLimit))
+	if err != nil {
+		return nil, fmt.Errorf("gh api comments for #%d: %w", number, err)
+	}
+	var wire []restComment
+	if err := json.Unmarshal(out, &wire); err != nil {
+		return nil, fmt.Errorf("parse comments for #%d: %w", number, err)
+	}
+	// The dangerous axis. A truncated pull request list makes a PR go missing,
+	// which is visible; truncated comments make the verdict WRONG — an
+	// untriaged PR can read as triaged, or a re-review can vanish behind an
+	// older disposition.
+	if len(wire) >= commentLimit {
+		return nil, fmt.Errorf("pull request #%d returned %d comments (a full page); its triage verdict would be computed from partial data", number, commentLimit)
+	}
+
+	comments := make([]Comment, 0, len(wire))
+	for _, w := range wire {
+		comments = append(comments, Comment{
+			Author: w.User.Login, Body: w.Body, CreatedAt: w.CreatedAt,
+		})
+	}
+	return comments, nil
+}
+
+// repoBase renders the REST path prefix. An empty repo yields gh's own
+// `{owner}/{repo}` placeholders, which gh resolves from the current repository —
+// preserving the default the session-start probe relies on, since it passes ""
+// and runs wherever the shell happens to be.
+func repoBase(repo string) string {
+	if repo == "" {
+		return "repos/{owner}/{repo}"
+	}
+	return "repos/" + repo
 }
 
 // Marker returns the triage heading a registry declares, for a caller that needs

--- a/cli/internal/prtriage/fetch_test.go
+++ b/cli/internal/prtriage/fetch_test.go
@@ -1,0 +1,343 @@
+package prtriage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeGH stands in for the `gh` binary. It exists because the fetch path had no
+// seam at all before CLI-071: `FetchWithRegistry` reached for exec.CommandContext
+// directly, so the one code path observed failing in production (#1454) was the
+// one path no test could reach.
+//
+// It records every request, so a test can assert which endpoints were called and
+// not merely what came back — the difference between proving the transport and
+// hoping about it.
+type fakeGH struct {
+	mu        sync.Mutex
+	requests  []string
+	inFlight  int
+	maxFlight int
+
+	// responses maps a substring of the request path to its canned body. The
+	// first match wins, so a test can register a general list plus specific
+	// per-PR comment payloads.
+	responses map[string]string
+	errs      map[string]error
+	delay     time.Duration
+}
+
+func (f *fakeGH) run(ctx context.Context, args ...string) ([]byte, error) {
+	joined := strings.Join(args, " ")
+
+	f.mu.Lock()
+	f.requests = append(f.requests, joined)
+	f.inFlight++
+	if f.inFlight > f.maxFlight {
+		f.maxFlight = f.inFlight
+	}
+	f.mu.Unlock()
+
+	defer func() {
+		f.mu.Lock()
+		f.inFlight--
+		f.mu.Unlock()
+	}()
+
+	if f.delay > 0 {
+		select {
+		case <-time.After(f.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	for frag, err := range f.errs {
+		if strings.Contains(joined, frag) {
+			return nil, err
+		}
+	}
+	for frag, body := range f.responses {
+		if strings.Contains(joined, frag) {
+			return []byte(body), nil
+		}
+	}
+	return nil, fmt.Errorf("fakeGH: no canned response for %q", joined)
+}
+
+func (f *fakeGH) seen() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.requests))
+	copy(out, f.requests)
+	return out
+}
+
+// testRegistry mirrors the real harness/review-attestation.json: reviewers are
+// declared with BARE logins, which is the GraphQL spelling. REST returns the
+// `[bot]` suffix, so the fold in normaliseLogin is what makes these agree.
+func testRegistry() Registry {
+	var r Registry
+	r.Triage.Marker = "## Review triage"
+	r.Reviewers = []Reviewer{
+		{Login: "coderabbitai", ReviewMarkers: []string{"No actionable comments were generated"}},
+		{Login: "github-actions", ReviewMarkers: []string{"## PR Reviewer Guide"}},
+	}
+	return r
+}
+
+// TestFetchWithRunnerDrivesTheWholePath is AC1: the fetch path runs end to end
+// with no network and no `gh` on PATH. Before CLI-071 this test could not be
+// written at all.
+func TestFetchWithRunnerDrivesTheWholePath(t *testing.T) {
+	fake := &fakeGH{responses: map[string]string{
+		"/pulls": `[{"number":10,"title":"a reviewed PR","html_url":"https://github.com/o/r/pull/10"},
+		            {"number":11,"title":"a quiet PR","html_url":"https://github.com/o/r/pull/11"}]`,
+		"/issues/10/comments": `[{"user":{"login":"github-actions[bot]"},
+		                          "body":"## PR Reviewer Guide\nfindings here",
+		                          "created_at":"2026-09-02T10:00:00Z"}]`,
+		"/issues/11/comments": `[]`,
+	}}
+
+	got, err := fetchWith(context.Background(), fake.run, "o/r", testRegistry())
+	if err != nil {
+		t.Fatalf("fetchWith: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("queue length = %d, want 1 (only #10 carries untriaged reviewer output)\n%+v", len(got), got)
+	}
+	// AC6 rides here: every field the two renderers consume is pinned, so a
+	// transport that parsed but mismapped — REST spells three of these
+	// differently from the GraphQL shape it replaced — cannot pass by producing
+	// a queue of the right length with hollow entries.
+	st := got[0]
+	if st.PR.Number != 10 {
+		t.Errorf("Number = %d, want 10", st.PR.Number)
+	}
+	if st.PR.Title != "a reviewed PR" {
+		t.Errorf("Title = %q, want %q", st.PR.Title, "a reviewed PR")
+	}
+	if st.PR.URL != "https://github.com/o/r/pull/10" {
+		t.Errorf("URL = %q — REST calls this field html_url, not url", st.PR.URL)
+	}
+	if !st.Pending {
+		t.Errorf("PR #10 has reviewer output and no triage record; want Pending")
+	}
+	if st.Reviewer != "github-actions" {
+		t.Errorf("Reviewer = %q, want the registry's bare login %q", st.Reviewer, "github-actions")
+	}
+	if want := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC); !st.At.Equal(want) {
+		t.Errorf("At = %v, want %v — REST spells this created_at, not createdAt, and a zero "+
+			"timestamp silently turns the queue's comparison into a wrong answer", st.At, want)
+	}
+	if st.Reason != "github-actions reviewed, never triaged" {
+		t.Errorf("Reason = %q", st.Reason)
+	}
+}
+
+// TestFetchUsesRESTOnly is AC2. The point of the change is that no GraphQL call
+// remains, and the only way to keep that true is to assert on the requests
+// themselves — a reintroduced `gh pr list` would otherwise pass every other test
+// in this file, since the queue it produces is identical.
+func TestFetchUsesRESTOnly(t *testing.T) {
+	fake := &fakeGH{responses: map[string]string{
+		"/pulls":             `[{"number":7,"title":"t","html_url":"u"}]`,
+		"/issues/7/comments": `[]`,
+	}}
+
+	if _, err := fetchWith(context.Background(), fake.run, "o/r", testRegistry()); err != nil {
+		t.Fatalf("fetchWith: %v", err)
+	}
+
+	seen := fake.seen()
+	if len(seen) == 0 {
+		t.Fatal("no requests recorded")
+	}
+	for _, req := range seen {
+		if !strings.HasPrefix(req, "api ") {
+			t.Errorf("request %q is not a `gh api` REST call — GraphQL is what CLI-071 removed", req)
+		}
+		if strings.Contains(req, "pr list") || strings.Contains(req, "graphql") {
+			t.Errorf("request %q reintroduces the GraphQL path", req)
+		}
+	}
+}
+
+// TestFetchFoldsTheBotLoginSuffix is AC3, and it is the highest-consequence test
+// here. The registry declares `github-actions`; REST returns
+// `github-actions[bot]`. Under GraphQL normaliseLogin was defensive. Under REST
+// it is load-bearing on every single match, and deleting it does not error — it
+// empties the queue, which is the precise failure this package exists to prevent
+// (#1033).
+func TestFetchFoldsTheBotLoginSuffix(t *testing.T) {
+	for _, login := range []string{"coderabbitai[bot]", "github-actions[bot]"} {
+		t.Run(login, func(t *testing.T) {
+			marker := "No actionable comments were generated"
+			if strings.HasPrefix(login, "github-actions") {
+				marker = "## PR Reviewer Guide"
+			}
+			fake := &fakeGH{responses: map[string]string{
+				"/pulls": `[{"number":3,"title":"t","html_url":"u"}]`,
+				"/issues/3/comments": fmt.Sprintf(
+					`[{"user":{"login":%q},"body":%q,"created_at":"2026-09-02T10:00:00Z"}]`,
+					login, marker+"\nbody"),
+			}}
+
+			got, err := fetchWith(context.Background(), fake.run, "o/r", testRegistry())
+			if err != nil {
+				t.Fatalf("fetchWith: %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("queue is empty for author %q — the [bot] suffix is not being folded", login)
+			}
+		})
+	}
+}
+
+// TestFetchRefusesTruncationOnBothAxes is AC4. REST paginates where GraphQL did
+// not, so there are now two ways to silently answer from partial data. The
+// comment axis is the dangerous one: a truncated PR list makes a PR go missing
+// (visible), while truncated comments make a triaged PR look untriaged, or worse,
+// an untriaged one look clean.
+func TestFetchRefusesTruncationOnBothAxes(t *testing.T) {
+	t.Run("a full page of pull requests", func(t *testing.T) {
+		var sb strings.Builder
+		sb.WriteString("[")
+		for i := 0; i < prLimit; i++ {
+			if i > 0 {
+				sb.WriteString(",")
+			}
+			fmt.Fprintf(&sb, `{"number":%d,"title":"t","html_url":"u"}`, i+1)
+		}
+		sb.WriteString("]")
+
+		fake := &fakeGH{responses: map[string]string{
+			"/pulls":    sb.String(),
+			"/comments": `[]`,
+		}}
+		_, err := fetchWith(context.Background(), fake.run, "o/r", testRegistry())
+		if err == nil {
+			t.Fatal("a full page of pull requests must refuse, not answer from partial data")
+		}
+		if !strings.Contains(err.Error(), "truncated") {
+			t.Errorf("error %q should say the queue may be truncated", err)
+		}
+	})
+
+	t.Run("a full page of comments on one PR", func(t *testing.T) {
+		var sb strings.Builder
+		sb.WriteString("[")
+		for i := 0; i < commentLimit; i++ {
+			if i > 0 {
+				sb.WriteString(",")
+			}
+			fmt.Fprintf(&sb, `{"user":{"login":"someone"},"body":"c%d","created_at":"2026-09-02T10:00:00Z"}`, i)
+		}
+		sb.WriteString("]")
+
+		fake := &fakeGH{responses: map[string]string{
+			"/pulls":             `[{"number":5,"title":"t","html_url":"u"}]`,
+			"/issues/5/comments": sb.String(),
+		}}
+		_, err := fetchWith(context.Background(), fake.run, "o/r", testRegistry())
+		if err == nil {
+			t.Fatal("a full page of comments must refuse: a truncated comment list yields a WRONG verdict, not a missing one")
+		}
+		if !strings.Contains(err.Error(), "#5") {
+			t.Errorf("error %q should name the pull request whose comments were truncated", err)
+		}
+	})
+}
+
+// TestFetchFansOutConcurrently is AC5, the session-start latency budget
+// (mem.go bounds the probe at 5s and it runs on every session start). Asserting
+// observed concurrency rather than wall-clock keeps this deterministic — a
+// timing assertion would be flaky on a loaded CI runner and would eventually be
+// deleted, which is how a guard becomes decorative.
+func TestFetchFansOutConcurrently(t *testing.T) {
+	const prs = 10
+	var sb strings.Builder
+	sb.WriteString("[")
+	for i := 0; i < prs; i++ {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		fmt.Fprintf(&sb, `{"number":%d,"title":"t","html_url":"u"}`, i+1)
+	}
+	sb.WriteString("]")
+
+	fake := &fakeGH{
+		delay: 20 * time.Millisecond,
+		responses: map[string]string{
+			"/pulls":    sb.String(),
+			"/comments": `[]`,
+		},
+	}
+
+	start := time.Now()
+	if _, err := fetchWith(context.Background(), fake.run, "o/r", testRegistry()); err != nil {
+		t.Fatalf("fetchWith: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	fake.mu.Lock()
+	peak := fake.maxFlight
+	fake.mu.Unlock()
+
+	if peak < 2 {
+		t.Errorf("peak in-flight requests = %d: the per-PR calls are serial, so %d open PRs cost %d round-trips against a 5s session-start budget",
+			peak, prs, prs+1)
+	}
+	if peak > commentFanout {
+		t.Errorf("peak in-flight requests = %d, exceeds the %d cap: unbounded fan-out is its own failure mode", peak, commentFanout)
+	}
+	if serial := prs * fake.delay; elapsed > serial {
+		t.Errorf("elapsed %v is no better than issuing all %d calls serially (%v)", elapsed, prs, serial)
+	}
+}
+
+// TestFetchReportsFailureRatherThanAnEmptyQueue pins the rule the package
+// documents: a queue that could not be computed must never read as a queue with
+// nothing in it. Both axes can fail, so both are checked.
+func TestFetchReportsFailureRatherThanAnEmptyQueue(t *testing.T) {
+	t.Run("the list call fails", func(t *testing.T) {
+		fake := &fakeGH{errs: map[string]error{"/pulls": fmt.Errorf("gh: exit status 1")}}
+		got, err := fetchWith(context.Background(), fake.run, "o/r", testRegistry())
+		if err == nil {
+			t.Fatalf("want an error, got a queue of %d", len(got))
+		}
+	})
+
+	t.Run("one PR's comments fail", func(t *testing.T) {
+		fake := &fakeGH{
+			responses: map[string]string{"/pulls": `[{"number":9,"title":"t","html_url":"u"}]`},
+			errs:      map[string]error{"/issues/9/comments": fmt.Errorf("gh: exit status 1")},
+		}
+		got, err := fetchWith(context.Background(), fake.run, "o/r", testRegistry())
+		if err == nil {
+			t.Fatalf("want an error, got a queue of %d — a PR whose comments could not be read is not a PR with no comments", len(got))
+		}
+	})
+}
+
+// TestFetchTargetsTheCurrentRepoByDefault pins the empty-repo default. gh
+// substitutes {owner}/{repo} from the current repository, which is how the old
+// `gh pr list` default behaved and what the session-start probe relies on: it
+// passes "" and runs wherever the shell happens to be.
+func TestFetchTargetsTheCurrentRepoByDefault(t *testing.T) {
+	fake := &fakeGH{responses: map[string]string{"/pulls": `[]`}}
+	if _, err := fetchWith(context.Background(), fake.run, "", testRegistry()); err != nil {
+		t.Fatalf("fetchWith: %v", err)
+	}
+	seen := fake.seen()
+	if len(seen) != 1 {
+		t.Fatalf("want exactly one request for an empty PR list, got %d: %v", len(seen), seen)
+	}
+	if !strings.Contains(seen[0], "repos/{owner}/{repo}/pulls") {
+		t.Errorf("request %q should use gh's {owner}/{repo} placeholders when no repo is given", seen[0])
+	}
+}

--- a/cli/internal/prtriage/prtriage_test.go
+++ b/cli/internal/prtriage/prtriage_test.go
@@ -1,10 +1,8 @@
 package prtriage
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 )
@@ -147,37 +145,11 @@ func TestTheRealRegistryServesBothConsumers(t *testing.T) {
 	}
 }
 
-// 100 open PRs indicates boundary truncation on `gh pr list --limit 100`.
-// It must return a loud error rather than silently returning a truncated queue.
-func TestParseWireBoundaryLimit(t *testing.T) {
-	r := reg()
-
-	// Under 100: success
-	out99 := `[{"number": 1, "title": "t", "url": "u", "comments": [{"author": {"login": "github-actions"}, "body": "## PR Reviewer Guide\nx", "createdAt": "2026-08-20T01:00:00Z"}]}]`
-	got, err := parseWire([]byte(out99), r)
-	if err != nil {
-		t.Fatalf("parseWire with 1 PR returned unexpected error: %v", err)
-	}
-	if len(got) != 1 {
-		t.Fatalf("expected 1 item, got %d", len(got))
-	}
-
-	// 100 entries: boundary limit error
-	var sb strings.Builder
-	sb.WriteString("[")
-	for i := 1; i <= 100; i++ {
-		if i > 1 {
-			sb.WriteString(",")
-		}
-		fmt.Fprintf(&sb, `{"number": %d, "title": "t%d", "url": "u%d", "comments": []}`, i, i, i)
-	}
-	sb.WriteString("]")
-
-	_, err = parseWire([]byte(sb.String()), r)
-	if err == nil {
-		t.Fatal("expected loud error when wire returns 100 items (boundary limit), got nil")
-	}
-	if !strings.Contains(err.Error(), "hit boundary limit") || !strings.Contains(err.Error(), "100") {
-		t.Fatalf("error must cite boundary limit and count, got: %v", err)
-	}
-}
+// The boundary-truncation guard used to be tested here against `parseWire`, the
+// helper that unpacked `gh pr list --json`'s nested GraphQL shape. CLI-071
+// removed both that transport and that helper, so the test moved to
+// `TestFetchRefusesTruncationOnBothAxes` in fetch_test.go — which is strictly
+// stronger: it exercises the guard through the real fetch path rather than a
+// helper, and it covers the SECOND axis REST introduced. Comments now paginate
+// too, and a truncated comment list yields a wrong verdict rather than a
+// visibly missing pull request.

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -277,5 +277,6 @@ tags: [lessons, index, dotfiles]
 | [257 - A one-time migration with no removal date is indistinguishable from live code, and two of eleven turned out not to be finished](lesson-257-a-one-time-migration-with-no-removal-date-is.md) | 2026-09-02 |  |
 | [258 - An argument passed through two independent quoting conventions is only as safe as the weaker one](lesson-258-an-argument-passed-through-two-independent-quoting-layers.md) | 2026-09-02 |  |
 | [259 - A justification outlives its mechanism as easily as a name outlives its contract, and the cleanup that taught us the first lesson left an instance of it](lesson-259-a-justification-outlives-its-mechanism.md) | 2026-09-02 |  |
+| [260 - The path with no seam is the path with no test, and it is the one that fails in production](lesson-260-the-path-with-no-seam-is-the-path-with-no-test.md) | 2026-09-02 |  |
 
 - [2026-08-30 Intercepting Cobra Errors without Breaking SilenceErrors](2026-08-30-cobra-silence-errors-interception.md)

--- a/docs/lessons/lesson-260-the-path-with-no-seam-is-the-path-with-no-test.md
+++ b/docs/lessons/lesson-260-the-path-with-no-seam-is-the-path-with-no-test.md
@@ -1,0 +1,102 @@
+# 260 - The path with no seam is the path with no test, and it is the one that fails in production
+
+**Date:** 2026-09-02
+**Area:** CLI, testing, PR triage
+
+## What happened
+
+`dotf pr triage-queue` failed on 2026-09-02 with `gh pr list: exit status 1`.
+GitHub's GraphQL bucket was refusing every list and write while REST served the
+same data throughout. That command is the mechanism the pr-stewardship doctrine
+names by hand — run it at session start, and again before reporting PR work
+complete — so #1454 was filed against the transport: swap the GraphQL call for
+REST.
+
+Measuring before writing found two things the ticket had wrong, and one it had
+not looked for.
+
+**Wrong: the proposed fix could not work.** It called for a one-line swap to
+`GET /repos/{o}/{r}/pulls`, with a field mapping listing `number`, `title`,
+`head.ref`, `draft`, `user.login`. But the queue's algorithm is a timestamp
+comparison between the newest reviewer comment and the newest recorded triage
+(`prtriage.go:95-141`) — **the comments are the algorithm**, and that endpoint
+returns none of them. `gh pr list --json comments` is a single GraphQL query
+returning pull requests with their comments *nested*; REST has no such nesting.
+The honest shape is 1 + N calls, with the join moved into our code.
+
+**Overstated: "unavailable."** Both consumers already failed loud. The command
+exits non-zero with the reason; the session brief injects
+`[pr-triage] queue could not be computed: …` followed by *"This is not an empty
+queue"*. The worst failure the ticket implied — an outage reading as a clear
+queue — did not exist. What was missing was a workaround once the signal fired,
+not the signal.
+
+**Not looked for, and the actual defect:** `FetchWithRegistry` called
+`exec.CommandContext(ctx, "gh", …)` directly. No injection point, therefore no
+test — the package's four tests all covered pure functions. **The one path
+observed failing in production was the only path in the package nothing
+exercised**, and that was true whichever transport it spoke.
+
+## The lesson
+
+A missing seam does not read as missing coverage. The package looked well
+tested: four tests, a clean domain, careful comments about failure modes. The
+gap was invisible because the untested part was the part that *reaches outside* —
+and reaching outside is exactly what cannot fail in a unit test, so nothing ever
+drew attention to its absence.
+
+The correlation is not a coincidence. The code that talks to the network, the
+filesystem or another binary is simultaneously the code most likely to fail in
+production and the code that is hardest to test *without a seam* — so the two
+properties select for the same lines. Wherever a package calls `exec`, `http` or
+`os` directly from a function with real logic in it, that function is both the
+riskiest and the least covered.
+
+**So when a production failure points at a subsystem, ask what made that path
+untestable before asking what made it fail.** The transport was the presenting
+symptom and the smaller half. Framing the work as "migrate to REST" would have
+justified it on an outage observed exactly once, and left the real defect in
+place regardless of which API it called.
+
+## What was done
+
+The seam came first and the transport followed:
+
+```go
+type ghRunner func(ctx context.Context, args ...string) ([]byte, error)
+
+func FetchWithRegistry(ctx context.Context, repo string, reg Registry) ([]Status, error) {
+	return fetchWith(ctx, execGH, repo, reg)
+}
+```
+
+The exported signature is unchanged; `fetchWith` takes the runner. Eight tests
+now drive the fetch path with canned payloads, no network and no `gh` on PATH.
+
+Three consequences of the transport change were only visible once it was
+testable, and each became a test:
+
+- **`normaliseLogin` was promoted from defensive to load-bearing.** The registry
+  declares `github-actions`; REST returns `github-actions[bot]`. Under GraphQL
+  the `[bot]` fold was insurance. Under REST every match depends on it — and
+  removing it does not error, it silently empties the queue.
+- **REST paginates on two axes where GraphQL paginated on none.** A truncated
+  pull-request list makes a PR go *missing*, which is visible. Truncated
+  comments make the verdict *wrong*: an untriaged PR can read as triaged. Both
+  refuse now; the second matters more.
+- **1 + N met a five-second budget.** The session-start probe runs on every
+  session start under that bound. The fan-out is capped at 8 and the concurrency
+  test asserts *observed peak* rather than wall-clock, because a timing
+  assertion on a loaded runner gets loosened until it means nothing.
+
+Measured after: 0.94 / 0.96 / 0.95 s against the live repository, and output
+byte-identical to what the GraphQL implementation printed for the same repo
+earlier the same session.
+
+## Related
+
+- Lesson 259 — a justification outlives its mechanism. Applied here as a sweep of
+  the *prose*, which caught a fixture error string (`"gh pr list: exit status 4"`)
+  this change had made unproducible.
+- #1033 — the login-spelling trap that this change moved onto the critical path.
+- `docs/adr/adr-020-tooling-cli-go-convergence.md` — the CLI convergence this sits inside.

--- a/specs/CLI-071-triage-queue-transport/features.json
+++ b/specs/CLI-071-triage-queue-transport/features.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "CLI-071-triage-queue-transport-f1",
+    "behavior": "AC1 — the fetch path runs end to end against an injected fake, with no network and no gh on PATH; removing the seam makes it fail",
+    "verification": "cd cli && go test ./internal/prtriage/ -count=1 -v -run '^TestFetchWithRunnerDrivesTheWholePath$' | grep -q '^--- PASS: TestFetchWithRunnerDrivesTheWholePath'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-071-triage-queue-transport-f2",
+    "behavior": "AC2 — every request the seam receives is a `gh api` REST call; a reintroduced `gh pr list` is caught mechanically",
+    "verification": "cd cli && go test ./internal/prtriage/ -count=1 -v -run '^TestFetchUsesRESTOnly$' | grep -q '^--- PASS: TestFetchUsesRESTOnly'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-071-triage-queue-transport-f3",
+    "behavior": "AC3 — REST's `[bot]` login suffix folds against the registry's bare logins; deleting normaliseLogin empties the queue and fails this",
+    "verification": "cd cli && go test ./internal/prtriage/ -count=1 -v -run '^TestFetchFoldsTheBotLoginSuffix$' | grep -q '^--- PASS: TestFetchFoldsTheBotLoginSuffix'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-071-triage-queue-transport-f4",
+    "behavior": "AC4 — a full page of pull requests, and a full page of comments on any one of them, each refuse rather than answer from partial data",
+    "verification": "cd cli && go test ./internal/prtriage/ -count=1 -v -run '^TestFetchRefusesTruncationOnBothAxes$' | grep -q '^--- PASS: TestFetchRefusesTruncationOnBothAxes'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-071-triage-queue-transport-f5",
+    "behavior": "AC5 — the per-PR calls overlap and stay under the fan-out cap, so ten open PRs do not cost ten serial round-trips against the 5s session-start budget",
+    "verification": "cd cli && go test ./internal/prtriage/ -count=1 -v -run '^TestFetchFansOutConcurrently$' | grep -q '^--- PASS: TestFetchFansOutConcurrently'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-071-triage-queue-transport-f6",
+    "behavior": "AC6 — every field the renderers consume is populated identically from the REST payload, including the three REST spells differently",
+    "verification": "cd cli && go test ./internal/prtriage/ -count=1 -v -run '^TestFetchWithRunnerDrivesTheWholePath$' | grep -q '^--- PASS: TestFetchWithRunnerDrivesTheWholePath'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-071-triage-queue-transport-f7",
+    "behavior": "A failure on either axis is returned, never softened into an empty queue — the rule the whole package exists to enforce",
+    "verification": "cd cli && go test ./internal/prtriage/ -count=1 -v -run '^TestFetchReportsFailureRatherThanAnEmptyQueue$' | grep -q '^--- PASS: TestFetchReportsFailureRatherThanAnEmptyQueue'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-071-triage-queue-transport-f8",
+    "behavior": "An empty --repo still targets the current repository via gh's {owner}/{repo} placeholders, preserving the default the session-start probe relies on",
+    "verification": "cd cli && go test ./internal/prtriage/ -count=1 -v -run '^TestFetchTargetsTheCurrentRepoByDefault$' | grep -q '^--- PASS: TestFetchTargetsTheCurrentRepoByDefault'",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CLI-071-triage-queue-transport/proposal.md
+++ b/specs/CLI-071-triage-queue-transport/proposal.md
@@ -1,0 +1,110 @@
+---
+id: "CLI-071-triage-queue-transport"
+type: spec
+status: verifying # draft | implementing | verifying | archived
+created: "2026-09-02"
+issue: "mlorentedev/dotfiles#1454"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# CLI-071-triage-queue-transport
+
+## Why
+
+<!-- from issue #1454: CLI-071: dotf pr triage-queue dies with GraphQL, so the command that binds Definition of Done §4 is unavailable exactly when gh is degraded -->
+
+`dotf pr triage-queue` is the mechanism the always-injected pr-stewardship
+doctrine names by hand: run it at session start, and again before reporting any
+PR work complete. Its fetch path calls `exec.CommandContext(ctx, "gh", …)`
+directly at `fetch.go:60`, with no injection point — so `FetchWithRegistry` is
+unreachable from a test, and it has none. The four tests in the package cover
+only the pure functions. **The one path observed failing in production on
+2026-09-02 is the one path nothing exercises**, and that is true whichever
+transport it speaks.
+
+The transport is the second problem and the smaller one. `gh pr list --json` is
+a GraphQL call, and GraphQL refused every write and list for a stretch on
+2026-09-02 while REST served the identical data throughout. The command binds a
+doctrine, so a single point of failure it does not need is worth removing — but
+"unavailable" was overstated in the ticket and is corrected in its body: both
+consumers already fail loud, and neither reads an outage as an empty queue.
+
+## What
+
+After this change:
+
+1. `FetchWithRegistry` takes its GitHub access through an injected seam rather
+   than reaching for `exec` itself, so the fetch path is drivable from a test
+   with canned payloads and no network.
+2. The queue is assembled from REST only — `GET /repos/{o}/{r}/pulls` for the
+   open list, `GET /repos/{o}/{r}/issues/{n}/comments` per pull request — so a
+   GraphQL refusal no longer takes the command down.
+3. The session-start probe stays inside its five-second budget with the per-PR
+   fan-out bounded and measured, not assumed.
+4. Rendered output is byte-identical for identical input: this is a transport
+   and testability change, not a behaviour change.
+
+## Out of scope
+
+- **Distinct exit statuses for "pending" vs "could not answer."** `pr.go:49-51`
+  documents the shared status as a reasoned decision. Refuting that argument is
+  its own ticket, not a rider on this one.
+- **The triage algorithm.** `Evaluate`, `reviewOutput` and `lastTriage` are
+  untouched; if their behaviour changes, this change is wrong.
+- **The `pr-review-triage` skill and the reviewer registry.** This package lists
+  and never applies, and nothing here may erode that.
+
+## Risks / open questions
+
+- **R1 — the session-start latency budget (must be resolved before merge).**
+  `mem.go:204` bounds the probe at 5s and it runs on every session start. Serial
+  1+N against ten open PRs is eleven round-trips and can exceed it. Trading an
+  intermittent unavailability for a predictable degradation on the hot path
+  would be a net loss, so the fan-out is bounded and the latency measured.
+- **R2 — two pagination axes instead of none.** GraphQL returned PRs and their
+  comments in one response. REST paginates both. The old `parseWire` refused
+  when a full page of PRs came back rather than silently truncating; that
+  refusal must survive on **both** axes, because a PR whose comments were
+  truncated yields a *wrong* verdict rather than a visibly missing one.
+- **R3 — `normaliseLogin` moves onto the critical path.** The registry declares
+  `github-actions`; REST returns `github-actions[bot]`. `normaliseLogin` already
+  folds the two, but under GraphQL that was defensive and under REST it is
+  load-bearing on every match. Removing it would empty the queue silently — the
+  exact failure this package exists to prevent (see #1033).
+- **R4 — field names differ.** GraphQL `url` is REST `html_url`; GraphQL
+  `comments[].author.login` is REST `user.login`; `createdAt` is `created_at`.
+  A silent zero-value here degrades a timestamp comparison into a wrong answer,
+  not an error.
+
+## Acceptance criteria
+
+- [x] **AC1 — the fetch path is tested.** `FetchWithRegistry` runs end-to-end in
+      a test against an injected fake returning canned REST payloads, with no
+      network and no `gh` on PATH. Removing the seam makes the test fail.
+- [x] **AC2 — no GraphQL remains.** The package invokes only REST endpoints; a
+      test asserts the requests the seam receives, so a reintroduced `pr list`
+      is caught mechanically rather than by review.
+- [x] **AC3 — the bot-login fold is pinned by a REST-shaped payload.** A fixture
+      carrying the literal `github-actions[bot]` and `coderabbitai[bot]` resolves
+      against a registry declaring the bare logins. Deleting `normaliseLogin`
+      fails this test.
+- [x] **AC4 — truncation still refuses on both axes.** A full page of pull
+      requests, and a full page of comments on any one of them, each produce an
+      error rather than a short answer.
+- [x] **AC5 — the session-start budget holds, measured.** With the fan-out
+      bounded, a fake with a per-call delay representing ten open PRs completes
+      inside the 5s context, and the test fails if the calls are issued serially.
+- [x] **AC6 — the renderers see identical values.** Both renderers are pure
+      functions of `[]Status`, and that type is untouched, so "output unchanged"
+      reduces to "every consumed field is populated identically". A fixture pins
+      all six — `Number`, `Title`, `URL`, `Reviewer`, `At`, `Reason` — because
+      REST spells three of them differently (`html_url`, `user.login`,
+      `created_at`) and a mismapping yields a hollow entry, not an error.
+
+## References
+
+- Bitácora board: `mlorentedev/dotfiles#1454` (see the `issue:` frontmatter field)
+- `docs/adr/adr-020-tooling-cli-go-convergence.md` — the CLI convergence this package sits inside
+- Prior art for the seam: `cli/internal/doctor` `System` (`newSys(env, onPath, cmdOut)`)
+- #1033 — the login-spelling trap this change moves onto the critical path

--- a/specs/CLI-071-triage-queue-transport/tasks.md
+++ b/specs/CLI-071-triage-queue-transport/tasks.md
@@ -1,0 +1,65 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-09-02"
+---
+
+# Tasks - CLI-071-triage-queue-transport
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+
+## Setup
+
+- [x] Branch created from main: `fix/cli-071-triage-queue-transport` (off `origin/main` @ `45e2c61`)
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions" — R1 is resolved by AC5 rather than left open
+
+## Implementation
+
+> TDD order. The seam comes first because nothing else in this spec is testable
+> without it — every later task is written against a fake, never the network.
+
+- [x] [AC1] Failing test: `fetchWith` drives the whole path against an injected
+      fake runner, no `gh` on PATH, and returns the expected queue
+- [x] [AC1] Introduce the `ghRunner` seam and route `FetchWithRegistry` through
+      it, keeping the exported signature unchanged
+- [x] [AC2][AC4] Failing test: the fake records the requests it receives; assert
+      REST paths only, and assert a full page of pull requests still refuses
+- [x] [AC2] Replace the `gh pr list` call with `gh api repos/{owner}/{repo}/pulls`
+      and map the REST list shape (`html_url`, not `url`)
+- [x] [AC3][AC4] Failing test: per-PR comments, with a `[bot]`-suffixed author
+      resolving against the bare registry login, and a full comment page refusing
+- [x] [AC3] Fetch comments per pull request via
+      `gh api repos/{owner}/{repo}/issues/{n}/comments` and map `user.login` /
+      `created_at`
+- [x] [AC5] Failing test: a fake with a per-call delay, ten pull requests, must
+      complete well inside the 5s budget — fails if the calls are serial
+- [x] [AC5] Bound the per-PR fan-out with a semaphore-limited worker pool (no new
+      dependency; `x/sync` is not in `go.mod` and adding one is its own gate)
+- [x] [AC6] Pin every field the renderers consume, since both are pure functions
+      of `[]Status` and that type is untouched — plus a production smoke test
+      against the live repository, which turned out to be the stronger evidence
+- [x] Refactor: delete `ghPR`, fold the wire types into the REST shapes, and keep
+      every doc comment honest about what the code now does (lesson 259 —
+      grep the prose, not just the callers)
+
+## Closing
+
+- [x] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [x] Every acceptance criterion has a matching entry in `features.json` with a
+      non-vacuous verification command — **anchor every `-run` pattern**, because
+      `go test -run <no-match>` exits 0 and would make the check unfailable
+- [x] Mutation-test each new guard: remove the assertion it defends and watch the
+      test fail
+- [x] `go build ./... && go vet ./... && go test ./...` green
+- [x] `GOOS=windows go vet ./...` green (the Windows leg compiles the same tree)
+- [x] `golangci-lint run` with the pinned version from `versions.conf`
+- [x] No unrelated changes in the diff (no scope creep)
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder with `Refs #1454` (not `Closes`:
+      the spec-gate refuses a closing keyword on a PR that does not archive)
+
+## Machine-readable features
+
+See the sibling `features.json`. Each acceptance criterion maps to ≥1 feature with
+an executable `verification` command. The agent may not write `"state": "passing"`
+— only the harness may, after capturing exit code 0.

--- a/specs/CLI-071-triage-queue-transport/verification.md
+++ b/specs/CLI-071-triage-queue-transport/verification.md
@@ -1,0 +1,181 @@
+---
+tags: [spec, verification, templates]
+created: "2026-09-02"
+---
+
+# Verification - CLI-071-triage-queue-transport
+
+## Evidence
+
+- [x] **AC1 — the fetch path is tested** → `TestFetchWithRunnerDrivesTheWholePath`.
+      `fetchWith` runs end to end against an injected `ghRunner` with no network.
+      This test could not be written before the change: `FetchWithRegistry` called
+      `exec.CommandContext` directly and was unreachable.
+- [x] **AC2 — no GraphQL remains** → `TestFetchUsesRESTOnly` asserts on the
+      requests the seam receives, not merely on the queue that comes back. A
+      reintroduced `gh pr list` produces an identical queue and would pass every
+      other test in the package, so asserting the transport is the only way to
+      keep this true.
+- [x] **AC3 — the `[bot]` fold is pinned** → `TestFetchFoldsTheBotLoginSuffix`,
+      both declared reviewers, with REST-shaped `coderabbitai[bot]` /
+      `github-actions[bot]` authors against a registry declaring bare logins.
+- [x] **AC4 — truncation refuses on both axes** →
+      `TestFetchRefusesTruncationOnBothAxes`, one subtest per axis.
+- [x] **AC5 — the fan-out overlaps and is bounded** →
+      `TestFetchFansOutConcurrently` asserts *observed* peak concurrency rather
+      than wall-clock, so it is deterministic on a loaded CI runner. Both
+      directions are checked: serial fails it, and so does exceeding the cap.
+- [x] **AC6 — the renderers see identical values** → the field assertions in
+      `TestFetchWithRunnerDrivesTheWholePath`, plus the production smoke test
+      below, which is the stronger evidence of the two.
+
+Two behaviours beyond the acceptance criteria are also pinned, because both are
+load-bearing and neither had a test: a failure on either axis is returned rather
+than softened into an empty queue (`TestFetchReportsFailureRatherThanAnEmptyQueue`),
+and an empty `--repo` still resolves to the current repository
+(`TestFetchTargetsTheCurrentRepoByDefault`) — the default the session-start probe
+depends on, since it passes `""` and runs wherever the shell happens to be.
+
+## Test status
+
+```
+cd cli
+go build ./...            → clean
+go vet ./...              → clean
+GOOS=windows go vet ./... → clean
+go test ./... -count=1    → all packages ok, no failures
+golangci-lint run         → 0 issues   (v2.12.2, the versions.conf pin)
+gofmt -l internal/prtriage/ → clean
+```
+
+Three files elsewhere in `cli/` are unformatted on `main`
+(`internal/errors/latch_test.go`, `internal/fsmode/fsmode.go`,
+`internal/orca/orca.go`). They are pre-existing and were deliberately left alone
+rather than swept into this diff.
+
+**Production smoke test — the strongest evidence here.** The binary was built and
+run against the real repository, and its output compared against what the GraphQL
+implementation printed for the same repository earlier the same session:
+
+```
+$ dotf pr triage-queue
+1 pull request(s) awaiting a disposition:
+
+  #1455  feat(harness): fire the persona suggester on every prompt, failing open by construction
+         github-actions reviewed, never triaged, 2026-09-02 20:27
+         https://github.com/mlorentedev/dotfiles/pull/1455
+...
+exit=1
+```
+
+Byte-identical to the GraphQL output: same pull request, same reviewer, same
+reason, same timestamp, same URL, same exit status. AC6 is therefore verified
+against live data and not only against a fixture.
+
+**Latency, measured rather than assumed** (R1 was the risk that mattered): three
+consecutive runs against the live repository took **0.94 s / 0.96 s / 0.95 s** for
+1 + 2 REST calls, against the 5 s session-start budget in `cmd/mem.go`. Cost is
+dominated by `gh` process spawn (~0.3 s each), which is why the fan-out overlaps
+them; with the cap at 8, ten open pull requests cost two waves rather than ten
+round-trips.
+
+**No regressions.** One existing test was removed and one edited, both with cause:
+
+- `TestParseWireBoundaryLimit` tested the truncation guard through `parseWire`, a
+  helper that unpacked the GraphQL nesting. Both the helper and that transport are
+  gone. Its replacement, `TestFetchRefusesTruncationOnBothAxes`, is strictly
+  stronger — it drives the real fetch path and covers the second axis REST
+  introduced. A comment at the old site records where the coverage went.
+- `session_start_triage_test.go` carried a fixture error string,
+  `"gh pr list: exit status 4"`, that this change made unproducible. Updated to
+  `"gh api pulls: ..."`. Cosmetic to the renderer under test, and left stale it
+  would be lesson 259 committed again in the very PR that cites it.
+
+### Mutation testing
+
+Every new guard was mutated and each mutation was caught. A guard that survives
+its own mutation is decorative, and this spec's predecessor shipped exactly that
+defect.
+
+| Mutation | Detected by |
+|---|---|
+| drop the `[bot]` login fold | `TestFetchFoldsTheBotLoginSuffix` |
+| set `commentFanout = 1` (serialise the fan-out) | `TestFetchFansOutConcurrently` |
+| remove the comment page guard | `TestFetchRefusesTruncationOnBothAxes` |
+| remove the pull-request page guard | `TestFetchRefusesTruncationOnBothAxes` |
+| map `url` instead of `html_url` | `TestFetchWithRunnerDrivesTheWholePath` |
+| swallow a per-PR comment error | `TestFetchReportsFailureRatherThanAnEmptyQueue` |
+| reintroduce `gh pr list` | `TestFetchUsesRESTOnly` |
+| keep the GraphQL `createdAt` spelling | `TestFetchWithRunnerDrivesTheWholePath` |
+
+**The `features.json` commands were themselves checked for vacuity**, because the
+previous spec shipped a verification command naming a test that did not exist and
+it passed anyway:
+
+```
+$ go test ./internal/prtriage/ -run '^TestThisDoesNotExist$'                       → exit 0   ← the trap
+$ go test ... -v -run '^TestThisDoesNotExist$' | grep -q '^--- PASS: TestThis…'    → exit 1   ← the form used
+```
+
+Every entry in `features.json` uses the second form, so a renamed or deleted test
+fails its own verification instead of silently passing it.
+
+## Decisions made during implementation
+
+**The ticket's proposed fix could not work, and establishing that was the first
+task.** It called for a one-line swap to `GET /repos/{o}/{r}/pulls` with a field
+mapping that never mentioned comments — but the comments *are* the algorithm
+(`prtriage.go:95-141` compares reviewer timestamps against the triage marker), and
+that endpoint returns none. The honest shape is 1 + N. The ticket body was
+corrected in place before any code was written; this is the third ticket in four
+whose premise did not survive measurement.
+
+**The seam is the deliverable; the transport is the implementation.** Framing it
+the other way round would have justified the work on an outage observed exactly
+once, and left the actual defect — the only path in the package with no test was
+the only path observed failing — untouched regardless of transport.
+
+**`normaliseLogin` was promoted from defensive to load-bearing, so it got a test.**
+The registry declares `github-actions`; REST returns `github-actions[bot]`. Under
+GraphQL the fold was insurance. Under REST every match depends on it, and removing
+it does not error — it silently empties the queue, which is precisely the failure
+this package exists to prevent (#1033).
+
+**No new dependency.** `golang.org/x/sync` is not in `go.mod`, and adding one is
+its own Discipline Gate trigger. The bounded fan-out is a semaphore channel and a
+`WaitGroup`, about fifteen lines.
+
+**Concurrency is asserted by observed peak, not by wall-clock.** A timing
+assertion would be flaky on a loaded runner and would eventually be deleted or
+loosened into meaninglessness. Peak in-flight is deterministic and checks both
+directions — serial fails, and so does unbounded.
+
+**One unreadable pull request fails the whole answer.** A PR whose comments could
+not be fetched is not a PR with no comments, and returning the rest as a complete
+queue would reintroduce "cannot compute reads as nothing pending" through the back
+door.
+
+**Deliberately not done: the distinct exit statuses.** `pr.go:49-51` documents the
+shared status as a reasoned choice. Refuting that argument is its own ticket, and
+folding it in silently would have been a public-contract change smuggled inside a
+transport fix.
+
+## Promotion candidates
+
+- [x] Lesson for the repo's `docs/lessons/`? **Yes** — a seam is not a testing
+      detail: the path with no seam is the path with no test, and it will be the
+      path that fails in production. Worth writing because the transport looked
+      like the bug and was the smaller half.
+- [ ] ADR-worthy decision? **No.** ADR-020 already governs the CLI convergence;
+      this changes one package's transport inside it and establishes nothing new.
+- [ ] New pattern candidate for `00_meta/patterns/`? **No** — not yet observed in
+      a second project. Revisit if the same "vendor CLI called directly, therefore
+      untestable" shape turns up elsewhere.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/CLI-071-triage-queue-transport/` -> `specs/archive/CLI-071-triage-queue-transport/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Independent adversarial review recorded in `review.md` with a passing verdict
+- [ ] Promotions above executed (if any)

--- a/specs/CLI-071-triage-queue-transport/verification.md
+++ b/specs/CLI-071-triage-queue-transport/verification.md
@@ -44,9 +44,13 @@ go build ./...            → clean
 go vet ./...              → clean
 GOOS=windows go vet ./... → clean
 go test ./... -count=1    → all packages ok, no failures
+go test -race -count=3 ./internal/prtriage/  → clean
 golangci-lint run         → 0 issues   (v2.12.2, the versions.conf pin)
 gofmt -l internal/prtriage/ → clean
 ```
+
+The race detector is run explicitly because this change introduces the package's
+only concurrency and `golangci-lint` does not cover it. Three iterations, clean.
 
 Three files elsewhere in `cli/` are unformatted on `main`
 (`internal/errors/latch_test.go`, `internal/fsmode/fsmode.go`,
@@ -159,6 +163,20 @@ door.
 shared status as a reasoned choice. Refuting that argument is its own ticket, and
 folding it in silently would have been a public-contract change smuggled inside a
 transport fix.
+
+**Two other `gh pr list` sites were found and deliberately left alone.** The
+lesson-259 prose sweep surfaced them, so they are recorded here rather than left
+as an unstated skip: `scripts/bitacora-rollout.sh:132,196` and
+`harness/skills/catchup/SKILL.md:72`. Both carry the same GraphQL dependency this
+change removed from `prtriage`. Neither was migrated and neither was ticketed:
+they bind no doctrine, neither has been observed failing, and a vendor condition
+is not a defect in them. If GraphQL refusals recur, this note is where to start.
+
+**Also noticed, also out of scope:** `gh api pulls: exit status 1` still hides
+gh's own stderr reason (`HTTP 403`, `Not Found`). That opacity is pre-existing —
+the old message had the same shape — and unwrapping `*exec.ExitError` to surface
+`Stderr` is three lines that belong to whoever decides the error contract, not to
+a transport change.
 
 ## Promotion candidates
 


### PR DESCRIPTION
Spec: `specs/CLI-071-triage-queue-transport/`

## What this is

`dotf pr triage-queue` failed on 2026-09-02 with `gh pr list: exit status 1`
while GitHub's GraphQL bucket refused every list and write and REST served the
same data throughout. #1454 was filed against the transport. Measuring before
writing found the transport was the smaller half, and the ticket wrong in two
places — [its body has been corrected in place](https://github.com/mlorentedev/dotfiles/issues/1454).

**The actual defect: `FetchWithRegistry` called `exec.CommandContext` directly.**
No injection point, therefore no test — the package's four tests all covered pure
functions. The one path observed failing in production was the only path in the
package that nothing exercised, and that was true whichever API it spoke. The
seam is the deliverable here; the REST migration is its implementation.

**The ticket's proposed fix could not work as written.** It called for a one-line
swap to `GET /repos/{o}/{r}/pulls` with a field mapping naming `number`, `title`,
`head.ref`, `draft` — and never mentioning comments. But the comments *are* the
algorithm (`prtriage.go:95-141` compares reviewer timestamps against the triage
marker), and that endpoint returns none. `gh pr list --json comments` was a single
GraphQL query returning pull requests with comments **nested**; REST has no such
nesting, so the join moves into the package as a bounded fan-out.

**"Unavailable" was overstated.** Both consumers already fail loud — the command
exits non-zero with the reason, and the session brief injects `[pr-triage] queue
could not be computed: …` followed by *"This is not an empty queue"*. What was
missing was a workaround once the signal fired, not the signal.

## Three consequences, each now pinned by a test

- **`normaliseLogin` went from defensive to load-bearing.** The registry declares
  `github-actions`; REST returns `github-actions[bot]`. Removing the `[bot]` fold
  does not error — it silently empties the queue, the exact failure this package
  exists to prevent (#1033).
- **REST paginates on two axes where GraphQL paginated on none.** A truncated
  pull-request list makes a PR go *missing*, which is visible; truncated comments
  make the verdict *wrong* — an untriaged PR can read as triaged. Both refuse.
- **1+N had to meet the five-second session-start budget** (`cmd/mem.go`), which
  runs on every session start. Fan-out capped at 8; the concurrency test asserts
  *observed peak* rather than wall-clock, so it stays deterministic on a loaded
  runner instead of being loosened until it means nothing.

## Verification

```
go build ./...            → clean          golangci-lint run   → 0 issues (v2.12.2, the pin)
go vet ./...              → clean          gofmt -l internal/prtriage/ → clean
GOOS=windows go vet ./... → clean          go test ./... -count=1 → all ok
```

**Production smoke test**, the strongest evidence here — the binary run against
this repository, compared against what the GraphQL implementation printed for the
same repository earlier the same session:

```
1 pull request(s) awaiting a disposition:

  #1455  feat(harness): fire the persona suggester on every prompt, failing open by construction
         github-actions reviewed, never triaged, 2026-09-02 20:27
         https://github.com/mlorentedev/dotfiles/pull/1455
exit=1
```

Byte-identical: same PR, same reviewer, same reason, same timestamp, same URL,
same exit status. **Latency measured, not assumed:** 0.94 / 0.96 / 0.95 s across
three runs against the 5 s budget.

**Mutation testing — all eight caught:** dropping the `[bot]` fold; serialising
the fan-out; removing either page guard; mapping `url` instead of `html_url`;
swallowing a per-PR comment error; reintroducing `gh pr list`; keeping the
GraphQL `createdAt` spelling.

**The `features.json` commands were themselves checked for vacuity**, since the
previous spec shipped one naming a test that did not exist and it passed anyway:
`go test -run '^TestThisDoesNotExist$'` exits **0**, while the form used here
(`-v` piped through a `--- PASS:` grep) exits **1**.

## Removed or edited existing tests, with cause

- `TestParseWireBoundaryLimit` tested the truncation guard through `parseWire`,
  the helper that unpacked the GraphQL nesting. Both are gone. Its replacement
  drives the real fetch path and covers the second axis. A comment at the old
  site records where the coverage went.
- `session_start_triage_test.go` carried the fixture string
  `"gh pr list: exit status 4"`, which this change made unproducible — lesson 259
  would have been committed again in the PR that cites it.

## Out of scope, deliberately

Distinct exit statuses for "pending" vs "could not answer". `pr.go:49-51`
documents the shared status as a *reasoned* choice, not an oversight; refuting
that argument is its own ticket, and folding it in here would smuggle a
public-contract change inside a transport fix.

**Two other `gh pr list` sites were found and left alone**, recorded so the skip
is stated rather than silent: `scripts/bitacora-rollout.sh:132,196` and
`harness/skills/catchup/SKILL.md:72`. Same GraphQL dependency; neither binds a
doctrine, neither has been observed failing, and a vendor condition is not a
defect in them. Not ticketed.

Also pre-existing and untouched: `gh api pulls: exit status 1` still hides gh's
own stderr reason. Unwrapping `*exec.ExitError` belongs to whoever owns the error
contract, not to a transport change.

`go test -race -count=3 ./internal/prtriage/` → clean, run explicitly because
this adds the package's only concurrency and golangci-lint does not cover it.

Lesson: `docs/lessons/lesson-260-the-path-with-no-seam-is-the-path-with-no-test.md`

Refs #1454
