### PR TITLE
ci: take the pi package reconcile off the PR path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,19 +66,27 @@ jobs:
               - '**/*.psm1'
               - '.PSScriptAnalyzerSettings.psd1'
               - '.github/workflows/ci.yml'
-            # What can change what the pi package reconcile DOES: the manifest
-            # it reads, and the code in either twin that reads it. Nothing else
-            # can, because every entry is version-pinned and
-            # tests/pi-config.bats refuses an unpinned one -- so the same
-            # manifest always resolves to the same install set.
+            # What can change what the pi package reconcile DOES. This set is
+            # MAINTAINED BY HAND and is not proven closed — an earlier version
+            # of this comment claimed "nothing else can", and that claim is
+            # exactly what stopped `versions.conf` being noticed. Under-matching
+            # here is silent: the PR still runs test-windows, it just runs it
+            # with the reconcile skipped, and it goes green.
             #
-            # Both setup scripts are listed WHOLE rather than by the reconcile
-            # block, because a filter cannot see line ranges and a guard that
-            # silently under-matches is worse than one that runs too often.
+            # - ai/pi/**        the manifest and the deployed configs
+            # - setup-*.{sh,ps1} the code that reads them, listed WHOLE because
+            #                   a filter cannot see line ranges
+            # - versions.conf   PI_VERSION selects the pi binary that PERFORMS
+            #                   the reconcile (setup-linux.sh:722,
+            #                   setup-windows.ps1:1148). A version bump is the
+            #                   PR class that most needs nine real installs run
+            #                   by the NEW pi, and it was the one class that
+            #                   would have skipped them.
             pi:
               - 'ai/pi/**'
               - 'setup-linux.sh'
               - 'setup-windows.ps1'
+              - 'versions.conf'
               - 'tests/pi-*.bats'
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       powershell: ${{ steps.filter.outputs.powershell }}
+      # CI-002 (#1478): the first filter that is narrower than "is this code at
+      # all". HARNESS-041 asked whether a diff needs CI; this asks which PART of
+      # CI a diff needs, which one bucket cannot answer.
+      pi: ${{ steps.filter.outputs.pi }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -62,6 +66,20 @@ jobs:
               - '**/*.psm1'
               - '.PSScriptAnalyzerSettings.psd1'
               - '.github/workflows/ci.yml'
+            # What can change what the pi package reconcile DOES: the manifest
+            # it reads, and the code in either twin that reads it. Nothing else
+            # can, because every entry is version-pinned and
+            # tests/pi-config.bats refuses an unpinned one -- so the same
+            # manifest always resolves to the same install set.
+            #
+            # Both setup scripts are listed WHOLE rather than by the reconcile
+            # block, because a filter cannot see line ranges and a guard that
+            # silently under-matches is worse than one that runs too often.
+            pi:
+              - 'ai/pi/**'
+              - 'setup-linux.sh'
+              - 'setup-windows.ps1'
+              - 'tests/pi-*.bats'
 
   lint:
     runs-on: ubuntu-latest
@@ -397,12 +415,27 @@ jobs:
       # set here, on the CI step, and NOT in setup-windows.ps1: this is a
       # property of a throwaway runner, not of a developer's machine, and the
       # bootstrap scripts stay out of it (ADR-020 C7).
+      #
+      # CI-002 (#1478): on a PR whose diff cannot change what the pi reconcile
+      # does, skip it. That block is 883-2200s of this job — four runs of the
+      # same nine pinned packages, measured 2026-09-04 — and a Go-only PR was
+      # paying all of it. `pi` is the filter above; anything it matches runs the
+      # reconcile as before.
+      #
+      # PUSHES TO main NEVER SKIP, and after this the reconcile runs ONLY there.
+      # That is deliberate and it is the whole guard: coverage does not move to
+      # a schedule nobody reads. But it does mean main is now the only place a
+      # reconcile regression can surface, so the guard's value rests entirely on
+      # a red main being noticed. Stated out loud because the alternative is
+      # leaving it as an assumption, and an unread signal is how CI-001 stayed
+      # invisible for as long as it did.
       - name: Run setup-windows.ps1 end-to-end (PS 5.1 -> BUG-005 re-exec)
         if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
         shell: powershell
         env:
           DOTFILES_REPO_DIR: ${{ github.workspace }}
           npm_config_prefer_offline: "true"
+          DOTFILES_SKIP_PI_PACKAGES: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.pi != 'true') && '1' || '' }}
         run: .\setup-windows.ps1
 
       # The gate. Setup itself stays non-fatal on doctor (degrade-not-break, C9,

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -850,9 +850,26 @@ fi
 # version check above already reaches for $PI_BIN for the same reason.
 #
 # Idempotent by set difference, so a second run installs nothing and says so.
+#
+# DOTFILES_SKIP_PI_PACKAGES exists for one caller: a throwaway CI runner whose
+# diff cannot change what this block does (CI-002, #1478). The reconcile is
+# 883-2200s of a 20-45 minute job — measured across four runs of the same nine
+# pinned packages — and it reinstalls the same manifest whether or not the PR
+# went near it. Set it and the block is skipped LOUDLY; the coverage does not
+# move to a schedule nobody reads, it stays on pushes to the default branch
+# where a failure is somewhere people already look.
+#
+# It is deliberately not a config key or a flag in packages.json. A durable
+# switch would let a real machine end up permanently unconverged, which is the
+# opposite of what this script is for. An environment variable is scoped to the
+# one process that sets it and dies with it.
 PI_PACKAGES_SRC="$CURRENT_DIR/ai/pi/packages.json"
 if [ -f "$PI_PACKAGES_SRC" ]; then
-    if [ ! -x "$PI_BIN" ]; then
+    if [ -n "${DOTFILES_SKIP_PI_PACKAGES:-}" ]; then
+        # Loud, and it says what was NOT verified rather than only what was
+        # skipped: a line reading "skipped" is indistinguishable from "fine".
+        log_warning "DOTFILES_SKIP_PI_PACKAGES set — pi package reconcile skipped (nothing installed, nothing verified)"
+    elif [ ! -x "$PI_BIN" ]; then
         log_warning "pi not installed — skipping pi package reconcile (re-run setup after pi installs)"
     elif ! command -v npm >/dev/null 2>&1; then
         # `pi install` shells out to npm. Without this, the loop runs and every

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1276,9 +1276,28 @@ if ((Test-Path -LiteralPath $piSettingsDst -PathType Leaf) -and (Test-Path -Lite
 # is seed-if-missing because pi owns it, and `pi install` also unpacks the
 # package under the agent's npm dir, so an entry written by hand would name a
 # package that is not on disk.
+#
+# DOTFILES_SKIP_PI_PACKAGES exists for one caller: a throwaway CI runner whose
+# diff cannot change what this block does (CI-002, #1478). The reconcile is
+# 883-2200s of a 20-45 minute job -- measured across four runs of the same nine
+# pinned packages -- and it reinstalls the same manifest whether or not the PR
+# went near it. Set it and the block is skipped LOUDLY; the coverage does not
+# move to a schedule nobody reads, it stays on pushes to the default branch
+# where a failure is somewhere people already look.
+#
+# Linux parity: the same guard in setup-linux.sh.
+#
+# It is deliberately not a config key or an entry in packages.json. A durable
+# switch would let a real machine end up permanently unconverged, which is the
+# opposite of what this script is for. An environment variable is scoped to the
+# one process that sets it and dies with it.
 $piPackagesSrc = Join-Path $DotfilesDir 'ai\pi\packages.json'
 if (Test-Path -LiteralPath $piPackagesSrc -PathType Leaf) {
-    if (-not (Get-Command pi -ErrorAction SilentlyContinue)) {
+    if ($env:DOTFILES_SKIP_PI_PACKAGES) {
+        # Loud, and it says what was NOT verified rather than only what was
+        # skipped: a line reading "skipped" is indistinguishable from "fine".
+        Write-Warn "DOTFILES_SKIP_PI_PACKAGES set - pi package reconcile skipped (nothing installed, nothing verified)"
+    } elseif (-not (Get-Command pi -ErrorAction SilentlyContinue)) {
         Write-Warn "pi not installed - skipping pi package reconcile (re-run setup after pi installs)"
     } elseif (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
         # `pi install` shells out to npm. Without this the loop runs and every

--- a/specs/CI-002/features.json
+++ b/specs/CI-002/features.json
@@ -1,15 +1,15 @@
 [
   {
     "id": "CI-002-f1",
-    "behavior": "AC1 — both setup twins honour DOTFILES_SKIP_PI_PACKAGES",
+    "behavior": "AC1 \u2014 both setup twins honour DOTFILES_SKIP_PI_PACKAGES",
     "verification": "cd \"$(git rev-parse --show-toplevel)\" && grep -q 'DOTFILES_SKIP_PI_PACKAGES' setup-linux.sh && grep -q 'DOTFILES_SKIP_PI_PACKAGES' setup-windows.ps1",
     "state": "pending",
     "evidence": ""
   },
   {
     "id": "CI-002-f2",
-    "behavior": "AC2/AC3/AC4/AC5 — the guard is first, loud, never set on push, and the pi filter covers both twins",
-    "verification": "cd \"$(git rev-parse --show-toplevel)\" && ~/.local/bin/bats tests/pi-packages.bats 2>&1 | grep -c '^ok ' | grep -qx 22",
+    "behavior": "AC2/AC3/AC4/AC5 \u2014 the guard is first, loud, never set on push, and the pi filter covers the manifest, both twins and PI_VERSION's home",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && ~/.local/bin/bats tests/pi-packages.bats >/dev/null && for t in \"honour DOTFILES_SKIP_PI_PACKAGES\" \"the FIRST branch\" \"what was NOT verified\" \"never sets the skip on a push\" \"covers the manifest and BOTH twins\" \"wherever PI_VERSION is DECLARED\"; do grep -q \"$t\" tests/pi-packages.bats || exit 1; done",
     "state": "pending",
     "evidence": ""
   },
@@ -29,7 +29,7 @@
   },
   {
     "id": "CI-002-f5",
-    "behavior": "AC6 — the new assertions FAIL against a mutated tree (guard moved below the pi probe)",
+    "behavior": "AC6 \u2014 the new assertions FAIL against a mutated tree (guard moved below the pi probe)",
     "verification": "cd \"$(git rev-parse --show-toplevel)\" && cp setup-linux.sh /tmp/ci002.bak && python3 -c \"p='setup-linux.sh'; s=open(p).read(); a='    if [ -n \\\"\\${DOTFILES_SKIP_PI_PACKAGES:-}\\\" ]; then'; b='    if [ ! -x \\\"\\$PI_BIN\\\" ]; then\\n        log_warning \\\"x\\\"\\n    elif [ -n \\\"\\${DOTFILES_SKIP_PI_PACKAGES:-}\\\" ]; then'; assert a in s; open(p,'w').write(s.replace(a,b,1))\" && ! ~/.local/bin/bats tests/pi-packages.bats >/dev/null 2>&1; rc=$?; cp /tmp/ci002.bak setup-linux.sh; exit $rc",
     "state": "pending",
     "evidence": ""

--- a/specs/CI-002/features.json
+++ b/specs/CI-002/features.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "CI-002-f1",
+    "behavior": "AC1 — both setup twins honour DOTFILES_SKIP_PI_PACKAGES",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && grep -q 'DOTFILES_SKIP_PI_PACKAGES' setup-linux.sh && grep -q 'DOTFILES_SKIP_PI_PACKAGES' setup-windows.ps1",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CI-002-f2",
+    "behavior": "AC2/AC3/AC4/AC5 — the guard is first, loud, never set on push, and the pi filter covers both twins",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && ~/.local/bin/bats tests/pi-packages.bats 2>&1 | grep -c '^ok ' | grep -qx 22",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CI-002-f3",
+    "behavior": "The shell twin parses under BOTH shells and passes shellcheck with no new findings",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && bash -n setup-linux.sh && zsh -n setup-linux.sh && ~/.local/bin/shellcheck -S warning setup-linux.sh",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CI-002-f4",
+    "behavior": "The workflow is still valid YAML and the env line is guarded on pull_request",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && python3 -c \"import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml'))\" && grep -A0 'DOTFILES_SKIP_PI_PACKAGES:' .github/workflows/ci.yml | grep -q \"github.event_name == 'pull_request'\"",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CI-002-f5",
+    "behavior": "AC6 — the new assertions FAIL against a mutated tree (guard moved below the pi probe)",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && cp setup-linux.sh /tmp/ci002.bak && python3 -c \"p='setup-linux.sh'; s=open(p).read(); a='    if [ -n \\\"\\${DOTFILES_SKIP_PI_PACKAGES:-}\\\" ]; then'; b='    if [ ! -x \\\"\\$PI_BIN\\\" ]; then\\n        log_warning \\\"x\\\"\\n    elif [ -n \\\"\\${DOTFILES_SKIP_PI_PACKAGES:-}\\\" ]; then'; assert a in s; open(p,'w').write(s.replace(a,b,1))\" && ! ~/.local/bin/bats tests/pi-packages.bats >/dev/null 2>&1; rc=$?; cp /tmp/ci002.bak setup-linux.sh; exit $rc",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CI-002/proposal.md
+++ b/specs/CI-002/proposal.md
@@ -1,0 +1,91 @@
+---
+id: "CI-002"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-09-03"
+issue: "mlorentedev/dotfiles#1478"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# CI-002
+
+## Why
+
+`test-windows` is a required check whose cost is **unbounded**, and every PR pays it
+whether or not its diff can change the outcome. On 2026-09-04 it cancelled two unrelated
+PRs at a 30-minute ceiling; the ceiling was raised to 45 and **#1468 then exhausted 45
+minutes too** (02:58:19 → 03:43:24, cancelled). Four PRs were open at once with none
+mergeable.
+
+The cost is the pi package reconcile — nine serial `pi install` calls, measured at
+**883s, 1331s, 2201s and 2269s** across four runs of the same nine *version-pinned*
+packages. A Go-only PR (#1471) paid 23m2s of it for a manifest it never touched.
+
+## What
+
+Two changes, one mechanism and one policy.
+
+1. **`DOTFILES_SKIP_PI_PACKAGES`**, honoured by both setup twins as the **first** branch
+   of the reconcile guard chain, logging what was *not verified* rather than merely that
+   it skipped.
+2. **A `pi` path filter** in the `changes` job, and one `env:` line on `test-windows`
+   that sets the variable when — and only when — the event is `pull_request` **and** the
+   filter is false.
+
+This is PR 1 of CI-002. PR 2 is the wider filter audit (splitting `code`, re-gating each
+job), which is deliberately separate: it touches four jobs at once on a workflow whose
+only end-to-end verification is the job we are trying not to run.
+
+## Out of scope
+
+- **Why an install costs what it costs.** Seven observations at **421 ±1s across five
+  different packages** say it is a fixed ~7-minute timeout landing on whichever install
+  hits it, and how many hit it per run is what moves the phase. Identifying it needs the
+  `pi install` output, which both twins discard (stdout *and* stderr) on the package
+  loop. Tracked under #1472, which this does not close.
+- The wider filter audit (PR 2).
+- Branch protection settings.
+
+## Risks / open questions
+
+- **After this, the reconcile runs only on pushes to `main`.** That is intended — the
+  coverage does *not* move to a schedule nobody reads — but it means `main` becomes the
+  only place a reconcile regression can surface, so the guard's value rests entirely on a
+  red `main` being noticed. Stated in the workflow comment rather than left implicit,
+  because an unread signal is how this defect stayed invisible: `test-windows` was
+  `skipped` on 6 of the last 6 main runs before #1475.
+- **This is a real coverage reduction, not a relocation.** TEST-003 exists so a PR proves
+  setup works end to end on Windows, and the reconcile is a genuine part of setup.
+  Detection moves from pre-merge to the next push to `main`. Judged the right trade at
+  883–2200s of a 1348–2602s job, recorded here as a decision with its latency named.
+- **Not a config key or a `packages.json` entry.** A durable switch would let a real
+  machine end up permanently unconverged, which is the opposite of what setup is for. An
+  environment variable dies with the process that sets it.
+- **`setup-linux.sh`'s reconcile has never run in CI** — the `integration` container has
+  no npm, so it logs `npm not found` and skips. Pre-existing gap; the Linux guard is
+  therefore verified structurally here, not end to end. Not fixed in this PR.
+- Rejected: pre-seeding the live `settings.json` `packages` array in CI. It would make
+  the job fast by making the block report as verified without ever executing — a false
+  green, the failure class this repository keeps cataloguing.
+
+## Acceptance criteria
+
+- [ ] AC1 — Both twins honour `DOTFILES_SKIP_PI_PACKAGES`.
+- [ ] AC2 — The guard is the **first** branch, before the `pi`/`npm`/`jq` probes, in both
+      twins.
+- [ ] AC3 — The skip logs what was **not verified**, not merely that it skipped, in both
+      twins.
+- [ ] AC4 — CI never sets the variable on a `push`, so pushes to `main` always reconcile.
+- [ ] AC5 — The `pi` filter covers the manifest **and both twins**, so a PR that can
+      change the reconcile's behaviour still runs it.
+- [ ] AC6 — Every assertion above is shown to fail against a mutated tree, not merely to
+      pass against the real one.
+
+## References
+
+- Issue: https://github.com/mlorentedev/dotfiles/issues/1478
+- CI-001 (#1472) — the job-duration ticket this does not close.
+- #1480 — removes the npm cache, measured to buy nothing.
+- HARNESS-041 (#552) — introduced the `changes` job. Its question was *"does this diff
+  need CI?"*; this asks *"which part of CI?"*, which one bucket cannot answer.

--- a/specs/CI-002/tasks.md
+++ b/specs/CI-002/tasks.md
@@ -1,0 +1,60 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-09-03"
+---
+
+# Tasks - CI-002
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers** (optional, additive — borrowed from `github/spec-kit`, adapt-not-adopt per #141):
+> - `[P]` — this task has **no dependency on another unchecked task**, so it is safe to run in parallel (fan out to a `Workflow`, or just batch). TDD chains (test → implement → refactor of the *same* behavior) are sequential and must NOT carry `[P]`; independent behaviors can.
+> - `[AC<n>]` — this task helps satisfy **acceptance criterion #`<n>`** from `proposal.md`. Lets `/spec check` map coverage deterministically; omit it and the check falls back to semantic judgment.
+
+## Setup
+
+- [ ] Branch created from main: `feat/CI-002`
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+> Replace these with the actual steps for this feature. Keep them small (one commit each) and in TDD order.
+> The `[P]` / `[AC<n>]` markers are optional — see the legend above. Behaviors 1 and 2 below are independent, so their *first* test task carries `[P]`.
+
+- [ ] [P] [AC1] Write failing test for <behavior 1>
+- [ ] [AC1] Implement <module/function> to make it pass
+- [ ] Refactor for clarity (extract, rename, dedupe)
+- [ ] [P] [AC2] Write failing test for <behavior 2>
+- [ ] [AC2] Implement to make it pass
+- [ ] ...
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
+- [ ] Type checks pass
+- [ ] Lint passes
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
+
+Minimal `features.json` skeleton (drop into `<repo>/specs/CI-002/features.json`):
+
+```json
+[
+  {
+    "id": "CI-002-f1",
+    "behavior": "<one-line copy of an acceptance criterion>",
+    "verification": "<single shell command; exit 0 means pass>",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/CI-002/verification.md
+++ b/specs/CI-002/verification.md
@@ -1,0 +1,59 @@
+---
+tags: [spec, verification]
+created: "2026-09-03"
+---
+
+# Verification — CI-002 (PR 1: the reconcile skip)
+
+## Commands run, in this session
+
+```
+bash -n setup-linux.sh                       OK
+zsh  -n setup-linux.sh                       OK
+shellcheck setup-linux.sh                    15 pre-existing infos, 0 new
+python3 -c yaml.safe_load(ci.yml)            YAML OK
+bats tests/pi-packages.bats                  22/22 ok  (17 before, 5 added)
+features.json f1..f5                         5/5 PASS, each executed
+```
+
+PowerShell is not parseable locally (`pwsh` absent on this machine); the twin's syntax is
+covered by CI's `lint-powershell`, which gates on `**/*.ps1`.
+
+## AC6 — the assertions were mutation-tested, not merely run
+
+A test that passes on first write is not evidence. Five mutations, each applied to a real
+file and reverted:
+
+| # | Mutation | Result |
+|---|---|---|
+| M1 | `DOTFILES_SKIP_PI_PACKAGES: "1"` unconditionally (fires on `push`) | **caught** — f21 |
+| M2 | drop `setup-windows.ps1` from the `pi` filter | **caught** — f22 |
+| M3 | move the Linux guard below the `$PI_BIN` probe | **caught** — f19 |
+| M4 | move the Windows guard below the `Get-Command pi` probe | **caught** — f19 |
+| M5 | replace the loud message with a bare "skipped" | **caught** — f20 |
+
+## Two defects the mutation pass found in the tests themselves
+
+Both are the failure class this repository keeps cataloguing — a green result that measured
+the wrong thing — and neither was visible from a passing run.
+
+1. **`grep -n 'X' file | grep -v '^ *#'` does not filter comments.** `grep -n` prefixes a
+   line number, so every line starts with a digit and `^ *#` never matches. The ordering
+   assertion was anchoring on the *explanatory comment* above the block, which precedes
+   everything, so it passed regardless of where the guard actually sat. M3 did not fail
+   against it.
+2. **`[ ! -x "$PI_BIN" ]` also appears ~150 lines earlier**, in pi's own install block. A
+   file-wide search found that one and compared against the wrong branch, so the corrected
+   assertion failed on the *clean* tree. Fixed by slicing the reconcile block with `awk`
+   before comparing.
+
+## What is NOT verified here
+
+- **The Linux guard end to end.** `integration`'s container has no npm, so
+  `setup-linux.sh`'s reconcile block has never executed in CI at all — it logs
+  `npm not found — skipping pi package reconcile` and stops. Pre-existing gap, recorded in
+  the proposal, not introduced or fixed by this PR. The Linux guard is verified
+  structurally and by mutation only.
+- **The end-to-end effect on job duration.** That is measured by the first `pull_request`
+  run after this lands, and it is owed rather than claimed.
+- **Why an install costs ~421s.** Out of scope; #1472.

--- a/specs/CI-002/verification.md
+++ b/specs/CI-002/verification.md
@@ -47,6 +47,25 @@ the wrong thing — and neither was visible from a passing run.
    assertion failed on the *clean* tree. Fixed by slicing the reconcile block with `awk`
    before comparing.
 
+## A defect this PR's own evidence had, found in review
+
+`features.json` `f2` asserted `bats … | grep -c '^ok ' | grep -qx 22`. Adding the 23rd
+test — the derived `PI_VERSION` assertion, itself a review fix — made that command
+**fail**, and it is the command the archive gate reads as evidence.
+
+A hard-coded count is brittle in the one direction the spec is guaranteed to move:
+adding tests. Rewritten to assert the suite passes **and** that each named guarantee is
+present by name, then proven both ways:
+
+| | |
+|---|---|
+| add a 24th test | f2 still passes — no longer brittle |
+| rename a guarantee out of the file | f2 fails — not vacuous either |
+
+Surfaced by PR-Agent quoting the stale command back in its review of `46af234`. It
+reported no blocking issues and `#1478 fully compliant`; the defect was visible in what
+it quoted rather than in what it said.
+
 ## What is NOT verified here
 
 - **The Linux guard end to end.** `integration`'s container has no npm, so

--- a/tests/pi-packages.bats
+++ b/tests/pi-packages.bats
@@ -217,13 +217,46 @@ setup() {
 }
 
 @test "pi packages: the CI pi filter covers the manifest and BOTH twins" {
-    # Everything that can change what the reconcile does. A filter that misses
-    # one of these skips the reconcile on the exact PR that needed it, and the
-    # PR goes green.
+    # A filter that misses one of these skips the reconcile on the exact PR
+    # that needed it, and the PR goes green.
     CI="$BATS_TEST_DIRNAME/../.github/workflows/ci.yml"
-    filter=$(awk '/^            pi:$/{f=1;next} /^            [a-z]/{f=0} f' "$CI")
+    # The slice STOPS AT THE FIRST NON-ENTRY, and that is load-bearing. The
+    # obvious terminator -- "stop at the next 12-space key" -- does not fire
+    # here, so the slice ran past the block and swept up unrelated lines that
+    # mention these very paths; deleting an entry then still matched. Two
+    # earlier versions of this test were green for that reason and for the
+    # comment-prose variant of it. Anchor on the LIST, never on what follows it.
+    filter=$(awk '/^            pi:$/{f=1;next} f && !/^ *- /{exit} f' "$CI")
     [ -n "$filter" ]
     echo "$filter" | grep -q "ai/pi/\*\*"
     echo "$filter" | grep -q "setup-linux.sh"
     echo "$filter" | grep -q "setup-windows.ps1"
+}
+
+@test "pi packages: the CI pi filter covers wherever PI_VERSION is DECLARED" {
+    # DERIVED, not enumerated, and that distinction is the point. The test above
+    # greps for the three entries someone already wrote, so it is green by
+    # construction against any omission — an assertion that cannot fail for the
+    # reason it exists. It was, and `versions.conf` was missing: PI_VERSION
+    # selects the pi binary that performs the reconcile
+    # (setup-linux.sh:722, setup-windows.ps1:1148), so a version bump ran
+    # test-windows with the reconcile skipped. Caught in review on #1482, not by
+    # this suite.
+    #
+    # This one asks the REPOSITORY where PI_VERSION lives and requires the
+    # answer to be in the filter, so it survives the file being renamed or the
+    # pin moving, and it fails if the filter forgets it again.
+    CI="$BATS_TEST_DIRNAME/../.github/workflows/ci.yml"
+    REPO="$BATS_TEST_DIRNAME/.."
+    decl=$(cd "$REPO" && grep -rl '^PI_VERSION=' --include='*.conf' . | head -1)
+    [ -n "$decl" ]
+    decl=$(basename "$decl")
+    # The slice STOPS AT THE FIRST NON-ENTRY, and that is load-bearing. The
+    # obvious terminator -- "stop at the next 12-space key" -- does not fire
+    # here, so the slice ran past the block and swept up unrelated lines that
+    # mention these very paths; deleting an entry then still matched. Two
+    # earlier versions of this test were green for that reason and for the
+    # comment-prose variant of it. Anchor on the LIST, never on what follows it.
+    filter=$(awk '/^            pi:$/{f=1;next} f && !/^ *- /{exit} f' "$CI")
+    echo "$filter" | grep -q "$decl"
 }

--- a/tests/pi-packages.bats
+++ b/tests/pi-packages.bats
@@ -156,3 +156,74 @@ setup() {
 @test "pi packages: setup-windows degrades to a warning when pi is absent" {
     grep -q 'skipping pi package reconcile' "$SETUP_PS1"
 }
+
+# --- CI-002 (#1478): DOTFILES_SKIP_PI_PACKAGES -------------------------------
+#
+# The reconcile is 883-2200s of the Windows CI job, measured across four runs of
+# the same nine pinned packages, and a PR that cannot change what it does was
+# paying all of it. The guard takes it off the PR path. These tests exist
+# because every way this can go wrong is SILENT: a guard that skips when it
+# should not, a filter that under-matches, or a skip that logs like a success.
+
+@test "pi packages: both twins honour DOTFILES_SKIP_PI_PACKAGES" {
+    grep -q 'DOTFILES_SKIP_PI_PACKAGES' "$SETUP_SH"
+    grep -q 'DOTFILES_SKIP_PI_PACKAGES' "$SETUP_PS1"
+}
+
+@test "pi packages: the skip is the FIRST branch, before the pi/npm probes" {
+    # Order is the contract, not style. The runner sets the variable precisely
+    # so the expensive block never starts; if the guard sat after the `pi` and
+    # `npm` probes, a runner that has both would run the probes' side effects
+    # and only then decide to skip.
+    # Anchor on the BRANCH, never on a mention. `grep -n | grep -v '^ *#'` does
+    # not filter comments here — grep -n prefixes a line number, so the line
+    # starts with a digit and the comment pattern never matches. That version
+    # of this test matched the explanatory comment above the block, which sits
+    # before everything, so it passed no matter where the guard actually was.
+    # Caught by mutation: moving the guard below the $PI_BIN probe did not fail
+    # it. Same genus as every other green-for-the-wrong-reason in this repo.
+    # Sliced from the RECONCILE BLOCK, not from the file. `[ ! -x "$PI_BIN" ]`
+    # also appears in pi's own install block 150 lines earlier, so a file-wide
+    # search finds that one and compares against the wrong branch.
+    sh_block=$(awk '/^PI_PACKAGES_SRC=/{f=1} f' "$SETUP_SH")
+    sh_skip=$(printf '%s\n' "$sh_block" | grep -n 'DOTFILES_SKIP_PI_PACKAGES:-' | head -1 | cut -d: -f1)
+    sh_pi=$(printf '%s\n' "$sh_block" | grep -n '\[ ! -x "\$PI_BIN" \]' | head -1 | cut -d: -f1)
+    [ -n "$sh_skip" ]
+    [ -n "$sh_pi" ]
+    [ "$sh_skip" -lt "$sh_pi" ]
+
+    ps_block=$(awk '/^\$piPackagesSrc = Join-Path/{f=1} f' "$SETUP_PS1")
+    ps_skip=$(printf '%s\n' "$ps_block" | grep -n 'env:DOTFILES_SKIP_PI_PACKAGES' | head -1 | cut -d: -f1)
+    ps_pi=$(printf '%s\n' "$ps_block" | grep -n 'Get-Command pi -ErrorAction SilentlyContinue' | head -1 | cut -d: -f1)
+    [ -n "$ps_skip" ]
+    [ -n "$ps_pi" ]
+    [ "$ps_skip" -lt "$ps_pi" ]
+}
+
+@test "pi packages: the skip says what was NOT verified, not merely that it skipped" {
+    # A line reading "skipped" is indistinguishable from "fine" when someone
+    # scans a green log. Both twins must name the consequence.
+    grep -q 'nothing installed, nothing verified' "$SETUP_SH"
+    grep -q 'nothing installed, nothing verified' "$SETUP_PS1"
+}
+
+@test "pi packages: CI never sets the skip on a push to the default branch" {
+    # The guard's entire safety property. If this expression ever evaluates
+    # truthy on `push`, the reconcile runs NOWHERE and nothing says so.
+    CI="$BATS_TEST_DIRNAME/../.github/workflows/ci.yml"
+    run grep -n "DOTFILES_SKIP_PI_PACKAGES:" "$CI"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "github.event_name == 'pull_request'"
+}
+
+@test "pi packages: the CI pi filter covers the manifest and BOTH twins" {
+    # Everything that can change what the reconcile does. A filter that misses
+    # one of these skips the reconcile on the exact PR that needed it, and the
+    # PR goes green.
+    CI="$BATS_TEST_DIRNAME/../.github/workflows/ci.yml"
+    filter=$(awk '/^            pi:$/{f=1;next} /^            [a-z]/{f=0} f' "$CI")
+    [ -n "$filter" ]
+    echo "$filter" | grep -q "ai/pi/\*\*"
+    echo "$filter" | grep -q "setup-linux.sh"
+    echo "$filter" | grep -q "setup-windows.ps1"
+}


### PR DESCRIPTION
**PR 1 of CI-002.** Takes the pi package reconcile off the pull-request path.

## Why now

`test-windows` is a required check whose cost is **unbounded**, not merely high:

| PR | `test-windows` |
|---|---|
| **#1468** | **fail — 45m5s, cancelled** (02:58:19 → 03:43:24) |
| #1480 | pending |
| #1474 | pending, behind |
| #1471 | pass 23m2s, behind |

Four PRs open, none mergeable. The 30-minute ceiling cancelled two unrelated PRs; it was raised to 45 and #1468 exhausted 45 as well. **Raising the ceiling cannot win against this** — it only postpones the loss.

The cost is the reconcile: nine serial `pi install` calls, measured across four runs of the same nine **version-pinned** packages.

```
883s   1331s   2201s   2269s
```

#1471 — a Go-only change under `cli/` — paid 23m2s of it for a manifest it never touched.

So this is not a slow job being made faster. It is an **unbounded** one being taken off the blocking path.

## What changes

**`DOTFILES_SKIP_PI_PACKAGES`**, honoured by both twins as the **first** branch of the guard chain — before the `pi`/`npm`/`jq` probes, because the runner sets it precisely so the expensive block never starts. It logs what was **not verified**, not merely that it skipped: a line reading *"skipped"* is indistinguishable from *"fine"* to someone scanning a green log.

**A `pi` filter** in `changes` covering everything that can change what the reconcile does — the manifest and both twins, listed **whole**. Nothing else can change it: every entry is pinned and `tests/pi-config.bats` refuses an unpinned one, so the same manifest always resolves to the same install set. The twins are whole rather than line-scoped because a filter cannot see line ranges, and a guard that silently under-matches is worse than one that runs too often.

**One `env:` line** on `test-windows`, set when the event is `pull_request` **and** the filter is false.

It is an environment variable and not a config key or a `packages.json` entry: a durable switch would let a real machine end up permanently unconverged, which is the opposite of what setup is for.

## The design's weak seam, stated rather than assumed

**After this, the reconcile runs only on pushes to `main`** — so `main` becomes the only place a reconcile regression can surface, and the guard's value rests entirely on **a red `main` being noticed**. That sentence is in the workflow comment, not just here.

A scheduled run was considered and **rejected for exactly this reason**: it reproduces the property that made CI-001 invisible, where the evidence exists and nobody encounters it. `test-windows` was `skipped` on 6 of the last 6 main runs before #1475, which is how a required check degraded with nobody able to see it.

This is also a **real coverage reduction, not a relocation**. TEST-003 exists so a PR proves setup works end to end on Windows. Detection moves from pre-merge to the next push to `main`. Recorded as a decision with its latency named.

## Tests: mutated, not merely run

Five new assertions in `tests/pi-packages.bats` (17 → 22). Each was shown to **fail against a mutated tree**:

| Mutation | Caught by |
|---|---|
| the skip fires on `push` too | AC4 |
| the `pi` filter loses `setup-windows.ps1` | AC5 |
| the Linux guard moves below the `$PI_BIN` probe | AC2 |
| the Windows guard moves below the `Get-Command pi` probe | AC2 |
| the loud message becomes a bare "skipped" | AC3 |

**That pass found two defects in my own tests**, both green-for-the-wrong-reason and neither visible from a passing run:

1. **`grep -n X f \| grep -v '^ *#'` does not filter comments.** `grep -n` prefixes a line number, so every line starts with a digit and `^ *#` never matches. The ordering assertion was anchoring on the explanatory comment *above* the block — which precedes everything — so it passed wherever the guard actually sat.
2. **`[ ! -x "$PI_BIN" ]` also appears ~150 lines earlier**, in pi's own install block, so a file-wide search compared against the wrong branch and the corrected assertion then failed on the *clean* tree.

Both fixed by slicing the reconcile block with `awk` before comparing.

## Verified in this session

```
bash -n / zsh -n setup-linux.sh    OK          shellcheck   15 pre-existing infos, 0 new
yaml.safe_load(ci.yml)             OK          bats tests/*.bats   1541 tests, exit 0
bats tests/pi-packages.bats        22/22       features.json f1..f5  5/5, each executed
```

`pwsh` is absent on this machine, so the PowerShell twin's syntax is covered by CI's `lint-powershell`.

## Not verified, and owed rather than claimed

- **The Linux guard end to end.** `integration`'s container has no npm, so `setup-linux.sh`'s reconcile block has **never executed in CI at all** — it logs `npm not found` and stops. Pre-existing gap, recorded in the proposal, not introduced or fixed here. The Linux guard is verified structurally and by mutation only.
- **The effect on job duration.** Measured by the first `pull_request` run after this lands.

## Not closed by this

**#1472 (CI-001) stays open.** Why an install costs ~421s is unchanged and unknown: seven observations at **421 ±1s across five different packages** say it is a fixed timeout landing on whichever install hits it, and how many hit it per run is what moves the phase between 883s and 2201s. Reading its error text needs the `pi install` redirect removed from both twins — task one of the follow-up.

The wider filter audit is **PR 2** and stays separate: it re-gates four jobs at once on a workflow whose only end-to-end verification is the job we are trying not to run.

Refs #1478, #1472
