### PR TITLE
fix(setup): log what a pi install cost and what it printed, in both twins

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -900,6 +900,14 @@ if [ -f "$PI_PACKAGES_SRC" ]; then
             pi_pkg_added=0
             pi_pkg_failed=0
             pi_pkg_present=0
+            # A VERBOSITY threshold, not a bound. Nothing is killed for crossing
+            # it; it only decides whose captured output is worth printing. Being
+            # wrong therefore costs log lines, never a broken install — which is
+            # why it is a literal here and not a knob. Sized from the measured
+            # distribution on the Windows runner (#1486): normal installs land
+            # at 35-345s and the anomaly at 421 ±1s, so there is no clean gap to
+            # sit in, and this deliberately errs toward printing too much.
+            PI_INSTALL_SLOW_SECONDS=120
             while IFS= read -r pi_pkg; do
                 [ -n "$pi_pkg" ] || continue
                 if printf '%s\n' "$PI_PKG_PRESENT" | grep -Fxq "$pi_pkg"; then
@@ -907,11 +915,40 @@ if [ -f "$PI_PACKAGES_SRC" ]; then
                     continue
                 fi
                 log_info "Installing pi package $pi_pkg ..."
-                if "$PI_BIN" install "$pi_pkg" >/dev/null 2>&1; then
-                    pi_pkg_added=$((pi_pkg_added + 1))
+                # Both the elapsed time and the output used to be discarded here
+                # (`>/dev/null 2>&1`), and #1486 is what that cost: nine installs
+                # whose durations could only be reconstructed from GitHub's own
+                # line timestamps, and whose 421s outliers cannot be told apart
+                # from a slow success even in hindsight. The machine had the
+                # diagnostic in its hands and threw it away, then told the reader
+                # to reproduce it by hand.
+                pi_pkg_started=$(date +%s)
+                if pi_pkg_out=$("$PI_BIN" install "$pi_pkg" 2>&1); then
+                    pi_pkg_rc=0
                 else
-                    log_warning "pi install $pi_pkg failed — run \"$PI_BIN install $pi_pkg\" to see why"
+                    pi_pkg_rc=$?
+                fi
+                pi_pkg_elapsed=$(( $(date +%s) - pi_pkg_started ))
+
+                if [ "$pi_pkg_rc" -eq 0 ]; then
+                    pi_pkg_added=$((pi_pkg_added + 1))
+                    if [ "$pi_pkg_elapsed" -ge "$PI_INSTALL_SLOW_SECONDS" ]; then
+                        log_warning "pi install $pi_pkg took ${pi_pkg_elapsed}s — over the ${PI_INSTALL_SLOW_SECONDS}s diagnostic threshold, output follows"
+                    else
+                        log_info "pi package $pi_pkg installed in ${pi_pkg_elapsed}s"
+                    fi
+                else
                     pi_pkg_failed=$((pi_pkg_failed + 1))
+                    log_warning "pi install $pi_pkg failed after ${pi_pkg_elapsed}s (exit $pi_pkg_rc) — output follows"
+                fi
+
+                # Fenced, so that EMPTY output is itself legible. "The install
+                # printed nothing at all" is a finding; a bare dump makes it
+                # indistinguishable from "we never captured anything".
+                if [ "$pi_pkg_rc" -ne 0 ] || [ "$pi_pkg_elapsed" -ge "$PI_INSTALL_SLOW_SECONDS" ]; then
+                    printf '%s\n' "--- pi install $pi_pkg (exit $pi_pkg_rc, ${pi_pkg_elapsed}s) ---"
+                    printf '%s\n' "$pi_pkg_out"
+                    printf '%s\n' "--- end pi install $pi_pkg ---"
                 fi
             done <<EOF
 $PI_PKG_WANTED

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1336,18 +1336,63 @@ if (Test-Path -LiteralPath $piPackagesSrc -PathType Leaf) {
             $piAdded = 0
             $piFailed = 0
             $piAlready = 0
+            # A VERBOSITY threshold, not a bound. Nothing is killed for crossing
+            # it; it only decides whose captured output is worth printing. Being
+            # wrong therefore costs log lines, never a broken install - which is
+            # why it is a literal here and not a knob. Sized from the measured
+            # distribution on this runner (#1486): normal installs land at
+            # 35-345s and the anomaly at 421 +/-1s, so there is no clean gap to
+            # sit in, and this deliberately errs toward printing too much.
+            $piSlowSeconds = 120
             foreach ($piPkgName in $piWanted) {
                 if ($piPresent -contains $piPkgName) {
                     $piAlready++
                     continue
                 }
                 Write-Info "Installing pi package $piPkgName ..."
-                & pi install $piPkgName 2>$null | Out-Null
-                if ($LASTEXITCODE -eq 0) {
+                # Both the elapsed time and the output used to be discarded here
+                # (`2>$null | Out-Null`), and #1486 is what that cost: nine
+                # installs whose durations could only be reconstructed from
+                # GitHub's own line timestamps, and whose 421s outliers cannot be
+                # told apart from a slow success even in hindsight. The machine
+                # had the diagnostic in its hands and threw it away, then told the
+                # reader to reproduce it by hand.
+                $piSw = [System.Diagnostics.Stopwatch]::StartNew()
+                # `2>&1` on a NATIVE command turns its stderr lines into
+                # ErrorRecords, and under $ErrorActionPreference = 'Stop' those
+                # terminate - so a noisy-but-successful install would abort setup.
+                # The redirect this replaces avoided that by discarding stderr
+                # rather than by handling it. Pinned to Continue and restored.
+                $piPrevEap = $ErrorActionPreference
+                $ErrorActionPreference = 'Continue'
+                try {
+                    $piOut = (& pi install $piPkgName 2>&1 | Out-String)
+                    $piRc = $LASTEXITCODE
+                } finally {
+                    $ErrorActionPreference = $piPrevEap
+                }
+                $piSw.Stop()
+                $piElapsed = [int][math]::Round($piSw.Elapsed.TotalSeconds)
+
+                if ($piRc -eq 0) {
                     $piAdded++
+                    if ($piElapsed -ge $piSlowSeconds) {
+                        Write-Warn "pi install $piPkgName took ${piElapsed}s - over the ${piSlowSeconds}s diagnostic threshold, output follows"
+                    } else {
+                        Write-Info "pi package $piPkgName installed in ${piElapsed}s"
+                    }
                 } else {
-                    Write-Warn "pi install $piPkgName failed - run 'pi install $piPkgName' to see why"
                     $piFailed++
+                    Write-Warn "pi install $piPkgName failed after ${piElapsed}s (exit $piRc) - output follows"
+                }
+
+                # Fenced, so that EMPTY output is itself legible. "The install
+                # printed nothing at all" is a finding; a bare dump makes it
+                # indistinguishable from "we never captured anything".
+                if ($piRc -ne 0 -or $piElapsed -ge $piSlowSeconds) {
+                    Write-Host "--- pi install $piPkgName (exit $piRc, ${piElapsed}s) ---"
+                    Write-Host $piOut
+                    Write-Host "--- end pi install $piPkgName ---"
                 }
             }
 

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1363,6 +1363,16 @@ if (Test-Path -LiteralPath $piPackagesSrc -PathType Leaf) {
                 # terminate - so a noisy-but-successful install would abort setup.
                 # The redirect this replaces avoided that by discarding stderr
                 # rather than by handling it. Pinned to Continue and restored.
+                # Initialised to FAILURE, before the try, for two reasons that both
+                # end badly. If the call throws, `$piRc` is never assigned and the
+                # read below is of an unassigned variable -- which under
+                # `Set-StrictMode -Version Latest` (scripts\utils.ps1:11) is itself
+                # a terminating error, one thrown outside the try that was meant to
+                # contain it. And on any iteration after the first it would not even
+                # be unassigned: it would still hold the PREVIOUS package's result,
+                # so a broken install would be counted as whatever the last one did.
+                # An unknown outcome is a failure here, never a success.
+                $piRc = 1
                 $piPrevEap = $ErrorActionPreference
                 $ErrorActionPreference = 'Continue'
                 try {

--- a/specs/CI-003/features.json
+++ b/specs/CI-003/features.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "CI-003-f1",
+    "behavior": "AC1/AC2 — neither twin discards the install's output, and the call captures rather than streams it",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && ~/.local/bin/bats -f \"neither twin discards\" tests/pi-packages.bats && ~/.local/bin/bats -f \"output is CAPTURED\" tests/pi-packages.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CI-003-f2",
+    "behavior": "AC3/AC4/AC5 — elapsed on every outcome, the failure says what happened, the captured output is fenced",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && ~/.local/bin/bats -f \"elapsed time, on EVERY outcome\" tests/pi-packages.bats && ~/.local/bin/bats -f \"emits what happened\" tests/pi-packages.bats && ~/.local/bin/bats -f \"FENCED\" tests/pi-packages.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CI-003-f3",
+    "behavior": "AC6/AC7 — the Windows capture cannot be terminated by a noisy install, and the threshold gates verbosity only",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && ~/.local/bin/bats -f \"terminated by a noisy install\" tests/pi-packages.bats && ~/.local/bin/bats -f \"VERBOSITY only\" tests/pi-packages.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CI-003-f4",
+    "behavior": "The shell twin parses under BOTH shells and passes shellcheck; the PowerShell twin stays ASCII-only (PSScriptAnalyzer fails CI otherwise)",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && bash -n setup-linux.sh && zsh -n setup-linux.sh && ~/.local/bin/shellcheck --severity=error setup-linux.sh && python3 -c \"import sys; sys.exit(1 if any(ord(c)>126 for c in open('setup-windows.ps1',encoding='utf-8').read()) else 0)\"",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CI-003-f5",
+    "behavior": "AC8 — every assertion FAILS against a mutated tree, and the harness proves each mutation landed inside the reconcile block before reaching a verdict",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && python3 specs/CI-003/mutate-assertions.py",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CI-003-f6",
+    "behavior": "The mutation harness reports a HARNESS FAULT rather than a verdict when its own target is missing — the lesson-267 property, proven by removing an anchor",
+    "verification": "cd \"$(git rev-parse --show-toplevel)\" && cp specs/CI-003/mutate-assertions.py /tmp/ci003-mut.bak && python3 -c \"p='specs/CI-003/mutate-assertions.py'; s=open(p).read(); a='install \\\"\\$pi_pkg\\\" 2>&1)'; assert a in s; open(p,'w').write(s.replace(a,'THIS TARGET DOES NOT EXIST',1))\" && ! python3 specs/CI-003/mutate-assertions.py >/dev/null 2>&1; rc=$?; cp /tmp/ci003-mut.bak specs/CI-003/mutate-assertions.py; rm -f /tmp/ci003-mut.bak; exit $rc",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CI-003/mutate-assertions.py
+++ b/specs/CI-003/mutate-assertions.py
@@ -91,6 +91,13 @@ CASES = [
           repl="continue  # mutated\n                    printf '%s\\n' \"--- pi install $pi_pkg")),
     ("AC6", "terminated by a noisy install", PS,
      dict(find='} finally {', repl='}; if ($false) {')),
+    ("AC9", "outcome is unknown counts as FAILED", PS,
+     dict(find='                $piRc = 1', repl=None, drop=True)),
+    # The default's VALUE is the guarantee, not its presence: defaulted to 0, an
+    # install whose outcome is unknown is counted as a success, which is the exact
+    # outcome the line exists to prevent.
+    ("AC9", "outcome is unknown counts as FAILED", PS,
+     dict(find='                $piRc = 1', repl='                $piRc = 0')),
 ]
 
 

--- a/specs/CI-003/mutate-assertions.py
+++ b/specs/CI-003/mutate-assertions.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""AC8 — prove the CI-003 assertions fail against a mutated tree.
+
+A test that passes on first write is not evidence, so each assertion added by
+CI-003 is mutation-tested: break the guarantee, require the test to go red.
+
+WHAT MAKES THIS DIFFERENT FROM THE HARNESS THAT LIED (lesson 267)
+-----------------------------------------------------------------
+"The mutation was not caught" and "the mutation was not applied" are
+indistinguishable from outside a harness -- both yield a green suite and the
+words NOT CAUGHT -- and they demand opposite responses. The previous harness
+did `source.replace(entry, '', 1)`, deleted an identically-spelled line from a
+DIFFERENT block, and reported four sound assertions as vacuous.
+
+So this one refuses to reach a verdict it cannot support:
+
+  * every mutation is located by line position at or after the RECONCILE
+    BLOCK's anchor, never by a repo-wide string search;
+  * the mutated line is printed, before and after, so the diff is a fact rather
+    than a hypothesis;
+  * a mutation that produces an identical file, or a `-f` filter that selects no
+    test, is reported as a HARNESS FAULT and never as a result.
+
+Run from anywhere in the working tree:  python3 specs/CI-003/mutate-assertions.py
+Exit 0 iff every mutation was caught.
+"""
+import pathlib
+import re
+import subprocess
+import sys
+
+REPO = pathlib.Path(subprocess.run(
+    ["git", "rev-parse", "--show-toplevel"],
+    capture_output=True, text=True, check=True).stdout.strip())
+SH = REPO / "setup-linux.sh"
+PS = REPO / "setup-windows.ps1"
+SUITE = REPO / "tests" / "pi-packages.bats"
+BATS = pathlib.Path.home() / ".local" / "bin" / "bats"
+
+# The same anchors tests/pi-packages.bats slices on. If these drift, the tests
+# and this harness stop talking about the same region -- which is the failure
+# being defended against, so they are asserted rather than assumed.
+BLOCK_START = {
+    SH: re.compile(r"^PI_PACKAGES_SRC="),
+    PS: re.compile(r"^\$piPackagesSrc = Join-Path"),
+}
+
+
+def block_offset(path):
+    lines = path.read_text().splitlines()
+    for i, line in enumerate(lines):
+        if BLOCK_START[path].match(line):
+            return i, lines
+    raise SystemExit(f"HARNESS FAULT: block anchor not found in {path.name}")
+
+
+def mutate(path, find, repl, drop=False):
+    """First match AT OR AFTER the block anchor. Never the whole file."""
+    off, lines = block_offset(path)
+    for i in range(off, len(lines)):
+        if find in lines[i]:
+            before = lines[i]
+            if drop:
+                return lines[:i] + lines[i + 1:], i + 1, before, "<line deleted>"
+            after = lines[i].replace(find, repl)
+            return lines[:i] + [after] + lines[i + 1:], i + 1, before, after
+    raise SystemExit(
+        f"HARNESS FAULT: target not found in {path.name} at/after line {off + 1}: {find!r}")
+
+
+CASES = [
+    ("AC1", "neither twin discards", SH,
+     dict(find='install "$pi_pkg" 2>&1)', repl='install "$pi_pkg" >/dev/null 2>&1)')),
+    ("AC1", "neither twin discards", PS,
+     dict(find='2>&1 | Out-String)', repl='2>$null | Out-String)')),
+    ("AC2", "output is CAPTURED", SH,
+     dict(find='if pi_pkg_out=$("$PI_BIN"', repl='if $("$PI_BIN"')),
+    ("AC3", "elapsed time, on EVERY outcome", SH,
+     dict(find='installed in ${pi_pkg_elapsed}s', repl=None, drop=True)),
+    ("AC3", "elapsed time, on EVERY outcome", PS,
+     dict(find='installed in ${piElapsed}s', repl=None, drop=True)),
+    ("AC4", "emits what happened", SH,
+     dict(find='(exit $pi_pkg_rc) — output follows',
+          repl='— run \\"$PI_BIN install $pi_pkg\\" to see why')),
+    ("AC5", "FENCED", SH,
+     dict(find='"--- end pi install $pi_pkg ---"', repl=None, drop=True)),
+    ("AC5", "FENCED", PS,
+     dict(find='"--- end pi install $piPkgName ---"', repl=None, drop=True)),
+    ("AC7", "VERBOSITY only", SH,
+     dict(find="printf '%s\\n' \"--- pi install $pi_pkg",
+          repl="continue  # mutated\n                    printf '%s\\n' \"--- pi install $pi_pkg")),
+    ("AC6", "terminated by a noisy install", PS,
+     dict(find='} finally {', repl='}; if ($false) {')),
+]
+
+
+def run_case(name, path, spec):
+    original = path.read_text()
+    new, lineno, before, after = mutate(
+        path, spec["find"], spec["repl"], drop=spec.get("drop", False))
+    body = "\n".join(new) + "\n"
+    if body == original:
+        print("    HARNESS FAULT: the mutation produced an identical file")
+        return None
+    path.write_text(body)
+    try:
+        print(f"    @ {path.name}:{lineno}")
+        print(f"      -{before.strip()[:96]}")
+        print(f"      +{after.strip()[:96]}")
+        r = subprocess.run([str(BATS), "-f", name, str(SUITE)],
+                           capture_output=True, text=True, cwd=REPO)
+        selected = sum(1 for line in r.stdout.splitlines()
+                       if line.startswith(("ok ", "not ok ")))
+        if selected == 0:
+            print("    HARNESS FAULT: -f matched no test; nothing was exercised")
+            return None
+        caught = r.returncode != 0
+        print(f"      {selected} test(s) selected -> "
+              f"{'CAUGHT' if caught else '!!! NOT CAUGHT !!!'}")
+        return caught
+    finally:
+        path.write_text(original)
+
+
+def main():
+    results = []
+    for ac, name, path, spec in CASES:
+        print(f"\n== {ac}  {name}  [{path.name}]")
+        results.append((ac, name, path.name, run_case(name, path, spec)))
+    print("\n" + "=" * 68)
+    for ac, name, fname, caught in results:
+        verdict = "CAUGHT " if caught is True else (
+            "MISSED " if caught is False else "FAULT  ")
+        print(f"{verdict} {ac}  {name}  [{fname}]")
+    print("=" * 68)
+    sys.exit(0 if all(r[3] is True for r in results) else 1)
+
+
+main()

--- a/specs/CI-003/proposal.md
+++ b/specs/CI-003/proposal.md
@@ -115,6 +115,10 @@ Make the reconcile observable, in both twins, and nothing else.
       restore in a `finally`.
 - [ ] AC7 — The verbosity threshold controls printing only: nothing skips, kills or
       fails an install for crossing it.
+- [ ] AC9 — An install whose outcome is unknown counts as **failed**: `$piRc` is
+      defaulted to failure before the guarded call, so a throw cannot leave it unassigned
+      (a terminating error under `Set-StrictMode -Version Latest`, thrown outside the
+      `try` meant to contain it) nor holding the previous package's result.
 - [ ] AC8 — Every assertion above is shown to fail against a mutated tree, with the
       mutation's own diff as evidence that it landed inside the reconcile block.
 

--- a/specs/CI-003/proposal.md
+++ b/specs/CI-003/proposal.md
@@ -1,0 +1,128 @@
+---
+id: "CI-003"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-09-04"
+issue: "mlorentedev/dotfiles#1486"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# CI-003
+
+## Why
+
+CI-002 took the pi package reconcile off the PR path and said so plainly: *"the
+reconcile now runs ONLY on pushes to main… the guard's value rests entirely on a red
+main being noticed."*
+
+**The reconcile's cost varies 24x on byte-identical input**, and it sits inside a job
+with a 45-minute ceiling. So whether main verifies Windows setup at all is a coin flip
+on registry behaviour rather than a property of the code. Five pushes to main on
+2026-09-04, same nine version-pinned packages:
+
+| run | package phase | setup step | outcome |
+|---|---|---|---|
+| `33845866062` | (killed mid-loop) | 45m06s | **cancelled at ceiling** |
+| `33846609699` | — | — | **cancelled before any job started** (#1487) |
+| `33847200968` | **≥2430s** | 44m19s | **cancelled at ceiling** |
+| `33930483404` | **101.8s** | 6m24s | success |
+| `33930629978` | — | 6m57s | success |
+
+Two of the three that reached a verdict produced **no Windows verification at all** —
+`Post-setup doctor gate`, `Run Pester suites` and `Run PowerShell bats subset` all
+`skipped` — and `cancelled` is neither a pass nor a failure, so nothing goes red about
+it. The successful run reports `pi packages: 9 installed, 0 already present, 0 failed`,
+so 101.8s is a complete reconcile and not a run that skipped work.
+
+> An earlier draft of this section said main "does not complete, so it verifies
+> nothing". That was true of the three morning runs and **false of the current head**;
+> a peer session pointed at the two later ones and checking them directly confirmed it.
+> Corrected rather than deleted, because three cancellations read as a state is the same
+> sampling error the 421s constant is made of — and the replacement is a stronger claim,
+> not a retreat.
+
+The obvious response is to bound the reconcile. **It cannot be bounded yet**, and that
+is what this spec is for. Both twins discarded the install's stdout *and* stderr and
+logged no elapsed time, so between two consecutive `Installing pi package` lines the log
+holds literally nothing. A 421s install that **succeeded slowly** and one that **failed
+after retries** are indistinguishable, and they demand opposite bounds: a bound that
+kills a slow success turns working setup into broken setup; a bound on an install that
+was going to fail anyway is free.
+
+## What
+
+Make the reconcile observable, in both twins, and nothing else.
+
+1. **Log elapsed seconds for every install, on every outcome** — fast success, slow
+   success, failure. This is the line that answers *"did the 421s end in success?"*, and
+   no amount of captured output answers it on its own.
+2. **Capture the install's output instead of discarding it**, and emit it, fenced, when
+   the install fails **or** crosses a verbosity threshold. The message it replaces
+   (`run 'pi install X' to see why`) asked a human to reproduce by hand, later, a
+   failure the machine held in a variable at the time — and on the Windows runner that
+   reproduction is not available at all.
+
+## Out of scope
+
+- **The bound itself.** Chosen from the data step 1 produces, in the next PR. The
+  measured distribution is 35–345s for normal installs and 421 ±1s for the anomaly, so
+  there is no clean gap to sit in and any threshold picked today is a guess. #1486
+  §What.2 states this ordering.
+- **The 45-minute ceiling.** #1475 raised it 30 → 45 as an explicitly temporary loan and
+  recorded that the next slow night would eat 45 the way that one ate 30. This is that
+  night. Not raised again here.
+- **The concurrency hole** — a third push to main discarding the second *pending* run.
+  Real, measured on `33846609699`, filed as #1487.
+- **The wider path-filter audit** (#1478 PR 2).
+- **#1484** — `setup-linux.sh`'s reconcile has still never executed in CI. The Linux
+  half of this change is therefore verified structurally and by mutation, not end to
+  end. Unchanged by this spec, and stated rather than implied.
+
+## Risks / open questions
+
+- **The fix carries its own hazard, on the Windows side only.** `2>&1` on a *native*
+  command turns its stderr lines into `ErrorRecord`s, and under
+  `$ErrorActionPreference = 'Stop'` those terminate — so an install that writes a
+  warning to stderr and exits 0 would abort setup. The redirect being replaced
+  (`2>$null`) never met that hazard because it threw stderr away, which means the hazard
+  arrives *with* the fix rather than being pre-existing. The preference is pinned to
+  `Continue` around the call and restored in a `finally`, and AC6 asserts all three
+  parts.
+- **The verbosity threshold is a literal, not a knob.** Crossing it kills nothing; it
+  only decides whose output is printed, so being wrong costs log lines rather than a
+  broken install. Made explicit in both twins' comments because a number next to a
+  duration reads like a timeout.
+- **Captured output reaches the transcript.** It is npm's, on a CI runner with no
+  registry credentials configured, and it is emitted only on failure or on a slow
+  install. Judged acceptable; noted because "capture and print" is a shape that deserves
+  the question asked out loud rather than skipped.
+- **A real machine's normal run looks the same as before.** Installs under the threshold
+  log one extra line each and print nothing. Nine packages on a fresh machine that is
+  having a bad night will print nine blocks — which is the point.
+
+## Acceptance criteria
+
+- [ ] AC1 — Neither twin discards the install's output; the call captures it.
+- [ ] AC2 — The output is held, not streamed, so a normal run is not interleaved.
+- [ ] AC3 — Elapsed seconds are logged on **every** outcome in both twins: fast success,
+      slow success, failure.
+- [ ] AC4 — A failure emits what happened; the "reproduce it by hand" advice is gone
+      from the reconcile block in both twins.
+- [ ] AC5 — The captured output is fenced, so an install that printed **nothing** is
+      legible as such rather than indistinguishable from "nothing was captured".
+- [ ] AC6 — The Windows capture pins and restores `$ErrorActionPreference`, with the
+      restore in a `finally`.
+- [ ] AC7 — The verbosity threshold controls printing only: nothing skips, kills or
+      fails an install for crossing it.
+- [ ] AC8 — Every assertion above is shown to fail against a mutated tree, with the
+      mutation's own diff as evidence that it landed inside the reconcile block.
+
+## References
+
+- Issue: https://github.com/mlorentedev/dotfiles/issues/1486
+- #1472 — the closed predecessor whose diagnosis ("npm registry latency") this corrects.
+- #1478 / CI-002 — took the reconcile off the PR path; this closes the hole that opened.
+- #1487 — the concurrency hole found in the same measurement.
+- #1484 — the Linux reconcile has never run in CI.
+- Lesson 267 — a mutation harness must prove the mutation landed. Applied to AC8.

--- a/specs/CI-003/tasks.md
+++ b/specs/CI-003/tasks.md
@@ -1,0 +1,61 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-09-04"
+---
+
+# Tasks - CI-003
+
+> TDD order. One task = one focused commit.
+>
+> `[P]` — no dependency on another unchecked task. `[AC<n>]` — satisfies acceptance
+> criterion `<n>` from `proposal.md`.
+
+## Setup
+
+- [x] Branch created from main: `ci/ci-003-observable-bounded-reconcile` off `9c2758a`
+- [x] `proposal.md` complete, acceptance criteria testable
+- [x] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+- [x] [P] Verify the block anchors are UNIQUE before writing any assertion on them —
+      `pi install` appears in pi's own install block ~130 lines earlier in the
+      PowerShell twin, so a file-wide search reads the wrong code. Done first, on
+      purpose: this is the step lesson 267 says gets skipped.
+- [x] [AC1][AC2] `setup-linux.sh` — capture the install's output and its elapsed time
+      instead of `>/dev/null 2>&1`
+- [x] [AC3][AC4][AC5] `setup-linux.sh` — log elapsed on all three leaves; emit the
+      captured output, fenced, on failure or over the verbosity threshold; drop the
+      "run it by hand to see why" advice
+- [x] [AC1][AC2][AC3][AC4][AC5] `setup-windows.ps1` — the same, as the twin
+- [x] [AC6] `setup-windows.ps1` — pin `$ErrorActionPreference` to `Continue` around the
+      native call and restore it in a `finally`. The hazard arrives WITH the fix: the
+      redirect being replaced never met it because it discarded stderr
+- [x] [AC7] Both twins — the threshold is a literal named as a VERBOSITY knob, used only
+      by the two comparisons that decide whether to print
+- [x] Seven assertions in `tests/pi-packages.bats`, sliced from the reconcile block to a
+      file so `lib/refute`'s negative assertions apply (`! grep` mid-body cannot fail a
+      bats test)
+- [x] [AC8] `specs/CI-003/mutate-assertions.py` — ten mutations, each located by line
+      position inside the block, each printing its own diff before any verdict
+
+## Closing
+
+- [x] Every acceptance criterion covered by at least one test
+- [x] Every acceptance criterion has a `features.json` entry with a non-vacuous,
+      **executed** verification command
+- [x] Lint passes: `bash -n`, `zsh -n`, `shellcheck --severity=error`, ASCII-only `.ps1`
+- [x] No unrelated changes in the diff — `ci.yml` is deliberately untouched
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Deliberately NOT done
+
+- **No bound.** #1486 §What.2 orders it: the bound comes from the data this produces.
+  Chosen today it would be a guess between "35–345s is normal" and "421s is the
+  anomaly", with no gap between them.
+- **No ceiling change.** #1475's raise was a loan and this is the night it came due;
+  raising it again is the same loan.
+- **No `ci.yml` change at all.** `setup-*.{sh,ps1}` are already in the `pi` filter, so
+  this PR's own `test-windows` runs the full reconcile and produces the data. Nothing to
+  add.

--- a/specs/CI-003/verification.md
+++ b/specs/CI-003/verification.md
@@ -6,8 +6,12 @@ created: "2026-09-04"
 # Verification — CI-003
 
 All commands run on this branch (`ci/ci-003-observable-bounded-reconcile`, off `9c2758a`),
-in this session. `features.json` entries stay `pending`: the agent may not write the
-terminal `passing` state, so the executed output lives here.
+in this session. `features.json` entries stay `pending` for two reasons, and the second
+matters to a reviewer: the agent may not write the terminal `passing` state, **and this
+build of `dotf` has no `spec check`** — `dotf spec --help` lists `init`, `archive` and
+`review` only. So nothing machine-executes `features.json`; the executed output lives
+here because there is nowhere else for it to live. Six `pending` entries with empty
+`evidence` mean "no harness ran them", not "they were never run".
 
 ## The measurement this spec answers to
 
@@ -52,7 +56,8 @@ that is precisely what is unlogged.
 | AC5 | `the captured output is FENCED, so empty output is legible` | pass |
 | AC6 | `the PowerShell capture cannot be terminated by a noisy install` | pass |
 | AC7 | `the slow threshold gates VERBOSITY only, never the install` | pass |
-| AC8 | `specs/CI-003/mutate-assertions.py` | 10/10 caught |
+| AC9 | `an install whose outcome is unknown counts as FAILED, not as the last one's` | pass |
+| AC8 | `specs/CI-003/mutate-assertions.py` | **12/12 caught** |
 
 ## AC8 — the mutation run
 
@@ -70,7 +75,14 @@ CAUGHT  AC5  FENCED                         [setup-linux.sh]
 CAUGHT  AC5  FENCED                         [setup-windows.ps1]
 CAUGHT  AC7  VERBOSITY only                 [setup-linux.sh]
 CAUGHT  AC6  terminated by a noisy install  [setup-windows.ps1]
+CAUGHT  AC9  outcome is unknown counts as FAILED  [setup-windows.ps1]   (line deleted)
+CAUGHT  AC9  outcome is unknown counts as FAILED  [setup-windows.ps1]   ($piRc = 0)
 ```
+
+AC9 carries two mutations on purpose: deleting the default, and flipping its **value** to
+`0`. The value is the guarantee — defaulted to 0, an install whose outcome is unknown is
+counted as a success, which is precisely what the line exists to prevent, and a test that
+only checks the line's presence would pass.
 
 Sample, showing the diff that makes the verdict a fact rather than a hypothesis:
 
@@ -121,6 +133,13 @@ own `(exit $pi_pkg_rc, …)` label and reported control flow that is not there �
 finding, which is the same disease as a false pass. Now anchored at the start of a
 statement, with the reason recorded in the test.
 
+**And it happened again, in the same file, on AC9.** The ordering assertion first anchored
+on `try {` — but the reconcile block opens a `try` ~40 lines earlier to parse the manifest,
+so it compared the default's position against *that* one and reported a correctly-placed
+line as misplaced. Re-anchored on `$ErrorActionPreference = 'Continue'`, which is unique in
+the block. Three occurrences of one shape in one file is why the block slices, the anchor
+uniqueness check and the harness's diff output are all load-bearing rather than ceremony.
+
 ## Shell + lint layer
 
 ```
@@ -129,8 +148,8 @@ zsh  -n setup-linux.sh                          OK
 shellcheck --severity=error setup-linux.sh      OK
 setup-windows.ps1                               ASCII-only (0 non-ASCII chars)
 git diff --check                                OK
-tests/pi-packages.bats                          30/30 pass (23 -> 30)
-tests/*.bats (full suite)                       see PR body
+tests/pi-packages.bats                          31/31 pass (23 -> 31)
+tests/*.bats (full suite)                       1549/1549 pass, exit 0
 ```
 
 The `.ps1` check is not decoration: `.gitattributes:36` marks `*.ps1 text eol=crlf`, and
@@ -143,7 +162,8 @@ PSScriptAnalyzer fails CI on a non-ASCII `.ps1` without a BOM.
   this change is therefore verified structurally and by mutation, not end to end.
 - **The Windows twin runs for real on this PR.** `setup-windows.ps1` is in the `pi`
   filter, so `test-windows` performs the full reconcile against the new code — which is
-  both the behavioural test for AC1–AC6 and the run that produces the data #1486 §What.2
-  needs. If it is cancelled at the ceiling again, the captured output up to the kill is
+  both the behavioural test for AC1–AC6/AC9 and the run that produces the data #1486
+  §What.2 needs. AC9's own path — a throw inside the guarded call — is the one thing no
+  green run can exercise, so it stays structurally verified. If it is cancelled at the ceiling again, the captured output up to the kill is
   still in the log; a cancelled run keeps its log, which is the property that made this
   spec's own measurement possible.

--- a/specs/CI-003/verification.md
+++ b/specs/CI-003/verification.md
@@ -1,0 +1,149 @@
+---
+tags: [spec, verification]
+created: "2026-09-04"
+---
+
+# Verification — CI-003
+
+All commands run on this branch (`ci/ci-003-observable-bounded-reconcile`, off `9c2758a`),
+in this session. `features.json` entries stay `pending`: the agent may not write the
+terminal `passing` state, so the executed output lives here.
+
+## The measurement this spec answers to
+
+Two pushes to main, same nine version-pinned packages, same runner image. Per-package
+durations derived from the runner timestamps of consecutive `Installing pi package`
+lines — the only place they exist, because neither twin logs them:
+
+| package | `33847200968` (cancelled) | `33930483404` (success) |
+|---|---:|---:|
+| `npm:pi-effort@0.0.8` | **421.4s** | 1.4s |
+| `npm:pi-web-access@0.24.2` | 195.2s | 42.0s |
+| `npm:@ayulab/pi-rewind@0.4.6` | **421.7s** | **1.8s** |
+| `npm:@narumitw/pi-plan-mode@0.53.0` | 309.6s | 13.2s |
+| `npm:@narumitw/pi-goal@0.53.1` | **421.5s** | 2.3s |
+| `npm:pi-subagents@0.56.0` | 35.2s | 12.7s |
+| `npm:pi-memory@0.4.2` | 42.2s | 1.7s |
+| `npm:pi-cc-extensions@0.8.67` | 345.0s | 25.2s |
+| `npm:pi-add-dir@1.3.1` | ≥238.4s (killed) | 1.6s |
+| **total** | **≥2430s** | **101.8s** |
+
+The right-hand run reports `pi packages: 9 installed, 0 already present, 0 failed`, so
+101.8s is a *complete* reconcile — not one that skipped work. **24x on identical input.**
+
+The rows a package-shaped explanation cannot survive: `@ayulab/pi-rewind` at **421.7s and
+1.8s** — the package #1472 singled out as the slow one — and `pi-memory` at **421.5s,
+42.2s and 1.7s**, three draws on one pinned version. Ten observations in a 421 ±1s band
+across seven packages.
+
+Between two consecutive `Installing pi package` lines the log holds **nothing** — no
+success, no failure, no output. That is what this PR changes, and it is why no bound is
+chosen here: what settles the bound is whether those 421s installs succeed or fail, and
+that is precisely what is unlogged.
+
+## AC-by-AC
+
+| AC | Covered by | Result |
+|---|---|---|
+| AC1 | `neither twin discards the install's output` | pass |
+| AC2 | `the install's output is CAPTURED, not merely streamed` | pass |
+| AC3 | `every install logs its elapsed time, on EVERY outcome` | pass |
+| AC4 | `a failure emits what happened instead of telling the reader to redo it` | pass |
+| AC5 | `the captured output is FENCED, so empty output is legible` | pass |
+| AC6 | `the PowerShell capture cannot be terminated by a noisy install` | pass |
+| AC7 | `the slow threshold gates VERBOSITY only, never the install` | pass |
+| AC8 | `specs/CI-003/mutate-assertions.py` | 10/10 caught |
+
+## AC8 — the mutation run
+
+`python3 specs/CI-003/mutate-assertions.py` → exit 0. Every case prints the mutated line,
+before and after, at its line number inside the reconcile block, **before** the suite runs:
+
+```
+CAUGHT  AC1  neither twin discards          [setup-linux.sh]
+CAUGHT  AC1  neither twin discards          [setup-windows.ps1]
+CAUGHT  AC2  output is CAPTURED             [setup-linux.sh]
+CAUGHT  AC3  elapsed time, on EVERY outcome [setup-linux.sh]
+CAUGHT  AC3  elapsed time, on EVERY outcome [setup-windows.ps1]
+CAUGHT  AC4  emits what happened            [setup-linux.sh]
+CAUGHT  AC5  FENCED                         [setup-linux.sh]
+CAUGHT  AC5  FENCED                         [setup-windows.ps1]
+CAUGHT  AC7  VERBOSITY only                 [setup-linux.sh]
+CAUGHT  AC6  terminated by a noisy install  [setup-windows.ps1]
+```
+
+Sample, showing the diff that makes the verdict a fact rather than a hypothesis:
+
+```
+== AC1  neither twin discards  [setup-linux.sh]
+    @ setup-linux.sh:926
+      -if pi_pkg_out=$("$PI_BIN" install "$pi_pkg" 2>&1); then
+      +if pi_pkg_out=$("$PI_BIN" install "$pi_pkg" >/dev/null 2>&1); then
+      1 test(s) selected -> CAUGHT
+```
+
+## Both directions, on the two features that print nothing when they pass
+
+A command whose passing output is empty is exactly the shape that passes for the wrong
+reason, so each was run with its guarantee removed:
+
+- **f4** (shell syntax + shellcheck + ASCII-only `.ps1`): appended a single `é` to
+  `setup-windows.ps1` → **exit 1**. Restored.
+- **f6** (the harness must report a HARNESS FAULT rather than a verdict): replaced one
+  mutation target with a string that does not exist → the harness printed
+  `HARNESS FAULT: target not found in setup-linux.sh at/after line 866` and exited **1**.
+  Restored.
+
+Without these two runs, both entries were green commands that had not been shown capable
+of being red.
+
+## The harness's own defect, and why it is called out
+
+The previous mutation harness (lesson 267) did a repo-wide `replace(x, '', 1)`, deleted
+an identically-spelled line from a *different* filter block, and reported four sound
+assertions as vacuous. The one committed here refuses that outcome by construction:
+
+- mutations are located **at or after the reconcile block's anchor**, never repo-wide;
+- the mutated line is printed before and after, so "the mutation landed" is observed;
+- an identical file, a missing target, or a `-f` filter selecting zero tests is reported
+  as **HARNESS FAULT** and never as `NOT CAUGHT` — the two are no longer spelled the same.
+
+The same reasoning drove a decision *before* any assertion was written: the block anchors
+were checked for uniqueness first. `pi install` appears in pi's **own** install block ~130
+lines earlier in `setup-windows.ps1`, carrying its own "run: npm install -g …" advice, so
+a file-wide assertion for AC4 would have compared against the wrong code and passed.
+
+## One test's first draft was wrong, and the failure is kept in the comment
+
+`the slow threshold gates VERBOSITY only` first searched for the words
+`break|continue|exit|return` unanchored. It matched the literal `exit` inside the fence's
+own `(exit $pi_pkg_rc, …)` label and reported control flow that is not there — a false
+finding, which is the same disease as a false pass. Now anchored at the start of a
+statement, with the reason recorded in the test.
+
+## Shell + lint layer
+
+```
+bash -n setup-linux.sh                          OK
+zsh  -n setup-linux.sh                          OK
+shellcheck --severity=error setup-linux.sh      OK
+setup-windows.ps1                               ASCII-only (0 non-ASCII chars)
+git diff --check                                OK
+tests/pi-packages.bats                          30/30 pass (23 -> 30)
+tests/*.bats (full suite)                       see PR body
+```
+
+The `.ps1` check is not decoration: `.gitattributes:36` marks `*.ps1 text eol=crlf`, and
+PSScriptAnalyzer fails CI on a non-ASCII `.ps1` without a BOM.
+
+## Not verified here, and stated rather than implied
+
+- **The Linux twin's reconcile has never executed in CI** (#1484): the `integration`
+  container has no npm, so the block logs `npm not found` and skips. The Linux half of
+  this change is therefore verified structurally and by mutation, not end to end.
+- **The Windows twin runs for real on this PR.** `setup-windows.ps1` is in the `pi`
+  filter, so `test-windows` performs the full reconcile against the new code — which is
+  both the behavioural test for AC1–AC6 and the run that produces the data #1486 §What.2
+  needs. If it is cancelled at the ceiling again, the captured output up to the kill is
+  still in the log; a cancelled run keeps its log, which is the property that made this
+  spec's own measurement possible.

--- a/tests/pi-packages.bats
+++ b/tests/pi-packages.bats
@@ -19,6 +19,29 @@ setup() {
     SETUP_PS1="$REPO/setup-windows.ps1"
 }
 
+# Slice the RECONCILE BLOCK out of each twin, to a FILE. Every CI-003 assertion
+# below runs against these, never against the whole script, and that is
+# load-bearing rather than tidy: `pi install` appears in pi's OWN install block
+# ~130 lines earlier in the PowerShell twin, carrying its own
+# "run: npm install -g ..." advice, so a file-wide search compares against the
+# wrong block and reports the state of code this suite is not about. Same genus
+# as the $PI_BIN collision already documented at "the skip is the FIRST branch".
+#
+# A file and not a variable because lib/refute's negative assertions take a
+# path, and they must: `! grep` in the middle of a @test body cannot fail that
+# test (bash exempts `!` from set -e), which is the vacuous-pass this suite has
+# already been bitten by. Using the helper is not a style choice.
+slice_reconcile_blocks() {
+    SH_BLOCK="$BATS_TEST_TMPDIR/reconcile.sh.txt"
+    PS_BLOCK="$BATS_TEST_TMPDIR/reconcile.ps1.txt"
+    awk '/^PI_PACKAGES_SRC=/{f=1} f' "$SETUP_SH" > "$SH_BLOCK"
+    awk '/^\$piPackagesSrc = Join-Path/{f=1} f' "$SETUP_PS1" > "$PS_BLOCK"
+    # A slice that came back empty would make every refute_grep below pass for
+    # the wrong reason -- the exact failure lesson 267 records.
+    [ -s "$SH_BLOCK" ]
+    [ -s "$PS_BLOCK" ]
+}
+
 # --- the manifest ------------------------------------------------------------
 
 @test "pi packages: the manifest exists and is valid JSON with at least one entry" {
@@ -259,4 +282,115 @@ setup() {
     # comment-prose variant of it. Anchor on the LIST, never on what follows it.
     filter=$(awk '/^            pi:$/{f=1;next} f && !/^ *- /{exit} f' "$CI")
     echo "$filter" | grep -q "$decl"
+}
+
+
+# --- CI-003 (#1486): the reconcile must be observable ------------------------
+#
+# The whole ticket exists because both twins discarded the install's stdout AND
+# stderr and logged no elapsed time, so a 421s install could not be told apart
+# from a 42s one except by reading GitHub's own line timestamps -- and a slow
+# SUCCESS could not be told apart from a slow FAILURE at all. Those two demand
+# opposite fixes, which is why nothing could be bounded until this landed.
+
+@test "pi packages: neither twin discards the install's output" {
+    # The defect itself, asserted at the call site. `2>&1` alone is not enough:
+    # a call that merges stderr into stdout and then sends it to /dev/null is
+    # exactly as blind as the original was.
+    slice_reconcile_blocks
+    sh_call="$BATS_TEST_TMPDIR/sh_call.txt"
+    grep '"\$PI_BIN" install "\$pi_pkg"' "$SH_BLOCK" > "$sh_call"
+    [ -s "$sh_call" ]
+    refute_grep_fixed '/dev/null' "$sh_call"
+    grep -q '2>&1' "$sh_call"
+
+    ps_call="$BATS_TEST_TMPDIR/ps_call.txt"
+    grep '& pi install \$piPkgName' "$PS_BLOCK" > "$ps_call"
+    [ -s "$ps_call" ]
+    refute_grep_fixed 'Out-Null' "$ps_call"
+    refute_grep_fixed '2>$null' "$ps_call"
+    grep -q '2>&1' "$ps_call"
+}
+
+@test "pi packages: the install's output is CAPTURED, not merely streamed" {
+    # Streaming it would interleave nine installs' npm output into setup's
+    # transcript on every normal run. It is held and emitted only when it says
+    # something -- so the call must ASSIGN, not print.
+    slice_reconcile_blocks
+    grep -q 'pi_pkg_out=\$("\$PI_BIN" install' "$SH_BLOCK"
+    grep -q '\$piOut = (& pi install' "$PS_BLOCK"
+}
+
+@test "pi packages: every install logs its elapsed time, on EVERY outcome" {
+    # The single line that answers "did the 421s end in success?", which no
+    # amount of captured output answers on its own. Asserted per LEAF rather
+    # than once: a version logging elapsed only on failure, or only on the slow
+    # path, satisfies a single grep and still leaves the normal case silent --
+    # and the normal case is the one that was silent.
+    slice_reconcile_blocks
+    grep -q 'installed in \${pi_pkg_elapsed}s' "$SH_BLOCK"   # success, fast
+    grep -q 'took \${pi_pkg_elapsed}s' "$SH_BLOCK"           # success, slow
+    grep -q 'failed after \${pi_pkg_elapsed}s' "$SH_BLOCK"   # failure
+
+    grep -q 'installed in \${piElapsed}s' "$PS_BLOCK"
+    grep -q 'took \${piElapsed}s' "$PS_BLOCK"
+    grep -q 'failed after \${piElapsed}s' "$PS_BLOCK"
+}
+
+@test "pi packages: a failure emits what happened instead of telling the reader to redo it" {
+    # "run 'pi install X' to see why" asked a human to reproduce by hand, later,
+    # a failure the machine had in a variable at the time. On the Windows runner
+    # that reproduction is not available at all, so the advice was unactionable
+    # exactly where the failures happen.
+    slice_reconcile_blocks
+    refute_grep_fixed 'to see why' "$SH_BLOCK"
+    refute_grep_fixed 'to see why' "$PS_BLOCK"
+}
+
+@test "pi packages: the captured output is FENCED, so empty output is legible" {
+    # "The install printed nothing at all" is a finding. Dumped bare it is
+    # indistinguishable from "we captured nothing", which is the bug being
+    # replaced -- so the absence has to be visible, not inferred.
+    slice_reconcile_blocks
+    grep -q -- '--- pi install \$pi_pkg' "$SH_BLOCK"
+    grep -q -- '--- end pi install \$pi_pkg' "$SH_BLOCK"
+    grep -q -- '--- pi install \$piPkgName' "$PS_BLOCK"
+    grep -q -- '--- end pi install \$piPkgName' "$PS_BLOCK"
+}
+
+@test "pi packages: the slow threshold gates VERBOSITY only, never the install" {
+    # It must not become a bound by accident. Nothing may skip, kill or fail an
+    # install for crossing it: the loop still runs every package to completion,
+    # and #1486 says the real bound is chosen from the data this produces, not
+    # from a threshold picked before there was any.
+    slice_reconcile_blocks
+    grep -q 'PI_INSTALL_SLOW_SECONDS=[0-9]' "$SH_BLOCK"
+    grep -q '\$piSlowSeconds = [0-9]' "$PS_BLOCK"
+    # Whatever else the threshold is used for, it is not used to leave the loop.
+    # Anchored at the start of a STATEMENT: an unanchored word search matches
+    # the literal "exit" inside the fence's own `(exit $pi_pkg_rc, ...)` label
+    # and reports control flow that is not there -- a false finding, which is
+    # the same disease as a false pass and was this test's first draft.
+    sh_ctl="$BATS_TEST_TMPDIR/sh_ctl.txt"
+    grep -A2 'PI_INSTALL_SLOW_SECONDS"' "$SH_BLOCK" > "$sh_ctl" || true
+    [ -s "$sh_ctl" ]
+    refute_grep '^[-[:space:]]*(break|continue|exit|return)([[:space:]]|$)' "$sh_ctl"
+}
+
+@test "pi packages: the PowerShell capture cannot be terminated by a noisy install" {
+    # `2>&1` on a NATIVE command turns its stderr into ErrorRecords, and under
+    # $ErrorActionPreference = 'Stop' those TERMINATE -- so an install that
+    # writes a warning to stderr and exits 0 would abort setup. The redirect
+    # this replaced (`2>$null`) never met that hazard because it threw stderr
+    # away, so the hazard arrives WITH the fix. Pinned around the call and
+    # restored, or the change trades a blind spot for a crash.
+    # No Linux half: `sh` has no comparable coupling between stderr and control
+    # flow, and inventing a symmetric assertion would assert nothing.
+    slice_reconcile_blocks
+    grep -q "ErrorActionPreference = 'Continue'" "$PS_BLOCK"
+    grep -q '\$piPrevEap = \$ErrorActionPreference' "$PS_BLOCK"
+    grep -q '\$ErrorActionPreference = \$piPrevEap' "$PS_BLOCK"
+    # Restored on the throwing path too, or one bad install leaves every later
+    # native call in setup running under a preference it never asked for.
+    grep -q 'finally {' "$PS_BLOCK"
 }

--- a/tests/pi-packages.bats
+++ b/tests/pi-packages.bats
@@ -394,3 +394,27 @@ slice_reconcile_blocks() {
     # native call in setup running under a preference it never asked for.
     grep -q 'finally {' "$PS_BLOCK"
 }
+
+@test "pi packages: an install whose outcome is unknown counts as FAILED, not as the last one's" {
+    # `$piRc` is assigned INSIDE the try. If the call throws it is never assigned,
+    # and the read after the try is then of an unassigned variable -- which under
+    # Set-StrictMode -Version Latest is a terminating error thrown OUTSIDE the try
+    # meant to contain it. Worse on iteration 2+: it is not unassigned at all, it
+    # still holds the PREVIOUS package's result, so a broken install is counted as
+    # whatever the last one did. Defaulted to failure BEFORE the try, so an unknown
+    # outcome can never read as success.
+    slice_reconcile_blocks
+    grep -q '\$piRc = 1' "$PS_BLOCK"
+    # Order is the contract: the default must precede the guarded call, or it
+    # defaults nothing. Anchored on the EAP pin, which is unique in the block --
+    # `try {` is NOT: the manifest parse ~40 lines earlier opens one, and the
+    # first draft of this assertion compared against THAT and reported the
+    # default as misplaced when it is not. A false finding is the same disease
+    # as a false pass, and it is the third time in this file.
+    n_default=$(grep -n '\$piRc = 1' "$PS_BLOCK" | head -1 | cut -d: -f1)
+    n_pin=$(grep -n "ErrorActionPreference = 'Continue'" "$PS_BLOCK" | head -1 | cut -d: -f1)
+    n_read=$(grep -n '\$piRc = \$LASTEXITCODE' "$PS_BLOCK" | head -1 | cut -d: -f1)
+    [ -n "$n_default" ] && [ -n "$n_pin" ] && [ -n "$n_read" ]
+    [ "$n_default" -lt "$n_pin" ]
+    [ "$n_pin" -lt "$n_read" ]
+}


### PR DESCRIPTION
Refs #1486 — **part 1 of 2, so this does not close it.** #1486 §What.1 is the
observability; §What.2 is the bound, and the whole argument of this PR is that the bound
cannot be chosen until §What.1 has produced data. The spec stays `implementing` and
archives with part 2.

## The finding

The pi package reconcile costs **101.8s or ≥2430s** for the same nine version-pinned
packages, on the same runner image. **24x on identical input.** Two pushes to main:

| run | package phase | setup step | outcome |
|---|---:|---:|---|
| `33847200968` | **≥2430s** | 44m19s | **cancelled at the 45-minute ceiling** |
| `33930483404` | **101.8s** | 6m24s | success |

The cancelled one produced **no Windows verification at all** — `Post-setup doctor gate`,
`Run Pester suites` and `Run PowerShell bats subset` are all `skipped` — and `cancelled`
is neither a pass nor a failure, so nothing went red. The fast one reports
`pi packages: 9 installed, 0 already present, 0 failed`, which is what makes 101.8s a
*complete* reconcile rather than one that skipped work.

Per package:

| package | cancelled run | successful run |
|---|---:|---:|
| `npm:pi-effort@0.0.8` | **421.4s** | 1.4s |
| `npm:pi-web-access@0.24.2` | 195.2s | 42.0s |
| `npm:@ayulab/pi-rewind@0.4.6` | **421.7s** | **1.8s** |
| `npm:@narumitw/pi-plan-mode@0.53.0` | 309.6s | 13.2s |
| `npm:@narumitw/pi-goal@0.53.1` | **421.5s** | 2.3s |
| `npm:pi-subagents@0.56.0` | 35.2s | 12.7s |
| `npm:pi-memory@0.4.2` | 42.2s | 1.7s |
| `npm:pi-cc-extensions@0.8.67` | 345.0s | 25.2s |
| `npm:pi-add-dir@1.3.1` | ≥238.4s (killed) | 1.6s |

`@ayulab/pi-rewind` — the package #1472 singled out as the slow one — ran **421.7s and
1.8s**. `pi-memory` ran **421.5s, 42.2s and 1.7s** on one pin. Ten observations in a
421 ±1s band across seven packages: a fixed timeout on the install *operation*, landing
on whichever installs hit it. How many hit it per run is the whole variance.

## Why this PR does not fix it

Because it cannot yet, and that is the point. Both twins discarded the install's stdout
**and** stderr:

```powershell
& pi install $piPkgName 2>$null | Out-Null              # setup-windows.ps1:1345
```
```sh
"$PI_BIN" install "$pi_pkg" >/dev/null 2>&1             # setup-linux.sh:910
```

Between two consecutive `Installing pi package` lines the log holds **nothing**. So a
421s install that **succeeded slowly** and one that **failed after retries** are
indistinguishable — and they demand opposite bounds. A bound that kills a slow success
turns working setup into broken setup; a bound on an install that was failing anyway is
free. Durations alone cannot settle it either: one package spans 1.4s–421.7s.

Neither twin logged elapsed time, so every number above was reconstructed from Actions'
own line timestamps — which means the same diagnosis is simply unavailable on a real
machine.

## What changed

Both twins, together:

- **Elapsed seconds logged on every outcome** — fast success, slow success, failure. This
  is the line that answers *"did the 421s end in success?"*, which no amount of captured
  output answers on its own.
- **The install's output captured, not discarded**, and emitted **fenced** when the
  install fails or crosses a verbosity threshold. Fenced because "the install printed
  nothing at all" is itself a finding, and a bare dump makes it indistinguishable from
  "nothing was captured" — which is the bug being replaced.
- **`run 'pi install X' to see why` is gone.** It asked a human to reproduce by hand,
  later, a failure the machine held in a variable at the time. On the Windows runner that
  reproduction is not available at all.
- **`$ErrorActionPreference` pinned and restored in a `finally`** around the PowerShell
  call. `2>&1` on a *native* command turns stderr into `ErrorRecord`s, and under `Stop`
  those terminate — so an install that writes a warning and exits 0 would abort setup.
  The redirect being replaced never met that hazard because it threw stderr away, which
  means **the hazard arrives with the fix**.
- **`$piRc` defaulted to failure before the guarded call.** It was assigned only *inside*
  the `try`. A throw would leave it unassigned — and reading an unassigned variable under
  `Set-StrictMode -Version Latest` is itself a terminating error, thrown outside the `try`
  meant to contain it. On iteration 2+ it would not even be unassigned: it would still
  hold the *previous* package's result, so a broken install would be counted as whatever
  the last one did. An unknown outcome is a failure, never a success.

## Deliberately not done

- **No bound.** #1486 §What.2 orders it: chosen from the data this produces.
- **No ceiling change.** #1475's 30 → 45 was an explicitly temporary loan that came due
  twice in one morning. Raising it again is the same loan.
- **No `ci.yml` change at all.** `setup-*.{sh,ps1}` are already in the `pi` filter, so
  **this PR's own `test-windows` runs the full reconcile against the new code** — it is
  the behavioural test *and* the run that produces the data. If it is cancelled at the
  ceiling, the captured output up to the kill is still in the log; a cancelled run keeps
  its log, which is the property that made this measurement possible in the first place.

## Verification

```
tests/*.bats                 1549/1549 pass, exit 0 (clean tree)
tests/pi-packages.bats       31/31 (23 -> 31)
bash -n / zsh -n             OK
shellcheck --severity=error  OK
setup-windows.ps1            ASCII-only (.gitattributes:36 marks it eol=crlf;
                             PSScriptAnalyzer fails CI on non-ASCII without a BOM)
git diff --check             OK
```

**Twelve mutations, twelve caught** — `python3 specs/CI-003/mutate-assertions.py`, exit 0. Each
prints the mutated line before and after, at its line number **inside the reconcile
block**, before the suite runs:

```
== AC1  neither twin discards  [setup-linux.sh]
    @ setup-linux.sh:926
      -if pi_pkg_out=$("$PI_BIN" install "$pi_pkg" 2>&1); then
      +if pi_pkg_out=$("$PI_BIN" install "$pi_pkg" >/dev/null 2>&1); then
      1 test(s) selected -> CAUGHT
```

That shape is lesson 267's requirement, and it is why the harness is committed rather
than described: the previous one did a repo-wide `replace(x, '', 1)`, deleted an
identically-spelled line from a *different* block, and reported four sound assertions as
vacuous. This one reports **HARNESS FAULT** — never `NOT CAUGHT` — for an identical file,
a missing target, or a `-f` filter selecting zero tests, so the two are no longer spelled
the same.

The same reasoning ran *before* any assertion was written: block anchors were checked for
uniqueness first. `pi install` appears in pi's **own** install block ~130 lines earlier in
`setup-windows.ps1`, carrying its own `run: npm install -g …` advice, so a file-wide
assertion would have compared against the wrong code and passed.

**Both directions on the two checks that print nothing when they pass** — a green command
that has never been shown capable of being red is not evidence:

- shell syntax + shellcheck + ASCII-only: appended one `é` to `setup-windows.ps1` →
  **exit 1**.
- the harness-fault path: replaced one mutation target with a string that does not exist
  → `HARNESS FAULT: target not found in setup-linux.sh at/after line 866`, **exit 1**.

## Corrections made while building this

- **#1486's original body said main "does not complete, so it verifies nothing anywhere".
  That was false of the current head** — true of three morning runs, and a peer session
  pointed at two later ones that succeeded. Verified directly, then the ticket's title and
  body were corrected. Three cancellations read as a state is the same sampling error that
  made #1472 call `pi-rewind` the slow package.
- **One assertion's first draft was wrong.** `the slow threshold gates VERBOSITY only`
  searched for `break|continue|exit|return` unanchored and matched the literal `exit`
  inside the fence's own `(exit $pi_pkg_rc, …)` label — a false *finding*, which is the
  same disease as a false pass. Anchored now, with the reason kept in the test.
- **And again, on the `$piRc` ordering assertion.** It first anchored on `try {`, but the
  reconcile block opens a `try` ~40 lines earlier to parse the manifest, so it compared
  against *that* one and reported a correctly-placed line as misplaced. Re-anchored on
  `$ErrorActionPreference = 'Continue'`, unique in the block. Three occurrences of one
  shape in one file is why the block slices and the anchor-uniqueness check are
  load-bearing rather than ceremony.

## Not verified here

- **`setup-linux.sh`'s reconcile has still never executed in CI** (#1484): the
  `integration` container has no npm, so the block logs `npm not found` and skips. The
  Linux half is verified structurally and by mutation, not end to end. Unchanged by this
  PR, stated rather than implied.
- Also filed from this measurement: **#1487** — a third push to main discards the second
  *pending* run (`cancel-in-progress: false` protects the running run, not the queued
  one), so two merges close together can leave one commit with no CI at all.
