### PR TITLE
fix(harness): the crystallize skill told agents to run a script deleted in #1276

### DIFF
--- a/harness/skills/crystallize/SKILL.md
+++ b/harness/skills/crystallize/SKILL.md
@@ -67,7 +67,7 @@ tags: [tag1, tag2]
 - Update `## Last Crystallized: YYYY-MM-DD` to today
 
 ### Step 7 — Stamp
-- Run: `knowledge-crystallize.sh` (or `dotf vault crystallize`)
+- Run: `dotf vault crystallize` (add `--all` to stamp every project)
 - This updates currentDate and Last Crystallized automatically
 
 ### Step 8 — Report

--- a/scripts/check-doc-paths.sh
+++ b/scripts/check-doc-paths.sh
@@ -68,7 +68,15 @@ if [ "$#" -eq 0 ]; then
     # Auto-discover instruction files when invoked without arguments (BUG-088, #1021).
     # Governed files: all active agent instructions and READMEs.
     # Exclusions for stated reasons:
-    #   harness/ — generated artifacts from vault; checked by compile-harness.sh --check
+    #   harness/ — rendered from the vault; compile-harness.sh --check covers it,
+    #              but ONLY for enforced-region drift and clean rendering. It does
+    #              not resolve paths named in skill prose, and #1486's session found
+    #              harness/skills/crystallize/SKILL.md telling agents to run
+    #              knowledge-crystallize.sh, deleted by #1276. Recorded because the
+    #              earlier wording here read as "harness/ is covered", full stop,
+    #              which is how that line survived. Not closed by widening this
+    #              guard: the reference is a BARE FILENAME, so the blind spot
+    #              documented above owns it, not this exclusion.
     #   specs/   — per-feature historical proposals and archived logs, not standing instructions
     #   docs/    — historical decision records/lessons mentioning retired scripts by design
     if command -v git >/dev/null 2>&1 && { [ -d "$REPO_ROOT/.git" ] || [ -f "$REPO_ROOT/.git" ]; }; then


### PR DESCRIPTION
Two lines, and the second is why the first survived.

## The defect

`harness/skills/crystallize/SKILL.md:70`, step 7 of a skill agents follow in order:

```
- Run: `knowledge-crystallize.sh` (or `dotf vault crystallize`)
```

`scripts/knowledge-crystallize.sh` has not existed since **#1276** cut it over to the
CLI. The instruction names the dead one first and demotes the working one to a
parenthetical, so an agent reading top to bottom runs the script that is gone.

Found by a peer session while reviewing something else; verified here before acting on it.

## It is one line, not a class — measured before assuming

Ten bare filenames in `harness/skills/` resolve to nothing on disk. That number is
misleading, and checking which of them this repository *ever tracked* is what separates
them:

```
knowledge-crystallize.sh       tracked-in-history: 2   <- added, then deleted
deploy.sh / entrypoint.sh / head.sh / helm.sh
hermes-startup.sh / script.sh / validate.sh
vault-pull-daemon.sh / vault-validate.sh        tracked-in-history: 0
```

Nine of ten are generic example names in prose or files belonging to the Hermes agent
repo. So **one real, nine noise** — and that ratio is not just a filter, it is a
measurement of the exact false-positive rate that made `check-doc-paths.sh` stop
resolving bare filenames:

> Bare filenames are NOT checked. Resolving them by basename was tried and reverted: it
> flagged vault patterns, `machine.json` and `review.md` on AGENTS.md — files that
> legitimately live elsewhere. The cost is a real blind spot (a backticked `missing.md`
> passes), accepted deliberately.

**That decision stands, and this PR does not widen the guard.** The cost it named was
accepted knowingly; this is the cost being paid once, with evidence, not a reason to
reopen it. A basename-resolving guard would have flagged all ten.

## The second edit

`check-doc-paths.sh`'s auto-discovery excluded `harness/` with this reason:

```
#   harness/ — generated artifacts from vault; checked by compile-harness.sh --check
```

`--check` covers **enforced-region drift and clean rendering**. It does not resolve paths
named inside skill prose — and the same script's own header already warns
*"do not read a passing --check as type validation"*. So the exclusion promised a
coverage nobody had, and that is what stops the next reader looking. Corrected to state
what is actually covered, and which blind spot really owns this case.

This is the shape lesson 256 records: reading the block's own comment is what fails;
probe the target. The comment was probed, not believed.

## Verification

```
bash -n / zsh -n scripts/check-doc-paths.sh   OK
shellcheck --severity=error                   OK
./scripts/check-doc-paths.sh                  exit 0 (guard still passes)
./scripts/compile-harness.sh --check          exit 0
tests/check-doc-paths.bats                    19/19 pass
pre-commit (5 hooks)                          all passed
```

No test added, deliberately. The change is a corrected instruction and a corrected
comment; the guard that would assert the first is the one measured above as
9-of-10 false positives, and asserting a comment's prose is not a thing to build.
