### PR TITLE
fix(harness): scan ids over REST and yield on ownership, not on issue number

### DIFF
--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -278,6 +278,8 @@ tags: [lessons, index, dotfiles]
 | [258 - An argument passed through two independent quoting conventions is only as safe as the weaker one](lesson-258-an-argument-passed-through-two-independent-quoting-layers.md) | 2026-09-02 |  |
 | [259 - A justification outlives its mechanism as easily as a name outlives its contract, and the cleanup that taught us the first lesson left an instance of it](lesson-259-a-justification-outlives-its-mechanism.md) | 2026-09-02 |  |
 | [260 - The path with no seam is the path with no test, and it is the one that fails in production](lesson-260-the-path-with-no-seam-is-the-path-with-no-test.md) | 2026-09-02 |  |
-| [261 - A merged PR and a stuck PR are indistinguishable from the branch side](lesson-261-a-merged-pr-and-a-stuck-pr-look-identical-from-the-branch.md) | 2026-09-02 |  |
+| [261 - Never test secret guards against live credentials, and redact at the stream boundary](lesson-261-never-test-secret-guards-against-live-credentials-and-redact-at-the-stream-boundary.md) | 2026-09-02 |  |
+| [262 - A merged PR and a stuck PR are indistinguishable from the branch side](lesson-262-a-merged-pr-and-a-stuck-pr-look-identical-from-the-branch.md) | 2026-09-02 |  |
+| [263 - A population that cannot prove it is complete answers with a plausible number](lesson-263-a-population-that-cannot-prove-it-is-complete.md) | 2026-09-02 |  |
 
 - [2026-08-30 Intercepting Cobra Errors without Breaking SilenceErrors](2026-08-30-cobra-silence-errors-interception.md)

--- a/docs/lessons/lesson-262-a-merged-pr-and-a-stuck-pr-look-identical-from-the-branch.md
+++ b/docs/lessons/lesson-262-a-merged-pr-and-a-stuck-pr-look-identical-from-the-branch.md
@@ -1,5 +1,5 @@
 ---
-id: lesson-261
+id: lesson-262
 type: lesson
 status: active
 created: "2026-09-02"

--- a/docs/lessons/lesson-263-a-population-that-cannot-prove-it-is-complete.md
+++ b/docs/lessons/lesson-263-a-population-that-cannot-prove-it-is-complete.md
@@ -68,6 +68,29 @@ support it — produced by the tooling written to serve that ticket, roughly an 
 argued that a defect class surviving its own authors' knowledge cannot be fixed by writing it down
 again.
 
+## The class: three shapes of it were measured on one day
+
+This is not a `gh` quirk. A parallel session hit the same defect twice the same afternoon, in
+unrelated tooling, and the three together name the class better than any one of them:
+
+| Shape | The command | What it returned | The truth |
+|---|---|---|---|
+| **A pipeline** | `bats tests/*.bats \| tail -15` | `exit code 0` | `tail`'s status, not bats'. The run was `BATS_EXIT=1` |
+| **A filter** | `go test -run '<pattern matching nothing>'` | `ok`, exit 0 | Zero tests ran. A `features.json` command naming a deleted test passes forever |
+| **A regex** | `--paginate` output split with `re.findall` | `CLI` max `= 71` | `= 72`. Pages were dropped mid-body |
+
+**In every case the failure was success.** Not a crash, not an empty result that reads as
+suspicious — a well-formed, plausible answer. Nothing downstream could tell them from a real one,
+which is why all three survived until something outside the tool contradicted them.
+
+The general rule: **when a command can return a value without doing the work, the value is not
+evidence.** Ask what this invocation would print if it silently did nothing, and if the answer is
+"the same thing", the check does not exist yet. Concretely — put the assertion on the producer's
+exit status rather than a pipeline's (`set -o pipefail`, or capture `${PIPESTATUS[0]}`), make a
+zero-match filter an error rather than a pass, and make a measurement state its population.
+
+Instances 1 and 2 are recorded with their evidence in `specs/CLI-072-dotf-hooks-install/verification.md`.
+
 ## A second finding from the same pass
 
 Renumbering a collision needs an **owner**, and `harness/skills/new-ticket/SKILL.md` said the

--- a/docs/lessons/lesson-263-a-population-that-cannot-prove-it-is-complete.md
+++ b/docs/lessons/lesson-263-a-population-that-cannot-prove-it-is-complete.md
@@ -1,0 +1,89 @@
+---
+id: lesson-263
+type: lesson
+status: active
+created: "2026-09-02"
+owner: manu
+tags: [lesson, github, gh-cli, measurement, guards]
+---
+
+# A population that cannot prove it is complete answers with a plausible number
+
+## What happened
+
+While classifying duplicated `AREA-NNN` ids for GUARD-009 (#1448), I wrote a throwaway allocator
+to compute the next free number per area. It proposed:
+
+- **`CLI-072`** — already held by #1460, filed hours earlier by a parallel session.
+- **`TEST-002`**, from a computed maximum of `TEST-001`. The real maximum was `TEST-008`.
+
+The tool written to stop duplicate ids was about to allocate a duplicate id.
+
+## Cause
+
+`gh api --paginate` does not return one JSON array. It **concatenates** one array per page:
+`[...][...][...]`. I split them with a regex:
+
+```python
+re.findall(r'\[.*?\]\s*(?=\[|$)', raw, re.S)     # WRONG
+```
+
+Non-greedy `.*?` stops at the first `]` it finds — and issue bodies in this repo are full of them,
+in markdown links and tables. So the split landed mid-page, `json.loads` raised on the fragments,
+and the `except Exception: pass` beside it swallowed each failure. Some pages survived, most did
+not, and the result was a well-formed dict of maxima computed over a fraction of the corpus.
+
+Nothing errored. The number just came back low, and `CLI` max `71` is exactly as plausible as `72`.
+
+## The rule
+
+**A measurement that cannot demonstrate its own completeness must fail loudly, not return a
+number.** State the population, and prefer a form that cannot silently lose part of it:
+
+```bash
+# One line per issue. Pagination is gh's problem, not a regex's.
+gh api --paginate 'repos/<owner>/<repo>/issues?state=all&per_page=100' \
+  --jq '.[] | select(.pull_request==null) | [.number,.state,.title] | @tsv'
+```
+
+`--jq` is applied per page by `gh` itself, so the output is line-oriented and concatenation is
+harmless. Count the lines and say the count out loud; a population you can print is one a reviewer
+can check.
+
+Two corollaries this incident earned:
+
+- **Never pair a parser with a bare `except: pass`.** The handler is what converted a crash into a
+  wrong answer. If a chunk cannot be parsed, that is the finding.
+- **Print the plan before executing it.** The allocator's output was eleven rows of
+  `issue → new id`. Reading them is what caught `CLI-072`; no assertion in the script would have,
+  because the script had no idea what the true maximum was. For any batch of writes, render the
+  intent first and look at it.
+
+## Why it belongs with lesson 256 and #1448
+
+Lesson 256 says *probe the target, do not read the block's own comment*. This is the same rule
+pointed at a dataset: **I read the tool's summary of the corpus instead of the corpus.** And it is
+an instance of the very class #1448 exists to detect — a claim (`max = 71`) whose referent did not
+support it — produced by the tooling written to serve that ticket, roughly an hour after the ticket
+argued that a defect class surviving its own authors' knowledge cannot be fixed by writing it down
+again.
+
+## A second finding from the same pass
+
+Renumbering a collision needs an **owner**, and `harness/skills/new-ticket/SKILL.md` said the
+higher issue number yields. That is wrong whenever a spec folder exists, because the folder
+declares its owner in frontmatter:
+
+```
+specs/CLI-065-env-persist-sweep/proposal.md    issue: mlorentedev/dotfiles#1363
+```
+
+Here #1363 is the *higher* number and the rightful owner; renumbering it by the old rule would have
+orphaned an active spec — manufacturing the stale-referent defect the pass was cleaning up. The
+same reversal appeared in `docs/lessons/` minutes later: two files claimed `lesson-261`, and the
+later one was cited from `AGENTS.md`, `adr-028` and an open spec's acceptance criteria, while the
+earlier one was cited by nothing. **The earlier one yielded**, because inbound references, not
+timestamps, are what a rename actually breaks.
+
+The rule is now: *ownership evidence first (spec frontmatter, inbound references), ordering only as
+a tie-break.* Applied in `new-ticket/SKILL.md` in the same change as this lesson.

--- a/harness/skills/new-ticket/SKILL.md
+++ b/harness/skills/new-ticket/SKILL.md
@@ -198,15 +198,22 @@ The mapping is a suggestion like Type — the human can override in step 3. Labe
 
 ```bash
 REPO=mlorentedev/dotfiles; AREA=HARNESS
-gh issue list --repo "$REPO" --state all --limit 800 --json title | python3 -c "
-import json,sys,re
+# REST + --paginate, one line per issue. NOT `gh issue list`: that is GraphQL and
+# fails under a secondary rate limit — which is exactly when parallel sessions are
+# filing tickets and the scan matters most.
+gh api --paginate "repos/$REPO/issues?state=all&per_page=100" \
+  --jq '.[] | select(.pull_request==null) | .title' | tee /tmp/nnn-scan.txt | python3 -c "
+import sys,re
 A='$AREA'
-ns=[int(m.group(1)) for r in json.load(sys.stdin)
-    for m in [re.match(rf'{A}-0*(\d+)', r['title'], re.I)] if m]
+ns=[int(m.group(1)) for line in sys.stdin
+    for m in [re.match(rf'{A}-0*(\d+)\b', line, re.I)] if m]
 print('%03d' % (max(ns)+1 if ns else 1))"
+wc -l < /tmp/nnn-scan.txt   # say the population out loud; a short scan is a wrong answer
 ```
 
 NNN is **zero-padded to 3 digits** to match the convention (`HARNESS-016`, `OPS-002`). Scans both open and closed issues (forward-only, per §3 — never reuse a retired number). If the AREA also has `specs/<AREA>-NNN-*` directories that outrun the issues, cross-check and take the higher.
+
+> **Never hand-split `--paginate` output.** It concatenates one JSON array per page (`[...][...]`), and splitting them with a regex breaks on the first `]` inside an issue body — dropping pages **silently** and returning a plausible-but-low maximum. On 2026-09-02 that produced a proposal of `CLI-072`, an id another session already held, from a scan that put `TEST` at `001` when the real maximum was `008`. Let `--jq` do the paging (it is applied per page by `gh`) and keep the output line-oriented. See `docs/lessons/lesson-263-*`.
 
 ### Concurrency guard — parallel sessions race scan-then-create (2026-07-07)
 
@@ -214,7 +221,18 @@ NNN is **zero-padded to 3 digits** to match the convention (`HARNESS-016`, `OPS-
 
 1. **Re-scan immediately before `gh issue create`** — at create time, not minutes earlier when the proposal was computed.
 2. **Scan the board's `ID` field too, not only the home repo's issue titles** — a concurrent session may have claimed `AREA-NNN` from another repo or before its issue lands in your scan window. If GraphQL is rate-limited, fall back to REST title scans (`gh api repos/<owner>/<repo>/issues`) across the bitácora repos.
-3. **Verify right after creating** — re-run the scan; if a duplicate raced in, renumber immediately. Yield rule: the ticket WITHOUT its board `ID` field set renumbers; if neither is set, the higher issue `#number` yields.
+3. **Verify right after creating** — re-run the scan; if a duplicate raced in, renumber immediately.
+
+**Yield rule — ownership evidence first, ordering only as a tie-break.** Apply in order, and stop at the first that decides:
+
+1. **A spec folder decides it.** `specs/<AREA>-NNN-*/proposal.md` names its owner in frontmatter (`issue: mlorentedev/dotfiles#1363`). That issue keeps the id; the other yields, *whatever the numbers are*. Renumbering past an active spec orphans it — manufacturing the stale-referent defect of #1448.
+2. **Otherwise, inbound references decide it.** The claimant cited from `AGENTS.md`, an ADR, a runbook or another spec's acceptance criteria keeps the id, because those citations are what a rename actually breaks.
+3. **Otherwise, the board `ID` field decides it** — the ticket without it renumbers.
+4. **Otherwise the higher issue `#number` yields.**
+
+Ordering was the whole rule until 2026-09-02, and it was wrong in 3 of 11 collisions resolved that day: `CLI-065`, `HARNESS-067` and `REFACTOR-011` were all owned by the *higher* number because a spec said so. The same reversal decided a `lesson-261` collision the same hour — the later file was cited from `AGENTS.md`, `adr-028` and an open spec, so the earlier one yielded.
+
+**Renumbering is a title-only edit.** Never touch the body, the scope or the board item, and leave a comment on the issue saying what the id was, what it became, and which rule above decided it.
 
 ## Common mistakes
 


### PR DESCRIPTION
## What

Fixes the two rules that governed `AREA-NNN` allocation, both of which were measured wrong today
while running #1448's AC5 classification, and records the failure that exposed them.

Documentation and skill prose only — no Go, no shell, no behaviour change.

## Why

**The scan was GraphQL.** `new-ticket/SKILL.md` computed the next free id with `gh issue list`,
which fails under a GitHub secondary rate limit. That is exactly the condition under which parallel
sessions are filing tickets, so the scan was unavailable precisely when it was load-bearing. Now
`gh api --paginate --jq`, one line per issue, PRs excluded, population printed.

**A throwaway allocator I wrote for the same pass proposed an id another session already held.**
`CLI-072` is #1460. The scan behind it put `TEST` at maximum `001` when the real maximum is `008`.
Cause: `--paginate` concatenates one JSON array per page and I split them with
`re.findall(r'\[.*?\]')`, which breaks on the first `]` inside an issue body — dropping pages
silently and returning a plausible number. Caught only because the plan was printed before it ran.
That is `docs/lessons/lesson-263`.

**The yield rule was wrong in 3 of 11 collisions.** It said the higher issue number renumbers.
`CLI-065`, `HARNESS-067` and `REFACTOR-011` are each owned by the *higher* number, because a spec
folder's frontmatter says so (`issue: mlorentedev/dotfiles#1363`). Applying the old rule would have
orphaned three active spec folders — manufacturing the stale-referent defect #1448 exists to catch.
The rule is now ownership-first: spec frontmatter, then inbound references, then the board `ID`
field, and ordering only as a tie-break.

## The lesson-261 collision, resolved by the new rule applied to itself

Two files claimed `lesson-261`: the merged-PR one (landed 22:15) and the secret-guards one
(22:25). Ordering says the later yields. **Ownership says the opposite and wins**: the later file
is cited from `AGENTS.md:65`, `docs/adr/adr-028:338` and `specs/SEC-001-secrets-run-guard/tasks.md`
AC8, while the earlier is cited by nothing but its own index row. So `261` stays where the
references point and the merged-PR lesson becomes `262`. `_index.md` also gains the row the
collision had swallowed — the secret-guards lesson was never indexed.

## Verification

```
pre-commit   Detect hardcoded secrets / Run dotfiles tests / bats @test names /
             Check referenced doc paths in instruction files / Validate message format   all Passed
```

The doc-path check is the one that matters here: it is what proves the renamed lesson and the new
`lesson-263-*` reference resolve, and that `AGENTS.md` and `adr-028` still point at a file that
exists.

## Not in scope

The detector itself (#1448 AC1-AC4) is deliberately not started — 174 issues opened against 103
closed in the last 14 days, so the meta-work cap applies and classification was the cheaper honest
half. The classification result, the fixtures it produced and the two findings above are recorded
on #1448.

Deploy note: `harness/skills/**` reaches `~/.claude/skills/` through `scripts/compile-harness.sh`,
so the change is inert for running agents until the next deploy.

Refs #1448
