### PR TITLE
feat(harness): architect becomes the fourth enforceable persona, and a typo in any skill id now fails

### DIFF
--- a/cli/internal/harness/persona_test.go
+++ b/cli/internal/harness/persona_test.go
@@ -294,8 +294,13 @@ func TestEveryDeclaredSkillHasARecord(t *testing.T) {
 	for _, p := range personas {
 		for _, s := range p.Skills {
 			record := filepath.Join(root, "harness", "skills", s.ID, "SKILL.md")
-			if _, err := os.Stat(record); err != nil {
-				t.Errorf("persona %q declares skill %q, but harness/skills/%s/SKILL.md does not exist "+
+			// IsRegular, not a bare nil error: os.Stat succeeds on a directory,
+			// so the obvious form accepts `SKILL.md/` as a record. That is this
+			// guard failing in exactly the way it exists to catch — an
+			// instrument reporting green because it measured the wrong object.
+			info, err := os.Stat(record)
+			if err != nil || !info.Mode().IsRegular() {
+				t.Errorf("persona %q declares skill %q, but harness/skills/%s/SKILL.md is not a readable file "+
 					"— the presence block would render an id nothing can invoke, and the gate would "+
 					"name an obligation with no skill behind it", p.Name, s.ID, s.ID)
 			}

--- a/cli/internal/harness/persona_test.go
+++ b/cli/internal/harness/persona_test.go
@@ -249,7 +249,7 @@ func TestMigratedPersonasStillGateSomething(t *testing.T) {
 		byName[p.Name] = p
 	}
 
-	for _, name := range []string{"reviewer", "builder", "shipper"} {
+	for _, name := range []string{"reviewer", "builder", "shipper", "architect"} {
 		p, ok := byName[name]
 		if !ok {
 			t.Errorf("%s is missing from the roster", name)
@@ -263,6 +263,42 @@ func TestMigratedPersonasStillGateSomething(t *testing.T) {
 		}
 		if gated == 0 {
 			t.Errorf("%s has been migrated but now gates nothing — reverted to the flat form?", name)
+		}
+	}
+}
+
+// TestEveryDeclaredSkillHasARecord closes a gap found by mutation, not by
+// reading: a persona declaring a skill id that does not exist passes EVERY
+// existing check. Measured 2026-09-05 by renaming architect's `pattern-loader`
+// to `pattern-loaderZZZ-does-not-exist` —
+//
+//	compile-harness.sh --check      rc=0
+//	go test ./internal/harness/     ok
+//	bats tests/skills-pipeline.bats 23/23 ok
+//
+// Nothing was red. The id would have rendered into every harness's presence
+// block and the gate would have named an obligation no agent could satisfy,
+// because there is no such skill to invoke.
+//
+// This matters to THIS epic specifically rather than in principle: migrating a
+// persona means hand-editing skill ids in a vault record, and #1504 added
+// `pr-review-triage` to shipper by hand. That one was verified by hand too. The
+// next one will not be.
+func TestEveryDeclaredSkillHasARecord(t *testing.T) {
+	root := repoRootForTest(t)
+	personas, err := LoadPersonas(filepath.Join(root, "harness", "agents"))
+	if err != nil {
+		t.Fatalf("the shipped persona records do not load: %v", err)
+	}
+
+	for _, p := range personas {
+		for _, s := range p.Skills {
+			record := filepath.Join(root, "harness", "skills", s.ID, "SKILL.md")
+			if _, err := os.Stat(record); err != nil {
+				t.Errorf("persona %q declares skill %q, but harness/skills/%s/SKILL.md does not exist "+
+					"— the presence block would render an id nothing can invoke, and the gate would "+
+					"name an obligation with no skill behind it", p.Name, s.ID, s.ID)
+			}
 		}
 	}
 }

--- a/harness/agents/architect/AGENT.md
+++ b/harness/agents/architect/AGENT.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/agents/definitions/architect/AGENT.md
-generated_sha: 2584c7a2f56c8493
+generated_sha: d990d292892a6ab9
 id: agent-architect
 type: agent
 status: active
@@ -48,7 +48,11 @@ Read `pattern-loader` as the peer of `read-all-adrs` rather than as an extra. AD
 
 This is why the loader applies **no default severity**. Defaulting to `warn` would make an unmigrated persona *"silently inert while every check reported it as wired — presence dressed as enforcement"*; defaulting to `block` would turn every already-declared skill into a hard gate the day it shipped. Three of three here is a choice about this persona, not a rule about personas.
 
-Raising any of these to `block` is gated on evidence, not on confidence: no severity moves until a real dispatch is observed resolving this persona, with two dispatches of one role carrying different `agent_id`s. One blocker applies with particular force — a *named* dispatch sends its name as `agent_type`, so its role never resolves and the gate silently turns off. Until that is fixed, read a `[gate] warn` line as the obligation it states.
+Raising any of these to `block` is gated on evidence, not on confidence: no severity moves until a real dispatch is observed resolving this persona **from the deployed record**, with two dispatches of one role carrying different `agent_id`s.
+
+The deployed half of that sentence is the one that bites. The gate reads the deploy directory, never your checkout, so a migration that is merged is not a migration that is in force — and the record it reads then reports `allow` with *"all blocking skills consumed"*, which is what a persona that satisfied every obligation also produces. Enforcement being off and enforcement passing are the same line in the journal.
+
+A named dispatch used to defeat role resolution outright; that is fixed for a **witnessed** dispatch, which the gate maps back to its true type. The residual is the unwitnessed one, which still falls through to the roster and finds no persona under its name.
 
 ## Boundaries
 

--- a/harness/agents/architect/AGENT.md
+++ b/harness/agents/architect/AGENT.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/agents/definitions/architect/AGENT.md
-generated_sha: 17da1734ab7a3903
+generated_sha: 2584c7a2f56c8493
 id: agent-architect
 type: agent
 status: active
@@ -11,7 +11,13 @@ description: Decide-phase persona. Invoke before a decision that will be expensi
 kind: invocable
 model: top
 capabilities: [read, search, edit, skill]
-skills: [read-all-adrs, architecture-session, pattern-loader]
+skills:
+  - id: read-all-adrs
+    enforce: warn
+  - id: architecture-session
+    enforce: warn
+  - id: pattern-loader
+    enforce: warn
 owner: manu
 ---
 
@@ -32,7 +38,17 @@ Turn an open question into a decision that is written down, justified against al
 
 ## Forced skills
 
-Your phase's skills are enforced by hook, not left to memory: `read-all-adrs`, `architecture-session`, `pattern-loader`. Reach for the one that fits rather than improvising. The order is not arbitrary: `read-all-adrs` declares itself a mandatory pre-step before `architecture-session`, because deciding without knowing what was already decided is how a repo acquires two contradictory ADRs. And `architecture-session` refuses to advance past its reference-audit gate on purpose — that gate is the point, not an obstacle.
+Your phase's skills: `read-all-adrs`, `architecture-session`, `pattern-loader`. The order is not arbitrary: `read-all-adrs` declares itself a mandatory pre-step before `architecture-session`, because deciding without knowing what was already decided is how a repo acquires two contradictory ADRs. And `architecture-session` refuses to advance past its reference-audit gate on purpose — that gate is the point, not an obstacle.
+
+**All three carry `enforce: warn`, and this is the only persona where that is the right answer.** `dotf harness gate` names any of them you have not invoked, on stderr, and lets the call through.
+
+The other migrated personas gate a subset, because their lists mix skills that hold on every task with skills that apply to one kind of work — a gate naming `debug-hardware` or `terraform` on every call teaches you to scroll past `[gate]` lines, and the severity is worth exactly as much as the attention it still commands. **Here there is no such subset.** All three are the decide phase itself: you cannot decide well without knowing what was already decided (`read-all-adrs`), without the session that produces options and a rejection list (`architecture-session`), or without checking the pattern library that already holds an audited answer (`pattern-loader`). None of the three is situational, so gating all three costs no attention that the phase does not already owe.
+
+Read `pattern-loader` as the peer of `read-all-adrs` rather than as an extra. ADRs record what *this* repository decided; the pattern library records what was decided across all of them. Searching outside before either is how a constraint that only the local pattern records gets missed — and re-derived wrongly.
+
+This is why the loader applies **no default severity**. Defaulting to `warn` would make an unmigrated persona *"silently inert while every check reported it as wired — presence dressed as enforcement"*; defaulting to `block` would turn every already-declared skill into a hard gate the day it shipped. Three of three here is a choice about this persona, not a rule about personas.
+
+Raising any of these to `block` is gated on evidence, not on confidence: no severity moves until a real dispatch is observed resolving this persona, with two dispatches of one role carrying different `agent_id`s. One blocker applies with particular force — a *named* dispatch sends its name as `agent_type`, so its role never resolves and the gate silently turns off. Until that is fixed, read a `[gate] warn` line as the obligation it states.
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary

- Migrates `architect` to the enforceable mapping form — the fourth of the six invocable personas #1497 covers, and the first that gates its whole list rather than a subset.
- Adds `TestEveryDeclaredSkillHasARecord`, closing a gap found by mutation: a typo in a skill id passed `--check`, `go test` and bats alike.
- Removes a false claim the record had carried since it was written (`"enforced by hook, not left to memory"`), and corrects a `block` precondition that named a since-closed issue.

## SDD checklist

- [x] Issue exists on the bitácora GitHub Project — part of **#1497** (epic; this PR migrates one persona and does not close it)
- [x] Diff conforms to the ~300 LOC atomic cap — well under; one persona record, one test file
- [x] Spec folder — covered by the epic's own scope rather than a new `specs/<id>/`; `spec-gate` passes because the production diff is below its threshold
- [x] `proposal.md` Why / What / Acceptance criteria — carried by #1497, which states the migration's acceptance criteria for all six personas
- [x] `tasks.md` in TDD order — the guard test was written and proven failing (by mutation) before the migration it protects
- [x] `verification.md` — evidence is inline under **Verification** below, produced in-session

## SDD skip rationale

Not applicable — no `skip-sdd` label. This PR is one step of the #1497 epic, not an exemption from it. One persona per PR is a measured decision, not a convenience: `harness/agents/**` is **not** in spec-gate's `_excluded()`, so persona prose counts as production LOC and batching three migrations would cross the 50-line threshold.

## Test plan

- [x] `bats tests/*.bats` — **1554/1554**, exit 0
- [x] `shellcheck` — not applicable; no `.sh` changed in this PR
- [x] `cd cli && go test ./...` — passes, `-count=1`
- [x] `./scripts/compile-harness.sh --check` — no drift
- [x] Manual verification: with the deploy dir stale, the gate is silent; run against `--repo-root` at this branch it emits three `[gate] warn` lines naming `read-all-adrs`, `architecture-session` and `pattern-loader`. **The deployed record is not this one** — see the caveat under Verification.

---

Fourth of the six invocable personas #1497 covers, after `reviewer` (#1412), `builder` (#1494) and `shipper` (#1504).

## architect gates all three, and it is the only persona so far where that is right

`architect` declared its skills in the flat list, which `LoadPersona` reads as `EnforceUnset`, so the gate resolved the persona and acted on nothing. Its prose claimed they were *"enforced by hook, not left to memory"* — false for all three, and false since the record was written. Third persona found carrying that same false sentence.

| persona | gated | why the split |
|---|---|---|
| `builder` | 2 of 9 | `debug-hardware`, `mcp-builder`, `async-python-patterns` are irrelevant to most work |
| `shipper` | 3 of 5 | nothing here is delivered by Helm or Terraform |
| **`architect`** | **3 of 3** | **there is no situational subset** |

The reason 3-of-3 is not inconsistency: `read-all-adrs`, `architecture-session` and `pattern-loader` *are* the decide phase. You cannot decide well without knowing what was already decided, without the session that produces options and a rejection list, or without checking the pattern library that already holds an audited answer. Gating all three costs no attention the phase does not already owe. The prose now states this, so the choice reads as a judgement about this persona rather than a rule about personas.

`pattern-loader` is stated as the **peer** of `read-all-adrs` rather than an extra: ADRs record what this repository decided, the pattern library records what was decided across all of them, and searching outside before either is how a constraint only the local pattern records gets missed and re-derived wrongly.

## A guard for a gap found by mutation, not by reading

Before writing anything I checked whether a **typo in a skill id** would be caught. It is not. Renaming architect's `pattern-loader` to `pattern-loaderZZZ-does-not-exist`:

```
compile-harness.sh --check        rc=0
go test ./internal/harness/       ok
bats tests/skills-pipeline.bats   23/23 ok
```

Nothing red. The bad id would render into **every harness's presence block**, and the gate would name an obligation with no skill behind it — an instruction the agent cannot satisfy because there is nothing to invoke.

This is not hypothetical for this epic. Migrating a persona *is* hand-editing skill ids in a vault record, and **#1504 added `pr-review-triage` to shipper by hand**. I verified that one by hand. The next one would not have been.

`TestEveryDeclaredSkillHasARecord` walks the real roster and asserts each declared id has a `harness/skills/<id>/SKILL.md`. It is in this PR rather than a ticket because the class it guards is the operation this PR performs.

## Verification

Run in this session:

- `go build` · `go vet` · `GOOS=windows go vet` · `go test ./... -count=1` — all clean
- `golangci-lint run` — **0 issues** at the pinned 2.12.2, version checked against `versions.conf`
- `bats tests/*.bats` — **1554/1554**, exit 0
- `compile-harness.sh --check` — no drift

**Both assertions proven in the failing direction**, each mutation confirmed to have landed first:

| mutation | caught by |
|---|---|
| `pattern-loader` → a nonexistent id | `TestEveryDeclaredSkillHasARecord` — names the persona, the id, and the missing path |
| architect reverted to the flat form | `TestMigratedPersonasStillGateSomething` — *"architect has been migrated but now gates nothing"* |

**Payload: 11974 of 12000 — byte-identical to #1504's.** architect gained no skill id, only severities, so the delta is zero. That is now the fourth independent confirmation that the presence block renders ids only and severity never reaches it, which is what makes the two remaining migrations (`curator`, `planner`) free of cap risk as well.

Production diff is 22 LOC, under spec-gate's 50 threshold. `harness/agents/**` is **not** in `_excluded()`, so persona prose does count — checked rather than assumed, and it is why this is one persona per PR rather than the three remaining at once.

## Scope correction carried from #1507

#1497 says "five remaining". It is **six invocable personas, not seven**. `hermes-nan` is `kind: autonomous`, runs externally on NaN, and has produced **zero** gate decisions across 32 ledger files and ~8,200 records — the gate is a `PreToolUse` hook in this harness and never sees it. Gating it would enforce nothing. That needs a code change to `checks_agent_skills.go`, which does not filter by `kind` and therefore cannot reach its own `Pass` state without a meaningless migration; filed as **#1507**.

After this PR the remainder is **`curator` and `planner`**.

Refs #1497


## Applied from review

`afc3d13` — CodeRabbit found that the new guard accepted a **directory** in place of `SKILL.md`: `os.Stat` returns a nil error for any filesystem entry, not only a regular file. That is the guard failing in precisely the way it exists to catch, so it is fixed here rather than ticketed. `IsRegular` rather than `!IsDir`, which also excludes devices and FIFOs — this repository has already lost a Windows build to a `syscall.Mkfifo` that every Linux check passed (#1075).
