### PR TITLE
docs(lessons): renumber the secrets-wrapper lesson to 270, resolving a collision

### DIFF
--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -284,9 +284,9 @@ tags: [lessons, index, dotfiles]
 | [264 - When the documentation does not name a field, read the executable — twice it decided a design](lesson-264-a-hooks-timeout-semantics-are-not-in-the-documentation.md) | 2026-09-03 |  |
 | [267 - A mutation harness must prove the mutation landed](lesson-267-a-mutation-harness-must-prove-the-mutation-landed.md) | 2026-09-04 |  |
 | [268 - A refused question and a negative answer print the same thing](lesson-268-a-refused-question-and-a-negative-answer-print-the-same-thing.md) | 2026-09-04 |  |
-| [269 - A security wrapper that breaks the tool it protects gets routed around](lesson-269-a-security-wrapper-that-breaks-the-tool-it-protects-gets-routed-around.md) | 2026-09-05 |  |
 | [265 - A correct measurement answering the wrong question, three times in one session](lesson-265-a-correct-measurement-answering-the-wrong-question.md) | 2026-09-03 |  |
 | [266 - Two measurements agreeing is not reproducibility](lesson-266-two-measurements-agreeing-is-not-reproducibility.md) | 2026-09-04 |  |
 | [269 - A generated file fixed without its source is a countdown, and the drift guard says OK either way](lesson-269-a-generated-file-fixed-without-its-source-is-a-countdown.md) | 2026-09-05 |  |
+| [270 - A security wrapper that breaks the tool it protects gets routed around](lesson-270-a-security-wrapper-that-breaks-the-tool-it-protects-gets-routed-around.md) | 2026-09-05 |  |
 
 - [2026-08-30 Intercepting Cobra Errors without Breaking SilenceErrors](2026-08-30-cobra-silence-errors-interception.md)

--- a/docs/lessons/lesson-270-a-security-wrapper-that-breaks-the-tool-it-protects-gets-routed-around.md
+++ b/docs/lessons/lesson-270-a-security-wrapper-that-breaks-the-tool-it-protects-gets-routed-around.md
@@ -1,4 +1,4 @@
-# Lesson 269 — A security wrapper that breaks the tool it protects gets routed around
+# Lesson 270 — A security wrapper that breaks the tool it protects gets routed around
 
 **Date:** 2026-09-05
 **Context:** SEC-002 (#1506) — `dotf secrets run` gave every child a pipe, so `pi` exited silently


### PR DESCRIPTION
Rename plus one index row plus the H1. No content changes.

Two lessons numbered **269** reached `main` about ninety minutes apart, from two sessions working in
parallel:

```
ddad532  21:20  269 - a generated file fixed without its source is a countdown   (#1505)
46dc9d8  22:42  269 - a security wrapper that breaks the tool it protects        (#1508)
```

Mine is the later one, so mine renumbers to **270**. Nothing references the old filename, so the
change is contained.

**The part that actually misleads is the index**, which carried two rows both labelled 269 — a
reader following either link lands on a file whose number does not identify it.

## Cause, since the fix does not prevent a repeat

The number is allocated by reading `docs/lessons/`, and two sessions that read the directory before
either has written get the same answer. The check is a directory listing at authoring time and it
cannot see a lesson still sitting on someone else's branch. Neither session did anything wrong and
neither could have noticed.

Not fixing that here — a real fix is either a CI assertion that lesson numbers are unique in the
merged tree (cheap, catches it at the PR rather than after) or dropping sequential numbering
entirely. Worth a ticket; this PR just unbreaks the index.
