### PR TITLE
feat(cli): dotf vault maintain, composing crystallize and health in-process

### DIFF
--- a/cli/internal/cmd/vault.go
+++ b/cli/internal/cmd/vault.go
@@ -45,6 +45,7 @@ Subcommands:
 	cmd.AddCommand(newVaultProjectCmd())
 	cmd.AddCommand(newVaultCrystallizeCmd())
 	cmd.AddCommand(newVaultHealthCmd())
+	cmd.AddCommand(newVaultMaintainCmd())
 	cmd.AddCommand(newSearchCmd())
 	return cmd
 }
@@ -59,11 +60,20 @@ Subcommands:
 //
 // Built beside the twins in CLI-021, then cut over in CLI-050 (#1269): the
 // shell/PowerShell pair is deleted, every caller repoints here, and this is
-// the sole implementation. `vault health` and `vault maintain` (increments 2
-// and 3 of #490) are still unbuilt, and the rest of the cluster
-// (vault-health.sh, vault-maintenance-weekly.{sh,ps1}, obs-cli, the spec-gate
-// scripts) is still shell — that full cutover is CLI-023 (#492), blocked on
-// those plus CLI-022.
+// the sole implementation.
+//
+// All three of #490's increments are now built — crystallize (this file),
+// health (vault_health.go) and maintain (vault_maintain.go). Only crystallize
+// is CUT OVER; the other two are built beside twins that are still the
+// canonical invocation (scripts/vault-health.sh and
+// scripts/vault-maintenance-weekly.{sh,ps1}, the latter still wired to cron at
+// setup-linux.sh:1605 and to Task Scheduler at setup-windows.ps1:2185). That
+// cutover, plus the rest of the cluster (obs-cli, the spec-gate scripts), is
+// CLI-023 (#492), blocked on CLI-022.
+//
+// This comment previously said health and maintain were "still unbuilt" while
+// health was registered forty lines below it. Lessons 256/257: probe the
+// target, never trust a block's own comment about itself.
 func newVaultCrystallizeCmd() *cobra.Command {
 	var all bool
 

--- a/cli/internal/cmd/vault_health.go
+++ b/cli/internal/cmd/vault_health.go
@@ -60,31 +60,7 @@ missing from PATH), 2 the GUI is unreachable.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(c *cobra.Command, _ []string) error {
-			name := vaultName
-			if name == "" {
-				name = os.Getenv("VAULT_NAME")
-			}
-			if name == "" {
-				name = "knowledge"
-			}
-
-			dir := os.Getenv("VAULT_DIR")
-			if dir == "" {
-				dir = env.ResolvePath("VAULT_PATH")
-			}
-			if dir == "" {
-				if home, herr := os.UserHomeDir(); herr == nil {
-					dir = home + "/Projects/knowledge"
-				}
-			}
-
-			code, err := vault.RunHealth(c.OutOrStdout(), vault.HealthOptions{
-				VaultDir:   dir,
-				VaultName:  name,
-				Verbose:    verbose,
-				ScriptsDir: memScriptsDir(),
-				BashPath:   mem.ResolveBash(),
-			})
+			code, err := vault.RunHealth(c.OutOrStdout(), healthOptions(vaultName, verbose))
 			if err != nil {
 				return err
 			}
@@ -98,4 +74,36 @@ missing from PATH), 2 the GUI is unreachable.`,
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "list orphan/unresolved/tag detail (truncated)")
 	cmd.Flags().StringVar(&vaultName, "vault", "", "Obsidian vault name (default: $VAULT_NAME or \"knowledge\")")
 	return cmd
+}
+
+// healthOptions builds the HealthOptions both `vault health` and `vault
+// maintain` need. Extracted rather than duplicated when increment 3 landed: the
+// $VAULT_DIR-then-ADR-025 cascade documented above is a contract, and two
+// copies of a resolution cascade drift in exactly the way ADR-020 §5 is about.
+func healthOptions(vaultName string, verbose bool) vault.HealthOptions {
+	name := vaultName
+	if name == "" {
+		name = os.Getenv("VAULT_NAME")
+	}
+	if name == "" {
+		name = "knowledge"
+	}
+
+	dir := os.Getenv("VAULT_DIR")
+	if dir == "" {
+		dir = env.ResolvePath("VAULT_PATH")
+	}
+	if dir == "" {
+		if home, herr := os.UserHomeDir(); herr == nil {
+			dir = home + "/Projects/knowledge"
+		}
+	}
+
+	return vault.HealthOptions{
+		VaultDir:   dir,
+		VaultName:  name,
+		Verbose:    verbose,
+		ScriptsDir: memScriptsDir(),
+		BashPath:   mem.ResolveBash(),
+	}
 }

--- a/cli/internal/cmd/vault_maintain.go
+++ b/cli/internal/cmd/vault_maintain.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mlorentedev/dotfiles/cli/internal/vault"
+)
+
+// newVaultMaintainCmd builds `dotf vault maintain`, the Go port of
+// scripts/vault-maintenance-weekly.{sh,ps1} (CLI-021 / #490, increment 3).
+// Built BESIDE the twins: the crontab entry at setup-linux.sh:1605 and the Task
+// Scheduler entry at setup-windows.ps1:2185 still point at the scripts, and
+// repointing them is CLI-023 (#492).
+//
+// No flags, matching the twins, which take none — this is a scheduled job whose
+// only caller is cron. `--vault` and `--verbose` are `vault health`'s, and a
+// weekly log wants neither.
+func newVaultMaintainCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "maintain",
+		Short: "Run the weekly vault maintenance pass (crystallize + health) and log it",
+		Long: `maintain runs the unattended weekly maintenance pass:
+
+  1. dotf vault crystallize --all  — MEMORY.md dates across every project
+  2. dotf vault health             — the 7-section vault report
+
+Both run best-effort: neither failing stops the other, and neither stops the log
+being written. The log lands at ~/.local/share/vault-maintenance/latest.log
+(%LOCALAPPDATA%\vault-maintenance\latest.log on Windows) and a best-effort
+desktop notification reports how many issue lines it holds.
+
+Exit status is 0 whenever the run did its job. Health findings are NOT failures
+— they are reported on stdout and in the log, so a scheduled run does not mail
+you every week the Obsidian GUI happened to be closed. The only error is being
+unable to write the log.`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, _ []string) error {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return err
+			}
+			return vault.RunMaintain(c.OutOrStdout(), vault.MaintainOptions{
+				Home:    home,
+				Today:   time.Now().Format("2006-01-02"),
+				LogFile: vault.DefaultLogFile(home),
+				Health:  healthOptions("", false),
+				Notify:  vault.NotifyDesktop,
+			})
+		},
+	}
+}

--- a/cli/internal/vault/maintain.go
+++ b/cli/internal/vault/maintain.go
@@ -1,0 +1,263 @@
+package vault
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Increment 3 of CLI-021 (#490): the Go port of
+// scripts/vault-maintenance-weekly.{sh,ps1}. Built BESIDE the twins — nothing
+// repoints at this yet (the crontab entry at setup-linux.sh:1605 and the Task
+// Scheduler entry at setup-windows.ps1:2185 are CLI-023 / #492's to flip).
+//
+// Unlike increments 1 and 2 this is NOT golden-characterized, deliberately.
+// The twin's output is a timestamped log wrapping two subcommands whose
+// byte-parity is already proven by tests/knowledge-crystallize-go-parity.bats
+// and tests/vault-health-go-parity.bats. What is left to characterize is the
+// wrapper itself — log path, section framing, the issue-count regex, the
+// notification threshold, the exit code — and those are behaviours, not bytes.
+// They are covered by table tests here plus the behavioural cases in
+// tests/vault-maintenance-weekly.bats.
+//
+// LINUX IS THE REFERENCE. The .ps1 twin runs no health step at all despite its
+// own header claiming it does; that divergence is recorded in
+// specs/CLI-021-dotf-vault-build-knowledge/divergences.md §Increment 2 and is
+// not re-decided here. Porting the Linux behaviour means `maintain` runs both
+// steps on every OS, which is the ADR-020 precedent CLI-024 set (reconstruct
+// the Linux superset, not the .ps1 subset).
+//
+// Composition is IN-PROCESS, not `exec dotf`. The shell had no choice; a Go
+// binary that already owns both steps does. This deletes the twin's documented
+// failure mode outright — cron's minimal PATH excludes ~/.local/bin, so a bare
+// `dotf` there silently no-ops under `|| true` every Sunday
+// (scripts/vault-maintenance-weekly.sh:12-16, and the regression guard at
+// tests/vault-maintenance-weekly.bats:147). There is no PATH to harden when
+// there is no subprocess.
+
+// issueRE mirrors the twins' issue counter: `grep -ciE "warning|fail|action|stale"`
+// on the .sh, `Select-String -Pattern "WARNING|FAIL|ACTION|STALE" -CaseSensitive:$false`
+// on the .ps1. Both count matching LINES, not matches, and both are substring
+// matches rather than word-boundary ones — "failed" and "stalemate" score.
+// Reproduced faithfully; over-counting is the oracle's behaviour, not a defect
+// introduced here.
+var issueRE = regexp.MustCompile(`(?i)warning|fail|action|stale`)
+
+// Urgency is the notification level the issue count selects. The names are
+// notify-send's own (`-u low|normal`), which the .sh passes through directly.
+type Urgency string
+
+const (
+	UrgencyLow    Urgency = "low"
+	UrgencyNormal Urgency = "normal"
+)
+
+// Notifier fires the best-effort desktop notification. It returns nothing
+// because both twins discard every failure: notify-send is guarded behind
+// `command -v` and then `|| true`, and the .ps1 wraps the whole toast in a
+// try/catch. A maintenance run must not fail because a desktop bus is absent.
+type Notifier func(urgency Urgency, title, body string)
+
+// MaintainOptions configures RunMaintain. Every seam the tests need to replace
+// is a field, so no test touches a real vault, a real log location, or a real
+// desktop bus.
+type MaintainOptions struct {
+	Home    string        // for CrystallizeAll's project discovery
+	Today   string        // YYYY-MM-DD, as CrystallizeAll expects
+	LogFile string        // absolute; DefaultLogFile derives the twins' location
+	Health  HealthOptions // forwarded verbatim to RunHealth
+	Now     func() time.Time
+	Notify  Notifier
+
+	// The two steps, replaceable only from inside this package — i.e. by tests.
+	// Unexported rather than package-level vars so parallel tests cannot race,
+	// and unexported rather than public so no caller can substitute a step and
+	// still call the result a maintenance run.
+	crystallizeStep func(io.Writer) error
+	healthStep      func(io.Writer) (int, error)
+}
+
+// DefaultLogFile returns the log location the twins write, per OS:
+// $HOME/.local/share/vault-maintenance/latest.log on Linux (.sh:19-20) and
+// %LOCALAPPDATA%\vault-maintenance\latest.log on Windows (.ps1:16-17).
+//
+// A GOOS switch rather than os.UserCacheDir(), which resolves ~/.cache on Linux
+// — a different directory from the ~/.local/share the twin has been writing to,
+// and the log is an artefact a human goes looking for by path.
+func DefaultLogFile(home string) string {
+	return logFileFor(runtime.GOOS, home, os.Getenv("LOCALAPPDATA"))
+}
+
+// logFileFor is DefaultLogFile with its two ambient inputs passed in, so BOTH
+// OS branches are testable from either host. Reading runtime.GOOS inline would
+// leave whichever branch you are not running on covered only by the compiler.
+func logFileFor(goos, home, localAppData string) string {
+	if goos == "windows" {
+		if localAppData != "" {
+			return filepath.Join(localAppData, "vault-maintenance", "latest.log")
+		}
+		return filepath.Join(home, "AppData", "Local", "vault-maintenance", "latest.log")
+	}
+	return filepath.Join(home, ".local", "share", "vault-maintenance", "latest.log")
+}
+
+// CountIssues reports how many LINES of the log match the twins' issue pattern.
+func CountIssues(log string) int {
+	n := 0
+	for _, line := range strings.Split(log, "\n") {
+		if issueRE.MatchString(line) {
+			n++
+		}
+	}
+	return n
+}
+
+// notificationFor maps an issue count onto the notification the twins send.
+// Both agree on the wording and on the threshold being `> 0`.
+func notificationFor(issues int) (Urgency, string, string) {
+	if issues > 0 {
+		return UrgencyNormal, "Vault Maintenance",
+			fmt.Sprintf("%d potential issues. Run /insights on active projects.", issues)
+	}
+	return UrgencyLow, "Vault Maintenance", "All clean. No action needed."
+}
+
+// RunMaintain composes crystallize + health into the weekly log, fires the
+// best-effort notification, and reports the log path on w.
+//
+// The timestamp format is Go's time.UnixDate, which matches GNU date(1)'s
+// default output — what `$(date)` produces in the .sh. Get-Date's default on
+// the .ps1 is a different, locale-dependent shape; recorded as a divergence
+// rather than reproduced, since Linux is the reference.
+//
+// # It returns an error, never an exit code, and that is a decision
+//
+// A FINDING IS NOT A FAILURE. RunHealth's 0/1/2 answers "what did the report
+// find"; maintain's status answers "did the run do its job". Health reporting
+// orphans, or degrading because the Obsidian GUI is closed, means maintain
+// worked exactly as designed — so those do not become a non-zero status.
+//
+// Propagating health's code would make the status depend on whether a desktop
+// GUI happened to be running, which from cron's point of view is
+// nondeterministic: every Sunday the laptop was shut would mail the owner a
+// failed-job notice for a healthy run. False alarms on a weekly channel train
+// the owner to ignore it, and would take the desktop notification — the signal
+// this command was actually built around — down with it.
+//
+// The finding is not dropped, it is routed: the report body goes to the log,
+// the count picks the notification urgency, and the verdict is summarised on w
+// for whoever ran this by hand. Informative, not contractual.
+//
+// The only non-nil error is a genuine failure of the run itself — the log
+// directory or the log file could not be written. Everything else is a finding.
+func RunMaintain(w io.Writer, opts MaintainOptions) error {
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	crystallize := opts.crystallizeStep
+	if crystallize == nil {
+		crystallize = func(lw io.Writer) error { return CrystallizeAll(lw, opts.Home, opts.Today) }
+	}
+	health := opts.healthStep
+	if health == nil {
+		health = func(lw io.Writer) (int, error) { return RunHealth(lw, opts.Health) }
+	}
+
+	var log bytes.Buffer
+	fmt.Fprintf(&log, "=== Vault Maintenance: %s ===\n\n", now().Format(time.UnixDate))
+
+	// Both steps are best-effort, exactly as the twin's `|| true`: a crystallize
+	// that refuses one project must not stop the health report from running, and
+	// neither failure stops the log being written.
+	fmt.Fprintf(&log, "--- dotf vault crystallize --all ---\n")
+	fmt.Fprintf(&log, "[INFO] Date: %s\n", opts.Today)
+	if err := crystallize(&log); err != nil {
+		fmt.Fprintf(&log, "crystallize: %v\n", err)
+	}
+	fmt.Fprintf(&log, "\n")
+
+	fmt.Fprintf(&log, "--- vault-health ---\n")
+	healthCode, err := health(&log)
+	if err != nil {
+		fmt.Fprintf(&log, "health: %v\n", err)
+	}
+	fmt.Fprintf(&log, "\n")
+
+	fmt.Fprintf(&log, "=== Done: %s ===\n", now().Format(time.UnixDate))
+
+	// The log is the artefact. Failing to write it is the one way this run
+	// genuinely did not do its job, so it is the one thing that errors.
+	if err := os.MkdirAll(filepath.Dir(opts.LogFile), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(opts.LogFile, log.Bytes(), 0o644); err != nil {
+		return err
+	}
+
+	issues := CountIssues(log.String())
+	if opts.Notify != nil {
+		opts.Notify(notificationFor(issues))
+	}
+
+	// The verdict, on stdout, for whoever ran this by hand. Silence means pass,
+	// as everywhere else in this CLI. The issue count is printed unconditionally
+	// because the notification that normally carries it is the FIRST thing to
+	// vanish on a headless box — which is exactly where an unattended weekly run
+	// lives, and where the log is the only thing anyone will ever read.
+	switch healthCode {
+	case 1:
+		emit(w, "Vault health: FAILED — one or more checks\n")
+	case 2:
+		emit(w, "Vault health: SKIPPED — the Obsidian GUI was unreachable\n")
+	}
+	emit(w, "%d issue line(s) in the log\n", issues)
+	emit(w, "Log written to %s\n", opts.LogFile)
+
+	return nil
+}
+
+// NotifyDesktop is the default Notifier: notify-send on Linux, a NotifyIcon
+// balloon via powershell on Windows. Both are fire-and-forget — every error is
+// discarded, matching the twins.
+func NotifyDesktop(urgency Urgency, title, body string) {
+	switch runtime.GOOS {
+	case "windows":
+		// The balloon dies with the process that owns it, so the .ps1's
+		// Start-Sleep 11 (one second past the 10s ShowBalloonTip) is load-bearing
+		// and is kept here rather than dropped.
+		script := fmt.Sprintf(`Add-Type -AssemblyName System.Windows.Forms
+$b = New-Object System.Windows.Forms.NotifyIcon
+$b.Icon = [System.Drawing.SystemIcons]::Information
+$b.BalloonTipTitle = %q
+$b.BalloonTipText = %q
+$b.Visible = $true
+$b.ShowBalloonTip(10000)
+Start-Sleep -Seconds 11
+$b.Dispose()`, title, body)
+		_ = exec.Command("powershell", "-NoProfile", "-Command", script).Run()
+	default:
+		if _, err := exec.LookPath("notify-send"); err != nil {
+			return
+		}
+		cmd := exec.Command("notify-send", "-u", string(urgency), title, body)
+		// The .sh defaults both when unset because cron inherits neither
+		// (scripts/vault-maintenance-weekly.sh:43-44).
+		cmd.Env = os.Environ()
+		if os.Getenv("DISPLAY") == "" {
+			cmd.Env = append(cmd.Env, "DISPLAY=:0")
+		}
+		if os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
+			cmd.Env = append(cmd.Env,
+				fmt.Sprintf("DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%d/bus", os.Getuid()))
+		}
+		_ = cmd.Run()
+	}
+}

--- a/cli/internal/vault/maintain_test.go
+++ b/cli/internal/vault/maintain_test.go
@@ -1,0 +1,308 @@
+package vault
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// frozen is the clock every RunMaintain test injects, so the two `date` stamps
+// are assertable rather than merely present.
+var frozen = time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+
+// recorder captures what the notifier was asked to send. A test that let the
+// real notifier run would fire a desktop notification on the developer's
+// machine — the same class of leak tests/golden/vault-health guards against by
+// replacing PATH rather than extending it.
+type recorder struct {
+	calls []string
+}
+
+func (r *recorder) notify(u Urgency, title, body string) {
+	r.calls = append(r.calls, fmt.Sprintf("%s|%s|%s", u, title, body))
+}
+
+// baseOpts builds an options set that touches no vault, no real log location
+// and no desktop bus.
+func baseOpts(t *testing.T, crystallizeOut string, healthOut string, healthCode int) (MaintainOptions, *recorder) {
+	t.Helper()
+	rec := &recorder{}
+	return MaintainOptions{
+		Home:    t.TempDir(),
+		Today:   "2026-09-05",
+		LogFile: filepath.Join(t.TempDir(), "vault-maintenance", "latest.log"),
+		Now:     func() time.Time { return frozen },
+		Notify:  rec.notify,
+		crystallizeStep: func(w io.Writer) error {
+			_, _ = io.WriteString(w, crystallizeOut)
+			return nil
+		},
+		healthStep: func(w io.Writer) (int, error) {
+			_, _ = io.WriteString(w, healthOut)
+			return healthCode, nil
+		},
+	}, rec
+}
+
+func TestCountIssues(t *testing.T) {
+	tests := []struct {
+		name string
+		log  string
+		want int
+	}{
+		{"empty", "", 0},
+		{"no keywords", "everything is fine\nnothing to see", 0},
+		{"one warning", "WARNING: stale file", 1},
+		{"case insensitive", "warning\nWARNING\nWaRnInG", 3},
+		// grep -c counts LINES, not matches: three keywords on one line is one.
+		{"counts lines not matches", "warning fail action stale", 1},
+		{"one per line", "warning\nfail\naction\nstale", 4},
+		// Faithful to the oracle's substring matching, which over-counts.
+		// Reproduced, not fixed — see maintain.go's comment on issueRE.
+		{"substring matches over-count", "the build failed\nstalemate reached", 2},
+		{"blank lines ignored", "warning\n\n\nfail", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CountIssues(tt.log); got != tt.want {
+				t.Errorf("CountIssues(%q) = %d, want %d", tt.log, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNotificationFor(t *testing.T) {
+	tests := []struct {
+		name        string
+		issues      int
+		wantUrgency Urgency
+		wantBody    string
+	}{
+		{"clean", 0, UrgencyLow, "All clean. No action needed."},
+		{"boundary at one", 1, UrgencyNormal, "1 potential issues. Run /insights on active projects."},
+		{"many", 7, UrgencyNormal, "7 potential issues. Run /insights on active projects."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, title, body := notificationFor(tt.issues)
+			if u != tt.wantUrgency {
+				t.Errorf("urgency = %q, want %q", u, tt.wantUrgency)
+			}
+			if title != "Vault Maintenance" {
+				t.Errorf("title = %q, want %q", title, "Vault Maintenance")
+			}
+			if body != tt.wantBody {
+				t.Errorf("body = %q, want %q", body, tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestLogFileFor(t *testing.T) {
+	tests := []struct {
+		name         string
+		goos         string
+		home         string
+		localAppData string
+		want         string
+	}{
+		{
+			name: "linux uses XDG data dir under home",
+			goos: "linux", home: "/home/u",
+			want: filepath.Join("/home/u", ".local", "share", "vault-maintenance", "latest.log"),
+		},
+		{
+			// os.UserCacheDir() would give ~/.cache here — a DIFFERENT directory
+			// from the one the twin has been writing to for the log's whole life.
+			name: "linux is not the cache dir",
+			goos: "linux", home: "/home/u", localAppData: `C:\Users\u\AppData\Local`,
+			want: filepath.Join("/home/u", ".local", "share", "vault-maintenance", "latest.log"),
+		},
+		{
+			name: "windows prefers LOCALAPPDATA",
+			goos: "windows", home: `C:\Users\u`, localAppData: `C:\Users\u\AppData\Local`,
+			want: filepath.Join(`C:\Users\u\AppData\Local`, "vault-maintenance", "latest.log"),
+		},
+		{
+			name: "windows falls back under home when LOCALAPPDATA is unset",
+			goos: "windows", home: `C:\Users\u`,
+			want: filepath.Join(`C:\Users\u`, "AppData", "Local", "vault-maintenance", "latest.log"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := logFileFor(tt.goos, tt.home, tt.localAppData); got != tt.want {
+				t.Errorf("logFileFor(%q, %q, %q) = %q, want %q",
+					tt.goos, tt.home, tt.localAppData, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunMaintainWritesLogWithBothSections(t *testing.T) {
+	opts, _ := baseOpts(t, "crystallize ran\n", "health ran\n", 0)
+	var out strings.Builder
+
+	if err := RunMaintain(&out, opts); err != nil {
+		t.Fatalf("RunMaintain: %v", err)
+	}
+
+	raw, err := os.ReadFile(opts.LogFile)
+	if err != nil {
+		t.Fatalf("log not written: %v", err)
+	}
+	log := string(raw)
+
+	stamp := frozen.Format(time.UnixDate)
+	for _, want := range []string{
+		"=== Vault Maintenance: " + stamp + " ===",
+		"--- dotf vault crystallize --all ---",
+		"crystallize ran",
+		"--- vault-health ---",
+		"health ran",
+		"=== Done: " + stamp + " ===",
+	} {
+		if !strings.Contains(log, want) {
+			t.Errorf("log missing %q\n--- log ---\n%s", want, log)
+		}
+	}
+
+	// Ordering is the point of a composition: health must follow crystallize,
+	// and the footer must follow both. Contains() alone would pass on any order.
+	iCryst := strings.Index(log, "--- dotf vault crystallize --all ---")
+	iHealth := strings.Index(log, "--- vault-health ---")
+	iDone := strings.Index(log, "=== Done:")
+	if iCryst >= iHealth || iHealth >= iDone {
+		t.Errorf("sections out of order: crystallize=%d health=%d done=%d", iCryst, iHealth, iDone)
+	}
+
+	if !strings.Contains(out.String(), "Log written to "+opts.LogFile) {
+		t.Errorf("stdout missing the log path, got %q", out.String())
+	}
+}
+
+// The property tests/vault-maintenance-weekly.bats:171 asserts of the shell:
+// the issue count picks a notification urgency and NOTHING else. It must never
+// become a failure, however many issues the log carries.
+func TestRunMaintainIssueCountNeverFails(t *testing.T) {
+	noisy := "WARNING: stale\nfail\naction needed\nwarning again\n"
+	opts, rec := baseOpts(t, noisy, "", 0)
+	var out strings.Builder
+
+	if err := RunMaintain(&out, opts); err != nil {
+		t.Fatalf("a log full of issue keywords must not fail the run, got %v", err)
+	}
+	if len(rec.calls) != 1 {
+		t.Fatalf("want exactly one notification, got %d", len(rec.calls))
+	}
+	if !strings.HasPrefix(rec.calls[0], string(UrgencyNormal)+"|") {
+		t.Errorf("issues present must raise urgency to %q, got %q", UrgencyNormal, rec.calls[0])
+	}
+}
+
+func TestRunMaintainCleanLogNotifiesLow(t *testing.T) {
+	// No issue keywords anywhere — including in the frame this function writes
+	// itself, which is why the section headers deliberately avoid them.
+	opts, rec := baseOpts(t, "all good\n", "all good\n", 0)
+
+	if err := RunMaintain(io.Discard, opts); err != nil {
+		t.Fatalf("RunMaintain: %v", err)
+	}
+	if len(rec.calls) != 1 {
+		t.Fatalf("want exactly one notification, got %d", len(rec.calls))
+	}
+	if !strings.HasPrefix(rec.calls[0], string(UrgencyLow)+"|") {
+		t.Errorf("a clean log must notify at %q, got %q", UrgencyLow, rec.calls[0])
+	}
+}
+
+// A FINDING IS NOT A FAILURE. Health's 1 and 2 are report verdicts, not run
+// failures: they reach stdout, never the error. See RunMaintain's doc comment.
+func TestRunMaintainHealthVerdictIsReportedNotFailed(t *testing.T) {
+	tests := []struct {
+		name       string
+		healthCode int
+		wantLine   string
+	}{
+		{"pass is silent", 0, ""},
+		{"failed checks", 1, "Vault health: FAILED — one or more checks"},
+		{"gui unreachable", 2, "Vault health: SKIPPED — the Obsidian GUI was unreachable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, _ := baseOpts(t, "", "", tt.healthCode)
+			var out strings.Builder
+
+			if err := RunMaintain(&out, opts); err != nil {
+				t.Fatalf("health code %d must not fail the run, got %v", tt.healthCode, err)
+			}
+			got := out.String()
+			if tt.wantLine == "" {
+				if strings.Contains(got, "Vault health:") {
+					t.Errorf("a passing health check must print no verdict, got %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.wantLine) {
+				t.Errorf("stdout = %q, want it to contain %q", got, tt.wantLine)
+			}
+		})
+	}
+}
+
+// Both steps are best-effort, exactly as the twin's `|| true`: a crystallize
+// that fails must not stop health from running, nor the log from being written.
+func TestRunMaintainCrystallizeFailureDoesNotStopHealth(t *testing.T) {
+	opts, _ := baseOpts(t, "", "health still ran\n", 0)
+	opts.crystallizeStep = func(io.Writer) error { return errors.New("refused: yaml-wrapped") }
+	var out strings.Builder
+
+	if err := RunMaintain(&out, opts); err != nil {
+		t.Fatalf("a failing crystallize must not fail the run, got %v", err)
+	}
+
+	raw, err := os.ReadFile(opts.LogFile)
+	if err != nil {
+		t.Fatalf("log not written: %v", err)
+	}
+	log := string(raw)
+	if !strings.Contains(log, "refused: yaml-wrapped") {
+		t.Errorf("the crystallize error belongs IN the log, got:\n%s", log)
+	}
+	if !strings.Contains(log, "health still ran") {
+		t.Errorf("health must run after a failed crystallize, got:\n%s", log)
+	}
+}
+
+// The log is the artefact. Failing to write it is the one genuine failure of
+// the run, and the only thing that errors.
+func TestRunMaintainUnwritableLogIsAnError(t *testing.T) {
+	opts, _ := baseOpts(t, "", "", 0)
+	// A regular file where the log's parent directory must go: MkdirAll fails.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	opts.LogFile = filepath.Join(blocker, "vault-maintenance", "latest.log")
+
+	if err := RunMaintain(io.Discard, opts); err == nil {
+		t.Fatal("an unwritable log location must return an error")
+	}
+}
+
+// A nil Notifier is the headless case — no desktop bus, nothing to notify. It
+// must be a no-op, not a nil-func panic, because that is how this runs under
+// cron on a server.
+func TestRunMaintainNilNotifierIsSafe(t *testing.T) {
+	opts, _ := baseOpts(t, "warning everywhere\n", "", 0)
+	opts.Notify = nil
+
+	if err := RunMaintain(io.Discard, opts); err != nil {
+		t.Fatalf("a nil Notifier must be a no-op, got %v", err)
+	}
+}

--- a/specs/CLI-021-dotf-vault-build-knowledge/divergences.md
+++ b/specs/CLI-021-dotf-vault-build-knowledge/divergences.md
@@ -1,7 +1,7 @@
 ---
 id: "CLI-021-dotf-vault-build-knowledge"
 type: spec
-status: draft
+status: implementing
 created: "2026-08-09"
 issue: "mlorentedev/dotfiles#490"
 tags: [spec, divergences]
@@ -9,6 +9,10 @@ template_version: "1.0"
 ---
 
 # Twin divergences — `knowledge-crystallize.sh` vs `.ps1`
+
+> **Increment 3's divergences live in `tasks.md` §4**, under *"Recorded, not fixed"* — the header
+> timestamp shape, the `Out-File -Encoding UTF8` BOM, and the issue regex's substring over-count.
+> Noted here so a reader of this file does not conclude increment 3 had none.
 
 Task 1's last bullet: *"Enumerate every behaviour where `.sh` and `.ps1` disagree today. Linux is
 the reference; anything `.ps1`-only must be listed before it is dropped."*

--- a/specs/CLI-021-dotf-vault-build-knowledge/proposal.md
+++ b/specs/CLI-021-dotf-vault-build-knowledge/proposal.md
@@ -1,7 +1,7 @@
 ---
 id: "CLI-021-dotf-vault-build-knowledge"
 type: spec
-status: draft # draft | implementing | verifying | archived
+status: implementing # draft | implementing | verifying | archived
 created: "2026-08-08"
 issue: "mlorentedev/dotfiles#490"   # repo#NNN — GitHub issue / Project item that tracks this spec
 tags: [spec, proposal]
@@ -102,7 +102,12 @@ independently shippable and the atomic-PR cap will not hold all of them at once.
 - [ ] The HARNESS-029 invariant from BUG-060 holds in the Go implementation, proven by a test that
       fails against a deliberately naive append.
 - [ ] Table-driven unit tests for the path encode/decode and the section-insertion logic.
-- [ ] **No twin deleted, no caller repointed** — `git diff` touches only `cli/` and `specs/`.
+- [ ] **No twin deleted, no caller repointed.** Stated as "`git diff` touches only `cli/` and
+      `specs/`" when this was written, which increments 1 and 2 both broke honestly — a twin port
+      needs its characterization tests, and those live in `tests/`. Corrected to what
+      `verification.md` has actually been enforcing all along, which is the negative that matters:
+      **nothing under `scripts/`, `setup-*.{sh,ps1}`, or the vault.** Those are where the cutover
+      would leak, and the leak is what splitting PR5 from PR7 exists to prevent.
 - [ ] The shell scripts remain the canonical invocation; docs and skills unchanged.
 
 ## References

--- a/specs/CLI-021-dotf-vault-build-knowledge/tasks.md
+++ b/specs/CLI-021-dotf-vault-build-knowledge/tasks.md
@@ -1,7 +1,7 @@
 ---
 id: "CLI-021-dotf-vault-build-knowledge"
 type: spec
-status: draft
+status: implementing
 created: "2026-08-08"
 issue: "mlorentedev/dotfiles#490"
 tags: [spec, tasks]
@@ -151,7 +151,92 @@ and the PowerShell weekly runs no health step despite its header. Both recorded 
 
 ## 4. Increment 3 — `dotf vault maintain`
 
-- [ ] Compose crystallize + health, mirroring `vault-maintenance-weekly.{sh,ps1}`.
+**No golden corpus here, deliberately.** The twin is a 52-line wrapper whose output is a
+timestamped log around two subcommands whose byte-parity is *already* proven by increments 1 and 2.
+What is left to characterize is the wrapper — log path, section framing, the issue-count regex, the
+notification threshold, the exit code — and those are behaviours, not bytes. Building a third
+fixture scheme to re-prove the inner two would measure the same thing a third time.
+
+**Composition is in-process, not `exec dotf`.** The shell had no choice; a Go binary that already
+owns both steps does. It deletes the twin's own documented failure mode: cron's minimal PATH
+excludes `~/.local/bin`, so a bare `dotf` there silently no-ops under `|| true` every Sunday
+(`vault-maintenance-weekly.sh:12-16`, guarded by that file's bats case at line 147). There is no
+PATH to harden when there is no subprocess. This is not "improving while translating" — the defect
+being removed is an artifact of subprocess composition, not a behaviour of the maintenance run.
+
+**Linux is the reference, and it was already chosen.** The `.ps1` runs no health step despite its
+own header claiming it does — `divergences.md` §Increment 2. `maintain` runs both steps on every
+OS, per the ADR-020 precedent CLI-024 set (reconstruct the Linux superset, not the `.ps1` subset).
+
+### The open decision: what does `dotf vault maintain` exit with?
+
+The twin always exits 0 — every step is `|| true`, and `vault-maintenance-weekly.bats:171` asserts
+that the issue count "only drives the notification urgency, **never the exit code**". That settles
+the *issue count*. It does not settle `RunHealth`'s return, which the shell swallows with `|| true`
+and never had a way to surface.
+
+| | Always 0 (faithful) | Propagate health's code |
+|---|---|---|
+| Cron / Task Scheduler | silent, as today | cron mails the owner on every non-zero Sunday |
+| Human running it directly | must read the log to learn anything | exit status carries the verdict |
+| Precedent | the oracle's literal behaviour | `vault_health.go:23-33` — this spec already diverged from the oracle once, on vault resolution, because `dotf vault health` is a **new directly-invokable entry point** and the oracle's gap existed only because nothing called it standalone |
+
+- [x] **Decided: exit 0 whenever the run did its job; health's verdict goes to stdout, never to the
+      status.** *A finding is not a failure.* `RunHealth`'s 0/1/2 answers "what did the report
+      find"; maintain's status answers "did the run do its job". Propagating health's code would
+      make the status depend on whether a desktop GUI happened to be running — nondeterministic
+      from cron's view, and code 2 would mail the owner a failed-job notice every Sunday the laptop
+      was shut. False alarms on a weekly channel train the owner to ignore it, taking the desktop
+      notification (the signal this command was built around) down with it. The finding is routed
+      instead: report body to the log, count to the notification urgency, verdict to stdout for
+      whoever ran it by hand. The only error is being unable to write the log.
+      **`maintainExitCode` was deleted rather than made to `return 0`** — a function ignoring both
+      its parameters is a trap for the next reader who "fixes" it by wiring it to `os.Exit`; with
+      it went the `int` from `RunMaintain`'s signature.
+      *Not* the same fork `vault_health.go:23-33` took: there the oracle had a GAP (nothing called
+      it standalone), here the oracle made a DECISION, and it made it as a cron job.
+- [x] Compose crystallize + health, mirroring `vault-maintenance-weekly.{sh,ps1}`. →
+      `cli/internal/vault/maintain.go`, wired as `dotf vault maintain` in
+      `cli/internal/cmd/vault_maintain.go`. Zero flags, matching the twins.
+      `healthOptions()` was EXTRACTED from `vault_health.go` rather than copied — the
+      `$VAULT_DIR`-then-ADR-025 cascade is a contract, and two copies drift.
+- [x] Table tests for `CountIssues`, `notificationFor`, `logFileFor` (both GOOS), and the
+      composition against injected steps — no real vault, no real log location, no desktop bus.
+      → `cli/internal/vault/maintain_test.go`, 22 cases.
+      - `DefaultLogFile` was split into a thin `runtime.GOOS` wrapper over `logFileFor(goos, home,
+        localAppData)`, so BOTH OS branches are tested from either host. Reading `runtime.GOOS`
+        inline leaves the branch you are not running on covered only by the compiler.
+      - The two steps are injectable as **unexported** struct fields: package-level vars would let
+        parallel tests race the seam, and exported ones would let a caller substitute a step and
+        still call the result a maintenance run.
+      - **Mutation-verified, and the harness proves each mutation landed before believing the red**
+        (lesson 267): threshold `>0`→`>1` killed by `TestNotificationFor/boundary_at_one`; the
+        code-1 verdict line silenced, killed by `.../failed_checks`; the crystallize error swallowed
+        instead of logged, killed by `TestRunMaintainCrystallizeFailureDoesNotStopHealth`;
+        `LOCALAPPDATA` ignored, killed by `TestLogFileFor/windows_prefers_LOCALAPPDATA`.
+- [x] Extend `tests/vault-maintenance-weekly.bats` with Go-path behavioural cases (log location,
+      section order, exit status under health findings). 13 shell cases + 4 Go cases, 17 total.
+      **No golden corpus and no `GVH_IMPL_MODE`-style parity runner here, deliberately** — see the
+      head of this section. The Go cases assert the wrapper's behaviour directly; the shell-only
+      cases (bash/zsh syntax, `set -euo`, `BASH_SOURCE`) stay shell-only because they characterize
+      a shell, not the command.
+      - The fourth case is the one that earns its place: **the Go path needs no PATH hardening
+        under a cron-minimal PATH.** The `.sh` must `export PATH="$HOME/.local/bin:$PATH"` or its
+        bare `dotf` silently no-ops under `|| true` every Sunday, and carries a regression guard for
+        exactly that (line 147). In-process composition has no subprocess to fail to resolve, and
+        the case asserts that structurally rather than by comment.
+
+### Recorded, not fixed — divergences this port accepts
+
+- **Header timestamp.** `time.UnixDate` matches GNU `date(1)`'s default, which is what `$(date)`
+  emits in the `.sh`. `Get-Date`'s default in the `.ps1` is a different, locale-dependent shape;
+  Linux is the reference, so the `.ps1` shape is dropped rather than reproduced.
+- **Log encoding.** `Out-File -Encoding UTF8` writes a BOM under Windows PowerShell 5.1. Go writes
+  none. The log is read by humans and by `grep`, both of which are better off without it.
+- **The issue regex over-counts.** `warning|fail|action|stale` is a substring match, so "failed"
+  and "stalemate" score, and the section headers the wrapper itself prints are counted alongside
+  the tools' output. Reproduced faithfully — it is the oracle's behaviour, and the count only
+  picks a notification urgency.
 
 ## 5. Close out
 
@@ -168,12 +253,28 @@ shell and must keep doing so until the cutover PR.** Verified present 2026-08-08
 
 ### Callers (executable — break if the script moves)
 
+**Re-verified 2026-09-04 against `origin/main` @ `9c2758a`, by grep, not by reading this table.**
+The four rows that were here are gone: all of them named `knowledge-crystallize.{sh,ps1}`, which
+CLI-050 (#1269) deleted and cut over. Only comments referencing it survive
+(`vault-maintenance-weekly.sh:13`, `.ps1:28`) and those are historical notes, not callers. The rows
+below replace them and are what CLI-023 actually has to repoint.
+
 | Location | What it does |
 |---|---|
-| `scripts/vault-maintenance-weekly.sh:22` | invokes `knowledge-crystallize.sh --all` |
-| `scripts/vault-maintenance-weekly.ps1:25` | invokes `knowledge-crystallize.ps1 -All` |
-| `setup-linux.sh:117` | `chmod +x` on the `.sh` |
-| `setup-windows.ps1:1593-1598` | deploys the `.ps1` into the scripts dir |
+| `setup-linux.sh:1605` | **crontab entry** — `7 10 * * 0 $CURRENT_DIR/scripts/vault-maintenance-weekly.sh`, plus the `grep`/`crontab -` at 1606/1613 |
+| `setup-windows.ps1:2185` | **Task Scheduler** — `$expectedTaskScript = "$DotfilesDir\scripts\vault-maintenance-weekly.ps1"` |
+| `scripts/vault-maintenance-weekly.sh:32` | invokes `$SCRIPT_DIR/vault-health.sh` (the `.ps1` twin invokes no health step at all — `divergences.md` §Increment 2) |
+| `setup-linux.sh:116` | `chmod +x` on `vault-health.sh` |
+| `scripts/vault.sh:63` | dispatcher `exec`s `vault-health.sh` |
+| **`cli/internal/mem/session_start.go:135`** | **the Go CLI shells out to the shell twin.** `vaultHealth()` builds `<ScriptsDir>/vault-health.sh` and runs it for the SessionStart brief, with `ansiSeq` at :57 stripping the colours it emits. The least obvious caller by far — `dotf` calling the script `dotf` is replacing — and it is the one that makes deleting `vault-health.sh` a Go change, not a shell change |
+
+### Not this ticket, found while re-verifying — worth a ticket of its own
+
+`harness/skills/crystallize/SKILL.md:70` reads *"Run: `knowledge-crystallize.sh` (or `dotf vault
+crystallize`)"*. That script was **deleted** by CLI-050; the skill names a nonexistent command
+first and the working one as the parenthetical. Out of scope here (this PR's acceptance forbids
+touching anything but `cli/`, `tests/` and `specs/`, and `harness/` belongs to the parallel
+persona/gate work), but it is a live instruction pointing at nothing.
 
 ### Docs and comments (stale text — no runtime break)
 

--- a/specs/CLI-021-dotf-vault-build-knowledge/verification.md
+++ b/specs/CLI-021-dotf-vault-build-knowledge/verification.md
@@ -1,7 +1,7 @@
 ---
 id: "CLI-021-dotf-vault-build-knowledge"
 type: spec
-status: draft
+status: implementing
 created: "2026-08-08"
 issue: "mlorentedev/dotfiles#490"
 tags: [spec, verification]
@@ -27,16 +27,38 @@ skipping — because a shell always knows its own `$SCRIPT_DIR`; that path is co
 `session_start.go`'s own separate `vault-health.sh` exec (SessionStart brief) are untouched, per this
 increment's build-beside scope.
 
-**Increment 3 — `dotf vault maintain`:** not started
+**Increment 3 — `dotf vault maintain`:** landed — `cli/internal/vault/maintain.go` +
+`cli/internal/cmd/vault_maintain.go`. **Not golden-characterized, deliberately** (rationale at the
+head of `tasks.md` §4): the twin is a 52-line wrapper around two subcommands whose byte-parity is
+already proven by increments 1 and 2, so a third fixture scheme would re-measure the same thing.
+The wrapper's own behaviours are covered by 22 table tests
+(`cli/internal/vault/maintain_test.go`) and 4 end-to-end bats cases against the built binary
+(`tests/vault-maintenance-weekly.bats`, 17 total in the file alongside the 13 shell cases).
+
+Composition is **in-process**, which removes the twin's documented cron failure mode rather than
+reproducing it, and the fourth bats case asserts that structurally by running under
+`PATH=/usr/bin:/bin`.
+
+An end-to-end run against an empty home and an empty vault, with no `obsidian` on `PATH`, produces
+both sections in order, the GNU-`date`-shaped stamps, `Vault health: FAILED — one or more checks`
+on stdout, and **exit 0** — the exit-code decision working, not asserted.
 
 ## Test status
 
-- Golden characterization (#672 / CLI-031): captured for both crystallize and health.
+- Golden characterization (#672 / CLI-031): captured for crystallize and health. **Not** for
+  maintain, by the reasoning above — recorded as a decision, not an omission.
 - Go/shell parity suites: `tests/knowledge-crystallize-go-parity.bats` (13/13, `help` excluded —
   documented), `tests/vault-health-go-parity.bats` (16/16).
-- Table-driven units: `cli/internal/vault/crystallize_test.go`, `cli/internal/vault/health_test.go`.
-- `test-windows` CI: unchanged by this spec so far — `GOOS=windows go vet ./...` passes for both
-  increments' code, but neither has been run on an actual Windows box.
+- Table-driven units: `crystallize_test.go`, `health_test.go`, `maintain_test.go`.
+- **Mutation-verified for increment 3**, with the harness proving each mutation LANDED before
+  believing the red (lesson 267 — a mutation that silently fails to apply reads as a passing test):
+  four mutations, four kills, each by the test named for it. Detail in `tasks.md` §4.
+- `GOOS=windows go vet ./...`, `go vet ./...`, `go build ./...`, and the pinned
+  `golangci-lint` (v2.12.2, matching `versions.conf`) all clean.
+- `test-windows` CI: none of the three increments has been run on an actual Windows box. The
+  Windows log path (`%LOCALAPPDATA%`) is unit-tested from Linux via `logFileFor`, and the
+  PowerShell toast in `NotifyDesktop` is **unexercised anywhere** — it is fire-and-forget by
+  design, so a failure is silent by construction. Stated as a gap, not covered.
 
 ## The proof that matters most here
 

--- a/tests/vault-maintenance-weekly.bats
+++ b/tests/vault-maintenance-weekly.bats
@@ -259,7 +259,15 @@ _go_log() { printf '%s/.local/share/vault-maintenance/latest.log' "$FAKE_HOME"; 
         "$DOTF_BIN" vault maintain
     [ "$status" -eq 0 ]
     [[ "$output" == *"Vault health:"* ]]
-    grep -qE 'warning|fail|action|stale' "$(_go_log)" || true
+    # No `|| true` here: an assertion that cannot fail is not an assertion. The
+    # log genuinely carries issue lines under an empty HOME (crystallize warns
+    # twice that it found no MEMORY.md), so this passes on its own merits.
+    #
+    # `-i` is load-bearing and was missing on the first draft: the twin counts
+    # with `grep -ciE` and the Go port with a `(?i)` regex, but the lines in the
+    # log are `[WARNING]` in caps. Dropping the flag made this assertion false,
+    # which the removed `|| true` had been hiding.
+    grep -qiE 'warning|fail|action|stale' "$(_go_log)"
 }
 
 @test "dotf vault maintain needs no PATH hardening under a cron-minimal PATH" {
@@ -268,8 +276,13 @@ _go_log() { printf '%s/.local/share/vault-maintenance/latest.log' "$FAKE_HOME"; 
     # line 147 above). The Go port composes IN-PROCESS, so there is no
     # subprocess whose resolution can fail — this asserts that structurally, by
     # running with a PATH that contains neither ~/.local/bin nor the build dir.
+    #
+    # $TMP stays on PATH for the notify-send stub ONLY. It is neither
+    # ~/.local/bin nor the build dir, so the structural claim is untouched, and
+    # without it /usr/bin/notify-send resolves and pops a real balloon on the
+    # developer's desktop every time this suite runs.
     _build_dotf_maintain
-    run env HOME="$FAKE_HOME" VAULT_DIR="$FAKE_VAULT" PATH="/usr/bin:/bin" \
+    run env HOME="$FAKE_HOME" VAULT_DIR="$FAKE_VAULT" PATH="$TMP:/usr/bin:/bin" \
         "$DOTF_BIN" vault maintain
     [ "$status" -eq 0 ]
     log="$(_go_log)"

--- a/tests/vault-maintenance-weekly.bats
+++ b/tests/vault-maintenance-weekly.bats
@@ -174,3 +174,105 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Log written to"* ]]
 }
+
+# --- The Go path: `dotf vault maintain` (CLI-021 increment 3, #490) ---
+#
+# BUILT BESIDE the script above, which is still what cron runs
+# (setup-linux.sh:1605) — the cutover is CLI-023 (#492). So both implementations
+# are live and both are exercised here.
+#
+# Deliberately NOT a golden-parity suite, unlike increments 1 and 2. The twin's
+# output is a timestamped log wrapping two subcommands whose byte-parity is
+# already proven by knowledge-crystallize-go-parity.bats and
+# vault-health-go-parity.bats; re-proving it through a third fixture scheme
+# would measure the same thing a third time. What is left to characterize is
+# the WRAPPER — log location, section framing, exit status — and those are
+# behaviours. The unit-level seams (issue regex, notification threshold, the
+# per-OS log path) are table-tested in cli/internal/vault/maintain_test.go.
+#
+# Skips (never fails) when the Go toolchain is absent, so a shell-only checkout
+# still runs the rest of this file — same reasoning as the two parity suites
+# (#807 / BUG-055).
+
+_build_dotf_maintain() {
+    command -v go >/dev/null 2>&1 || skip "go toolchain not installed"
+    DOTF_BIN="${BATS_FILE_TMPDIR:-$TMP}/dotf-maintain"
+    if [ ! -x "$DOTF_BIN" ]; then
+        # A missing toolchain skips (above); a toolchain that FAILS to build is
+        # a real defect and must fail, not read as harmless skips.
+        ( cd "$BATS_TEST_DIRNAME/../cli" && go build -o "$DOTF_BIN" ./cmd/dotf ) || return 1
+    fi
+    export DOTF_BIN
+    # An empty HOME: no ~/.claude/projects, so crystallize discovers nothing.
+    # An empty VAULT_DIR and no `obsidian` on PATH: health degrades exactly as
+    # it does on a headless box. No vault, no network, no desktop bus touched.
+    export FAKE_HOME="$TMP/gohome"
+    export FAKE_VAULT="$TMP/govault"
+    mkdir -p "$FAKE_HOME" "$FAKE_VAULT"
+    # A no-op notify-send FIRST on PATH, so the notification branch can never
+    # reach the real desktop bus — the leak tests/golden/vault-health guards
+    # against by replacing PATH rather than extending it.
+    cat > "$TMP/notify-send" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$TMP/notify-send"
+}
+
+_go_log() { printf '%s/.local/share/vault-maintenance/latest.log' "$FAKE_HOME"; }
+
+@test "dotf vault maintain writes the log at the twin's location and reports its path" {
+    _build_dotf_maintain
+    run env HOME="$FAKE_HOME" VAULT_DIR="$FAKE_VAULT" PATH="$TMP:/usr/bin:/bin" \
+        "$DOTF_BIN" vault maintain
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Log written to"* ]]
+    # Same path the .sh has always written, because a human looks for the log by
+    # path and the cutover must not move it.
+    [ -f "$(_go_log)" ]
+}
+
+@test "dotf vault maintain log captures both maintenance sections in order" {
+    _build_dotf_maintain
+    run env HOME="$FAKE_HOME" VAULT_DIR="$FAKE_VAULT" PATH="$TMP:/usr/bin:/bin" \
+        "$DOTF_BIN" vault maintain
+    [ "$status" -eq 0 ]
+    log="$(_go_log)"
+    grep -qF 'dotf vault crystallize --all' "$log"
+    grep -qF 'vault-health' "$log"
+    grep -qF '=== Done:' "$log"
+    # Order, not mere presence: health after crystallize, footer after both.
+    cryst=$(grep -n 'dotf vault crystallize --all' "$log" | head -1 | cut -d: -f1)
+    health=$(grep -n -- '--- vault-health ---' "$log" | head -1 | cut -d: -f1)
+    done_line=$(grep -n '=== Done:' "$log" | head -1 | cut -d: -f1)
+    [ "$cryst" -lt "$health" ]
+    [ "$health" -lt "$done_line" ]
+}
+
+@test "dotf vault maintain exits 0 when health reports findings (a finding is not a failure)" {
+    # No obsidian on PATH, so health cannot pass: it reports and the report
+    # lands in the log. The RUN still did its job, so the status stays 0 —
+    # otherwise cron mails the owner every week the GUI happened to be closed.
+    # This is the guard for that decision (spec tasks.md §4), not an accident.
+    _build_dotf_maintain
+    run env HOME="$FAKE_HOME" VAULT_DIR="$FAKE_VAULT" PATH="$TMP:/usr/bin:/bin" \
+        "$DOTF_BIN" vault maintain
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Vault health:"* ]]
+    grep -qE 'warning|fail|action|stale' "$(_go_log)" || true
+}
+
+@test "dotf vault maintain needs no PATH hardening under a cron-minimal PATH" {
+    # The .sh MUST export PATH="$HOME/.local/bin:$PATH" or its bare `dotf` call
+    # silently no-ops under `|| true` every Sunday (its lines 12-16, guarded at
+    # line 147 above). The Go port composes IN-PROCESS, so there is no
+    # subprocess whose resolution can fail — this asserts that structurally, by
+    # running with a PATH that contains neither ~/.local/bin nor the build dir.
+    _build_dotf_maintain
+    run env HOME="$FAKE_HOME" VAULT_DIR="$FAKE_VAULT" PATH="/usr/bin:/bin" \
+        "$DOTF_BIN" vault maintain
+    [ "$status" -eq 0 ]
+    log="$(_go_log)"
+    refute_grep_fixed 'command not found' "$log"
+    grep -qF '=== Done:' "$log"
+}


### PR DESCRIPTION
Increment 3 of CLI-021 — the last of the three subcommands that resolve the `dotf vault` noun collision. Built beside the twins: no caller repointed, no script deleted, the crontab (`setup-linux.sh:1605`) and Task Scheduler (`setup-windows.ps1:2185`) entries untouched. That cutover is CLI-023 (#492).

## The ticket's premise was partly false, and measuring it was the first work

The spec described three unbuilt increments. Measured against `origin/main` before writing anything:

| Increment | Real state |
|---|---|
| 1 · `vault crystallize` | done **and cut over** — the twins were deleted by CLI-050 (#1269) |
| 2 · `vault health` | **built** — `health.go` (528 LOC), registered, with a 16/16 parity suite |
| 3 · `vault maintain` | genuinely absent |

A comment at `cli/internal/cmd/vault.go:60` asserted health and maintain were "still unbuilt" while `newVaultHealthCmd()` was registered forty lines below it. Reading that comment instead of probing the target would have meant reimplementing increment 2. Lessons 256/257, again. The comment is corrected here.

## Composition is in-process, not `exec dotf`

The shell twin had no choice and pays for it: cron starts with a minimal PATH that excludes `~/.local/bin`, so its bare `dotf` call silently no-ops under `|| true` every Sunday. It hardens PATH to compensate and carries a regression guard (`tests/vault-maintenance-weekly.bats:147`) for the day someone removes that.

There is no PATH to harden when there is no subprocess. A bats case asserts this structurally by running the binary under `PATH=/usr/bin:/bin`.

This is not "improving while translating" — the defect removed is an artifact of subprocess composition, not a behaviour of the maintenance run.

## A finding is not a failure

The one real design decision, and the reasoning is in `RunMaintain`'s doc comment because it will outlive this PR.

`RunHealth`'s 0/1/2 answers *what did the report find*. Maintain's status answers *did the run do its job*. Propagating health's code would make the status depend on whether a desktop GUI happened to be running — nondeterministic from cron's view, and code 2 (GUI unreachable) would mail the owner a failed-job notice **every Sunday the laptop was shut**. False alarms on a weekly channel train the owner to ignore it, taking the desktop notification — the signal this command was built around — down with it.

So the finding is routed rather than dropped: report body to the log, count to the notification urgency, verdict to stdout for whoever ran it by hand. The only error is being unable to write the log.

`maintainExitCode` was **deleted** rather than made to `return 0` — a function ignoring both its parameters is a trap for the next reader who "fixes" it by wiring it to `os.Exit`. The `int` left `RunMaintain`'s signature with it.

This is deliberately *not* the fork `vault_health.go:23-33` took. There the oracle had a **gap** (nothing called it standalone); here the oracle made a **decision**, and it made it as a cron job.

## Linux is the reference

The `.ps1` twin runs no health step at all despite its own header claiming it does — already recorded in `divergences.md` §Increment 2, not re-decided here. `maintain` runs both steps on every OS, per the ADR-020 precedent CLI-024 set.

## Testing

**No golden corpus, deliberately.** The twin is a 52-line wrapper around two subcommands whose byte-parity is already proven by `knowledge-crystallize-go-parity.bats` and `vault-health-go-parity.bats`. A third fixture scheme would measure the same thing again. What is left is the wrapper's own behaviour.

- **22 table tests** (`maintain_test.go`) — issue regex, notification threshold, both OS log paths, composition against injected steps. No real vault, no real log location, no desktop bus.
- **4 end-to-end bats cases** against the built binary, alongside the 13 shell cases in the same file.
- **Mutation-verified, with the harness proving each mutation LANDED before believing the red** (lesson 267). Five mutations, five kills: notification threshold `>0`→`>1`; the code-1 verdict line silenced; the crystallize error swallowed; `LOCALAPPDATA` ignored; and health's exit code propagated — which reddens both the unit test and the bats case, so the decision above is guarded at both layers.

Two test defects were found by review, not by a red suite, and the second commit fixes them. One assertion ended in `|| true` — the shape flagged as Major on #1482 — and removing it turned the test red, revealing the assertion was *also* wrong (`grep -qE` is case-sensitive; the log lines are `[WARNING]`). The `|| true` had been hiding a defect in the test itself. The other case fired a real desktop notification on every local run.

`healthOptions()` is **extracted** from `vault_health.go` rather than copied — the `$VAULT_DIR`-then-ADR-025 cascade is a contract, and two copies drift. `DefaultLogFile` is split over `logFileFor(goos, home, localAppData)` so both OS branches are tested from either host; reading `runtime.GOOS` inline leaves the branch you are not running on covered only by the compiler.

## Spec corrections in the same PR

The next session inherits the ticket, not the transcript.

- The flip checklist's four "callers" rows all named `knowledge-crystallize.{sh,ps1}`, deleted by CLI-050. Replaced with the six that actually exist — including **`cli/internal/mem/session_start.go:135`, where the Go CLI shells out to the very script it is replacing**. That is the row that makes deleting `vault-health.sh` a Go change, not a shell change.
- The acceptance criterion said "`git diff` touches only `cli/` and `specs/`", which increments 1 and 2 both broke honestly (a twin port needs its tests). Corrected to the negative `verification.md` has actually been enforcing: nothing under `scripts/`, `setup-*.{sh,ps1}`, or the vault.
- Found while re-verifying, **out of scope and unfixed**: `harness/skills/crystallize/SKILL.md:70` tells agents to run `knowledge-crystallize.sh`, which CLI-050 deleted, naming the working command only as a parenthetical.

## Verification

`go build ./...`, `go vet ./...`, `GOOS=windows go vet ./...`, `go test ./... -count=1`, and `golangci-lint` at the `versions.conf` pin (v2.12.2) — all clean. Full bats suite 1546/1546.

Diff scope confirmed: nothing under `scripts/`, `setup-*.{sh,ps1}`, or the vault.

Not run on an actual Windows box. The `%LOCALAPPDATA%` path is unit-tested from Linux; the PowerShell toast in `NotifyDesktop` is unexercised anywhere and is fire-and-forget by design, so a failure there is silent by construction. Stated as a gap, not covered.

Refs #490
