### PR TITLE
feat(harness): shipper becomes the third enforceable persona, and adopts an orphaned skill

### DIFF
--- a/cli/internal/harness/persona_test.go
+++ b/cli/internal/harness/persona_test.go
@@ -249,7 +249,7 @@ func TestMigratedPersonasStillGateSomething(t *testing.T) {
 		byName[p.Name] = p
 	}
 
-	for _, name := range []string{"reviewer", "builder"} {
+	for _, name := range []string{"reviewer", "builder", "shipper"} {
 		p, ok := byName[name]
 		if !ok {
 			t.Errorf("%s is missing from the roster", name)

--- a/cli/internal/harness/roles_test.go
+++ b/cli/internal/harness/roles_test.go
@@ -42,6 +42,16 @@ func TestResolveRoles(t *testing.T) {
 		t.Errorf("test-driven-development should resolve to [builder], got %v", got)
 	}
 
+	// `pr-review-triage` is named by the `git-workflow` rule and, until shipper
+	// adopted it, was declared by no persona at all — so the join read it, found
+	// no owner and dropped it. The rule still resolved through a sibling skill,
+	// which is exactly why nothing was red. Asserting the skill ALONE is what
+	// distinguishes "the rule resolves" from "this skill has an owner"; only the
+	// second is what changed. See #1499 for the guard that cannot tell them apart.
+	if got := ResolveRoles(Suggestion{Skills: []string{"pr-review-triage"}}, personas); len(got) != 1 || got[0] != "shipper" {
+		t.Errorf("pr-review-triage should resolve to [shipper], got %v", got)
+	}
+
 	// Sorted output is the determinism contract: same input, same bytes.
 	multi := ResolveRoles(Suggestion{Skills: []string{"terraform", "audit", "read-all-adrs"}}, personas)
 	for i := 1; i < len(multi); i++ {

--- a/harness/agents/shipper/AGENT.md
+++ b/harness/agents/shipper/AGENT.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/agents/definitions/shipper/AGENT.md
-generated_sha: ead9e03f1abf72e1
+generated_sha: 86c1ecfacc81c6fe
 id: agent-shipper
 type: agent
 status: active
@@ -11,7 +11,15 @@ description: Ship-phase persona. Invoke to get a verified change into the world 
 kind: invocable
 model: mid
 capabilities: [read, search, edit, shell, skill]
-skills: [using-git-worktrees, docker, helm, terraform]
+skills:
+  - id: using-git-worktrees
+    enforce: warn
+  - id: docker
+    enforce: warn
+  - id: pr-review-triage
+    enforce: warn
+  - helm
+  - terraform
 owner: manu
 ---
 
@@ -34,7 +42,19 @@ Land the change deliberately and leave the tree clean behind it. Shipping is the
 
 ## Forced skills
 
-Your phase's skills are enforced by hook, not left to memory: `using-git-worktrees`, `docker`, `helm`, `terraform`. Reach for the one that fits rather than improvising.
+Your phase's skills: `using-git-worktrees`, `docker`, `pr-review-triage`, `helm`, `terraform`. Reach for the one that fits rather than improvising.
+
+**Three of the five are watched by hook; two are not, and the split is deliberate.** `using-git-worktrees`, `docker` and `pr-review-triage` carry `enforce: warn` — `dotf harness gate` names them on stderr when you have not invoked them, and lets the call through.
+
+They are the three that hold whatever is being shipped. Isolation applies to every change without exception: a ship-phase change that is not in its own worktree and its own branch has already collided with whatever else is running. `pr-review-triage` is the mechanism behind *"an open PR is not finished work"* — that obligation was stated in this record's mandate long before any skill was declared for it, which is exactly how the skill ended up owned by nobody. And `docker` is gated because this repository does ship a container: `tests/Dockerfile.integration` is built by the `integration` job, and its build is where delivery actually breaks here.
+
+`helm` and `terraform` are declared as bare strings, which the loader reads as `EnforceUnset` and the gate refuses to act on. That is a recorded state, not an oversight — `dotf harness gate` and `dotf doctor` both list them as ungated, so nothing here is invisible.
+
+**The reason they are ungated is local, and you should not read it as a claim about the skills.** In this repository nothing is delivered by Helm or Terraform, so gating them would name them on every call and teach you to scroll past `[gate]` lines; the severity is worth exactly as much as the attention it still commands. In a repository that ships charts or state files, those same two skills *are* the ship phase, and the right severity there is not the right severity here. A persona travels between repositories; a severity was chosen against one.
+
+This is why the loader applies **no default severity**. Defaulting to `warn` would make an unmigrated persona *"silently inert while every check reported it as wired — presence dressed as enforcement"*; defaulting to `block` would turn every already-declared skill into a hard gate the day it shipped. So a skill is gated because someone chose to gate it, and the ungated ones are listed rather than assumed.
+
+Raising any of these to `block` is gated on evidence, not on confidence: no severity moves until a real dispatch is observed resolving this persona, with two dispatches of one role carrying different `agent_id`s. One blocker applies here with particular force — a *named* dispatch sends its name as `agent_type`, so its role never resolves and the gate silently turns off. Until that is fixed, read a `[gate] warn` line as the obligation it states.
 
 ## Boundaries
 

--- a/harness/skills/crystallize/SKILL.md
+++ b/harness/skills/crystallize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/skills/crystallize/SKILL.md
-generated_sha: d6d6cf0c738eab7d
+generated_sha: 1b585b8def0a52a1
 id: crystallize-skill
 type: skill
 status: active


### PR DESCRIPTION
Third of the five personas #1497 covers. `reviewer` was the canary (#1412), `builder` was the second (#1494), this is `shipper`.

## What changed

`shipper` declared its four skills in the flat list, which `LoadPersona` reads as `EnforceUnset`, so `dotf harness gate` resolved the persona and acted on nothing. Its own "Forced skills" section said the skills were *"enforced by hook, not left to memory"* — false for all four, and false since the record was written. Same defect `builder`'s prose carried for all nine.

| skill | before | after | why |
|---|---|---|---|
| `using-git-worktrees` | flat | **`enforce: warn`** | Isolation applies to every change without exception |
| `docker` | flat | **`enforce: warn`** | This repo does ship a container — `tests/Dockerfile.integration`, built by `integration`, is where delivery actually breaks here |
| `pr-review-triage` | **absent** | **`enforce: warn`** | See below |
| `helm` | flat | bare string | Nothing here is delivered by Helm |
| `terraform` | flat | bare string | Nothing here is delivered by Terraform |

The prose now states that the last two are ungated **because of this repository**, not as a property of the skills. A persona travels between repositories — in one that ships charts or state files those two *are* the ship phase — and a severity was chosen against one. That distinction was missing from `builder`'s rewrite and is worth having in the record rather than in a PR description.

## `pr-review-triage` was owned by nobody

Found while auditing the join, not while writing this. The skill exists in `harness/skills/`, is named by the `git-workflow` rule in `harness/triggers.json:91`, and **was declared by no persona at all** — while this record's mandate has required *"an open PR is not finished work... dispositioned"* since before the skill was written. So the join read it, found no owner, and dropped it.

`TestRoleJoinDrift` stayed green through all of that, because it counts **rules that resolve**, not **skills that are owned** — and `git-workflow` resolves through `using-git-worktrees` regardless. That guard gap is filed as **#1499**, with `project-maturation` still sitting behind it. This PR closes the one row, not the class.

The new assertion is deliberately on the skill **alone**:

```go
if got := ResolveRoles(Suggestion{Skills: []string{"pr-review-triage"}}, personas); ...
```

Asserting the rule would have passed before this change too. Only the single-skill form distinguishes "the rule resolves" from "this skill has an owner".

## Also: the crystallize stamp, which is my own loose end

`--refresh` reverted `harness/skills/crystallize/SKILL.md`, putting back `knowledge-crystallize.sh` — the script deleted in #1276 and removed from that record by #1490 six hours earlier. Root cause was mine: **#1490 fixed the generated file and left the vault source stale**, so `--refresh` was propagating a stale SSOT *correctly*. Fixed at source in knowledge `57b6b1ae`; the `generated_sha` here is what makes the round-trip clean.

Second instance of that shape in two days after `new-ticket`. Fixing a generated file without its source is not a fix, it is a countdown.

## Two findings filed rather than folded in

- **#1502** — `compile-harness.sh --check` returns **rc=0 on both** the correct and the reverted `crystallize`, and passes `AGENTS.md` by name while `--refresh` adds two paragraphs to it. A guard returning OK on a tree it would itself rewrite is why neither reversion was ever caught by anything but a human reading `git status`.
- **#1499** — the ownership blind spot above.

One `--refresh` on clean `ca81157` moved **seven** files in three directions: four forward (auto-merge doctrine paragraphs, owned by another branch), one backward, one stamp-only, one mine. Every line of output reads `[refresh] skill record: ...` regardless. The five that are not mine are reverted here; direction was checked per file, not assumed.

## Verification

Run in this session:

- `go build ./...`, `go vet ./...`, `GOOS=windows go vet ./...`, `go test ./... -count=1` — all clean
- `golangci-lint run` — **0 issues** at the pinned 2.12.2 (`versions.conf`), version confirmed against the pin
- `~/.local/bin/bats tests/*.bats` — **1554/1554**, exit 0
- `compile-harness.sh --check` — no harness drift
- `shellcheck scripts/compile-harness.sh` — clean

**Both new assertions proven in the failing direction**, each mutation confirmed to have landed before the verdict:

| mutation | result |
|---|---|
| shipper reverted to the flat form | `TestMigratedPersonasStillGateSomething`: *"shipper has been migrated but now gates nothing"* |
| `pr-review-triage` removed from shipper | `TestResolveRoles`: *"should resolve to [shipper], got []"* |

**Payload cap, predicted before the work and confirmed after:** 11974 of 12000, 26 to spare. The migration itself costs **0 characters** — confirmed on three trees all landing on 11956 — because the presence block renders ids only and severity is `gate`'s input, not the payload's. The single new id costs 18. Numbers and the budget consequence are on #1241.

## Not claimed

No genuine `shipper` dispatch has been observed producing `warn`. That requires the record to be deployed first, and the deploy dir is written by `setup-linux.sh` / `dotf deploy` — hand-placing a file there would prove the gate reads a file I put there, not that a deploy produces the state. It is also still blocked in general by **#1434**: a *named* dispatch sends its name as `agent_type`, so its role never resolves and the gate silently turns off. Carried as a precondition on the remaining migrations and on any `block` promotion.

Refs #1497
