### PR TITLE
docs(lessons): 269 — a generated file fixed without its source is a countdown

### DIFF
--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -286,5 +286,6 @@ tags: [lessons, index, dotfiles]
 | [268 - A refused question and a negative answer print the same thing](lesson-268-a-refused-question-and-a-negative-answer-print-the-same-thing.md) | 2026-09-04 |  |
 | [265 - A correct measurement answering the wrong question, three times in one session](lesson-265-a-correct-measurement-answering-the-wrong-question.md) | 2026-09-03 |  |
 | [266 - Two measurements agreeing is not reproducibility](lesson-266-two-measurements-agreeing-is-not-reproducibility.md) | 2026-09-04 |  |
+| [269 - A generated file fixed without its source is a countdown, and the drift guard says OK either way](lesson-269-a-generated-file-fixed-without-its-source-is-a-countdown.md) | 2026-09-05 |  |
 
 - [2026-08-30 Intercepting Cobra Errors without Breaking SilenceErrors](2026-08-30-cobra-silence-errors-interception.md)

--- a/docs/lessons/lesson-269-a-generated-file-fixed-without-its-source-is-a-countdown.md
+++ b/docs/lessons/lesson-269-a-generated-file-fixed-without-its-source-is-a-countdown.md
@@ -1,0 +1,138 @@
+# Lesson 269 — A generated file fixed without its source is a countdown, and the drift guard says OK either way
+
+**Date:** 2026-09-05
+**Context:** Two reversions in two days (`new-ticket`, `crystallize`), found by two different sessions, neither found by the guard whose job it is
+
+## What happened
+
+`harness/skills/**` and `harness/agents/**` are **generated** from the knowledge vault. Each record
+carries its provenance in frontmatter:
+
+```yaml
+generated: true
+generated_from: 00_meta/skills/crystallize/SKILL.md
+generated_sha: d6d6cf0c738eab7d
+```
+
+`scripts/compile-harness.sh --refresh` re-renders every one of them from the vault. Twice in two
+days, someone fixed a defect by editing the **generated** file, merged it, and had the fix silently
+reverted the next time anybody ran `--refresh`.
+
+### Instance 1 — `new-ticket`
+
+A fix sat uncommitted in the main checkout for roughly 20 hours before anyone noticed it had been
+undone. Nothing reported it. It was found because a human happened to read `git status` in a
+checkout they were passing through.
+
+### Instance 2 — `crystallize`
+
+PR #1490 removed a reference to `knowledge-crystallize.sh`, a script deleted in #1276, from
+`harness/skills/crystallize/SKILL.md`. It merged. Six hours later a `--refresh` in a fresh worktree
+put the deleted script's name straight back:
+
+```diff
+-- Run: `dotf vault crystallize` (add `--all` to stamp every project)
+++ Run: `knowledge-crystallize.sh` (or `dotf vault crystallize`)
+```
+
+**`--refresh` was not malfunctioning. It was propagating a stale SSOT correctly.** The vault's
+`00_meta/skills/crystallize/SKILL.md:67` still carried the old line, because #1490 had fixed the
+render and never touched the source. The generated file was right for six hours and wrong forever
+after.
+
+## The part that makes this a guard bug, not a discipline problem
+
+`compile-harness.sh --check` is the repository's drift guard for exactly these artifacts. It runs
+in CI. Agents cite it as evidence the tree matches the vault. Measured on a clean tree at `ca81157`:
+
+| state | `crystallize/SKILL.md` md5 | contains the deleted script | `--check` |
+|---|---|---|---|
+| A — as committed, #1490's fix in place | `1bb56a86` | no | `[check] OK -> record crystallize`, **rc=0** |
+| B — after `--refresh` reverted it | `d84f1c33` | **yes** | `[check] OK -> record crystallize`, **rc=0** |
+
+**Both pass.** `--check` returns rc=0 on a tree that `--refresh` — the same script, one flag apart —
+would itself rewrite. Not confined to skill records: on the same run it printed `[check] OK ->
+AGENTS.md` while `--refresh` added two doctrine paragraphs to that file.
+
+So the two reversions were not missed through carelessness. The instrument that exists to catch them
+was answering a different question, confidently, in the affirmative. Filed as **#1502**, separately
+from the reversion incident (**#1493**) — an incident and a broken instrument get fixed at different
+speeds and should not share a ticket.
+
+## The blast radius nobody sees until they look
+
+One `--refresh` on a clean tree moved **seven** files in **three different directions**:
+
+```
+ M AGENTS.md                             forward  — doctrine the repo lacks, owned by another branch
+ M ai/claude/CLAUDE.md                   forward  — same
+ M ai/orca/ORCA.md                       forward  — same
+ M harness/enforced/no-auto-merge.md     forward  — same
+ M harness/agents/shipper/AGENT.md       MINE     — the one-line change I intended
+ M harness/skills/crystallize/SKILL.md   BACKWARD — reverts #1490
+ M harness/skills/new-ticket/SKILL.md    stamp    — content identical, generated_sha differs
+```
+
+Every line of `--refresh`'s output reads `[refresh] skill record: …` regardless. **The command
+distinguishes none of these, and the direction is the only thing that matters.** A narrow intent —
+one field on one persona — produces a seven-file review in which six files belong to other people
+and one of them is a regression.
+
+## Content-identical is not the same property as clean-after-refresh
+
+A subtle residue, and both fixes hit it. After repairing the vault source, `--refresh` leaves the
+record's **content** identical — but the file still shows as modified, because `generated_sha` was
+computed from the *old* source. Two different claims:
+
+- *"the round-trip is content-identical"* — what both fixes achieved
+- *"`git status` is clean after `--refresh`"* — what neither achieved until the stamp was carried
+
+The second is the one that stops the next person seeing noise and learning to ignore it. The first
+sounds like it implies the second and does not.
+
+## The lesson
+
+**Editing a render is never a fix. It is a fix with a timer on it, and the timer is however long
+until the next person runs the generator.**
+
+The failure is attractive because the render is where you found the defect, the render is what the
+consumer reads, and editing it makes the symptom go away immediately — including in CI, including
+in review. Nothing in the loop distinguishes it from a real fix. In both instances here the change
+was correct, reviewed, and merged; it simply had no durability.
+
+This is the same shape as lesson 092 (*editing a committed render without its source of truth*) and
+lesson 009 (*always edit the repo copy, never the deployed system*), which is worth stating plainly:
+**this class has now been documented three times and recurred anyway.** Documentation is not a
+mechanism. #1502 is the mechanism.
+
+## What to do instead
+
+- **Read the frontmatter before editing any file under `harness/`.** `generated: true` and
+  `generated_from:` are there precisely to answer this, and they are the first eight lines of the
+  file. Both instances edited a file whose second line said not to.
+- **Fix the vault, then `--refresh`, then commit both the content and the stamp.** The stamp is what
+  makes the round-trip idempotent for everyone else.
+- **After any `--refresh`, check the direction of every file it touched — not just the count.**
+  `git diff -- <file>` per file. Seven moved files with one intended change is normal; six of them
+  being someone else's is also normal. Reverting the ones that are not yours is the routine step,
+  and it needs the diff, because forward and backward look the same in `git status`.
+- **Do not read a green `--check` as "my tree matches the vault".** Until #1502 lands it does not
+  test that. Run `--refresh` in a scratch clone and diff if you need the answer.
+- **Prefer `--refresh` in a fresh worktree off `main`,** so unrelated drift shows up as *someone
+  else's uncommitted change* rather than mixing into your own diff.
+
+## Relation to the neighbouring lessons
+
+Lesson 268 is the immediate neighbour and the same failure at the tooling boundary: *"no drift"* and
+*"I did not check for drift"* print identically. The table above is that sentence with numbers
+attached — `--check` emits the identical `OK` line for a correct file and a reverted one, so its
+output carries no information about the thing it names.
+
+Lesson 267's requirement — a mutation harness must prove the mutation **landed** — is the same
+demand made of a guard: prove the check **ran against the thing it names**. A guard that would pass
+whatever the file contained has not checked the file, and no amount of green tells you which case
+you are in.
+
+Lessons 220 and 214 name the parent class: *a thing verified by a proxy is not verified*, and *a
+declared status is not evidence — probe the system*. `--check`'s `OK` is a proxy for "the render
+matches the source", and the two instances here are what it costs when the proxy is not the thing.


### PR DESCRIPTION
Documents the class behind two reversions in two days, and the measurement explaining why neither was caught by anything but a human reading `git status`.

## The class

`harness/skills/**` and `harness/agents/**` are generated from the vault, with `generated_from` and `generated_sha` in their frontmatter. Twice this week a defect was fixed by editing the **generated** record and merging it, and `compile-harness.sh --refresh` undid the fix the next time anyone ran it — **correctly**, because the vault source was still stale.

- **`new-ticket`** — the fix sat uncommitted in the main checkout for ~20h before anyone noticed. Nothing reported it.
- **`crystallize`** — #1490 removed a reference to `knowledge-crystallize.sh`, a script deleted in #1276. Six hours later a `--refresh` put the deleted script's name straight back. Root cause was mine: I fixed the render and left `00_meta/skills/crystallize/SKILL.md:67` alone. Fixed at source in knowledge `57b6b1ae`; the stamp is carried in #1504.

## The measurement, which is what makes it a guard bug

| state | `crystallize/SKILL.md` md5 | contains the deleted script | `--check` |
|---|---|---|---|
| as committed, #1490's fix in place | `1bb56a86` | no | `OK -> record crystallize`, **rc=0** |
| after `--refresh` reverted it | `d84f1c33` | **yes** | `OK -> record crystallize`, **rc=0** |

`--check` returns rc=0 on a tree that `--refresh` would itself rewrite, and prints an identical line either way. On the same run it passed `AGENTS.md` by name while `--refresh` added two doctrine paragraphs to it.

So neither reversion was missed through carelessness — the instrument that exists to catch them was answering a different question, in the affirmative. That is **#1502**, filed separately from the reversion incident (**#1493**): an incident and a broken instrument get fixed at different speeds and should not share a ticket.

## Two details worth having written down

**Blast radius.** One `--refresh` on clean `ca81157` moved seven files in three directions — four forward (doctrine owned by another branch), one backward, one stamp-only, one intended. Every line of output reads `[refresh] skill record: …` regardless, so direction has to be checked per file with `git diff`.

**Content-identical ≠ clean after `--refresh`.** After a source fix the record's content matches but `generated_sha` still differs, computed from the old source. Both fixes this week achieved the first and neither the second until the stamp was carried. The second is what stops the next person seeing noise and learning to ignore it.

## Not claimed

This is documentation, and the lesson says so about itself: this is the **third** time the class has been written down (lessons 009 and 092 are the earlier two) and it recurred anyway. Documentation is not a mechanism — #1502 is. The lesson is worth having so the next occurrence is recognised in seconds rather than investigated, not because writing it prevents anything.

## Verification

- `scripts/check-doc-paths.sh` — rc=0
- Every lesson cross-referenced in the body (009, 092, 214, 220, 267, 268) confirmed to exist on disk rather than assumed
- `_index.md` row added alongside the file
- Pre-commit hooks green: secrets, dotfiles tests, bats `@test` names, referenced doc paths, message format

Docs-only; no production LOC.
