### PR TITLE
fix(harness): shipper's block precondition named a closed issue and the wrong risk

### DIFF
--- a/harness/agents/shipper/AGENT.md
+++ b/harness/agents/shipper/AGENT.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/agents/definitions/shipper/AGENT.md
-generated_sha: 86c1ecfacc81c6fe
+generated_sha: 00ca37afa44c04ca
 id: agent-shipper
 type: agent
 status: active
@@ -54,7 +54,11 @@ They are the three that hold whatever is being shipped. Isolation applies to eve
 
 This is why the loader applies **no default severity**. Defaulting to `warn` would make an unmigrated persona *"silently inert while every check reported it as wired — presence dressed as enforcement"*; defaulting to `block` would turn every already-declared skill into a hard gate the day it shipped. So a skill is gated because someone chose to gate it, and the ungated ones are listed rather than assumed.
 
-Raising any of these to `block` is gated on evidence, not on confidence: no severity moves until a real dispatch is observed resolving this persona, with two dispatches of one role carrying different `agent_id`s. One blocker applies here with particular force — a *named* dispatch sends its name as `agent_type`, so its role never resolves and the gate silently turns off. Until that is fixed, read a `[gate] warn` line as the obligation it states.
+Raising any of these to `block` is gated on evidence, not on confidence: no severity moves until a real dispatch is observed resolving this persona **from the deployed record**, with two dispatches of one role carrying different `agent_id`s.
+
+The deployed half of that sentence is the one that bites. The gate reads the deploy directory, never your checkout, so a migration that is merged is not a migration that is in force — and the record written while it is inert is indistinguishable from the record written when everything passed. An unmigrated persona has nothing to enforce, so the gate reports `allow` with *"all blocking skills consumed"*, which is the same line a persona that satisfied every obligation produces.
+
+A named dispatch used to defeat role resolution outright; that is fixed for a **witnessed** dispatch, which the gate maps back to its true type. The residual is the unwitnessed one, which still falls through to the roster and finds no persona under its name.
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary

- **shipper's record named a closed issue as a live blocker.** It said a named dispatch sends its name as `agent_type`, "so its role never resolves and the gate silently turns off", and told the reader that stood "until that is fixed". #1434 closed 2026-09-04 via #1471 — ~19h *before* #1504 merged the sentence. The residual is narrower than the claim: a **witnessed** named dispatch is mapped back to its true type, and only an **unwitnessed** one still falls through to the roster.
- **Replaced with the precondition that does hold**, matching the correction #1509 already applied to architect: the gate reads the **deploy dir**, so a merged migration is not an enforced one — and the record written while it is inert is indistinguishable from the record written when everything passed (#1510).
- **Fixed at the source, not in the generated file.** `harness/agents/shipper/AGENT.md` carries `generated_sha`; the edit is in the vault (`knowledge` `eceee5da`) and this is the `--refresh` output. Editing the record directly is the failure mode that produced the side finding below.

### Evidence the correction is right, measured this session

The release deployed at `21:23:50Z`, and three genuine dispatches then landed in the gate ledger through the deployed `PreToolUse` hook — the one acceptance criterion no PR in this epic could assert:

```
21:32:21Z  agent_type=architect  agent_id=a51b7c05…  resolved=architect  outcome=warn
           warned=[architecture-session, pattern-loader, read-all-adrs]
21:33:45Z  agent_type=architect  agent_id=a918411d…  resolved=architect  outcome=warn
           warned=[architecture-session, pattern-loader, read-all-adrs]
21:33:47Z  agent_type=shipper    agent_id=a972839b…  resolved=shipper    outcome=warn
           warned=[docker, pr-review-triage, using-git-worktrees]
```

That is architect's "two dispatches of one role carrying different `agent_id`s" satisfied, plus shipper's first. A *named* dispatch resolving correctly was already evidenced by the 116 `adversarial-pr14 → reviewer` records the dispatch map produced — which is precisely why the removed sentence was false.

Driving v0.54.0's gate against each deployed record separately shows the contrast the epic is about — same binary, same deploy dir, same payload shape:

| persona | form | gate output |
|---|---|---|
| architect | mapping | 3 warns |
| shipper | mapping | 3 warns |
| builder | mapping (2 of 9) | 2 warns |
| curator | flat list | **silent** |
| planner | flat list | **silent** |

## SDD checklist

- [x] Issue exists on the bitácora GitHub Project — `Refs #1497` (epic); this corrects prose merged by #1504
- [x] Diff conforms to ~300 LOC atomic cap — 5 changed lines in one generated record
- [ ] Spec folder `specs/<feature-id>/` is included in this PR (or `skip-sdd` label below)
- [ ] `proposal.md` has filled Why / What / Acceptance criteria
- [ ] `tasks.md` is in TDD order
- [ ] `verification.md` will be filled before merge (evidence + commit hashes)

## SDD skip rationale

Prose correction to a single generated record: one false sentence replaced with three accurate ones, no logic, no contract, no new dependency. Under the 50-LOC production threshold. The design decision it documents was already specced and reviewed on #1509, which applied the identical correction to architect and whose independent review flagged that "the same false sentence is already merged in shipper's record from #1504 and needs the same correction" — this is that follow-up.

## Test plan

- [x] `cd cli && go build ./... && go vet ./... && go test ./internal/harness/ ./internal/cmd/` — ok
- [x] `./scripts/compile-harness.sh --check` — `rc=0`, no harness drift
- [x] `--refresh` is idempotent: a second run produces no further diff
- [x] Manual verification: three real dispatches recorded in the gate ledger (table above), read from `~/.local/state/dotfiles/gate/`, all after the deploy timestamp

## Side finding, fixed at the vault and NOT in this PR

The first `--refresh` also stripped the `<!-- full-only:begin/end -->` markers from `harness/enforced/no-auto-merge.md`. Cause: #1495 added those markers to the **generated record** but never to its vault source, so every subsequent `--refresh` reverts them — the same "generated record edited without its source" class that #1495 itself was fixing for the new-ticket skill.

It is not cosmetic. Per `compile-harness.sh`, the markers keep a region out of the **compact doctrine payload**, which is what agy and codex receive *instead of* the constitution under a 12000-character cap. Without them the auto-merge **exception** — 1686 characters carrying its four qualifying conditions — ships next to the prohibition it qualifies, and "an agent that knows an exception exists may try to qualify for it".

- **No live exposure:** the deployed `~/.gemini/GEMINI.md` was rendered from `d03033e`, which carries the markers.
- **Fixed at source:** `knowledge` `0c835e6d`. `--refresh` is now idempotent, which is how this PR's diff came out clean.
- **Guard ticketed separately:** `HARNESS-056` asserts the *mechanism* on a synthetic fixture; nothing asserts the real record still has its markers. That gap, not this PR, is where the guard belongs.
