### PR TITLE
docs(lessons): record the correct-measurement-wrong-question shape, and land an orphaned regen

### DIFF
--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -282,5 +282,6 @@ tags: [lessons, index, dotfiles]
 | [262 - A merged PR and a stuck PR are indistinguishable from the branch side](lesson-262-a-merged-pr-and-a-stuck-pr-look-identical-from-the-branch.md) | 2026-09-02 |  |
 | [263 - A population that cannot prove it is complete answers with a plausible number](lesson-263-a-population-that-cannot-prove-it-is-complete.md) | 2026-09-02 |  |
 | [265 - A correct measurement answering the wrong question, three times in one session](lesson-265-a-correct-measurement-answering-the-wrong-question.md) | 2026-09-03 |  |
+| [266 - Two measurements agreeing is not reproducibility](lesson-266-two-measurements-agreeing-is-not-reproducibility.md) | 2026-09-04 |  |
 
 - [2026-08-30 Intercepting Cobra Errors without Breaking SilenceErrors](2026-08-30-cobra-silence-errors-interception.md)

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -281,5 +281,6 @@ tags: [lessons, index, dotfiles]
 | [261 - Never test secret guards against live credentials, and redact at the stream boundary](lesson-261-never-test-secret-guards-against-live-credentials-and-redact-at-the-stream-boundary.md) | 2026-09-02 |  |
 | [262 - A merged PR and a stuck PR are indistinguishable from the branch side](lesson-262-a-merged-pr-and-a-stuck-pr-look-identical-from-the-branch.md) | 2026-09-02 |  |
 | [263 - A population that cannot prove it is complete answers with a plausible number](lesson-263-a-population-that-cannot-prove-it-is-complete.md) | 2026-09-02 |  |
+| [265 - A correct measurement answering the wrong question, three times in one session](lesson-265-a-correct-measurement-answering-the-wrong-question.md) | 2026-09-03 |  |
 
 - [2026-08-30 Intercepting Cobra Errors without Breaking SilenceErrors](2026-08-30-cobra-silence-errors-interception.md)

--- a/docs/lessons/lesson-265-a-correct-measurement-answering-the-wrong-question.md
+++ b/docs/lessons/lesson-265-a-correct-measurement-answering-the-wrong-question.md
@@ -1,0 +1,113 @@
+# 265 - A correct measurement answering the wrong question, three times in one session
+
+**Date:** 2026-09-03
+**Area:** verification, CI, cross-session coordination
+
+## What happened
+
+Three separate near-misses in a single session on CLI-072's archive. Every
+measurement taken was accurate. Every conclusion drawn from it was wrong,
+because the question being answered was not the question that mattered. None of
+the three announced itself as an error — each produced a plausible, well-formed
+result that nothing downstream could distinguish from a correct one.
+
+They are recorded together because they are one failure, not three.
+
+### 1. The exit status of the wrong process
+
+Verifying the Go suite before committing:
+
+```bash
+go test ./... 2>&1 | grep -v "^ok\|no test files" | tail -10; echo "GO_SUITE_EXIT=$?"
+```
+
+`GO_SUITE_EXIT=0` — and it reports **`tail`'s** status, not `go test`'s. `tail`
+succeeds whether the suite passed or every package failed.
+
+This is the exact defect `.claude/CLAUDE.md` had gained a prohibited-patterns row
+for **that same morning** (#1465, the `${PIPESTATUS[0]}` entry: *"a verification
+that reads a pipeline's exit status is exactly where this bites: `cmd | tail`
+reports `tail`'s status, so a failing `cmd` passes"*). Reading the rule did not
+prevent writing the bug. The honest form redirects to a file and reads `$?`
+directly:
+
+```bash
+go test ./... > /tmp/gotest.log 2>&1; echo "GO_TEST_EXIT=$?"
+```
+
+### 2. The green check that was a different job
+
+`test-windows` was cancelled at its 30-minute ceiling. A peer session offered a
+control: *"my `test (windows-latest)` went green at about the same time on a
+larger Go diff, so the runner is not slow tonight — it looks specific to your
+run."* That was relayed onward as evidence before anyone checked it.
+
+`test (windows-latest)` is the **Go test matrix** leg and runs in ~1m25s.
+`test-windows` is a **different job** that runs `setup-windows.ps1` end-to-end
+and normally takes 9-10m. The green one controlled for nothing. The peer's own
+`test-windows`, on a different branch and a different diff, was cancelled at the
+same ceiling — which is the opposite conclusion.
+
+Two names differing by punctuation, in the same check list, for jobs with
+nothing in common.
+
+### 3. The rogue writer that was the owner
+
+`ai/pi/models.json` — a tracked file — appeared modified in a worktree nobody
+claimed. Two agents investigated it properly and refuted each other's mechanisms
+with real evidence: the deploy target is a regular file, not a symlink, so
+nothing writes through from `~/.pi/agent/`; `git show HEAD:` matched the deployed
+copy exactly; the writer was narrowed to a single worktree's cwd; a timing
+argument clearing `pi` was itself corrected, because the file kept growing after
+the window that argument covered.
+
+Every measurement was right. The file was being edited, by hand, by the one
+human on the machine, who was still typing while it was being measured — and who
+had already told the other session so.
+
+## The shape
+
+All three, and the three of the same family recorded in lesson 260's session:
+**the verification succeeds.** That is the genus. A crash, a timeout, a
+suspicious empty result — those announce themselves. These return a plausible
+value that is correct as an answer to a question nobody asked:
+
+| Measured | Believed to mean | Actually meant |
+|---|---|---|
+| `tail` exited 0 | the suite passed | `tail` ran |
+| `test (windows-latest)` green | Windows CI is healthy | one 1m25s Go job passed |
+| a tracked file changed unbidden | a tool is writing it | a person is writing it |
+
+## What to do differently
+
+**Name the question before trusting the number.** In all three cases the gap
+between "what I measured" and "what I need to know" was one sentence long and
+was never written down. Writing it is the whole defence.
+
+**When a result is surprising, check the cheapest explanation first, and check
+it before building a mechanism.** "A tracked file changed and I did not change
+it" has a far more likely cause on a single-user machine than a rogue tool. Two
+agents spent half an hour on hypotheses because neither tested the framing, only
+the mechanisms inside it.
+
+**A peer's measurement is evidence, not a conclusion — verify the premise, not
+the description.** The wrong-job control was accepted and relayed onward because
+it was plausible and offered in good faith. Checking it cost one `gh pr checks`
+call. Throughout the rest of the session the opposite habit — reading
+`.pre-commit-config.yaml` rather than accepting a description of it, reading
+`setup-windows.ps1:1305` rather than accepting an analysis of it — corrected a
+peer's claim once and one of our own proposals once.
+
+**Never read a pipeline's exit status.** Redirect and read `$?`. The rule was in
+the repo's own instructions and was still violated within hours; a rule that is
+read is not a rule that is followed, which is why the prohibited-patterns table
+exists and why this belongs beside it.
+
+## See also
+
+- Lesson 260 — the same genus at a different altitude: `go test -run '<no-match>'`
+  exits 0, so a command naming a deleted test passes forever.
+- `.claude/CLAUDE.md`, prohibited patterns — the four silent rows.
+- #1472 — the CI defect these near-misses surrounded: a required check that is
+  `skipped` on `main` accumulates no evidence about itself in the one place
+  people look.

--- a/docs/lessons/lesson-266-two-measurements-agreeing-is-not-reproducibility.md
+++ b/docs/lessons/lesson-266-two-measurements-agreeing-is-not-reproducibility.md
@@ -1,0 +1,128 @@
+# Lesson 266 — Two measurements agreeing is not reproducibility
+
+**Date:** 2026-09-04
+**Context:** CI-001 (#1472), measured on #1475 across two sessions
+
+## What happened
+
+`test-windows` was cancelling at its 30-minute ceiling. The log showed the pi
+package reconcile consuming most of the job, with one package standing out:
+
+| Sample | `@ayulab/pi-rewind` |
+|---|---|
+| 2026-09-03 | **421s** |
+| 2026-09-04, cold run | **422s** |
+
+Two independent sessions, on different runners on different nights, one second
+apart across seven minutes. Both sessions read that as reproducibility and
+started reasoning about mechanism.
+
+The evidence got better, which made it worse. `npm view @ayulab/pi-rewind@0.4.6`
+returns **0 dependencies, empty `scripts`, 148 KB, 5 files** — the smallest,
+simplest package in the manifest, taking 8x longer than the largest (7.5 MB,
+69 files, 50s). A tiny package with nothing to build, deterministically eating
+seven minutes, is a genuinely interesting fact and it demanded an explanation.
+
+Both sessions produced one, and they disagreed:
+
+- *Retry ladder.* A constant is the signature of timeouts, which are constants.
+  Therefore it is on the network path, and `prefer-offline` against a warm cache
+  removes the lookup that triggers it.
+- *Fixed cost.* A cost that reproduces to the second is fixed, and fixed costs of
+  that size are not on the download path.
+
+Both sessions recorded predictions before the data, agreed a falsification
+condition, and refined the experiment for an hour. The care was real. It was
+spent entirely inside a premise nobody had tested.
+
+Then the warm run landed:
+
+| package | cold | warm | ratio |
+|---|---:|---:|---:|
+| pi-effort | 136s | 272s | 2.0x |
+| pi-web-access | 50s | 255s | 5.1x |
+| **@ayulab/pi-rewind** | **422s** | **269s** | **0.6x** |
+| @narumitw/pi-plan-mode | 123s | **422s** | 3.4x |
+| **@narumitw/pi-goal** | **3s** | **268s** | **89.3x** |
+| pi-subagents | 60s | 167s | 2.8x |
+| pi-memory | 38s | 141s | 3.7x |
+| pi-cc-extensions | 37s | 251s | 6.8x |
+| pi-add-dir | 13s | 224s | 17.2x |
+
+Read the warm column as a set: 272, 255, 269, 422, 268, 167, 141, 251, 224.
+**There is no slow package.** pi-rewind came in at 269s, indistinguishable from
+pi-goal's 268s — and pi-goal was **three seconds** cold.
+
+The outlier did not disappear. It **moved**. The ~422s now sits on pi-plan-mode.
+Same magnitude, different package, next run.
+
+## The lesson
+
+**n=2 agreeing is not reproducibility. It is two samples that agreed.**
+
+Two points cannot distinguish "constant" from "high-variance distribution that
+happened to be sampled twice near the same value". The tighter the agreement, the
+more convincing the coincidence looks — 421 vs 422 read as *more* rigorous than
+421 vs 460 would have, when it carried no more information about the underlying
+distribution.
+
+Three failure modes stacked, and the third is the one that made it expensive:
+
+1. **Agreement was read as low variance.** Nobody asked what the spread was,
+   because two points cannot show a spread.
+2. **Corroborating evidence was mistaken for confirmation.** The `npm view` data
+   was real, precise, independently verified, and answered a question that did not
+   exist. Evidence for a phenomenon cannot be evidence that the phenomenon exists.
+   It was the most convincing part of the case and the most misleading.
+3. **Rigour was applied inside the premise instead of to it.** Predictions before
+   data, an agreed falsification condition, a named dead zone, an explicit refusal
+   to claim a mechanism without log support. Every one of those disciplines is
+   correct. All of them operated on "why is pi-rewind slow" and none on "is
+   pi-rewind slow". Careful reasoning downstream of an untested premise is more
+   dangerous than sloppy reasoning, because it produces confidence.
+
+The prior lesson (265) is the same family: a correct measurement answering the
+wrong question. This is its sharper case — a correct measurement answering a
+question about a phenomenon that was never established.
+
+## What to do instead
+
+- **State n out loud whenever a number is called reproducible.** "Reproducible
+  (n=2)" would have stopped both sessions in one line. Reproducibility is a claim
+  about a distribution; two points do not describe one.
+- **Before explaining a pattern, get a third sample.** Cheaper than an hour of
+  mechanism. In this case the third sample was a single CI rerun, available from
+  the start.
+- **Watch for the outlier moving, not just shrinking.** A per-item anomaly that
+  relocates between runs is per-invocation variance, not an item property. If the
+  identity of the extreme value is not stable, no explanation of that item can be
+  right.
+- **Treat strong corroborating evidence as a reason to re-check the premise, not
+  as permission to stop.** The moment the story got compelling was the moment to
+  ask whether the thing being explained was real.
+
+## What survived, and it was never the interesting part
+
+The measurement did answer the question it was run to answer, which is the only
+reason the night was not wasted: a confirmed 310 MB cache hit made the package
+phase **2.6x slower** (882s to 2269s), nine of ten packages regressed, and the
+job was **cancelled at 45 minutes** on a ceiling the uncached run cleared by
+seven. The npm download cache does not fix CI-001; on the only warm run ever
+measured it is the difference between a job that completes and one that dies.
+
+Note that this conclusion never needed a mechanism, and both sessions nearly
+traded it for one.
+
+## Coda: the instrument was blindfolded the whole time
+
+Both setup twins discard `pi install`'s output entirely —
+`setup-windows.ps1:1326` (`2>$null | Out-Null`) and `setup-linux.sh:893`
+(`>/dev/null 2>&1`), stdout and stderr, on the package loop specifically. So
+"does npm emit retry warnings during those seven minutes" had no answer in the
+artifact and never did. Both mechanisms were unfalsifiable against the only
+evidence available, and neither session checked that before designing an
+experiment around it.
+
+Timings survived because they come from the script's own `Write-Info` lines,
+which is the only reason the table above exists. **Before designing an experiment
+around an artifact, confirm the artifact can distinguish the outcomes.**

--- a/docs/lessons/lesson-266-two-measurements-agreeing-is-not-reproducibility.md
+++ b/docs/lessons/lesson-266-two-measurements-agreeing-is-not-reproducibility.md
@@ -101,17 +101,86 @@ question about a phenomenon that was never established.
   as permission to stop.** The moment the story got compelling was the moment to
   ask whether the thing being explained was real.
 
-## What survived, and it was never the interesting part
+## The same error again, one hour later, inside this document
 
-The measurement did answer the question it was run to answer, which is the only
-reason the night was not wasted: a confirmed 310 MB cache hit made the package
-phase **2.6x slower** (882s to 2269s), nine of ten packages regressed, and the
-job was **cancelled at 45 minutes** on a ceiling the uncached run cleared by
-seven. The npm download cache does not fix CI-001; on the only warm run ever
-measured it is the difference between a job that completes and one that dies.
+The first draft of this lesson said the cache made the package phase **2.6x
+slower** — 882s cold against 2269s warm — and called it the finding that survived.
 
-Note that this conclusion never needed a mechanism, and both sessions nearly
-traded it for one.
+It does not survive. A third run settled it, and it was already on disk when that
+sentence was written: the post-merge run on `main` was **cold** (no `npm-pi` cache
+hit in its log; the main-scoped cache was created *by* that run at 03:41:27) and
+its package phase was **2201s**.
+
+| run | package phase | cache |
+|---|---:|---|
+| PR, cold | 883s | no |
+| **main, cold** | **2201s** | **no** |
+| PR, warm | 2269s | yes |
+
+**Two cold runs differ by 2.5x.** The warm run sits beside the slower cold one,
+not beyond it. So "2.6x slower with a confirmed cache hit" was n=1 against n=1
+across a distribution whose spread had never been measured — the exact error this
+lesson is about, committed in the paragraph claiming to have escaped it.
+
+What survives is narrower and needs no mechanism: **the cache produced no
+benefit, so the download leg is not where the time is**, and CI-001 does not close
+on the change. What does *not* survive is that the cache is harmful — nor the
+mechanism proposed for it (Defender scanning a 310 MB cache directory, predicting
+a slowdown proportional to cache size), which the cold `main` run refutes by
+reproducing the slowdown with no cache at all. That hypothesis was hedged at
+length, labelled explicitly as not a claim, and still wrong; the hedging bought
+nothing that the next data point did not buy outright.
+
+## The constant was real. Both sessions attached it to the wrong noun.
+
+Per-package on `main`'s cold run:
+
+| package | time |
+|---|---:|
+| **pi-effort** | **421.4s** |
+| pi-web-access | 63.5s |
+| @ayulab/pi-rewind | 122.4s |
+| @narumitw/pi-plan-mode | 53.5s |
+| @narumitw/pi-goal | 405.7s |
+| pi-subagents | 132.2s |
+| **pi-memory** | **421.5s** |
+| **pi-cc-extensions** | **422.5s** |
+| pi-add-dir | 158.2s |
+
+Four packages at ~420s in a single run. Every observation of that band across all
+runs:
+
+| run | package | time |
+|---|---|---:|
+| 2026-09-03 | pi-rewind | 421s |
+| PR cold | pi-rewind | 422s |
+| PR warm | pi-plan-mode | 422s |
+| main cold | pi-effort | 421.4s |
+| main cold | pi-memory | 421.5s |
+| main cold | pi-cc-extensions | 422.5s |
+
+**Six observations at 421 ± 1s across four distinct packages.** That is a fixed
+timeout — seven minutes exactly — landing on whichever install happens to hit it.
+How many installs hit it per run is what moves the package phase from 883s to
+2200s, and it is why "27 of 30 minutes", "22-23 minutes" and "43 minutes" are all
+descriptions of the same job.
+
+So the constant both sessions saw was genuine. It is a property of the
+**operation**, not of any package. The retry-ladder hypothesis was directionally
+right about a timeout and wrong about what it belonged to — which is not a
+vindication. It was right for a reason its author could not have known, defended
+with `npm view` evidence that was irrelevant to it, and it would have been
+abandoned entirely if the third run had not arrived.
+
+## The compounding lesson
+
+The first correction took an hour and a third data point. The second took ten
+minutes and a fourth. Both were available from the start: a CI rerun and a
+post-merge run that had already happened.
+
+**When a conclusion is expensive to be wrong about, spend the next sample before
+publishing, not after.** Every wrong claim in this document was cheap to falsify
+and none of them were falsified before they were written down.
 
 ## Coda: the instrument was blindfolded the whole time
 

--- a/docs/lessons/lesson-266-two-measurements-agreeing-is-not-reproducibility.md
+++ b/docs/lessons/lesson-266-two-measurements-agreeing-is-not-reproducibility.md
@@ -159,11 +159,22 @@ runs:
 | main cold | pi-memory | 421.5s |
 | main cold | pi-cc-extensions | 422.5s |
 
-**Six observations at 421 ± 1s across four distinct packages.** That is a fixed
-timeout — seven minutes exactly — landing on whichever install happens to hit it.
-How many installs hit it per run is what moves the package phase from 883s to
-2200s, and it is why "27 of 30 minutes", "22-23 minutes" and "43 minutes" are all
-descriptions of the same job.
+**Six observations at 421 ± 1s across four distinct packages.** That is strong
+evidence for a **constant**, landing on whichever install happens to hit it, and
+how many hit it per run is what moves the package phase from 883s to 2200s — which
+is why "27 of 30 minutes", "22-23 minutes" and "43 minutes" are all descriptions
+of the same job.
+
+A fixed timeout is the obvious candidate for a constant that lands on arbitrary
+work, and 421s is close enough to seven minutes to be worth checking against pi's
+and npm's fetch-retry defaults. But that is a *candidate*, not a finding: no
+artifact confirms it, and this document has already been wrong twice tonight by
+naming a mechanism a data point ahead of the evidence. It stays unnamed until the
+`pi install` redirect is removed and something can read the error text.
+
+Note also pi-goal's 405.7s in the same run, which is near the band without being
+in it. It is recorded rather than explained; a sixteen-second gap is exactly the
+kind of detail a satisfying story quietly absorbs.
 
 So the constant both sessions saw was genuine. It is a property of the
 **operation**, not of any package. The retry-ladder hypothesis was directionally

--- a/harness/skills/handoff/SKILL.md
+++ b/harness/skills/handoff/SKILL.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/skills/handoff/SKILL.md
-generated_sha: 05f103c348e50bde
+generated_sha: 9adceba0eebaff80
 id: handoff-skill
 type: skill
 status: active
@@ -156,7 +156,7 @@ several sessions running at once, these are the places two of them can collide:
 | `MEMORY.md` handoff | `dotf mem handoff-write` (never an Edit) |
 | Vault `sessions/` | the thread-scoped filename from `dotf mem thread` |
 | `~/.dotfiles` deploy dir | `setup-linux.sh` / `dotf deploy` |
-| `~/.claude/settings.json` and peers | the harness deploy path, which merges by marker |
+| Agent harness settings (`settings.json`, etc.) | the harness deploy path, which merges by marker |
 | The git stash | never bare `git stash` — see the standing order |
 
 Everything else a session touches lives inside its own worktree or its own


### PR DESCRIPTION
Docs-only. Touches no `cli/` and no shell, so it should not trip #1472's `test-windows` wall — the path filter reduced #1465's run of that job to 12s.

**Lesson 265** records three near-misses from one session as a single failure. The genus: *the verification succeeds*, and returns a plausible value that answers a question nobody asked.

| Measured | Believed to mean | Actually meant |
|---|---|---|
| `tail` exited 0 | the suite passed | `tail` ran |
| `test (windows-latest)` green | Windows CI is healthy | one 1m25s Go job passed |
| a tracked file changed unbidden | a tool is writing it | a person is writing it |

The first happened hours after #1465 added that exact row to the prohibited-patterns table, which is the point: a rule that is read is not a rule that is followed. The third cost two agents half an hour of correct measurements and mutually refuted mechanisms, because neither tested the framing — only the mechanisms inside it.

Cross-links lesson 260 as the same genus at a different altitude.

**Also lands an orphan.** `harness/skills/handoff/SKILL.md` was sitting modified in the main checkout with its vault source (`00_meta/skills/handoff/SKILL.md`) already committed and no PR to carry the regeneration. Content is the deploy-path wording going agent-agnostic; `generated_sha` moves with it.

**Possible trivial conflict:** `docs/lessons/_index.md` gains one row here and one in #1471 (lesson 264). Whichever merges second resolves one line.