### PR TITLE
fix(cli): make Gate f's claims falsifiable, and stop calling a constant a signal

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,11 +20,17 @@ All shell scripts MUST work in **both bash and zsh**. Before modifying any `.sh`
 | `set -- $var` / unquoted `$var` to split into fields | read line by line, or `${=var}` in zsh | **Fails silently.** zsh does not word-split unquoted parameters: you get one field containing everything, not N |
 | `. file` (no slash) to source from the cwd | `. ./file` | **Fails silently.** A slashless argument to `.` is searched on `$PATH` only; bash also falls back to the cwd, zsh does not. In a `$(...)` the result is an empty string, not an error |
 | `${PIPESTATUS[0]}` to check a piped command | drop the pipe and use `$?`, or `set -o pipefail` when the pipe is needed | **Fails silently.** zsh spells it `$pipestatus[1]` and arrays are 1-indexed, so the bash form expands to **nothing** — `EXIT=` rather than an error. A verification that reads a pipeline's exit status is exactly where this bites: `cmd \| tail` reports `tail`'s status, so a failing `cmd` passes |
+| `path=`, `status=`, `cdpath=`, `manpath=`, `fignore=` as ordinary variable names | any other name — `target`, `rc`, … | **Fails silently, and destructively.** In zsh these are *tied* to their uppercase counterparts: `path` IS `$PATH` as an array. Assigning a string to `path` wipes the command search path, so every later `cp`/`mv`/`grep` becomes "command not found" — and a script that interprets a failed command as "nothing matched" will report a clean result. Measured 2026-09-05: a mutation harness reported `ANCHOR-MISS` ("the pattern was not found") for all 8 mutations when the real cause was that `md5sum` no longer existed. `zsh -n` passes clean; only running it finds this |
 
-> The last four rows fail **silently**: they return an empty or single-element result instead of an
+> The last five rows fail **silently**: they return an empty or single-element result instead of an
 > error, and empty reads as a finding. Every row above them breaks loudly. Before believing an
 > empty result from a shell sweep, re-run it in the other shell — see `docs/lessons.md`,
 > *"a shell incompatibility that answers wrongly beats one that fails"*.
+>
+> **A script whose failure path reports "found nothing" needs a preflight.** The last row's damage
+> was not the wiped `PATH`, it was that the wipe arrived dressed as a result. Any script that
+> reports absence — no match, no diff, no mutation applied — should assert its tools exist before
+> it starts, so a broken environment exits loudly instead of answering the question wrongly.
 
 ## Verification Commands
 

--- a/cli/internal/cmd/worktree.go
+++ b/cli/internal/cmd/worktree.go
@@ -237,8 +237,9 @@ clean git status, confirmed merged PR, and minimum age.`,
 				// gateF only scans worktrees that reached StateReapable, so a
 				// run with nothing to consider also produces 0, and printing a
 				// reach for a scan that never happened would be its own lie.
-				c.Printf("Gate f reach: %d process(es) belong to root or another user and cannot be inspected;\n"+
-					"              one of theirs sitting in a worktree is invisible to this scan.\n",
+				c.Printf("Gate f reach: %d process(es) could not be inspected (other users, root, or\n"+
+					"              same-user processes that opt out); one of those sitting in a\n"+
+					"              worktree is invisible to this scan.\n",
 					report.UninspectableProcesses)
 			}
 

--- a/cli/internal/cmd/worktree.go
+++ b/cli/internal/cmd/worktree.go
@@ -225,10 +225,20 @@ clean git status, confirmed merged PR, and minimum age.`,
 				c.Printf("note: no process-liveness check on this platform, so nothing can be reaped.\n")
 				c.Printf("      Gate f refuses rather than guesses; remove one deliberately with `dotf worktree done`.\n")
 			} else if report.UninspectableProcesses > 0 {
-				// A partial scan, said out loud. These are almost always other
-				// users' processes, whose cwd only they and root may read, so
-				// the scan cannot rule out that one of them is inside.
-				c.Printf("note: %d process(es) could not be inspected, so this scan was partial.\n",
+				// Gate f's reach, not a warning. This number is non-zero on
+				// every Linux machine — reading /proc/<pid>/cwd is gated by
+				// ptrace_may_access, and a desktop runs hundreds of processes
+				// this user may not read (measured: 364 of 571, 20 of them the
+				// caller's own). It said "this scan was partial" before, which
+				// is a warning light wired to always-on, and a reader learns to
+				// skip those.
+				//
+				// Still gated on > 0, because 0 is ambiguous rather than good:
+				// gateF only scans worktrees that reached StateReapable, so a
+				// run with nothing to consider also produces 0, and printing a
+				// reach for a scan that never happened would be its own lie.
+				c.Printf("Gate f reach: %d process(es) belong to root or another user and cannot be inspected;\n"+
+					"              one of theirs sitting in a worktree is invisible to this scan.\n",
 					report.UninspectableProcesses)
 			}
 

--- a/cli/internal/worktree/sweep.go
+++ b/cli/internal/worktree/sweep.go
@@ -92,26 +92,42 @@ type SweepReport struct {
 	// and those are different facts.
 	ProcessDiscovery bool `json:"process_discovery"`
 	// UninspectableProcesses is the largest number of processes any single
-	// worktree's scan could not read the cwd of — almost always another user's,
-	// since /proc/<pid>/cwd is readable only by its owner and root. Non-zero
-	// means every reap decision in this run rested on a partial scan. Reported
-	// rather than acted on: refusing on it would make sweep inert on Linux,
-	// because /proc/1/cwd is unreadable to every non-root caller.
+	// worktree's scan could not read the cwd of.
+	//
+	// It states Gate f's REACH; it is not an anomaly signal, and an earlier
+	// version of this comment claimed it was. The number is non-zero on every
+	// Linux machine by construction: /proc/<pid>/cwd is gated by
+	// ptrace_may_access, so a scan run as an ordinary user can never read
+	// root's processes, another user's, or same-uid ones that set
+	// PR_SET_DUMPABLE=0 (systemd --user, ssh-agent, browser sandboxes). One
+	// desktop measurement: 364 of 571 processes out of reach, 20 of them the
+	// caller's own. A count that can never be zero cannot warn about anything.
+	//
+	// Reported rather than acted on: refusing on it would make sweep
+	// permanently inert on Linux, which is the same trap as answering "nobody
+	// is inside" — it makes the tool useless instead of dangerous, but it makes
+	// it useless every single run.
 	UninspectableProcesses int `json:"uninspectable_processes"`
 }
 
 // GateFReading is what Gate f could actually establish about one worktree.
 //
 // It is a struct and not a bool because the scan has three outcomes, not two.
-// A process whose cwd cannot be read is neither inside nor outside: /proc/<pid>/cwd
-// is readable only by the process owner and root, so an ordinary user's scan
-// cannot see another user's cwd. Collapsing that into "not inside" is the
-// fail-open an adversarial review caught here; collapsing it into "inside"
-// would make sweep permanently inert, since /proc/1/cwd is unreadable to every
-// non-root caller. Reporting the count is the third option, and it matches what
-// ProcessDiscovery does one level up: make a partial answer legible as partial.
+// A process whose cwd cannot be read is neither inside nor outside: reading
+// /proc/<pid>/cwd is gated by ptrace_may_access, so an ordinary user's scan
+// cannot see root's cwd, another user's, or a same-uid process that made itself
+// non-dumpable. Collapsing that into "not inside" is the fail-open an
+// adversarial review caught here; collapsing it into "inside" would make sweep
+// permanently inert, since /proc/1/cwd is unreadable to every non-root caller.
+//
+// The third option is to keep the fact and be honest about what it is: a
+// statement of how far the gate can see, not a warning that something is wrong.
+// See the SweepReport field for the measurement.
 type GateFReading struct {
-	Inside        bool
+	Inside bool
+	// Uninspectable is a coverage figure, never a threshold. Nothing decides on
+	// it, because nothing can: an unreadable process stays unreadable however
+	// many of them there are.
 	Uninspectable int
 }
 
@@ -124,13 +140,14 @@ type GateFReading struct {
 // the CI does not have, which is how the defect this replaced survived review.
 var hostProcessInside = isHostProcessInside
 
-func isCandidateForReap(info Info, absCwd string) bool {
-	_, ok := gateF(info, absCwd)
-	return ok
-}
-
 // gateF returns the reading alongside the decision, so a caller that wants to
-// report how complete the scan was does not have to run it twice.
+// report how far the scan reached does not have to run it twice.
+//
+// This is the function production calls. It used to have a bool-returning
+// wrapper, isCandidateForReap, which no caller outside the tests used — so the
+// tests that pinned Gate f's refusal were pinning a function that could not
+// affect a deletion. Removed rather than kept for convenience: a test seam into
+// dead code reports coverage it does not have.
 func gateF(info Info, absCwd string) (GateFReading, bool) {
 	if info.State != StateReapable {
 		return GateFReading{}, false

--- a/cli/internal/worktree/sweep_proc_linux.go
+++ b/cli/internal/worktree/sweep_proc_linux.go
@@ -28,8 +28,15 @@ const processDiscoverySupported = true
 // /proc/<pid>/cwd is ALREADY resolved by the kernel and filepath.Abs is not.
 // Without it a worktree reached by a symlinked path compares unequal to the
 // physical path every process reports, so the gate answers "nobody is inside"
-// while a shell sits in it — the same fail-open this file exists to remove,
-// arriving through a different door.
+// while a shell sits in it.
+//
+// That closes the symlink door and NOT the general one. This comparison is
+// still on strings, and a path is not an identity: a process in another mount
+// namespace reports its own view, so a container bind-mounting the worktree at
+// /wt-mount-target compares unequal to the host path and reads as outside while
+// it is inside. Reproduced and tracked as #1523 — the fix is dev+ino identity
+// (os.SameFile), which this change does not attempt because it cannot yet be
+// given a test that fails in CI.
 func isHostProcessInside(targetPath string) GateFReading {
 	absTarget, err := filepath.Abs(targetPath)
 	if err != nil {
@@ -72,6 +79,10 @@ func isHostProcessInside(targetPath string) GateFReading {
 type cwdVerdict int
 
 const (
+	// cwdOutside is the ZERO VALUE, and it is the permissive one: a caller that
+	// forgets a case in a switch, or reads an uninitialised cwdVerdict, gets
+	// "safe to delete". Stated here because it is the wrong default for a
+	// fail-closed gate and nothing in the type says so.
 	cwdOutside cwdVerdict = iota
 	cwdInside
 	cwdUnreadable
@@ -95,14 +106,16 @@ func isNumericPID(name string) bool {
 // snapshot, processes exit between the ReadDir and the Readlink constantly, and
 // a process that no longer exists is genuinely not in the worktree.
 //
-// EACCES is a real limitation and is reported rather than resolved.
-// /proc/<pid>/cwd is readable only by the process owner and root, so a scan run
-// as an ordinary user cannot see another user's cwd — including root's. Making
-// that answer `Inside: true` would be the fail-closed reflex and it would make
-// sweep permanently inert on Linux, since /proc/1/cwd is EACCES to every
-// non-root caller and therefore every scan would refuse. Counting them instead
-// keeps the tool useful while making a partial scan visible as a partial scan,
-// which is the same choice ProcessDiscovery makes one level up.
+// EACCES is a permanent property of the platform, not an event. Reading
+// /proc/<pid>/cwd is gated by ptrace_may_access, so an ordinary user's scan can
+// never see root's processes, another user's, or a same-uid process that set
+// PR_SET_DUMPABLE=0. Making that answer `Inside: true` would be the fail-closed
+// reflex and it would make sweep permanently inert on Linux, since /proc/1/cwd
+// is EACCES to every non-root caller and therefore every scan would refuse.
+//
+// So they are counted — but as a statement of the gate's reach, not as a
+// warning. The count is non-zero on every Linux machine, which is exactly why
+// it cannot mean "something is wrong here"; see SweepReport.UninspectableProcesses.
 func inspectProcessCwd(pidName, absTarget string) cwdVerdict {
 	dest, err := os.Readlink(filepath.Join("/proc", pidName, "cwd"))
 	if err != nil {

--- a/cli/internal/worktree/sweep_proc_linux_test.go
+++ b/cli/internal/worktree/sweep_proc_linux_test.go
@@ -144,9 +144,17 @@ func TestUninspectableProcessesAreCountedByTheRealScan(t *testing.T) {
 	// cwd this user may not read, and it must not silently become vacuous on a
 	// machine where that is untrue. /proc/1 is the natural witness — it is
 	// root's, and ptrace_may_access denies every non-root caller.
+	//
+	// The skip is narrow and it is LOUD, because a skip and a pass are the same
+	// colour in CI: `go test` without -v prints neither, so a test that quietly
+	// stopped running looks exactly like one that keeps passing. Whoever reads
+	// this on a machine where it skipped gets told which condition did it.
+	euid := os.Geteuid()
 	if _, err := os.Readlink("/proc/1/cwd"); err == nil {
-		t.Skip("/proc/1/cwd is readable here (running as root, or an unusual kernel policy), " +
-			"so this machine has nothing for the counter to count")
+		t.Skipf("NOT EXECUTED: /proc/1/cwd is readable at euid=%d, so every process on this "+
+			"machine is inspectable and the counter has nothing to count. This is expected "+
+			"under root and nowhere else; the CI leg that pins this behaviour runs unprivileged.",
+			euid)
 	}
 
 	// An empty directory, so the scan runs to completion instead of returning

--- a/cli/internal/worktree/sweep_proc_linux_test.go
+++ b/cli/internal/worktree/sweep_proc_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -36,7 +37,7 @@ func startChildIn(t *testing.T, dir string) {
 	// The child must have been chdir'd before /proc reflects it.
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		if dest, err := os.Readlink(filepath.Join("/proc", itoa(cmd.Process.Pid), "cwd")); err == nil {
+		if dest, err := os.Readlink(filepath.Join("/proc", strconv.Itoa(cmd.Process.Pid), "cwd")); err == nil {
 			if resolved, rerr := filepath.EvalSymlinks(dir); rerr == nil && dest == resolved {
 				return
 			}
@@ -44,18 +45,6 @@ func startChildIn(t *testing.T, dir string) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatalf("child never reported a cwd of %s in /proc", dir)
-}
-
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var buf []byte
-	for n > 0 {
-		buf = append([]byte{byte('0' + n%10)}, buf...)
-		n /= 10
-	}
-	return string(buf)
 }
 
 func TestGateFSeesAProcessLivingInTheWorktree(t *testing.T) {
@@ -102,31 +91,100 @@ func TestGateFSeesThroughASymlinkedWorktreePath(t *testing.T) {
 	}
 }
 
-func TestGateFMatchesASubdirectoryButNotASiblingWithASharedPrefix(t *testing.T) {
+func TestGateFMatchesAProcessInASubdirectory(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "repo-wt-feat")
+	nested := filepath.Join(target, "sub", "deep")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	startChildIn(t, nested)
+
+	if !isHostProcessInside(target).Inside {
+		t.Error("a process in a subdirectory of the worktree was not counted as inside; " +
+			"a shell two levels down still loses its work when the worktree is removed")
+	}
+}
+
+// The negative half, in its own test with its own root.
+//
+// Round 3 caught the previous version asserting nothing here: it spawned a child
+// inside the target as well, then re-derived the target's own path and called
+// that "the sibling", so the comparison was a tautology and its failure branch
+// was a t.Skip. The naive-prefix mutation survived the whole suite.
+//
+// Nothing lives inside target here, which is what makes the assertion mean
+// something: the only process anywhere near is in a directory whose name has
+// target's name as a string prefix.
+func TestGateFDoesNotMatchASiblingSharingANamePrefix(t *testing.T) {
 	root := t.TempDir()
 	target := filepath.Join(root, "repo-wt-feat")
 	sibling := filepath.Join(root, "repo-wt-feature-two")
-	nested := filepath.Join(target, "sub", "deep")
-	for _, d := range []string{nested, sibling} {
+	for _, d := range []string{target, sibling} {
 		if err := os.MkdirAll(d, 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", d, err)
 		}
 	}
 
-	startChildIn(t, nested)
-	if !isHostProcessInside(target).Inside {
-		t.Error("a process in a subdirectory of the worktree was not counted as inside")
+	startChildIn(t, sibling)
+
+	if isHostProcessInside(target).Inside {
+		t.Error("a process in repo-wt-feature-two was reported as inside repo-wt-feat: the " +
+			"prefix test is not separator-anchored, so every worktree whose name prefixes " +
+			"another one is now unreapable while nothing is in it")
+	}
+}
+
+// The producer of the uninspectable count, which no test drove before round 3 —
+// replacing `reading.Uninspectable++` with a no-op left the suite green, so the
+// count could have pinned at 0 forever while the report claimed a reach the scan
+// never had.
+func TestUninspectableProcessesAreCountedByTheRealScan(t *testing.T) {
+	// Anchor first: this test rests on there being at least one process whose
+	// cwd this user may not read, and it must not silently become vacuous on a
+	// machine where that is untrue. /proc/1 is the natural witness — it is
+	// root's, and ptrace_may_access denies every non-root caller.
+	if _, err := os.Readlink("/proc/1/cwd"); err == nil {
+		t.Skip("/proc/1/cwd is readable here (running as root, or an unusual kernel policy), " +
+			"so this machine has nothing for the counter to count")
 	}
 
-	startChildIn(t, sibling)
-	if isHostProcessInside(sibling).Inside != true {
-		t.Error("sanity: the sibling itself should report its own process")
+	// An empty directory, so the scan runs to completion instead of returning
+	// early on the first process found inside.
+	reading := isHostProcessInside(t.TempDir())
+
+	if reading.Inside {
+		t.Fatal("a freshly created temp directory reported a process inside it; the fixture " +
+			"is wrong and the count below would not mean what it says")
 	}
-	// The prefix check must be separator-anchored: "repo-wt-feat" is a string
-	// prefix of "repo-wt-feature-two", and a naive HasPrefix would swallow it.
-	otherRoot := filepath.Join(root, "repo-wt-feat")
-	if got := isHostProcessInside(otherRoot); !got.Inside {
-		t.Skip("cannot isolate: the nested child also matches this path")
+	if reading.Uninspectable == 0 {
+		t.Error("the scan reported full reach over every process on a machine where " +
+			"/proc/1/cwd is unreadable; an uncounted unreadable process is one the gate " +
+			"silently treated as outside")
+	}
+}
+
+// AC2's fail-closed branch for an unresolvable target. It needs no injection —
+// only a path that does not exist — which is why round 3 rejected the claim that
+// this branch could not be reached by a test.
+func TestGateFRefusesWhenTheTargetCannotBeResolved(t *testing.T) {
+	if got := isHostProcessInside(filepath.Join(t.TempDir(), "no-such-worktree")); !got.Inside {
+		t.Error("Gate f answered \"nobody is inside\" for a path it could not resolve; the " +
+			"caller deletes on that answer, so an unresolvable target must read as occupied")
+	}
+}
+
+// The Linux half of AC4. The !linux half is pinned by
+// TestUnsupportedPlatformDoesNotAdvertiseDiscovery on the Windows leg; this side
+// had only a test that skipped when the constant was false and then asserted a
+// package-level var was non-nil, which it cannot be. Flipping the constant to
+// false left the suite green while sweep would have printed "no process-liveness
+// check on this platform" next to a working one.
+func TestProcessDiscoveryIsAdvertisedOnLinux(t *testing.T) {
+	if !processDiscoverySupported {
+		t.Error("Linux walks /proc and answers from real processes, but the constant says " +
+			"this platform has no process discovery; sweep would announce a refusal it is " +
+			"not making and explain away every empty result")
 	}
 }
 
@@ -143,9 +201,8 @@ func TestIsNumericPID(t *testing.T) {
 }
 
 // A process that exits between the ReadDir and the Readlink is genuinely not in
-// the worktree, so it must read as `outside` and not as `unreadable`: counting
-// it would report a partial scan on every busy machine and make the signal
-// meaningless.
+// the worktree, so it must read as `outside` and not as `unreadable`: /proc is a
+// snapshot and processes leave during every scan.
 func TestVanishedProcessCountsAsOutsideNotUnreadable(t *testing.T) {
 	if got := inspectProcessCwd("4294967295", t.TempDir()); got != cwdOutside {
 		t.Errorf("a non-existent pid gave %v, want cwdOutside — /proc is a snapshot and "+

--- a/cli/internal/worktree/sweep_proc_linux_test.go
+++ b/cli/internal/worktree/sweep_proc_linux_test.go
@@ -145,16 +145,27 @@ func TestUninspectableProcessesAreCountedByTheRealScan(t *testing.T) {
 	// machine where that is untrue. /proc/1 is the natural witness — it is
 	// root's, and ptrace_may_access denies every non-root caller.
 	//
-	// The skip is narrow and it is LOUD, because a skip and a pass are the same
-	// colour in CI: `go test` without -v prints neither, so a test that quietly
-	// stopped running looks exactly like one that keeps passing. Whoever reads
-	// this on a machine where it skipped gets told which condition did it.
+	// Skipping locally is right — under root the counter genuinely has nothing
+	// to count, and failing there would be a false alarm. But a skip and a pass
+	// are the same colour in CI: `go test` without -v prints neither, so a test
+	// that quietly stopped running looks exactly like one that keeps passing.
+	// A longer skip message does not fix that; it is invisible either way.
+	//
+	// So the skip is local-only. On CI this is the leg that pins the behaviour,
+	// and a skip there is a silent loss of the only coverage the producer has —
+	// which is what happens the day someone moves these tests into a root
+	// container. Fail instead, and say why.
 	euid := os.Geteuid()
 	if _, err := os.Readlink("/proc/1/cwd"); err == nil {
-		t.Skipf("NOT EXECUTED: /proc/1/cwd is readable at euid=%d, so every process on this "+
-			"machine is inspectable and the counter has nothing to count. This is expected "+
-			"under root and nowhere else; the CI leg that pins this behaviour runs unprivileged.",
-			euid)
+		if os.Getenv("CI") != "" {
+			t.Fatalf("CI is running at euid=%d with a readable /proc/1/cwd, so the "+
+				"uninspectable counter is unexercised on the one leg that pins it. Either "+
+				"the job gained privileges or the kernel policy changed; both make this "+
+				"test silently worthless, which is why it fails here instead of skipping.",
+				euid)
+		}
+		t.Skipf("not executed: /proc/1/cwd is readable at euid=%d, so every process here is "+
+			"inspectable and the counter has nothing to count", euid)
 	}
 
 	// An empty directory, so the scan runs to completion instead of returning

--- a/cli/internal/worktree/sweep_proc_test.go
+++ b/cli/internal/worktree/sweep_proc_test.go
@@ -1,8 +1,10 @@
 package worktree
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // The refusing branch of Gate f only executes on a platform this CI does not
@@ -15,6 +17,10 @@ import (
 // Driving the seam both ways is what makes the fix checkable. The direction
 // that matters is the second one: a gate that cannot answer must not clear the
 // worktree for deletion.
+//
+// Every test here drives gateF or SweepWithRunner, never a wrapper. Round 3
+// found the previous version pinning isCandidateForReap, which production did
+// not call — a refusal proven on a function that could not prevent a deletion.
 
 func withHostProcessInside(t *testing.T, answer bool) {
 	t.Helper()
@@ -44,8 +50,7 @@ func reapableInfo(t *testing.T) Info {
 func TestGateFRefusesWhenProcessDiscoveryCannotAnswer(t *testing.T) {
 	withHostProcessInside(t, true)
 
-	info := reapableInfo(t)
-	if isCandidateForReap(info, "/somewhere/else") {
+	if _, ok := gateF(reapableInfo(t), "/somewhere/else"); ok {
 		t.Error("a worktree was cleared for reaping while Gate f reported a live process inside; " +
 			"an unanswerable gate must refuse, because the caller deletes on a false")
 	}
@@ -54,37 +59,17 @@ func TestGateFRefusesWhenProcessDiscoveryCannotAnswer(t *testing.T) {
 func TestGateFAllowsAReapableWorktreeWhenNothingIsInside(t *testing.T) {
 	withHostProcessInside(t, false)
 
-	info := reapableInfo(t)
-	if !isCandidateForReap(info, "/somewhere/else") {
+	if _, ok := gateF(reapableInfo(t), "/somewhere/else"); !ok {
 		t.Error("a reapable worktree with no process inside was refused; the gate has stopped " +
 			"discriminating and now refuses everything, which passes the test above vacuously")
 	}
 }
 
-// processDiscoverySupported is a build-tag constant, so this asserts the value
-// for the platform the test binary was built for rather than a fixed answer.
-// It pins the contract that the two files agree on the constant's meaning: it
-// is true exactly where isHostProcessInside can observe processes.
-func TestProcessDiscoveryIsReportedForThisPlatform(t *testing.T) {
-	// Linux is the only implemented platform today. If a Windows or Darwin
-	// implementation lands, this test must be updated in the same change --
-	// which is the point: the constant should never drift from reality
-	// silently, since a false one makes sweep inert and a true one makes it
-	// dangerous.
-	if !processDiscoverySupported {
-		t.Skip("no process discovery on this platform; the refusal path is covered above")
-	}
-
-	if hostProcessInside == nil {
-		t.Fatal("process discovery is advertised as supported but Gate f has no implementation")
-	}
-}
-
-// A partial scan must not silently become a clean one. Uninspectable processes
-// deliberately do NOT block the reap -- refusing on them would make sweep inert
-// on Linux, since /proc/1/cwd is unreadable to every non-root caller -- so the
-// count is the only thing standing between "scanned and found nothing" and
-// "could not see several processes and found nothing among the rest".
+// Uninspectable processes deliberately do NOT block the reap -- refusing on them
+// would make sweep inert on Linux, since /proc/1/cwd is unreadable to every
+// non-root caller. This pins that the count survives the trip to the report;
+// that the producer actually increments it is a separate test, in
+// sweep_proc_linux_test.go, because a seam cannot see its own producer.
 func TestUninspectableProcessesDoNotBlockButAreCarried(t *testing.T) {
 	withGateFReading(t, GateFReading{Inside: false, Uninspectable: 7})
 
@@ -94,8 +79,85 @@ func TestUninspectableProcessesDoNotBlockButAreCarried(t *testing.T) {
 			"permanently inert on Linux, which is why they are reported instead")
 	}
 	if reading.Uninspectable != 7 {
-		t.Errorf("gateF dropped the uninspectable count: got %d, want 7 — a partial scan " +
-			"that reports nothing is indistinguishable from a complete one",
-			reading.Uninspectable)
+		t.Errorf("gateF dropped the uninspectable count: got %d, want 7 — the report would "+
+			"then describe a reach the scan did not have", reading.Uninspectable)
+	}
+}
+
+// The gate that actually guards the deletion is the SECOND one.
+//
+// SweepWithRunner consults Gate f twice: once to select candidates, and again
+// inside reapSingleWorktree under the lock, immediately before removing the
+// worktree. The re-check exists for the window between them -- a shell that
+// cds in while the sweep is deciding -- and a seam with one constant answer can
+// never reach it, because a constant `true` is refused by the first call and a
+// constant `false` never exercises the second. Round 3 measured the
+// consequence: deleting the re-check left the whole suite green.
+//
+// So this seam answers false first and true afterwards, which is precisely the
+// TOCTOU the re-check is for.
+func TestSweepRefusesWhenAProcessArrivesAfterTheGate(t *testing.T) {
+	original := hostProcessInside
+	calls := 0
+	hostProcessInside = func(string) GateFReading {
+		calls++
+		return GateFReading{Inside: calls > 1}
+	}
+	t.Cleanup(func() { hostProcessInside = original })
+
+	tmpDir := t.TempDir()
+	mainRepo := filepath.Join(tmpDir, "myrepo")
+	reapableWT := filepath.Join(tmpDir, "myrepo-wt-reapable")
+	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.MkdirAll(reapableWT, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	now := time.Now()
+	if err := SaveMetadata(reapableWT, Metadata{
+		ReapOK:         true,
+		CreatedAt:      now.Add(-2 * time.Hour),
+		LeaseExpiresAt: now.Add(-1 * time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveMetadata: %v", err)
+	}
+
+	removed := []string{}
+	runner := &MockSweepRunner{
+		MockGitRunner: MockGitRunner{
+			PorcelainOutput: "worktree " + mainRepo + "\nHEAD 1111\nbranch refs/heads/main\n\n" +
+				"worktree " + reapableWT + "\nHEAD 2222\nbranch refs/heads/feat/reapable\n\n",
+			MergedBranches: map[string]bool{"feat/reapable": true},
+		},
+		OnWorktreeRemove: func(_, path string) error {
+			removed = append(removed, path)
+			return nil
+		},
+	}
+
+	report, err := SweepWithRunner(SweepOptions{
+		RepoRoot: mainRepo,
+		LockPath: filepath.Join(tmpDir, "sweep.lock"),
+	}, runner, now)
+	if err != nil {
+		t.Fatalf("unexpected error during sweep: %v", err)
+	}
+
+	// The anchor: without it, a fixture that never became reapable would pass
+	// this test by reaping nothing for the wrong reason.
+	if calls < 2 {
+		t.Fatalf("Gate f was consulted %d time(s); the fixture never reached the re-check, "+
+			"so this test proves nothing about it", calls)
+	}
+	if len(removed) != 0 {
+		t.Errorf("a worktree was removed after Gate f reported a process had arrived inside it: %v", removed)
+	}
+	if len(report.Reaped) != 0 {
+		t.Errorf("sweep reported reaping %v despite the second gate refusing", report.Reaped)
+	}
+	if report.SkippedCount != 2 { // mainRepo + the worktree the re-check saved
+		t.Errorf("expected 2 skipped (main and the refused worktree), got %d", report.SkippedCount)
 	}
 }

--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -291,5 +291,6 @@ tags: [lessons, index, dotfiles]
 | [271 - Hooks are re-read, personas are not, and one measurement was generalised into both](lesson-271-hooks-reload-personas-do-not-and-the-difference-was-assumed-away.md) | 2026-09-02 |  |
 | [272 - Fail-closed worktree garbage collection requires in-tree leases and positive confirmation](lesson-272-fail-closed-worktree-garbage-collection-and-in-tree-leases.md) | 2026-09-05 |  |
 | [273 - The fix and the detector can be the same edit](lesson-273-the-fix-and-the-detector-can-be-the-same-edit.md) | 2026-09-05 |  |
+| [274 - A constant test double cannot reach a check that exists for change](lesson-274-a-constant-test-double-cannot-reach-a-check-that-exists-for-change.md) | 2026-09-05 |  |
 
 - [2026-08-30 Intercepting Cobra Errors without Breaking SilenceErrors](2026-08-30-cobra-silence-errors-interception.md)

--- a/docs/lessons/lesson-274-a-constant-test-double-cannot-reach-a-check-that-exists-for-change.md
+++ b/docs/lessons/lesson-274-a-constant-test-double-cannot-reach-a-check-that-exists-for-change.md
@@ -1,0 +1,96 @@
+---
+id: lesson-274
+type: lesson
+status: active
+created: "2026-09-05"
+owner: manu
+tags: [lesson, testing, toctou, test-doubles, review]
+---
+
+# 274 — A constant test double cannot reach a check that exists for change
+
+## What happened
+
+`dotf worktree sweep` asks Gate f — "is a live process sitting in this worktree?" — **twice**. Once
+to pick candidates, and again inside `reapSingleWorktree`, under the lock, immediately before the
+directory is removed. The second call is a TOCTOU guard: it exists for the window in which a shell
+`cd`s in while the sweep is still deciding.
+
+Gate f is injected through a package-level seam, and five tests drove it. An adversarial review
+deleted the second check outright:
+
+```go
+if err != nil || absWT == absCwd || hostProcessInside(absWT).Inside {   // before
+if err != nil || absWT == absCwd {                                      // mutated
+```
+
+The whole suite stayed **green**. Two review rounds had passed over it.
+
+## Why it happened
+
+Every one of those tests installed a double that returned the *same answer every call*. That
+answer can be `true` or `false`, and **neither reaches the second check**:
+
+| The double always says | What happens |
+|---|---|
+| `true` ("someone is inside") | the *first* gate refuses; control never gets near the re-check |
+| `false` ("nobody is inside") | the re-check runs and agrees; deleting it changes no outcome |
+
+The second check only matters when the answer **changes between the two calls**. A constant double
+makes it unreachable-in-effect: present in the trace, but incapable of altering any assertion. The
+mutation is invisible not because the test forgot to assert, but because the *shape of the double*
+excluded the only scenario in which the code under test does anything.
+
+The fix is one line of double, and it is the whole lesson:
+
+```go
+calls := 0
+hostProcessInside = func(string) GateFReading {
+    calls++
+    return GateFReading{Inside: calls > 1}   // absent, then present
+}
+```
+
+Plus the anchor, because this test can now go vacuous in a new way — if the fixture never becomes
+reapable, Gate f is consulted zero times and the test passes having exercised nothing:
+
+```go
+if calls < 2 {
+    t.Fatalf("Gate f was consulted %d time(s); the fixture never reached the re-check", calls)
+}
+```
+
+## Why it matters
+
+**The shape of a test double is part of the property being tested, not plumbing.** Choosing a
+constant stub silently narrows the reachable state space, and the narrowing does not show up as a
+gap — it shows up as a passing test with a confident name.
+
+The general form: **a guard that exists because a value can change cannot be tested by a double
+that holds it still.** Re-checks under a lock, retry loops, cache invalidation, optimistic
+concurrency, revalidation after a slow call — every one of them is a second read whose entire
+purpose is disagreeing with the first. Stub them constant and you have tested the first read twice.
+
+There is a companion trap in the same family. `isCandidateForReap` was a bool wrapper around the
+real gate that **no production caller used**; two of the tests pinned Gate f's refusal on it. A
+seam into dead code reports coverage it does not have, so before trusting a gate's tests, check
+that the function they call is the one production calls.
+
+## What to do about it
+
+1. **When a check is a re-read, the double must change its answer.** Name the call ordinal in the
+   stub. If a constant stub can satisfy the test, the test is not about the re-read.
+2. **Count the calls and assert the count.** It is the anchor for this class: it converts "the
+   guard did not fire" into "the guard was never reached", which are different results that a
+   green suite renders identically — see [[lesson-267]].
+3. **Mutate by deletion, specifically.** Removing a guard entirely is a sharper probe than altering
+   its condition; a condition change can still be caught by luck, a deletion cannot.
+4. **Check the seam lands in production code.** `grep` the function the test drives for callers
+   outside `_test.go` files.
+
+## Related
+
+- [[lesson-267]] — a mutation harness must prove the mutation landed.
+- [[lesson-273]] — the fix and the detector can be the same edit; this is its sibling, where the
+  *double* is what deletes the detector.
+- [[lesson-272]] — fail-closed worktree garbage collection, the change these guards belong to.

--- a/specs/BUG-093-gate-f-fail-closed/features.json
+++ b/specs/BUG-093-gate-f-fail-closed/features.json
@@ -51,8 +51,8 @@
   {
     "id": "BUG-093-gate-f-fail-closed-f8",
     "behavior": "Every mutation the round-3 review reported as surviving now fails the suite, and the harness reports ANCHOR-MISS rather than a result when a patch does not land",
-    "verification": "cd cli && go test ./internal/worktree/ -count=1 && grep -q 'ANCHOR-MISS' ../specs/BUG-093-gate-f-fail-closed/verification.md",
+    "verification": "bash specs/BUG-093-gate-f-fail-closed/mutate.sh",
     "state": "verified",
-    "evidence": "7 CAUGHT (5 round-3 survivors + 2 earlier regressions), 1 SURVIVED and declared (the filepath.Abs branch, unreachable by input). Full output in verification.md"
+    "evidence": "exit 0: 7 CAUGHT (5 round-3 survivors + 2 earlier regressions), 1 declared survivor (the filepath.Abs branch, unreachable by input), 0 regressions. The harness is committed and exits non-zero if an expected-CAUGHT mutation survives - it is a check, not a report; the earlier form grepped a word in a markdown file"
   }
 ]

--- a/specs/BUG-093-gate-f-fail-closed/features.json
+++ b/specs/BUG-093-gate-f-fail-closed/features.json
@@ -9,30 +9,30 @@
   {
     "id": "BUG-093-gate-f-fail-closed-f2",
     "behavior": "On Linux every failure that prevents the SCAN answers true (Abs, EvalSymlinks, ReadDir); a per-process failure is three-valued and unreadable is counted, not folded into either answer",
-    "verification": "cd cli && go test ./internal/worktree/ -run 'GateFSeesThroughASymlinkedWorktreePath|VanishedProcess|Uninspectable' -count=1",
+    "verification": "cd cli && go test ./internal/worktree/ -run 'GateFSeesThroughASymlinkedWorktreePath|GateFRefusesWhenTheTargetCannotBeResolved|VanishedProcess|UninspectableProcessesAreCountedByTheRealScan' -count=1 -v 2>&1 | grep -c '^--- PASS'",
     "state": "verified",
-    "evidence": "symlink regression mutation-proven: removing EvalSymlinks fails TestGateFSeesThroughASymlinkedWorktreePath"
+    "evidence": "4 PASS; the EvalSymlinks and Uninspectable-producer branches are both mutation-proven (round 3 findings 7 and 4)"
   },
   {
     "id": "BUG-093-gate-f-fail-closed-f3",
-    "behavior": "On any non-Linux platform isHostProcessInside answers true for every input, and processDiscoverySupported is false",
+    "behavior": "On any non-Linux platform isHostProcessInside answers true for every input and processDiscoverySupported is false, and that path is EXECUTED rather than only compiled",
     "verification": "cd cli && GOOS=windows go vet ./internal/worktree/ && GOOS=darwin go vet ./internal/worktree/",
     "state": "verified",
-    "evidence": "GOOS=windows and GOOS=darwin vet clean; asserted at runtime by sweep_proc_other_test.go on the Windows leg"
+    "evidence": "vet clean for both; and the build-tag-flip proxy in verification.md RUNS sweep_proc_other.go on Linux -> rc=0. Round 3 finding 7: vet alone cannot see a runtime failure, which is how round 2 shipped a red Windows leg"
   },
   {
     "id": "BUG-093-gate-f-fail-closed-f4",
-    "behavior": "isCandidateForReap refuses when Gate f says a process is inside and allows when it says none is, both driven through a seam",
-    "verification": "cd cli && go test ./internal/worktree/ -run 'GateF' -count=1",
+    "behavior": "gateF - the function production calls - refuses when Gate f says a process is inside and allows when it says none is; and the under-lock re-check in reapSingleWorktree refuses a process that arrives after the candidate scan",
+    "verification": "cd cli && go test ./internal/worktree/ -run 'GateFRefusesWhenProcessDiscoveryCannotAnswer|GateFAllowsAReapableWorktree|SweepRefusesWhenAProcessArrivesAfterTheGate|UninspectableProcessesDoNotBlock' -count=1 -v 2>&1 | grep -c '^--- PASS'",
     "state": "verified",
-    "evidence": "TestGateFRefusesWhenProcessDiscoveryCannotAnswer + TestGateFAllowsAReapableWorktreeWhenNothingIsInside, both PASS"
+    "evidence": "4 PASS. Round 3 finding 5: the previous tests pinned isCandidateForReap, which no production caller used; the wrapper is deleted and the re-check is now driven through SweepWithRunner with a false-then-true seam"
   },
   {
     "id": "BUG-093-gate-f-fail-closed-f5",
-    "behavior": "dotf worktree sweep reports absent process discovery, and a non-zero uninspectable count when the scan ran but could not see everything",
-    "verification": "grep -q 'no process-liveness check on this platform' cli/internal/cmd/worktree.go && grep -q 'could not be inspected, so this scan was partial' cli/internal/cmd/worktree.go",
+    "behavior": "dotf worktree sweep reports absent process discovery before its counts, and states Gate f's reach as coverage rather than as a partial-scan warning",
+    "verification": "grep -q 'no process-liveness check on this platform' cli/internal/cmd/worktree.go && grep -q 'Gate f reach:' cli/internal/cmd/worktree.go && ! grep -q 'so this scan was partial' cli/internal/cmd/worktree.go",
     "state": "verified",
-    "evidence": "the note is printed before the counts in newWorktreeSweepCmd"
+    "evidence": "the note precedes the counts in newWorktreeSweepCmd; the always-firing 'partial' warning is gone (round 3 finding 2). Asserted by grep knowingly - see verification.md, Accepted gaps"
   },
   {
     "id": "BUG-093-gate-f-fail-closed-f6",
@@ -43,9 +43,16 @@
   },
   {
     "id": "BUG-093-gate-f-fail-closed-f7",
-    "behavior": "The real /proc traversal is tested against live child processes, not only through the seam",
-    "verification": "cd cli && go test ./internal/worktree/ -run 'GateFSees|GateFDoesNotInvent|GateFMatches|IsNumericPID|Vanished' -count=1",
+    "behavior": "The real /proc traversal is tested against live child processes, including the negative half of the separator-anchored prefix check",
+    "verification": "cd cli && go test ./internal/worktree/ -run 'GateFSees|GateFDoesNotInvent|GateFMatchesAProcessInASubdirectory|GateFDoesNotMatchASibling|IsNumericPID|Vanished|Uninspectable|ProcessDiscoveryIsAdvertised' -count=1 -v 2>&1 | grep -c '^--- PASS'",
     "state": "verified",
-    "evidence": "sweep_proc_linux_test.go: 6 tests spawning real children; round-1 review found this file did not exist"
+    "evidence": "10 PASS. Round 3 finding 3: the old sibling test asserted nothing and used t.Skip as its failure branch; it is now two tests with isolated roots and the naive-prefix mutation fails"
+  },
+  {
+    "id": "BUG-093-gate-f-fail-closed-f8",
+    "behavior": "Every mutation the round-3 review reported as surviving now fails the suite, and the harness reports ANCHOR-MISS rather than a result when a patch does not land",
+    "verification": "cd cli && go test ./internal/worktree/ -count=1 && grep -q 'ANCHOR-MISS' ../specs/BUG-093-gate-f-fail-closed/verification.md",
+    "state": "verified",
+    "evidence": "7 CAUGHT (5 round-3 survivors + 2 earlier regressions), 1 SURVIVED and declared (the filepath.Abs branch, unreachable by input). Full output in verification.md"
   }
 ]

--- a/specs/BUG-093-gate-f-fail-closed/mutate.sh
+++ b/specs/BUG-093-gate-f-fail-closed/mutate.sh
@@ -18,28 +18,43 @@ set -u
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 CLI="$(cd "$HERE/../../cli" && pwd)"
 
+# Preflight, because the failure mode without it is a LIE rather than an error.
+# This script once used `path` as a local variable name. Under zsh `path` is a
+# special array tied to $PATH, so assigning a string to it destroyed the command
+# search path -- and every subsequent `cp` and `md5sum` vanished, which the loop
+# below reports as ANCHOR-MISS: "the pattern was not found". A broken
+# environment then reads as a mutation nobody could apply. `zsh -n` passes
+# clean, so nothing catches it but running it.
+for _cmd in md5sum cut cp mv python3 go grep sed; do
+    if ! command -v "$_cmd" >/dev/null 2>&1; then
+        printf 'PREFLIGHT FAILED: %s is not on PATH.\n' "$_cmd" >&2
+        printf 'Every result below would read as ANCHOR-MISS, which is not what happened.\n' >&2
+        exit 2
+    fi
+done
+
 pass=0
 fail=0
 expected_survivors=0
 
 run_mutation() {
     expect="$1"; label="$2"; file="$3"; from="$4"; to="$5"
-    path="$CLI/$file"
-    before="$(md5sum "$path" | cut -d' ' -f1)"
-    cp "$path" "$path.bak"
+    target="$CLI/$file"
+    before="$(md5sum "$target" | cut -d' ' -f1)"
+    cp "$target" "$target.bak"
 
-    python3 - "$path" "$from" "$to" <<'PY'
+    python3 - "$target" "$from" "$to" <<'PY'
 import sys
 p, a, b = sys.argv[1], sys.argv[2], sys.argv[3]
 s = open(p).read()
 open(p, 'w').write(s.replace(a, b, 1))
 PY
 
-    after="$(md5sum "$path" | cut -d' ' -f1)"
+    after="$(md5sum "$target" | cut -d' ' -f1)"
     if [ "$before" = "$after" ]; then
         printf '  ANCHOR-MISS  %s\n' "$label"
         printf '               the pattern was not found, so nothing was tested\n'
-        mv "$path.bak" "$path"
+        mv "$target.bak" "$target"
         fail=$((fail + 1))
         return
     fi
@@ -48,7 +63,7 @@ PY
     # verification's exit code through one is how a failing command passes.
     out="$(cd "$CLI" && go test ./internal/worktree/ -count=1 2>&1)"
     rc=$?
-    mv "$path.bak" "$path"
+    mv "$target.bak" "$target"
 
     if [ "$rc" -ne 0 ]; then
         if [ "$expect" = "CAUGHT" ]; then

--- a/specs/BUG-093-gate-f-fail-closed/mutate.sh
+++ b/specs/BUG-093-gate-f-fail-closed/mutate.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# Mutation harness for BUG-093 Gate f.
+#
+# Every mutation the round-3 adversarial review reported as SURVIVING must be
+# CAUGHT here. Run from anywhere; paths resolve from this file's location.
+#
+#   bash specs/BUG-093-gate-f-fail-closed/mutate.sh
+#
+# Exits non-zero if an expected-CAUGHT mutation survives, so it is a check and
+# not a report. The anchor is asserted before each mutation is applied: if the
+# patch does not change the file, the run reports ANCHOR-MISS and never a
+# result, because a no-op that reports "the tests caught it" is the defect this
+# spec is about (lesson 267).
+
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+CLI="$(cd "$HERE/../../cli" && pwd)"
+
+pass=0
+fail=0
+expected_survivors=0
+
+run_mutation() {
+    expect="$1"; label="$2"; file="$3"; from="$4"; to="$5"
+    path="$CLI/$file"
+    before="$(md5sum "$path" | cut -d' ' -f1)"
+    cp "$path" "$path.bak"
+
+    python3 - "$path" "$from" "$to" <<'PY'
+import sys
+p, a, b = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(p).read()
+open(p, 'w').write(s.replace(a, b, 1))
+PY
+
+    after="$(md5sum "$path" | cut -d' ' -f1)"
+    if [ "$before" = "$after" ]; then
+        printf '  ANCHOR-MISS  %s\n' "$label"
+        printf '               the pattern was not found, so nothing was tested\n'
+        mv "$path.bak" "$path"
+        fail=$((fail + 1))
+        return
+    fi
+
+    # Not a pipe: a pipeline reports the LAST command's status, and reading a
+    # verification's exit code through one is how a failing command passes.
+    out="$(cd "$CLI" && go test ./internal/worktree/ -count=1 2>&1)"
+    rc=$?
+    mv "$path.bak" "$path"
+
+    if [ "$rc" -ne 0 ]; then
+        if [ "$expect" = "CAUGHT" ]; then
+            printf '  CAUGHT       %s\n' "$label"
+            pass=$((pass + 1))
+        else
+            printf '  CAUGHT       %s (was declared uncovered -- update the spec)\n' "$label"
+            pass=$((pass + 1))
+        fi
+        printf '%s\n' "$out" | grep -E '^[[:space:]]+--- FAIL' | head -2 | sed 's/^/               /'
+    else
+        if [ "$expect" = "SURVIVES" ]; then
+            printf '  SURVIVED     %s (declared in verification.md)\n' "$label"
+            expected_survivors=$((expected_survivors + 1))
+        else
+            printf '  SURVIVED     %s  <-- REGRESSION\n' "$label"
+            fail=$((fail + 1))
+        fi
+    fi
+}
+
+printf '=== baseline (must be green, or every result below is meaningless) ===\n'
+base_out="$(cd "$CLI" && go test ./internal/worktree/ -count=1 2>&1)"
+base_rc=$?
+if [ "$base_rc" -ne 0 ]; then
+    printf 'BASELINE RED -- aborting\n%s\n' "$base_out"
+    exit 1
+fi
+printf '  baseline rc=0\n\n=== mutations the round-3 review found SURVIVING ===\n'
+
+run_mutation CAUGHT "finding 3: prefix test loses its separator anchor" \
+    "internal/worktree/sweep_proc_linux.go" \
+    'strings.HasPrefix(absDest, absTarget+string(filepath.Separator))' \
+    'strings.HasPrefix(absDest, absTarget)'
+
+run_mutation CAUGHT "finding 4: Uninspectable++ becomes a no-op" \
+    "internal/worktree/sweep_proc_linux.go" \
+    'reading.Uninspectable++' \
+    '_ = reading'
+
+run_mutation CAUGHT "finding 5: reapSingleWorktree drops the Gate f re-check" \
+    "internal/worktree/sweep.go" \
+    'if err != nil || absWT == absCwd || hostProcessInside(absWT).Inside {' \
+    'if err != nil || absWT == absCwd {'
+
+run_mutation CAUGHT "finding 6: Linux claims it has no process discovery" \
+    "internal/worktree/sweep_proc_linux.go" \
+    'const processDiscoverySupported = true' \
+    'const processDiscoverySupported = false'
+
+run_mutation CAUGHT "finding 7: unresolvable target fails OPEN" \
+    "internal/worktree/sweep_proc_linux.go" \
+    '		// The caller is about to delete this path, so it should exist. If it
+		// cannot be resolved, the comparison below cannot be trusted either.
+		return GateFReading{Inside: true}' \
+    '		return GateFReading{Inside: false}'
+
+printf '\n=== regressions from earlier rounds (must stay caught) ===\n'
+
+run_mutation CAUGHT "round 1 Blocker: EvalSymlinks resolution removed" \
+    "internal/worktree/sweep_proc_linux.go" \
+    '	absTarget = resolved' \
+    '	_ = resolved'
+
+run_mutation CAUGHT "round 1: caller ignores Gate f entirely" \
+    "internal/worktree/sweep.go" \
+    '	reading := hostProcessInside(absWT)
+	return reading, !reading.Inside' \
+    '	reading := hostProcessInside(absWT)
+	return reading, true'
+
+printf '\n=== declared uncovered in verification.md (expected to survive) ===\n'
+
+run_mutation SURVIVES "AC2: filepath.Abs error fails open (unreachable by input)" \
+    "internal/worktree/sweep_proc_linux.go" \
+    '	absTarget, err := filepath.Abs(targetPath)
+	if err != nil {
+		return GateFReading{Inside: true}
+	}' \
+    '	absTarget, err := filepath.Abs(targetPath)
+	if err != nil {
+		return GateFReading{Inside: false}
+	}'
+
+printf '\n=== summary ===\n'
+printf '  caught: %d   declared survivors: %d   regressions/anchor-miss: %d\n' \
+    "$pass" "$expected_survivors" "$fail"
+
+# Every mutation is reverted by its own run, so the tree must be back to green.
+# A red restore means a .bak did not make it home and every result above is
+# describing a tree nobody has now.
+(cd "$CLI" && go test ./internal/worktree/ -count=1 >/dev/null 2>&1)
+frc=$?
+printf '  restored rc=%d\n' "$frc"
+
+if [ "$fail" -ne 0 ] || [ "$frc" -ne 0 ]; then
+    exit 1
+fi
+exit 0

--- a/specs/BUG-093-gate-f-fail-closed/proposal.md
+++ b/specs/BUG-093-gate-f-fail-closed/proposal.md
@@ -35,6 +35,25 @@ note: no process-liveness check on this platform, so nothing can be reaped.
 
 `SweepReport` gains `ProcessDiscovery bool` so a JSON consumer can tell the two apart too.
 
+## Scope of Gate f — what it can see, and what it never will
+
+**Gate f is the second layer, not the first.** A worktree only reaches `gateF` after it is already
+`StateReapable`, which requires on-disk metadata with `reap_ok` and an expired lease — a signal the
+tool writes and owns. Gate f is the best-effort check for "somebody is sitting in it anyway", and
+best-effort is a bound, not a hedge:
+
+- Reading `/proc/<pid>/cwd` is gated by `ptrace_may_access`. An ordinary user's scan can never read
+  root's processes, another user's, or a same-uid process that set `PR_SET_DUMPABLE=0`
+  (`systemd --user`, `ssh-agent`, browser sandboxes).
+- Measured on one ordinary desktop: **571 processes, 364 out of reach** — 344 owned by other users,
+  and 20 owned by the caller and still denied.
+
+So `UninspectableProcesses` is **non-zero on every Linux machine, by construction**. Round 3 caught
+the previous framing calling it a partial-scan *warning*: a warning that fires on every run is one
+readers learn to skip, and it was the answer to round 1's Major, so the mitigation signalled
+nothing. It is now reported as coverage — a statement of the gate's reach — and no decision is
+taken on it, because none can be: an unreadable process stays unreadable however many there are.
+
 ## Out of scope
 
 - **A real Windows implementation** (`ToolHelp32Snapshot` + per-process cwd) and a Darwin one
@@ -45,6 +64,32 @@ note: no process-liveness check on this platform, so nothing can be reaped.
   from a directory name. Same family, separate change, dispositioned in #1515's triage.
 - **Injecting the `/proc` directory read.** It would close the one mutation gap below, but it
   restructures a function this change is otherwise only moving.
+
+- **The mount-namespace fail-open, declared rather than fixed.** `/proc/<pid>/cwd` is resolved in
+  the *process's own* namespace, so a container bind-mounting the worktree reports its own view and
+  the string comparison misses it. Reproduced here, not cited:
+
+  ```
+  docker run -d -u 1000:1000 -v /tmp/wtmount-repro/repo-wt-feat:/wt-mount-target \
+             -w /wt-mount-target busybox sleep 60
+  host readlink /proc/2658284/cwd  -> /wt-mount-target
+  worktree path on host            -> /tmp/wtmount-repro/repo-wt-feat
+  dev/ino of /proc/<pid>/cwd       -> 50/992409
+  dev/ino of the worktree path     -> 50/992409     <- the same directory
+  string comparison                -> False         <- the gate says "outside"
+  ```
+
+  The same weakness produces the deleted-then-recreated case round 3 probed, and the same fix
+  retires both: identity by `dev`+`ino` (`os.SameFile`) instead of by string, walking parents for
+  the subdirectory case.
+
+  **Not fixed here because it cannot be given a test that fails in CI, and this spec's own lesson
+  is that a fix without one is worse than a declared gap.** The reproduction needs a mount
+  namespace: `unshare -Urm` is refused on the development machine
+  (`kernel.apparmor_restrict_unprivileged_userns = 1`, Ubuntu's default since 24.04), and whether
+  a GitHub `ubuntu-latest` runner permits one is not measurable from here. A test that skips on the
+  runner asserts nothing while reporting green — the exact shape of the vacuous test round 3 found
+  in this same file. **Tracked as #1523**, whose first task is that measurement rather than a patch.
 
 ## Risks / open questions
 
@@ -57,8 +102,18 @@ note: no process-liveness check on this platform, so nothing can be reaped.
   leg. Neither alone is sufficient — a seam test passes over a wrong implementation, and the
   platform test cannot see whether the caller honours the answer.
 - **`processDiscoverySupported` can drift from reality.** If a Windows implementation lands and
-  the constant is not flipped, `sweep` reports a liveness check it never performed. Pinned by a
-  test, and called out in the constant's own comment.
+  the constant is not flipped, `sweep` reports a liveness check it never performed. Pinned in
+  **both** directions, which round 3 showed it previously was not: the Linux side by
+  `TestProcessDiscoveryIsAdvertisedOnLinux` and the non-Linux side by
+  `TestUnsupportedPlatformDoesNotAdvertiseDiscovery`. The earlier Linux test skipped when the
+  constant was false and then asserted a package-level `var` was non-nil, which it cannot be — so
+  flipping the constant left the suite green.
+
+- **A green Linux suite is not evidence about Windows, and `go vet` is not either.** Round 2 shipped
+  a red `test (windows-latest)` while every local check passed: `GOOS=windows go vet` compiles the
+  non-Linux file and never runs it. Any test that expects a reap must drive the `hostProcessInside`
+  seam, because Gate f answers "occupied" unconditionally off Linux. AC7 now names the Windows
+  **test** leg, and the build-tag-flip proxy in `verification.md` executes that path locally.
 
 ## Acceptance criteria
 
@@ -83,10 +138,23 @@ note: no process-liveness check on this platform, so nothing can be reaped.
    `/proc/<pid>/cwd` is already resolved by the kernel and `filepath.Abs` is not.
 3. On any non-Linux platform, `isHostProcessInside` answers `true` for every input.
 4. `processDiscoverySupported` is `false` exactly where there is no implementation.
-5. `isCandidateForReap` refuses a `StateReapable` worktree when Gate f answers `true`, and
-   allows it when Gate f answers `false` — both directions driven by a test seam.
-6. `dotf worktree sweep` reports the absence of process discovery before its counts, and
-   reports a non-zero uninspectable count when the scan ran but could not see everything.
-7. `go build`, `go test ./...`, `golangci-lint run` and `GOOS=windows go vet ./...` are clean.
-8. The caller-side fix is mutation-proven: reverting it fails the suite, with the anchor
-   asserted before the mutation is applied.
+5. `gateF` — the function production calls — refuses a `StateReapable` worktree when Gate f
+   answers `true` and allows it when Gate f answers `false`, both directions driven by a test seam.
+
+   **Amended after round 3.** This named `isCandidateForReap`, a bool wrapper no production caller
+   used: the refusal was pinned on a function that could not prevent a deletion. The wrapper is
+   deleted.
+
+5b. The **re-check inside `reapSingleWorktree`** — the one that runs under the lock immediately
+   before removal — refuses when a process arrives after the candidate scan. This needs a seam that
+   answers `false` then `true`; a constant answer cannot reach it, because a constant `true` is
+   refused by the first call and a constant `false` never exercises the second.
+6. `dotf worktree sweep` reports the absence of process discovery before its counts, and states
+   Gate f's **reach** when the scan ran without full visibility — as coverage, not as a warning
+   (see *Scope of Gate f*).
+7. `go build`, `go test ./...`, `golangci-lint run` and `GOOS=windows go vet ./...` are clean, and
+   the **`test (windows-latest)` leg is green**. The vet is a compile check and cannot see a
+   runtime failure on that platform; round 2 proved that by shipping one. Locally this is
+   established with the build-tag-flip proxy, which runs the non-Linux implementation on Linux.
+8. Every mutation round 3 reported as surviving now fails the suite, with the anchor asserted
+   before each mutation is applied.

--- a/specs/BUG-093-gate-f-fail-closed/tasks.md
+++ b/specs/BUG-093-gate-f-fail-closed/tasks.md
@@ -50,3 +50,28 @@ created: "2026-09-05"
 - [x] Amend AC2 to state what the code can actually guarantee, and declare the amendment in
       `verification.md` rather than letting it pass silently.
 - [x] `SweepReport.UninspectableProcesses` + the partial-scan note in the command.
+- [x] **Undeclared at the time, recorded here after round 3 named it:** `dab7b6e` drove the
+      `hostProcessInside` seam in five pre-existing `sweep_test.go` tests. Necessary — Gate f
+      answering `true` off Linux makes any test that expects a reap fail on the Windows leg — but
+      it was a test change made after the review launched, and it moved the reviewed sha.
+
+## Round 3 (after the round-3 FAIL — the surviving-mutation round)
+
+- [x] Reframe `Uninspectable` from partial-scan warning to Gate f **reach**: `Scope of Gate f` in
+      the proposal, new CLI wording, three code comments rewritten. Measured first, then designed:
+      the uid-filtered rescue does not work (20 of 227 same-uid processes are EACCES).
+- [x] Split the vacuous sibling test into `TestGateFMatchesAProcessInASubdirectory` and
+      `TestGateFDoesNotMatchASiblingSharingANamePrefix`, each with its own root, no `t.Skip`.
+- [x] `TestUninspectableProcessesAreCountedByTheRealScan` — drives the producer, anchored on
+      `/proc/1/cwd` being unreadable so it cannot go vacuous on a root-run machine.
+- [x] `TestSweepRefusesWhenAProcessArrivesAfterTheGate` — the under-lock re-check, via a seam that
+      answers `false` then `true`, with a call-count anchor.
+- [x] `TestProcessDiscoveryIsAdvertisedOnLinux` replaces the unfalsifiable Linux pin.
+- [x] `TestGateFRefusesWhenTheTargetCannotBeResolved` — the `EvalSymlinks` branch, which needed
+      only a nonexistent path.
+- [x] Delete `isCandidateForReap` (no production caller); move its seam tests onto `gateF`.
+- [x] `strconv.Itoa` for the hand-rolled `itoa`; document `cwdVerdict`'s permissive zero value.
+- [x] Amend AC5/AC5b/AC6/AC7 and correct three false claims in `verification.md`.
+- [x] Reproduce the mount-namespace fail-open independently; declare it in *Out of scope* and file
+      it as **#1523** rather than shipping a fix with no CI-runnable test.
+- [x] Execute the non-Linux path locally with the build-tag-flip proxy — `go vet` cannot see it.

--- a/specs/BUG-093-gate-f-fail-closed/verification.md
+++ b/specs/BUG-093-gate-f-fail-closed/verification.md
@@ -67,9 +67,15 @@ Every command below was executed in this session.
 
 ### Mutation results
 
-Anchors asserted before applying: the harness compares the file's checksum after the patch and
-reports **ANCHOR-MISS** rather than a result if nothing changed, so a no-op cannot be read as
-"the tests caught it" (lesson 267).
+The harness is **committed** at `specs/BUG-093-gate-f-fail-closed/mutate.sh` and is `features.json`
+f8's verification command. It exits non-zero if any expected-CAUGHT mutation survives, so it is a
+check rather than a report — the previous form asserted that this markdown file contained the
+string `ANCHOR-MISS`, which is not the same claim.
+
+Anchors asserted before applying: it compares the file's checksum after the patch and reports
+**ANCHOR-MISS** rather than a result if nothing changed, so a no-op cannot be read as "the tests
+caught it" (lesson 267). The declared survivor is declared *to the harness*, so it prints as
+expected rather than as a failure, and a mutation that starts being caught says so.
 
 ```
 === mutations the round-3 review found SURVIVING ===
@@ -144,6 +150,12 @@ and makes that measurement its first task.
   (it constructs its own `RealSweepRunner`), and adding one to assert print ordering buys less
   than it costs. The grep is honest about being a grep; `features.json` f5 tracks the new wording.
 - **Mount namespaces** — #1523, above.
+- **`TestUninspectableProcessesAreCountedByTheRealScan` skips under root**, which is correct: the
+  counter genuinely has nothing to count there. The gap that mattered was **visibility** — `go test`
+  without `-v` prints neither a skip nor a pass, so a test that stopped running is the same colour
+  as one that keeps passing, and the `test (ubuntu-latest)` log confirms it: 25KB with no PASS or
+  SKIP lines in it. A longer skip message does not fix that. It now **fails** when `CI` is set,
+  and skips only locally — so the one leg that pins the producer can never lose it silently.
 
 ## Decisions made during implementation
 

--- a/specs/BUG-093-gate-f-fail-closed/verification.md
+++ b/specs/BUG-093-gate-f-fail-closed/verification.md
@@ -150,6 +150,14 @@ and makes that measurement its first task.
   (it constructs its own `RealSweepRunner`), and adding one to assert print ordering buys less
   than it costs. The grep is honest about being a grep; `features.json` f5 tracks the new wording.
 - **Mount namespaces** — #1523, above.
+- **The mutation harness itself carried a silent zsh defect**, found by running it rather than
+  reading it: it used `path` as a local variable, and in zsh `path` is tied to `$PATH`, so every
+  `cp`/`md5sum`/`mv` inside the function vanished and all 8 mutations reported **ANCHOR-MISS** —
+  "the pattern was not found" — when the real cause was that the tools had ceased to exist. No
+  corruption resulted (`cp` failed before any `.bak` was written), which was luck and not design.
+  Renamed, and a preflight now asserts its tools exist so a broken environment exits loudly
+  instead of answering the question wrongly. Four other sites in the repo have the same defect,
+  latent; filed as **#1530** with the measurement, plus a doc row in `.claude/CLAUDE.md`.
 - **`TestUninspectableProcessesAreCountedByTheRealScan` skips under root**, which is correct: the
   counter genuinely has nothing to count there. The gap that mattered was **visibility** — `go test`
   without `-v` prints neither a skip nor a pass, so a test that stopped running is the same colour

--- a/specs/BUG-093-gate-f-fail-closed/verification.md
+++ b/specs/BUG-093-gate-f-fail-closed/verification.md
@@ -5,116 +5,165 @@ created: "2026-09-05"
 
 # Verification - BUG-093-gate-f-fail-closed
 
-## Round 1 review: FAIL — disposition
+## Round 3 review: FAIL — disposition
 
-`agy/gemini-3.1-pro-high`, random draw, not the implementer. Verdict **FAIL** against
-`2d9f4114`, on 1 Blocker and 2 Majors. **All three were real and all three are applied.**
+`nan/qwen3.8-flash`, random draw, not the implementer. Verdict **FAIL** against `dab7b6e`, on
+6 REAL Majors and 4 REAL Minors. **Every one was real. None is argued down.**
+
+The shape of round 3 is worth naming before the table: the reviewer did not find a broken
+behaviour, it found **claims that no test could falsify**. Five mutations survived the whole
+suite — including the mitigation this spec added in round 2 as its answer to round 1.
 
 | # | Finding | Disposition |
 |---|---|---|
-| Blocker | `filepath.Abs` does not resolve symlinks, `/proc/<pid>/cwd` does — a symlinked worktree path never matches, so the gate fails open with a process inside | **Applied.** `filepath.EvalSymlinks` on the target before comparison; `TestGateFSeesThroughASymlinkedWorktreePath` is the regression, mutation-proven |
-| Major | `processCwdInside` returns false on `os.Readlink` error, contradicting AC2 | **Applied, and AC2 amended** — see below |
-| Major | `sweep_proc_linux.go` has zero test coverage; only the seam is exercised | **Applied.** `sweep_proc_linux_test.go`, 6 tests against real `/proc` with live child processes |
+| 1 (Major) | Mount-namespace fail-open: `/proc/<pid>/cwd` resolves in the process's own namespace, so a bind-mounted worktree compares unequal and reads as outside | **Declared, not fixed.** Reproduced independently (below), added to *Out of scope* with the measurement, the overclaiming code comment corrected, filed as **#1523**. Not fixed here because it has no CI-runnable test — see below |
+| 2 (Major) | `Uninspectable` is permanently maxed out, so the round-1 mitigation signals nothing | **Applied — this was the design blocker.** Reframed from warning to *reach*. New `Scope of Gate f` section, new CLI wording, three code comments rewritten |
+| 3 (Major) | `TestGateFMatchesASubdirectoryButNotASiblingWithASharedPrefix` never checks the "but not a sibling" half; `t.Skip` used as an assertion | **Applied.** Split into two tests with isolated roots; the naive-prefix mutation now fails |
+| 4 (Major) | No test drives `reading.Uninspectable++`; a no-op mutation left the suite green | **Applied.** `TestUninspectableProcessesAreCountedByTheRealScan`, anchored on `/proc/1/cwd` being unreadable |
+| 5 (Major) | After `dab7b6e` no test drives Gate f's refusal through `SweepWithRunner`; `isCandidateForReap` has no production caller | **Applied.** Wrapper deleted, seam tests moved onto `gateF`, and `TestSweepRefusesWhenAProcessArrivesAfterTheGate` drives the real path |
+| 6 (Major) | `processDiscoverySupported` is "pinned by a test" that cannot fail on Linux | **Applied.** `TestProcessDiscoveryIsAdvertisedOnLinux` replaces it; both directions now pinned |
+| 7 (Major) | Round 2 shipped a red `test (windows-latest)`; AC7 named `go vet`, which compiles and never runs | **Applied.** AC7 amended to name the Windows test leg; the build-tag-flip proxy is now part of this document; the false claims below are corrected |
+| 8 (Minor) | The `EvalSymlinks` fail-closed branch is untested, and the stated reason for that was wrong | **Applied.** `TestGateFRefusesWhenTheTargetCannotBeResolved` — it needed only a nonexistent path, exactly as the reviewer said |
+| 9 (Minor) | AC6 asserted by grep, not behaviour | **Accepted knowingly**, and said so — see *Accepted gaps* |
+| 10 (Minor) | Stale claims: "3 PASS" (was 7), "not filed as a ticket yet" (#1470 is OPEN) | **Corrected**, both |
+| 11 (Minor, SPECULATIVE) | `isCandidateForReap` dead, `itoa` reinvents `strconv.Itoa`, `cwdVerdict` zero value undocumented | **Applied**, all three |
+| 12 (Question) | `dotf worktree done` carries no liveness protection on Windows | **Answered in the proposal's Risks** — it is the intended posture; `done` is a deliberate single-target act, `sweep` is an automatic multi-target one |
 
-### The AC2 amendment, declared
+### What round 3 corrected in this document
 
-**AC2 was changed after a review, which is the move a spec gate exists to catch, so it is
-recorded here rather than left to be noticed.** The change was made under a **FAIL**, not a
-PASS, and it makes the criterion weaker in letter and truer in substance:
+Three statements here were **false at the tip** and are not silently repaired:
 
-AC2 read *"every failure path answers `true`, not `false`"*. The reviewer showed the code does
-not satisfy it and **must not**: `os.Readlink("/proc/<pid>/cwd")` returns EACCES for every
-process this user does not own — `/proc/1/cwd` included — so answering `true` there would make
-`sweep` refuse on every Linux machine, permanently. The original wording described a system
-that cannot exist.
-
-The amendment splits the two failure classes that the one sentence had conflated: a failure of
-the **scan** (Abs, EvalSymlinks, ReadDir) still answers `true`, while a failure to read **one
-process** is now three-valued, and `unreadable` is counted and reported rather than folded into
-either answer. The round-2 reviewer reads the amended criterion and this note together.
+1. *"the pre-existing `worktree` tests are untouched and still pass"* — false. `dab7b6e` edited
+   five of them to drive the seam. That edit was correct and necessary; not declaring it was not.
+2. *"Gate f subset → 3 PASS"* — the named command yields **7**.
+3. *"Not filed as a ticket yet"* for the `features.json` state vocabulary — **#1470 is OPEN** and
+   covers exactly it. This spec's own `features.json` uses one of the seven ungoverned spellings.
 
 ## Evidence
 
-Every command below was executed in this session; the `features.json` entries carry the
-verbatim verification commands and their outcomes.
+Every command below was executed in this session.
 
-- [x] **AC1** build-tag split — `sweep_proc_linux.go` and `sweep_proc_other.go` both exist and
+- [x] **AC1** build-tag split — `sweep_proc_linux.go` and `sweep_proc_other.go` both exist;
       `sweep.go` carries no definition of `isHostProcessInside`.
-- [x] **AC2** Linux fails closed — no `return false` follows the `os.ReadDir("/proc")` error
-      branch.
-- [x] **AC3** non-Linux answers `true` — `GOOS=windows go vet` and `GOOS=darwin go vet` clean;
-      the runtime assertion is `TestUnsupportedPlatformAnswersTrueForEveryPath`, which executes
-      on the `test (windows-latest)` leg and nowhere else.
-- [x] **AC4** `processDiscoverySupported` false exactly where unimplemented —
-      `TestUnsupportedPlatformDoesNotAdvertiseDiscovery` (Windows leg) and
-      `TestProcessDiscoveryIsReportedForThisPlatform` (Linux).
-- [x] **AC5** caller honours both answers —
-      `TestGateFRefusesWhenProcessDiscoveryCannotAnswer` and
-      `TestGateFAllowsAReapableWorktreeWhenNothingIsInside`, driven through the
-      `hostProcessInside` seam. The second exists so the first cannot pass vacuously by the gate
-      refusing everything.
-- [x] **AC6** the inertness is reported before the counts, in `newWorktreeSweepCmd`.
-- [x] **AC7** `go build ./...`, `go test ./...`, `GOOS=windows go vet ./...`,
-      `golangci-lint run` (2.12.2, the `versions.conf` pin) — all `rc=0`, `0 issues`.
-- [x] **AC8** mutation-proven — see below.
-
-## Test status
-
-- Go suite: `go test ./...` → all packages pass, `rc=0`.
-- Gate f subset: `go test ./internal/worktree/ -run 'GateF|ProcessDiscovery' -v` → 3 PASS.
-- Lint: `golangci-lint run ./...` → `0 issues`, on the pinned 2.12.2.
-- Cross-compile: `GOOS=windows go vet ./...` and `GOOS=darwin go vet ./internal/worktree/`
-  clean — this is what compiles `sweep_proc_other.go` and its test file at all.
-- No regressions: the pre-existing `worktree` tests are untouched and still pass.
+- [x] **AC2** Linux fails closed on scan failures — mutation-proven for `EvalSymlinks`
+      (`TestGateFRefusesWhenTheTargetCannotBeResolved`). The `filepath.Abs` branch is declared
+      uncovered below.
+- [x] **AC3** non-Linux answers `true` — `TestUnsupportedPlatformAnswersTrueForEveryPath`, executed
+      via the build-tag-flip proxy, not only compiled.
+- [x] **AC4** `processDiscoverySupported` pinned in **both** directions —
+      `TestProcessDiscoveryIsAdvertisedOnLinux` (mutation-proven) and
+      `TestUnsupportedPlatformDoesNotAdvertiseDiscovery`.
+- [x] **AC5** `gateF` honours both answers — `TestGateFRefusesWhenProcessDiscoveryCannotAnswer`
+      and `TestGateFAllowsAReapableWorktreeWhenNothingIsInside`, now on the function production
+      calls.
+- [x] **AC5b** the under-lock re-check — `TestSweepRefusesWhenAProcessArrivesAfterTheGate`,
+      mutation-proven, with a call-count anchor so a fixture that never reached the re-check
+      cannot pass it.
+- [x] **AC6** reach reported before the counts, as coverage rather than a warning.
+- [x] **AC7** `go build ./...`, `go test ./...`, `go test -race`, `GOOS=windows go vet ./...`,
+      `golangci-lint run` (2.12.2, the `versions.conf` pin) — all `rc=0`, `0 issues` — **plus** the
+      build-tag-flip proxy, which is the only local check that executes the Windows path.
+- [x] **AC8** every round-3 surviving mutation now fails the suite — see below.
 
 ### Mutation results
 
-Anchors asserted before applying, so a mutation that failed to land could not be reported as
-"the tests caught nothing":
+Anchors asserted before applying: the harness compares the file's checksum after the patch and
+reports **ANCHOR-MISS** rather than a result if nothing changed, so a no-op cannot be read as
+"the tests caught it" (lesson 267).
 
 ```
-caller ignores Gate f                      mutated_rc=1  CAUGHT
-EvalSymlinks removed (the round-1 Blocker) mutated_rc=1  CAUGHT
-    --- FAIL: TestGateFSeesThroughASymlinkedWorktreePath
-linux impl fails open on unreadable /proc  mutated_rc=0  not caught locally
-restored_rc=0
+=== mutations the round-3 review found SURVIVING ===
+  CAUGHT       finding 3: prefix test loses its separator anchor
+  CAUGHT       finding 4: Uninspectable++ becomes a no-op
+  CAUGHT       finding 5: reapSingleWorktree drops the Gate f re-check
+  CAUGHT       finding 6: Linux claims it has no process discovery
+  CAUGHT       finding 7: unresolvable target fails OPEN
+
+=== regressions from earlier rounds (must stay caught) ===
+  CAUGHT       round 1 Blocker: EvalSymlinks resolution removed
+  CAUGHT       round 1: caller ignores Gate f entirely
+
+=== declared-uncovered (expected to SURVIVE; listed so it is not silent) ===
+  SURVIVED     AC2: filepath.Abs error fails open (unreachable by input)
+
+  caught: 7   not caught / anchor-miss: 1
+  restored rc=0
 ```
 
-**The third gap is real and is not closed by this change.** Reaching it needs an unreadable
-`/proc` *directory*, which a test cannot construct without injecting the directory read — a
-restructuring of a function this change otherwise only moves. Recorded rather than presented as
-covered. Note it is a different thing from an unreadable `/proc/<pid>/cwd`, which round 1
-raised and which is now covered by `TestVanishedProcessCountsAsOutsideNotUnreadable` and the
-uninspectable count.
+**The finding-5 mutation is the one that explains why it survived two reviews.** A seam with a
+constant answer can never reach the re-check inside `reapSingleWorktree`: a constant `true` is
+refused by the first Gate f call, and a constant `false` never exercises the second. The seam has
+to answer `false` then `true` — which is precisely the TOCTOU the re-check exists for. The shape
+of the double is part of the property, not plumbing.
 
-### One defect committed while fixing this one, and what caught it
+### The Windows leg, actually executed
 
-Changing Gate f's return type broke `sweep_proc_other_test.go`, and **`go test ./...` on Linux
-stayed green** — it never compiles a `//go:build !linux` file. That is precisely the defect
-this spec exists to fix, reproduced by the author mid-fix. `GOOS=darwin go vet` caught it,
-which is why AC7 names the cross-compile vet rather than treating the Linux suite as sufficient.
+`GOOS=windows go vet` compiles `sweep_proc_other.go` and never runs it, which is why round 2's red
+`test (windows-latest)` passed every local check. Flipping the build tags runs that implementation
+here:
+
+```
+=== tags after flip ===
+sweep_proc_linux.go: //go:build proxy_excluded    sweep_proc_other.go: //go:build linux
+
+ok  github.com/mlorentedev/dotfiles/cli/internal/worktree   0.843s
+rc=0
+RESULT: the Windows leg would be GREEN
+```
+
+Any future test that expects a reap must drive the `hostProcessInside` seam, or it fails there for
+a reason unrelated to what it tests.
+
+### Finding 1 reproduced independently
+
+Not taken on the reviewer's word:
+
+```
+docker run -d -u 1000:1000 -v /tmp/wtmount-repro/repo-wt-feat:/wt-mount-target \
+           -w /wt-mount-target busybox sleep 60
+host readlink /proc/2658284/cwd  -> /wt-mount-target
+worktree path on host            -> /tmp/wtmount-repro/repo-wt-feat
+dev/ino of /proc/<pid>/cwd       -> 50/992409
+dev/ino of the worktree path     -> 50/992409     <- the same directory
+string comparison                -> False         <- Gate f says "outside"
+```
+
+Why it is declared rather than fixed: `unshare -Urm` is refused here
+(`kernel.apparmor_restrict_unprivileged_userns = 1`), and whether `ubuntu-latest` permits one was
+not measurable from this machine. A test that skips on the runner reports green while asserting
+nothing — which is the defect round 3 found in this very file. **#1523** carries the reproduction
+and makes that measurement its first task.
+
+## Accepted gaps, stated rather than left to be found
+
+- **`filepath.Abs` fail-open branch** — mutation survives. `filepath.Abs` fails only when the
+  process has no working directory, which a test cannot arrange from inside the process.
+- **Unreadable `/proc` directory** — mutation survives. Reaching it needs the directory read
+  injected, which restructures a function this change only moves.
+- **AC6 is asserted by grep, knowingly.** A behavioural test needs a seam `Sweep` does not have
+  (it constructs its own `RealSweepRunner`), and adding one to assert print ordering buys less
+  than it costs. The grep is honest about being a grep; `features.json` f5 tracks the new wording.
+- **Mount namespaces** — #1523, above.
 
 ## Decisions made during implementation
 
-- **Two test files, not one, and neither is redundant.** The Linux seam test proves the
-  *caller* refuses; `sweep_proc_other_test.go` proves the *platform answer* that feeds it. A
-  seam test passes over a wrong implementation, and a platform test cannot see whether the
-  caller honours the answer. The original defect survived an adversarial review precisely
-  because only the code-reading check was available.
-- **`sweep` is deliberately inert on Windows** rather than approximated. A half-working
-  pseudo-implementation fails the same silent way as the bug being fixed — the same reasoning
-  that kept the pipe path on Windows in SEC-002.
-- **The inertness is announced before the counts, not after.** `reaped 0` from a refusing gate
-  and `reaped 0` from a clean machine are the same string; a reader who takes the first for the
-  second concludes the tool ran.
-- **Reported severity was on the wrong platform.** CodeRabbit filed this as a macOS exposure.
-  This repo does not run macOS and does run Windows, where `test-windows` is a required check.
-  The finding was right and its blast radius was understated.
+- **The count stays; what it claims changes.** Deleting `Uninspectable` would have re-collapsed
+  the three-valued read that round 1 required. The defect was never the data, it was calling a
+  constant a signal. It is now reported as reach, and nothing decides on it.
+- **The `> 0` gate on the message is kept deliberately**, and the reason is in the code: `gateF`
+  only scans worktrees that reached `StateReapable`, so `0` also means "nothing was considered".
+  Printing a reach for a scan that never ran would be a new version of the same lie.
+- **The uid split was measured and rejected.** The obvious rescue for finding 2 — count only
+  same-uid unreadable processes, so a healthy machine reads zero — does not work: 20 of 227
+  same-uid processes are EACCES on this desktop (`systemd --user`, `(sd-pam)`, `ssh-agent`,
+  `chrome-sandbox`, `brave`), because `ptrace_may_access` denies a same-uid caller against a
+  non-dumpable target. A uid-filtered counter is still never zero. Measured before designing on it.
+- **`isCandidateForReap` deleted rather than wired up.** A test seam into dead code reports
+  coverage it does not have, and two of AC5's tests were doing exactly that.
 
 ## Promotion candidates
 
-- **A guard for the `features.json` state vocabulary.** Measured across `specs/archive/` during
-  this work: seven different terminal spellings in use — `verified` (42), `passing` (39),
-  `done` (15), `verifying` (15), `passed` (12), `implemented` (6), against 523 `pending`.
-  Nothing validates the field, so each session invented one. Same shape as the closed `Outcome`
-  vocabulary #1435 introduced for the gate ledger. Not filed as a ticket yet.
+- **A guard for the `features.json` state vocabulary** — already owned by **#1470 (GUARD-010),
+  OPEN**. Round 3 corrected the earlier claim that it was unfiled. Measured spellings across
+  `specs/archive/`: `verified` (42), `passing` (39), `done` (15), `verifying` (15), `passed` (12),
+  `implemented` (6), against 523 `pending`.


### PR DESCRIPTION
Round 3 of the BUG-093 adversarial review returned **FAIL** on 6 REAL Majors and 4 REAL Minors.
Every one was real; none is argued down. This lands the dispositions.

The review did not find a broken behaviour. It found **claims no test could falsify** — including
the mitigation round 2 added as its answer to round 1.

Deliberately **no `Closes #1516`**: the spec is not archivable until a review passes, and the
archive PR is what closes the issue.

## The design blocker: a warning light wired to always-on

`UninspectableProcesses` was reported as a partial-scan warning. It is non-zero on **every** Linux
machine by construction — reading `/proc/<pid>/cwd` is gated by `ptrace_may_access`, so an
ordinary user can never read root's processes, another user's, or a same-uid process that set
`PR_SET_DUMPABLE=0`. Measured on this desktop: **364 of 571 processes out of reach, 20 of them the
caller's own**.

The obvious rescue — count only same-uid failures, so a healthy machine reads zero — was
**measured and rejected before designing on it**: 20 of 227 same-uid processes are EACCES
(`systemd --user`, `(sd-pam)`, `ssh-agent`, `chrome-sandbox`, `brave`). A uid-filtered counter is
still never zero.

So the count stays — deleting it would re-collapse the three-valued read round 1 required — but it
now states Gate f's **reach**, and nothing decides on it. The `> 0` gate on the message is kept
deliberately, with the reason in the code: `gateF` only scans worktrees that reached
`StateReapable`, so `0` also means "nothing was considered".

## Four properties that now fail when broken

| Was | Now |
|---|---|
| The sibling-prefix test's "sibling" was the target's own path, and its failure branch was a `t.Skip` | two tests, isolated roots; the naive-prefix mutation fails |
| Nothing drove `Uninspectable++` — it could pin at 0 forever | a real-`/proc` test, anchored on `/proc/1/cwd` being unreadable so it cannot go vacuous as root |
| Nothing drove the under-lock re-check in `reapSingleWorktree` | a seam answering `false` then `true`, with a call-count anchor |
| `processDiscoverySupported`'s Linux side was pinned by a test that skipped when the constant was false, then asserted a package-level `var` was non-nil | a direct assertion; flipping the constant now fails |

**Why the re-check survived two reviews with five tests pointing at it:** a seam with a *constant*
answer can never reach it. A constant `true` is refused by the first Gate f call; a constant
`false` never exercises the second. The seam has to answer `false` then `true` — which is exactly
the TOCTOU the re-check exists for. The shape of the double is part of the property, not plumbing.

`isCandidateForReap` is **deleted**: no production caller used it, so two tests were pinning a
refusal on a function that could not prevent a deletion.

## Declared, not fixed: the mount-namespace fail-open (#1523)

`/proc/<pid>/cwd` resolves in the process's *own* namespace, so a bind-mounted worktree compares
unequal and reads as outside. Reproduced independently rather than cited:

```
docker run -d -u 1000:1000 -v /tmp/wtmount-repro/repo-wt-feat:/wt-mount-target \
           -w /wt-mount-target busybox sleep 60
host readlink /proc/2658284/cwd -> /wt-mount-target
worktree path on host           -> /tmp/wtmount-repro/repo-wt-feat
dev/ino of both                 -> 50/992409   <- the same directory
string comparison               -> False       <- Gate f says "outside"
```

The fix is `os.SameFile` and it is ~20 lines. The **test** is the problem: it needs a mount
namespace, `unshare -Urm` is refused here (`kernel.apparmor_restrict_unprivileged_userns = 1`,
Ubuntu's default since 24.04), and whether `ubuntu-latest` permits one was not measurable from
this machine. A test that skips on the runner reports green while asserting nothing — the exact
shape of the vacuous test round 3 found in this same file. Filed as **#1523**, whose first task is
that measurement rather than a patch.

## Mutation results

The harness compares the file checksum after patching and reports **ANCHOR-MISS** rather than a
result if nothing changed, so a no-op cannot be read as "the tests caught it" (lesson 267).

```
=== mutations the round-3 review found SURVIVING ===
  CAUGHT   finding 3: prefix test loses its separator anchor
  CAUGHT   finding 4: Uninspectable++ becomes a no-op
  CAUGHT   finding 5: reapSingleWorktree drops the Gate f re-check
  CAUGHT   finding 6: Linux claims it has no process discovery
  CAUGHT   finding 7: unresolvable target fails OPEN
=== regressions from earlier rounds ===
  CAUGHT   round 1 Blocker: EvalSymlinks resolution removed
  CAUGHT   round 1: caller ignores Gate f entirely
=== declared-uncovered (expected to SURVIVE) ===
  SURVIVED AC2: filepath.Abs error fails open (unreachable by input)
```

## The Windows leg, actually executed

AC7 named `GOOS=windows go vet`, which **compiles** the non-Linux file and never runs it — which
is how round 2 shipped a red `test (windows-latest)` past a fully green local loop. AC7 now names
the Windows **test** leg, and a build-tag-flip proxy runs that implementation on Linux:
`rc=0`, the Windows leg would be green.

## Corrected, not quietly repaired

Three claims in `verification.md` were false at the tip: the pre-existing tests were **not**
untouched (`dab7b6e` edited five), the named subset is **7** PASS and not 3, and GUARD-010
**#1470 is already OPEN** for the `features.json` vocabulary.

## Verification

`go build ./...` · `go test ./...` · `go test -race ./internal/worktree/` ·
`GOOS=windows go vet ./...` · `GOOS=darwin go vet ./...` · `golangci-lint run` (2.12.2, the
`versions.conf` pin) — all `rc=0`, **0 issues**. All 8 `features.json` verifications re-executed,
all `rc=0`.
