### PR TITLE
docs(spec): CLI-063 targets dotf deploy, after three of the ticket premises measured false

### DIFF
--- a/specs/CLI-063-dotf-deploy-claude/features.json
+++ b/specs/CLI-063-dotf-deploy-claude/features.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "CLI-063-dotf-deploy-claude-f1",
+    "behavior": "Claude's capabilities are declared in ai/deploy.json and reachable through `dotf deploy`, not through a new command noun",
+    "verification": "cd cli && go test ./internal/deploy/... -run TestClaudeEntriesDeclared",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-063-dotf-deploy-claude-f2",
+    "behavior": "ai/claude/plugins.json is the sole plugin list; the test fails if either twin's hardcoded ids drift from it",
+    "verification": "bats tests/claude-plugins-drift.bats",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-063-dotf-deploy-claude-f3",
+    "behavior": "env and enabledPlugins merge nested (a box-only key survives) and permissions.allow unions deduped; each case fails under top-level replace",
+    "verification": "cd cli && go test ./internal/deploy/... -run TestPerKeyMergePolicy",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-063-dotf-deploy-claude-f4",
+    "behavior": "A template key absent from the declared policy errors loudly instead of being silently skipped (the outputStyle defect)",
+    "verification": "cd cli && go test ./internal/deploy/... -run TestUnknownTemplateKeyIsAnError",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-063-dotf-deploy-claude-f5",
+    "behavior": "ai/deploy.json version is bumped and a decoder that predates the per-key field refuses the file rather than deploying every entry as plain merge",
+    "verification": "cd cli && go test ./internal/deploy/... -run TestManifestVersionRefusal",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-063-dotf-deploy-claude-f6",
+    "behavior": "The Go path emits no hooks key under any input; dotf harness bind remains the only hooks writer",
+    "verification": "cd cli && go test ./internal/deploy/... -run TestNeverEmitsHooks",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-063-dotf-deploy-claude-f7",
+    "behavior": "A plugin is counted as added only when its install succeeded (Linux reference behaviour); #1491's Windows divergence is recorded, not silently absorbed",
+    "verification": "cd cli && go test ./internal/deploy/... -run TestPluginCountOnSuccessOnly",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "CLI-063-dotf-deploy-claude-f8",
+    "behavior": "No twin is deleted and no caller repointed: the diff touches nothing under setup-*.{sh,ps1} or scripts/",
+    "verification": "test -z \"$(git diff --name-only origin/main...HEAD -- 'setup-*.sh' 'setup-*.ps1' 'scripts/')\"",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/CLI-063-dotf-deploy-claude/proposal.md
+++ b/specs/CLI-063-dotf-deploy-claude/proposal.md
@@ -1,0 +1,188 @@
+---
+id: "CLI-063-dotf-deploy-claude"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-09-04"
+issue: "mlorentedev/dotfiles#1339"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# CLI-063-dotf-deploy-claude
+
+## Why
+
+The Claude-side deploy — `.claude.json` snapshot guard, MCP registration, plugin installation,
+`settings.json` merge — is implemented twice, in jq and in PowerShell. **Claude is the only agent
+still deployed that way.** `ai/deploy.json` already routes `pi`, `orca-keybindings`,
+`copilot-settings`, `copilot-config`, `copilot-mcp` and `agy-settings` through `dotf deploy`; the
+four Claude capabilities are the last twins of their class.
+
+The part that hurts is not the line count. It is that the merge policy is **data wearing code's
+clothing**. `merge_claude_settings()` decides per key whether the template wins, the objects merge,
+or the arrays union. That policy exists in three places: a prose comment in `setup-linux.sh`, a
+prose comment in `setup-windows.ps1`, and two implementations meant to agree with both. Adding a key
+to `ai/claude/settings.json` requires editing all three, and `setup-linux.sh` records what happens
+when someone does not — `outputStyle` sat in the template while the deployed file had none,
+*"silently a no-op on every existing installation, reaching only machines bootstrapped from
+scratch"*, found by measuring this repo's own box rather than by any test.
+
+**Measured 2026-09-05 against `main` @ `568d73b`** (the line numbers in #1339's body are from
+2026-08-27 and have moved; these are located by content):
+
+| Capability | `setup-linux.sh` | `setup-windows.ps1` |
+|---|---|---|
+| Snapshot guard | `snapshot_claude_json`, `restore_claude_json_if_truncated` | `Backup-AndRestoreClaudeJson` |
+| MCP registration | the `claude mcp add` block | its PowerShell twin |
+| Plugin list + install | hardcoded id list + install loop | hardcoded id list + install loop |
+| `settings.json` merge | `merge_claude_settings()`, ~100 lines of jq | its PowerShell twin |
+
+**The twins are already behaviourally divergent**, which is what makes "port the twin" ambiguous
+rather than mechanical: `setup-windows.ps1` increments `$pluginsAdded` outside the success check and
+swallows the failure, so a plugin that failed to install is reported as added (**#1491**). No test
+pins the counter on either side.
+
+## What
+
+**Extend `dotf deploy` to cover Claude**, rather than build a new command. Nothing repointed,
+nothing deleted, no caller edited: after this work both paths exist and agree.
+
+### Why not `dotf agent claude sync`, as #1339 proposes
+
+Three of that framing's premises are false, and each was checked against the code rather than the
+ticket:
+
+1. **`dotf agent` is the wrong noun, by an accepted ADR.** ADR-032:122-124 fixes the boundary:
+   *"`dotf harness` is already assigned to `refresh` / `deploy` / `check` — the compile side… The
+   executor is the run side and takes its own noun: `dotf agent`… Keeping them separate is not
+   cosmetic: one is idempotent and offline, the other spawns processes and consumes quota."* Config
+   sync is idempotent and offline. It belongs on the side ADR-032 assigns to deploy, and the ADR
+   states that *the noun* is the part it fixes. That `dotf agent` already exists is not a licence to
+   use it — it is the reason the boundary needed writing down.
+2. **"`dotf deploy` has no merge kind" is false.** `strategy: merge` has existed since AI-039
+   (#1322) and is in production on three configs. Its documented semantics are precisely the policy
+   Claude needs at the top level: *"a managed key is owned by the repo, whole value, and
+   `dotf deploy <name>` puts it back when the tool changed it; an unmanaged key is the box's."*
+3. **This work is already on `dotf deploy`'s roadmap.** `ai/deploy.json`'s own `$comment` says:
+   *"opencode and the MCP registration blocks are deliberately absent — they are slices 2 and 3."*
+   CLI-063 is the continuation of CLI-039, not a new surface beside it.
+
+A separate `dotf agent claude sync` would build a **second, Claude-only deploy path parallel to the
+one every other agent already uses** — the twin shape ADR-020 exists to collapse, rebuilt under a
+noun reserved for something else.
+
+### What is genuinely missing, measured
+
+`mergeInto` (`cli/internal/deploy/deploy.go:433`) writes the source's **top-level** keys into the
+destination. Claude's six policies split cleanly against that:
+
+| Key | Policy in `merge_claude_settings()` | Covered by today's `strategy: merge`? |
+|---|---|---|
+| `attribution` | whole object, template wins | **yes** |
+| `autoCompactEnabled` | template wins | **yes** |
+| `precomputeCompactionEnabled` | template wins | **yes** |
+| `env` | **nested object merge** (`(.env // {}) + $tmpl.env`) | no — top-level replace loses the box's keys |
+| `enabledPlugins` | **nested object merge** | no — same |
+| `permissions.allow` | **array union, deduped** (`| unique`) | no — top-level replace drops the box's entries |
+
+So the deliverable is not "port 100 lines of jq". It is: **three per-key policies the deploy
+manifest cannot yet express**, plus two capabilities (`plugins`, the snapshot guard) that are not
+file installs at all. That is a much smaller and much better-defined change than #1339 assumed, and
+it generalises — `env`-style nested merge is not Claude-specific.
+
+### The SSOT files
+
+- **`ai/claude/plugins.json`** — new. The plugin ids currently hardcoded in both twins.
+- **`mcp-servers.json`** — already the SSOT and already shared; read unchanged.
+- **`ai/claude/settings.json`** — already the template. The per-key policy moves from two prose
+  comments into the manifest, declared per key.
+
+### Increments
+
+1. **Snapshot guard + plugin sync.** Smallest coherent unit, and where the duplicated *data* is
+   worst. The guard's threshold already exists in Go — `cli/internal/mem/session_start_adapter.go:83`,
+   `claude_json_min_bytes` defaulting to 10240, the same constant SDD-021's canary uses for the same
+   upstream bug (anthropics/claude-code#59870). Reuse it; do not restate it.
+2. **MCP registration.** Slice 3 as the manifest already names it. Reads `mcp-servers.json`, skips
+   entries `claude mcp get` already knows, surfaces `add` errors rather than swallowing them.
+   Carries HIVE-118's remove-then-re-add migration for the stale `uvx hive-vault` entry.
+3. **Per-key merge policy.** Extend the manifest's strategy vocabulary with the three policies above
+   and declare Claude's `settings.json` against it.
+
+The cutover is separate, and that split is not ceremony: #1450 asked for a deletion whose ticket
+turned out to be wrong about what was duplicated, and what worked there was **port, prove parity,
+then delete**. The pinning bats tests named in #1339's fix are the only thing currently asserting
+the shell behaviour the port must reproduce, so they are the *last* thing to go.
+
+## Out of scope
+
+- **Deleting or repointing anything.** No twin removed, no caller edited, no doc changed to say the
+  Go path is canonical.
+- **`hooks`.** HARNESS-045 AC1 moved hooks out of `merge_claude_settings` entirely — `dotf harness
+  bind` owns them, emitted from `harness/manifest.json`, and a bats guard refuses the literal jq
+  assignment because the old one *replaced the whole SessionStart array and deleted a live
+  third-party group*, measured 2026-08-27. **The port must not gain a second hooks writer.** This is
+  the single most likely way for this work to cause an incident.
+- **Fixing #1491 while translating.** Linux is the reference (ADR-020; the CLI-024 and CLI-021
+  precedents), so the Go path counts successes and the `.ps1` behaviour is a defect closed
+  deliberately with the divergence recorded — never absorbed silently into a translation.
+- **The MEM-002 claude-mem retirement block.** A one-time migration living adjacent to this code,
+  not part of it; #1431 owns it.
+- **Retro-fitting the new per-key policies onto copilot/agy.** They may benefit; changing a
+  production config's merge semantics is its own change with its own blast radius.
+
+## Risks / open questions
+
+- **How per-key policy is DECLARED is the one real design decision, and it is open.** Two shapes:
+  (a) keep `strategy: merge` and add a sibling `keys: { env: "deep", "permissions.allow": "union" }`
+  map; (b) mint new strategy names. (a) keeps one strategy and makes the exceptions explicit, which
+  matches how the file already documents `paths`; (b) multiplies the vocabulary. Recommend (a).
+  Either way `ai/deploy.json`'s `version` **must** bump to 4 — the file's own rule is *"a field an
+  old decoder does not know is invisible to it, the version is not"*, and an old `dotf` silently
+  treating a per-key entry as plain merge is exactly the `~/.copilot` wipe that rule was written
+  after.
+- **The merge policy is an ALLOW-LIST, and that is a trap with a measured instance.** A key present
+  in the template but absent from the policy is silently a no-op on every existing machine
+  (`outputStyle`). The Go path must make the list explicit *and* fail loudly on a template key it
+  does not recognise — otherwise it reproduces the defect with better syntax.
+- **`// empty` versus `has()` in the jq original is load-bearing.** In jq a condition evaluating to
+  `empty` makes the whole if-expression produce nothing, so a template omitting one optional key
+  would deploy **nothing at all**. Go has no equivalent hazard, which means the *test* for it must
+  be written deliberately rather than inherited from the shape of the code.
+- **Characterization oracle: there is no single capturable script here.** Unlike CLI-021, the
+  behaviour is spread across four regions that run at different points of a setup, with side effects
+  on `$HOME` and on `claude` itself. Golden capture does not transfer; see `tasks.md`, which settles
+  this rather than leaving it open.
+- **Plugin install and MCP registration are not file installs.** They shell out to `claude` and can
+  fail per item. `dotf deploy`'s plan/compare/install model assumes a file destination, so these two
+  need a plan representation that is honest about "this is an action, not a file" — the part of this
+  work least constrained by an existing pattern.
+
+## Acceptance criteria
+
+- [ ] Claude's four capabilities are reachable through `dotf deploy`, declared in `ai/deploy.json`.
+- [ ] `ai/claude/plugins.json` is the sole plugin list read by the Go path, and a test fails if the
+      twins' hardcoded lists drift from it.
+- [ ] `env`, `enabledPlugins` (nested merge) and `permissions.allow` (deduped union) are preserved
+      per the table above, each with a test that fails under top-level replace.
+- [ ] The per-key policy is declared in the manifest, and an unrecognised template key **fails
+      loudly** rather than being silently skipped.
+- [ ] `ai/deploy.json` `version` is bumped, and an older decoder refuses the file rather than
+      misreading it.
+- [ ] The Go path emits no `hooks` key under any input — asserted, not merely omitted.
+- [ ] Plugin counting reflects install success (Linux behaviour), with #1491's divergence recorded.
+- [ ] **No twin deleted, no caller repointed** — nothing under `setup-*.{sh,ps1}` or `scripts/`.
+
+## References
+
+- Bitácora board: mlorentedev/dotfiles#1339, and the measurement comments dated 2026-09-04/05
+- ADR-032:122-124 — the `dotf agent` / `dotf harness` noun boundary that rules out the original name
+- ADR-020 — strangler-fig; Linux is the reference twin
+- `ai/deploy.json` `$comment` — MCP registration named as slice 3 of CLI-039
+- AI-039 (#1322) — `strategy: merge` and the `~/.copilot` wipe it was written after
+- `specs/archive/SDD-002-settings-portability/proposal.md` — the per-key policy's origin
+- HARNESS-045 AC1 — hooks left this function; `dotf harness bind` owns them
+- SDD-021 / `cli/internal/mem/session_start_adapter.go:83` — the shared 10240-byte threshold
+- #1491 — the Windows plugin counter, filed while measuring this ticket
+- CLI-021 (#490) — the twin-port precedent: build beside, prove parity, cut over separately
+- #1450 — why "port then delete" and not "delete as asked"

--- a/specs/CLI-063-dotf-deploy-claude/tasks.md
+++ b/specs/CLI-063-dotf-deploy-claude/tasks.md
@@ -1,0 +1,94 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-09-04"
+---
+
+# Tasks - CLI-063-dotf-deploy-claude
+
+> TDD order. One task = one focused commit. Tick as you go.
+> `[P]` = no dependency on another unchecked task. `[AC<n>]` = satisfies acceptance criterion n.
+
+## Settled before implementation
+
+**Golden characterization capture does NOT transfer from CLI-021. Decided, not open.**
+
+CLI-021 captured a single script's stdout and diffed it byte-for-byte. That worked because
+`vault-maintenance-weekly.sh` was one process with one output stream. This is not that shape:
+
+- The four capabilities run at **four different points** of a setup, not as one invocation.
+- Their observable effect is on **`$HOME` and on `claude` itself**, not on stdout — a snapshot
+  guard's whole job is that nothing is printed and nothing is lost.
+- Two of them **shell out to `claude`**, so a capture on this box records that box's plugin
+  registry, not the behaviour.
+
+The honest instruments, per capability:
+
+| Capability | Oracle |
+|---|---|
+| `settings.json` merge | **Table tests over the policy table.** Input: a template + a box state. Expected: the merged object. Each of the six keys gets a case that FAILS under top-level replace. |
+| Plugin list | **A drift guard**, ~15 lines of bats: grep both twins' hardcoded ids and assert set-equality with `ai/claude/plugins.json`. This is AC2, and it is the only thing that can catch the twins diverging. |
+| Snapshot guard | **Unit test on the threshold predicate**, reusing `claude_json_min_bytes`. No file I/O needed to test "is this truncated". |
+| MCP registration | **Fake `claude` on PATH** recording argv. Asserts skip-if-present and error-surfacing without touching a real registry. |
+
+Nothing here is a golden file. Do not add one.
+
+## Setup
+
+- [x] `proposal.md` complete, acceptance criteria testable
+- [x] Command home settled against ADR-032 — `dotf deploy`, not `dotf agent` (owner decision 2026-09-05)
+- [x] Oracle question settled (above)
+- [ ] Branch off `main`, spec folder committed, #1339 set to In Progress
+
+## Increment 1 — snapshot guard + plugin sync (first PR, ≤300 LOC)
+
+- [ ] [P] [AC2] Failing bats: both twins' hardcoded plugin ids equal `ai/claude/plugins.json`
+- [ ] [AC2] Add `ai/claude/plugins.json` with the ids read out of the twins verbatim
+- [ ] [P] [AC7] Failing Go test: truncation predicate at the `claude_json_min_bytes` boundary
+- [ ] [AC7] Implement the predicate by **calling** the existing threshold in
+      `cli/internal/mem/session_start_adapter.go:83` — a second literal `10240` is the defect
+- [ ] [AC1] Plan/apply for the plugin capability; counts a plugin only on install success (#1491
+      divergence recorded in `divergences.md`, NOT fixed in the `.ps1`)
+- [ ] [AC6] **Negative test: the Go path emits no `hooks` key under any input.** Written in
+      increment 1 even though increment 1 does not write settings — the proposal names this as the
+      single most likely way to cause an incident, so the assertion predates the code that could
+      violate it
+- [ ] Refactor; `go build ./... && go vet ./... && go test ./...`, `GOOS=windows go vet ./...`,
+      pinned `golangci-lint`, `bats tests/*.bats`
+
+## Increment 2 — MCP registration
+
+- [ ] [P] Failing test with a fake `claude` on PATH: an entry already registered is skipped
+- [ ] Failing test: `claude mcp add` non-zero is surfaced, not swallowed
+- [ ] Implement reading `mcp-servers.json`; carry HIVE-118's remove-then-re-add for `uvx hive-vault`
+
+## Increment 3 — per-key merge policy
+
+> **Coordination point, not a blocker:** this increment edits `harness/manifest.json`'s neighbour
+> `ai/deploy.json` and bumps its `version`. `harness/manifest.json` itself is another session's
+> declared surface — if this increment ends up touching it, coordinate before editing.
+
+- [ ] [P] [AC3] Failing table test: `env` nested merge preserves a box-only key
+- [ ] [AC3] Failing table test: `enabledPlugins` nested merge preserves a box-only plugin
+- [ ] [AC3] Failing table test: `permissions.allow` unions and dedupes
+- [ ] [AC4] Failing test: a template key absent from the policy **errors**, not skipped silently
+      (this is the `outputStyle` defect; a passing test here is the whole point of the increment)
+- [ ] [AC3] Implement per-key policy declaration — recommended shape (a) from `proposal.md`:
+      `strategy: merge` plus a sibling `keys:` map
+- [ ] [AC5] Bump `ai/deploy.json` `version` to 4; failing test first that an older decoder refuses
+- [ ] Declare Claude's `settings.json` entry against the new policy
+
+## Closing
+
+- [ ] Every acceptance criterion covered by ≥1 test and ≥1 `features.json` entry with a
+      non-vacuous verification command
+- [ ] Lint + both layers green; `GOOS=windows go vet ./...` clean
+- [ ] `verification.md` filled in
+- [ ] **Independent adversarial review** (reviewer ≠ implementer) before `dotf spec archive`
+- [ ] No twin deleted, no caller repointed — verified by `git diff --stat` showing nothing under
+      `setup-*.{sh,ps1}` or `scripts/`
+
+## Machine-readable features
+
+Emits a sibling `features.json` per [[pattern-feature-list-as-primitive]]. The agent CANNOT write
+`"state": "passing"` — only the harness, after running `verification` and capturing exit 0, may set
+that terminal state.

--- a/specs/CLI-063-dotf-deploy-claude/verification.md
+++ b/specs/CLI-063-dotf-deploy-claude/verification.md
@@ -1,0 +1,52 @@
+---
+tags: [spec, verification, templates]
+created: "2026-09-04"
+---
+
+# Verification - CLI-063-dotf-deploy-claude
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+- **The command home moved from `dotf agent claude sync` to `dotf deploy` before any code was
+  written.** #1339's framing rested on three premises that measurement falsified: ADR-032:122-124
+  reserves `dotf agent` for the quota-spending run side; `strategy: merge` already exists (AI-039,
+  in production on three configs); and `ai/deploy.json`'s own `$comment` names MCP registration as
+  slice 3 of CLI-039. Owner decision 2026-09-05.
+- **The scope shrank as a result.** The "largest and subtlest" increment is not a 100-line jq port:
+  `mergeInto` already implements 3 of Claude's 6 key policies. What is missing is three per-key
+  behaviours (`env`, `enabledPlugins` nested merge; `permissions.allow` union) the manifest cannot
+  yet express.
+- **Golden characterization capture was ruled out deliberately**, not skipped. Four capabilities
+  running at four points of a setup, two of them shelling out to `claude`, have no single
+  capturable stream. See `tasks.md` for the per-capability oracle chosen instead.
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons/`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/CLI-063-dotf-deploy-claude/` -> `specs/archive/CLI-063-dotf-deploy-claude/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
Spec only. No production code, no twin touched, nothing repointed.

Refs #1339.

## What changed about the ticket

#1339 asked for `dotf agent claude sync`. Before writing code I checked its premises against the
tree, and three of them do not hold:

| #1339's premise | Measured |
|---|---|
| `dotf agent` is the right home ("already exists, so it's a subcommand, not a new noun") | **False.** ADR-032:122-124 fixes `dotf agent` as the *run* side — *"one is idempotent and offline, the other spawns processes and consumes quota"* — and states that the **noun** is the part it fixes. Config sync is idempotent and offline. |
| "`dotf deploy` has no merge kind" | **False.** `strategy: merge` shipped with AI-039 (#1322) and is in production on `copilot-settings`, `copilot-config`, `agy-settings`. |
| This is new surface | **False.** `ai/deploy.json`'s own `$comment`: *"the MCP registration blocks are deliberately absent — they are slices 2 and 3."* |

`ai/deploy.json` already routes `pi`, `orca-keybindings`, `copilot-settings`, `copilot-config`,
`copilot-mcp` and `agy-settings`. **Claude's configs are the only ones left in the shell twins.** So
a separate `dotf agent claude sync` would not have been a new path — it would have been a *second*
path for the one agent that hasn't migrated, which is ADR-020's twin shape rebuilt rather than
collapsed.

Owner decision 2026-09-05: extend `dotf deploy`. Spec renamed accordingly.

## The scope got smaller, and better defined

`mergeInto` (`cli/internal/deploy/deploy.go:433`) writes the source's **top-level** keys into the
destination. Claude's six policies split against that:

| Key | Policy | Covered today? |
|---|---|---|
| `attribution`, `autoCompactEnabled`, `precomputeCompactionEnabled` | template wins | **yes** |
| `env`, `enabledPlugins` | **nested** object merge | no — top-level replace loses the box's keys |
| `permissions.allow` | **array union, deduped** | no — top-level replace drops the box's entries |

So the "largest and subtlest" increment is not a 100-line jq port. It is three per-key behaviours
the manifest cannot yet express — and they generalise beyond Claude.

## The oracle question is settled, not deferred

Golden characterization capture does **not** transfer from CLI-021. Four capabilities run at four
points of a setup, their effect is on `$HOME` and on `claude` itself rather than stdout, and two of
them shell out. `tasks.md` names a per-capability oracle instead (policy table tests, a plugin drift
guard, a threshold unit test, a fake `claude` on PATH). No golden file is to be added.

## Risk carried forward explicitly

`hooks` must not gain a second writer. HARNESS-045 AC1 moved it out of `merge_claude_settings`
because the jq assignment **replaced the whole SessionStart array and deleted a live third-party
group**. `tasks.md` puts the negative assertion in increment 1 — before the code that could violate
it exists.

## Verification

Spec-only change; no code paths touched.

```
pre-commit: Detect hardcoded secrets .......... Passed
            Run dotfiles tests ................ Passed
            Check bats @test names ............ Passed
            Check referenced doc paths ........ Passed
            Validate message format ........... Passed
```
