### PR TITLE
fix(harness): stamp the new-ticket record with its source actual hash

### DIFF
--- a/harness/skills/new-ticket/SKILL.md
+++ b/harness/skills/new-ticket/SKILL.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/skills/new-ticket/SKILL.md
-generated_sha: cd89b515ade938f7
+generated_sha: 1d1c81043049e6c9
 id: new-ticket-skill
 type: skill
 status: active


### PR DESCRIPTION
One line. Closes the residue left by knowledge `613e0b21`.

That commit fixed the **content** of `harness/skills/new-ticket/SKILL.md` by restoring its stale
vault source, and I reported the round-trip as clean on that basis. It was half true: the body
round-trips, but the record's `generated_sha` still held the hash of the *pre-fix* source, so
`--refresh` kept reporting the file as modified and kept rewriting it.

**Content-identical and clean-after-`--refresh` are two different properties.** The frontmatter is
part of the file, and I checked the bytes without looking at it.

| | hash |
|---|---|
| vault `00_meta/skills/new-ticket/SKILL.md` | `1d1c81043049e6c9` |
| committed stamp (pre-fix source) | `cd89b515ade938f7` |

Found by `feat-harness-role-join-39`, which hit the identical residue on `crystallize` and left mine
alone rather than reaching into my tree. Verified here independently before changing anything.

## Why the new stamp is honest and not just well-formed

```
$ diff <(body of vault source) <(body of committed record)
BODIES IDENTICAL
$ grep -c 'paginate' <both>
3 / 3
```

So the value being written records a provenance that actually holds.

## What did not catch this

Every assertion on this field checks its **shape**, never its correctness:

```
tests/compile-harness.bats: grep -qE '^generated_sha: [0-9a-f]{16}'   x8
```

A stamp that is wrong but well formed passes all eight. **No guard is added in this PR**, and that
is deliberate rather than an omission: the check needs the vault to compute the expected hash, and
CI has no vault, so the honest home is a `dotf doctor` check rather than a bats assertion that
cannot run where it matters. Recorded on #1493, which already owns the instrument problem after that
session measured `--check` returning rc=0 on both the correct and the reverted tree.

Same shape as lesson 268: "no drift" and "I did not check for drift" print identically.

## Verification

```
pre-commit: Detect hardcoded secrets .......... Passed
            Run dotfiles tests ................ Passed
            Check bats @test names ............ Passed
            Check referenced doc paths ........ Passed
            Validate message format ........... Passed
```
