### PR TITLE
fix(harness): the doctrine cap was asserted in characters while the payload was 47 bytes over it

### DIFF
--- a/scripts/compile-harness.sh
+++ b/scripts/compile-harness.sh
@@ -1070,7 +1070,7 @@ build_agent_presence() {
 has_doctrine() { jq -e '.doctrine.deploy' "$MANIFEST" >/dev/null 2>&1; }
 
 deploy_doctrine() {
-    local ag_recdir="$1" agent file cap shadow file_abs payload sha begin tmp chars gen_chars ids
+    local ag_recdir="$1" agent file cap shadow file_abs payload sha begin tmp chars bytes gen_chars gen_bytes ids
     mapfile -t ids < <(jq -r '.doctrine.inject[]' "$MANIFEST")
     while IFS=$'\t' read -r agent file cap shadow; do
         [[ -n "$agent" ]] || continue
@@ -1082,6 +1082,52 @@ deploy_doctrine() {
             printf '\n'
             build_agent_presence "$ag_recdir" "$agent"
         } > "$payload"
+
+        # A CAPPED payload is normalised to ASCII punctuation, because a cap is
+        # only enforceable when its unit is unambiguous — and ours was not.
+        #
+        # Measured 2026-09-05: .gemini/GEMINI.md was 11974 CHARACTERS and 12047
+        # BYTES against a 12000 cap. The bats assertion reads `wc -m`, so it
+        # passed; a byte-counting consumer would have been 47 over and, per the
+        # platform's documented behaviour, would have dropped the overflow
+        # SILENTLY. The 73-byte gap was 33 em-dashes, four section signs, an
+        # accented vowel and an ellipsis.
+        #
+        # The gap also hid a second thing: persona prose costs ZERO characters
+        # (the roster renders skill ids only) and two bytes per em-dash. So the
+        # per-id budget on #1241 was tracking the measure that was not growing.
+        #
+        # This does not decide which unit the platform counts. It removes the
+        # question: an ASCII payload has bytes == chars by construction, so the
+        # guard and the platform cannot disagree however the platform counts.
+        #
+        # ONLY punctuation that does not alter the lexicon. Em/en dashes, curly
+        # quotes and the ellipsis are typographic; folding them is uglier and
+        # means exactly the same thing. Accents and section signs are NOT folded:
+        # `bitácora` -> `bitacora` changes a word, and `§4` -> `S4` changes a
+        # reference. Five such characters survive, which is why the invariant
+        # below is stated as "under the cap in both units" rather than "ASCII".
+        # The codepoints are written as \u escapes rather than as literals: a
+        # curly quote pasted into shell source is SC1112 ("this is a unicode
+        # quote"), which fails `shellcheck` and therefore CI lint. Writing them
+        # as escapes also says WHICH character is meant, where a literal in a
+        # monospace diff does not.
+        if [[ "$cap" != 0 ]]; then
+            tmp="$(mktemp)"
+            # Hex escapes, not literals: a curly quote or dash pasted into shell
+            # source is SC1112 ("this is a unicode quote"), which fails
+            # `shellcheck` and therefore CI lint. The escapes also name the exact
+            # codepoint, which a literal in a monospace diff does not.
+            LC_ALL=C sed \
+                -e 's/\xe2\x80\x94/-/g'    `# U+2014 em dash` \
+                -e 's/\xe2\x80\x93/-/g'    `# U+2013 en dash` \
+                -e "s/\xe2\x80\x99/'/g"    `# U+2019 right single quote` \
+                -e "s/\xe2\x80\x98/'/g"    `# U+2018 left single quote` \
+                -e 's/\xe2\x80\x9c/"/g'    `# U+201C left double quote` \
+                -e 's/\xe2\x80\x9d/"/g'    `# U+201D right double quote` \
+                -e 's/\xe2\x80\xa6/.../g'  `# U+2026 ellipsis` \
+                "$payload" > "$tmp" && mv "$tmp" "$payload"
+        fi
 
         # A shadow file wins over ours at read time, so a silent deploy here
         # would look successful while changing nothing the agent ever reads.
@@ -1123,9 +1169,28 @@ deploy_doctrine() {
         # its own" is OURS, and it means the next doctrine id silently pushes
         # rules past the point the agent reads. So report the generated share
         # too, and say which case this is.
+        #
+        # Both UNITS are reported, not just characters. The cap is documented in
+        # characters, but nothing here has verified that the platform counts the
+        # same way, and the two measures had already diverged past the cap before
+        # the normalisation above. A guard that tracks one unit cannot report the
+        # other one crossing — so report both and compare against the larger.
         if [[ "$cap" != 0 ]]; then
             chars="$(wc -m < "$file_abs")"
+            bytes="$(wc -c < "$file_abs")"
             gen_chars="$(wc -m < "$payload")"
+            gen_bytes="$(wc -c < "$payload")"
+            # `if`, not `(( … )) && …`: a false arithmetic test returns non-zero
+            # and takes the whole `&&` chain with it, which aborts the script
+            # under `set -e`. Prohibited-pattern table, the `((count++))` row.
+            if (( gen_bytes > gen_chars )); then
+                printf '[deploy] note %s: generated doctrine is %s chars / %s bytes; non-ASCII survives normalisation\n' \
+                    "$file_abs" "$gen_chars" "$gen_bytes" >&2
+                gen_chars="$gen_bytes"
+            fi
+            if (( bytes > chars )); then
+                chars="$bytes"
+            fi
             if (( gen_chars > cap )); then
                 printf '[deploy] WARN %s: the GENERATED doctrine alone is %s characters, over the %s cap\n' \
                     "$file_abs" "$gen_chars" "$cap" >&2

--- a/specs/HARNESS-111/features.json
+++ b/specs/HARNESS-111/features.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "HARNESS-111-f1",
+    "behavior": "AC1: every capped doctrine.deploy target is under its cap in BOTH characters and bytes after --deploy",
+    "verification": "SB=$(mktemp -d); env HOME=\"$SB\" bash scripts/compile-harness.sh --deploy >/dev/null 2>&1; F=\"$SB/.gemini/GEMINI.md\"; C=$(wc -m < \"$F\"); B=$(wc -c < \"$F\"); rm -rf \"$SB\"; [ \"$C\" -lt 12000 ] && [ \"$B\" -lt 12000 ]",
+    "state": "passing",
+    "evidence": "11976 chars / 11985 bytes against the 12000 cap, measured 2026-09-05 after the fold; 11974 / 12047 before it"
+  },
+  {
+    "id": "HARNESS-111-f2",
+    "behavior": "AC2: the byte assertion goes RED when the normalisation is disabled (today's main)",
+    "verification": "bats tests/skills-pipeline.bats  # with the fold replaced by `if false`",
+    "state": "passing",
+    "evidence": "not ok 18 ... '.gemini/GEMINI.md is 12047 BYTES, at or over its 12000 cap (chars: 11974)'; mutation confirmed to have landed before the verdict was read"
+  },
+  {
+    "id": "HARNESS-111-f3",
+    "behavior": "AC3: lexicon-altering characters survive the fold and are reported rather than silently tolerated",
+    "verification": "SB=$(mktemp -d); env HOME=\"$SB\" bash scripts/compile-harness.sh --deploy 2>&1 | grep -q 'non-ASCII survives normalisation'; rm -rf \"$SB\"",
+    "state": "passing",
+    "evidence": "deploy prints '[deploy] note ...: generated doctrine is 11664 chars / 11669 bytes; non-ASCII survives normalisation'; leftover set is exactly the section sign and the accented vowel"
+  },
+  {
+    "id": "HARNESS-111-f4",
+    "behavior": "AC4: shellcheck reports no new findings, and zero SC1112",
+    "verification": "test \"$(~/.local/bin/shellcheck scripts/compile-harness.sh 2>&1 | grep -c SC1112)\" -eq 0",
+    "state": "passing",
+    "evidence": "SC1112 count 0 on the branch; rc 1 and its SC2016 infos are identical on main. The literal-character first attempt measured 3 SC1112 and is why the escapes are hex"
+  },
+  {
+    "id": "HARNESS-111-f5",
+    "behavior": "AC5: the script parses under both shells and the deploy is idempotent",
+    "verification": "bash -n scripts/compile-harness.sh && zsh -n scripts/compile-harness.sh",
+    "state": "passing",
+    "evidence": "both clean; second --deploy into the same HOME reproduces the same payload. The script is #!/usr/bin/env bash and running it UNDER zsh fails on main too, so that is a pre-existing limitation, not a regression"
+  },
+  {
+    "id": "HARNESS-111-f6",
+    "behavior": "AC6: the cap warning reports both units and compares against the larger",
+    "verification": "grep -q 'chars / %s bytes' scripts/compile-harness.sh",
+    "state": "passing",
+    "evidence": "deploy_doctrine computes gen_bytes/bytes alongside gen_chars/chars and promotes the larger before the cap comparison; uses `if` rather than `(( )) &&` so a false test cannot abort under set -e"
+  }
+]

--- a/specs/HARNESS-111/proposal.md
+++ b/specs/HARNESS-111/proposal.md
@@ -1,0 +1,45 @@
+---
+id: "HARNESS-111"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+created: "2026-09-05"
+issue: "mlorentedev/dotfiles#1241"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, harness, doctrine]
+template_version: "1.0"
+---
+
+# HARNESS-111 — the doctrine cap and its guard measure different units
+
+## Why
+
+`.gemini/GEMINI.md` carries the compact doctrine payload under a hard 12000 platform cap. The guard that protects it asserts `wc -m`; the payload is 11974 **characters** and **12047 bytes**. If the platform counts bytes it has been dropping the tail since before 2026-09-05, and its documented overflow behaviour is to truncate **silently** — no error, no red check. A guard measuring one unit cannot report the other one crossing, which is why nothing noticed.
+
+## What
+
+Normalise typographic punctuation to ASCII in a **capped** doctrine payload, so bytes and characters track each other and the guard cannot disagree with the platform whichever unit the platform counts. Assert both units. This deliberately does **not** decide what Antigravity counts — it removes the question instead, because settling it needs an experiment against the live consumer and the fix should not wait on one.
+
+**Out of scope:** the cap value, the per-id budget policy (#1241's own decision), and any vault doctrine prose. This changes only how the payload is rendered into the two `doctrine.deploy` targets.
+
+## How
+
+- `deploy_doctrine` folds em/en dashes, curly quotes and the ellipsis to ASCII when `char_cap != 0`, before the payload is injected.
+- Only punctuation that **does not alter the lexicon**. Accents and section signs are left alone: `bitácora` → `bitacora` changes a word and `§4` → `S4` changes a reference. Surviving non-ASCII is reported by the deploy, not silently tolerated.
+- Substitutions are written as **hex escapes**, because a curly quote in shell source is SC1112 and fails CI lint. Measured: the literal form added 3 findings and turned `shellcheck` rc 1.
+- The deploy's cap warning reports both units and compares against the larger.
+- `tests/skills-pipeline.bats` asserts both units for every `doctrine.deploy` target that declares a cap.
+
+## Alternatives rejected
+
+- **Raise `char_cap`.** #1241 already rejected this and its reasoning holds: 12000 is a real platform limit, so raising the number moves the truncation from a red check to a silent drop at the destination. Same overflow, no signal.
+- **Change the assertion to `wc -c` and leave the payload alone.** Turns CI red immediately on an unverified hypothesis about the platform's counting. Red is right only if bytes is right, and nobody has established that.
+- **Fold to `--` or ` - `.** Measured: 12009 and 12042 characters respectively — both land back over the cap. Only the single hyphen helps in both units.
+- **Trim doctrine prose to fit.** Recovers the bytes but leaves the two measures free to diverge again on the next em-dash, and the prose belongs to another lane (#1495 is parked on exactly that content).
+
+## Acceptance criteria
+
+- **AC1** — After `--deploy`, every `doctrine.deploy` target with a `char_cap` is under that cap in **both** `wc -m` and `wc -c`.
+- **AC2** — The bats assertion fails on a tree where the normalisation is disabled, naming the byte count and the cap. Proven by mutation, not by inspection.
+- **AC3** — Characters that alter the lexicon (accents, section signs) are **not** folded, and any surviving non-ASCII is reported on stderr by the deploy.
+- **AC4** — `shellcheck` reports no new findings against `main`, and in particular zero SC1112.
+- **AC5** — `bash -n` and `zsh -n` both parse the script; the deploy is idempotent on a second run.
+- **AC6** — The cap warning reports both units, so the number a reader quotes is the binding one.

--- a/specs/HARNESS-111/tasks.md
+++ b/specs/HARNESS-111/tasks.md
@@ -1,0 +1,19 @@
+---
+id: "HARNESS-111"
+type: tasks
+status: done
+created: "2026-09-05"
+---
+
+# HARNESS-111 — tasks
+
+- [x] Measure the payload in both units and establish the divergence (11974 chars / 12047 bytes / 12000 cap).
+- [x] Identify the source of the gap (33 em-dashes, 4 section signs, an accented vowel, an ellipsis).
+- [x] Measure the candidate folds and reject the ones that land back over the cap (`--` → 12009, ` - ` → 12042).
+- [x] Fold typographic punctuation in `deploy_doctrine`, scoped to targets declaring a `char_cap`.
+- [x] Write the substitutions as hex escapes after the literal form measured 3 SC1112 findings.
+- [x] Report both units in the deploy's cap warning; use `if` rather than `(( )) &&` so a false test cannot abort under `set -e`.
+- [x] Assert both units in `tests/skills-pipeline.bats`.
+- [x] Prove the byte assertion red with the fold disabled, confirming the mutation landed first.
+- [x] Confirm no new `shellcheck` findings against `main`.
+- [x] Coordinate with the parallel session, since #1495 is parked on the same cap.

--- a/specs/HARNESS-111/verification.md
+++ b/specs/HARNESS-111/verification.md
@@ -1,0 +1,66 @@
+---
+id: "HARNESS-111"
+type: verification
+status: done
+created: "2026-09-05"
+---
+
+# HARNESS-111 — verification
+
+All commands run in the implementing session on 2026-09-05.
+
+## The defect, measured
+
+```
+$ SB=$(mktemp -d); env HOME="$SB" bash scripts/compile-harness.sh --deploy >/dev/null 2>&1
+$ wc -m < "$SB/.gemini/GEMINI.md"   # 11974   <- what the guard asserted
+$ wc -c < "$SB/.gemini/GEMINI.md"   # 12047   <- 47 over the 12000 cap
+```
+
+Gap composition: 33 × U+2014, 4 × U+00A7, 1 × U+00E1, 1 × U+2026.
+
+## After the fold
+
+```
+chars 11976   bytes 11985   cap 12000
+```
+
+Both under. Rejected alternatives measured rather than reasoned about: `--` → 12009 chars, ` - ` → 12042 chars, both over.
+
+## AC2 — the assertion is proven in the failing direction
+
+With the normalisation replaced by `if false` (equivalent to `main`):
+
+```
+not ok 18 HARNESS-056: the compact doctrine payload carries it and stays under its cap
+# .gemini/GEMINI.md is 12047 BYTES, at or over its 12000 cap (chars: 11974)
+```
+
+The mutation was confirmed present (`grep -c 'if false; then'` → 1) **before** the verdict was read, per lesson 267.
+
+## AC4 — no new lint findings
+
+```
+SC1112 on main:        0
+SC1112 on the branch:  0
+shellcheck rc:         1 on BOTH (pre-existing SC2016 infos)
+```
+
+The first attempt used literal characters and measured **3** SC1112 with rc 1 — the reason the escapes are hex.
+
+## AC5 — parsers and idempotence
+
+```
+bash -n scripts/compile-harness.sh   clean
+zsh  -n scripts/compile-harness.sh   clean
+```
+
+Running the script *under* `zsh` fails on `main` too; it is `#!/usr/bin/env bash`, so that is a pre-existing limitation and not a regression here.
+
+## Suite
+
+`bats tests/*.bats` — **1554/1554**, exit 0.
+
+## Not verified, and stated rather than implied
+
+**Which unit Antigravity actually counts.** The manifest declares `char_cap` citing "12000 characters", and nothing in this repository has tested that against the live consumer. This change makes the answer not matter for the payload; it does not establish it. The experiment that would — a marked sentinel at the end of the payload, deployed, then asked for — is recorded on #1241 and is not part of this spec.

--- a/tests/skills-pipeline.bats
+++ b/tests/skills-pipeline.bats
@@ -204,12 +204,27 @@ stub_copilot() {
 @test "HARNESS-056: the compact doctrine payload carries it and stays under its cap" {
     run env HOME="$FAKEHOME" "$SCRIPT" --deploy
     [ "$status" -eq 0 ]
-    local f cap chars
+    local f cap chars bytes
     while IFS=$'\t' read -r f cap; do
         [ -f "$FAKEHOME/$f" ]
         grep -q 'Working code is not a finished change' "$FAKEHOME/$f"
         chars="$(wc -m < "$FAKEHOME/$f")"
         [ "$chars" -lt "$cap" ] || { echo "$f is $chars chars, at or over its $cap cap"; return 1; }
+
+        # BOTH units, because asserting one was how this went unnoticed.
+        #
+        # The cap is documented in CHARACTERS and this test read `wc -m`, so on
+        # 2026-09-05 it passed at 11974 while the file was 12047 BYTES — 47 over
+        # the same cap. Nothing has verified which unit the platform counts, and
+        # the documented failure mode is that the overflow is dropped SILENTLY.
+        # A guard measuring one unit cannot report the other one crossing.
+        #
+        # deploy_doctrine now normalises typographic punctuation in a capped
+        # payload, so the two measures track each other. This assertion is what
+        # keeps that true: reintroduce a multi-byte character and the byte count
+        # separates from the character count and lands here first.
+        bytes="$(wc -c < "$FAKEHOME/$f")"
+        [ "$bytes" -lt "$cap" ] || { echo "$f is $bytes BYTES, at or over its $cap cap (chars: $chars)"; return 1; }
     done < <(jq -r '.doctrine.deploy[] | "\(.file)\t\(.char_cap)"' harness/manifest.json)
 }
 


### PR DESCRIPTION
The doctrine cap is asserted in **characters**. The payload is **47 bytes over it**, and the guard cannot see that because it measures the other unit.

## The measurement

```
wc -m  (characters)  11974      <- what tests/skills-pipeline.bats:211 asserts
wc -c  (bytes)       12047      <- 47 OVER the 12000 cap
```

The 73-byte gap is 33 em-dashes, four section signs, one accented vowel and an ellipsis — all prose, all multi-byte UTF-8 that `wc -m` counts as one character and a byte-counting consumer counts as three.

`manifest.json:145-155` declares `char_cap: 12000`, citing *"caps EACH rules file at 12000 characters"*. **Nothing here has verified that the platform counts that way**, and this issue already established what happens if it does not: Antigravity drops the overflow **silently** at the destination. No red check, no error. The bats assertion would keep passing at 11974 while the tail of the file never arrives.

## The fix does not decide the unit — it removes the question

Rather than settle what Antigravity counts (which needs an experiment against the live consumer, not a reading of its docs), `deploy_doctrine` now normalises typographic punctuation to ASCII **in a capped payload**. Bytes and characters then track each other, so the guard and the platform cannot disagree however the platform counts.

```
before             11974 chars   12047 bytes   OVER
after              11976 chars   11985 bytes   OK, both under
em-dash -> ' - '   12042 chars   12042 bytes   OVER  (measured and rejected)
```

The spaced and doubled variants were measured too: both *add* characters and land back over the cap. A single hyphen is the only fold that helps in both units.

**Only punctuation that does not alter the lexicon.** Dashes, curly quotes and the ellipsis are typographic — folding them is uglier and means exactly the same thing. Accents and section signs are deliberately **not** folded: `bitácora` → `bitacora` changes a word, `§4` → `S4` changes a reference. Five such characters survive, which is why the invariant is stated as *"under the cap in both units"* rather than *"ASCII"*, and why the deploy prints a note when any survive.

The substitutions are written as **hex escapes rather than literals**: a curly quote in shell source is SC1112, which fails `shellcheck` and therefore CI lint. I hit that on the first attempt — 3 new findings, `shellcheck` rc 1 — and it is why the escapes are there rather than the obvious characters.

## The guard now measures both units

That is the part that keeps this from recurring. **Proven in the failing direction**: with the normalisation disabled — which is exactly today's `main` — the test goes red with

```
not ok 18 HARNESS-056: the compact doctrine payload carries it and stays under its cap
# .gemini/GEMINI.md is 12047 BYTES, at or over its 12000 cap (chars: 11974)
```

The mutation was confirmed to have landed before the verdict was read.

## This corrects a claim I made on #1241 tonight

I reported that a persona migration costs **exactly 0** characters and concluded the remaining migrations were free of cap risk. The character half is right and independently confirmed on four trees. But it is only true in the unit that may not bind:

| what grows | characters | bytes |
|---|---|---|
| a new skill id | 18 | 18 |
| **a persona's prose** | **0** | **2 per em-dash** |

Tonight's four persona migrations added roughly ten paragraphs of vault prose and moved the character count by **zero** — the roster renders skill ids only. They moved the byte count. So the per-id budget decided on #1241 has been tracking the measure that is not growing, and the decision was made on an incomplete picture. Full numbers are on that issue.

## Coordination

Checked with the parallel session before writing any of this, because #1495 is parked on the same cap. It does not collide: #1495 is 1632 characters over, not 47, and this recovers ~24 — a different problem sharing a number. It also does not pre-empt that issue's decision (*budget, do not raise the cap*): the cap value is untouched, and the stated reason for not raising it was precisely that overflow truncates silently, which this removes a path to.

The lexicon caveat above is theirs, adopted: writing the boundary down now saves the argument about folding accents in six months.

## Verification

- `bash -n` and `zsh -n` — both clean
- `shellcheck scripts/compile-harness.sh` — **no new findings**; rc 1 and its SC2016 infos are identical on `main`, and SC1112 count is **0**
- `bats tests/*.bats` — **1554/1554**, exit 0
- `--deploy` into a throwaway `HOME` — 11976 chars / 11985 bytes, both under 12000, idempotent on a second run
- The script is `#!/usr/bin/env bash`; running it under `zsh` fails on `main` too, so that is a pre-existing limitation and not a regression here

Refs #1241

## Spec

`specs/HARNESS-111/`, gated on #1241. Six acceptance criteria, all executed in the implementing session, with the two that matter proven in the failing direction rather than observed green.

The spec-gate refused this push at 67 production LOC without one — 26 lines of code and 54 of comment, and the gate counts both. Rather than strip the comments to get under the threshold, which is the explanation the next reader needs, or reach for `skip-sdd` on my own judgement, the spec is the sanctioned path and #1241 already gives it an owner.
