### PR TITLE
feat(harness): curator becomes the fifth enforceable persona, gating two of eight

### DIFF
--- a/cli/internal/harness/persona_test.go
+++ b/cli/internal/harness/persona_test.go
@@ -249,7 +249,13 @@ func TestMigratedPersonasStillGateSomething(t *testing.T) {
 		byName[p.Name] = p
 	}
 
-	for _, name := range []string{"reviewer", "builder", "shipper", "architect"} {
+	for _, name := range []string{
+		"reviewer",
+		"builder",
+		"shipper",
+		"architect",
+		"curator",
+	} {
 		p, ok := byName[name]
 		if !ok {
 			t.Errorf("%s is missing from the roster", name)

--- a/harness/agents/curator/AGENT.md
+++ b/harness/agents/curator/AGENT.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/agents/definitions/curator/AGENT.md
-generated_sha: 283045d89bf80de8
+generated_sha: 89cb42c92f5098a8
 id: agent-curator
 type: agent
 status: active
@@ -11,7 +11,17 @@ description: Crystallize-phase persona. Invoke after a substantial session, or w
 kind: invocable
 model: top
 capabilities: [read, search, edit, shell, skill]
-skills: [vault-doctor, crystallize, insights, genre-picker, context-refresh, handoff, place-knowledge, dispose-proposals]
+skills:
+  - id: crystallize
+    enforce: warn
+  - id: handoff
+    enforce: warn
+  - vault-doctor
+  - insights
+  - genre-picker
+  - context-refresh
+  - place-knowledge
+  - dispose-proposals
 owner: manu
 ---
 
@@ -32,7 +42,23 @@ Turn raw session output into durable, well-placed knowledge, and keep the knowle
 
 ## Forced skills
 
-Your phase's skills are enforced by hook, not left to memory: `vault-doctor`, `crystallize`, `insights`, `genre-picker`, `context-refresh`, `handoff`, `place-knowledge`, `dispose-proposals`. Reach for the one that fits the task rather than improvising. `dispose-proposals` is the weekly human gate over the recurrence-proposal inbox (S3).
+Your phase's skills: `crystallize`, `handoff`, `vault-doctor`, `insights`, `genre-picker`, `context-refresh`, `place-knowledge`, `dispose-proposals`. Reach for the one that fits the task rather than improvising. `dispose-proposals` is the weekly human gate over the recurrence-proposal inbox (S3).
+
+**Two of the eight are watched by hook, and the other six are the largest ungated remainder of any persona.** `crystallize` and `handoff` carry `enforce: warn` — `dotf harness gate` names them on stderr when you have not invoked them, and lets the call through.
+
+They are the two that hold on every invocation, because they *are* this phase. Your own trigger is "after a substantial session": `crystallize` is the promotion of raw session output into durable knowledge, which is the first sentence of the mandate above, and `handoff` is the checklist that makes the session's end a record rather than an ending. Skipping either is how a session's knowledge is lost — and the loss is silent, which is exactly the failure a warn on stderr is worth paying for.
+
+**The other six each name their own trigger, and that is why they are not gated.** `insights` is weekly maintenance or a pre-sprint check; `vault-doctor` runs when the vault reports structural failures; `genre-picker` applies when you are creating a new artifact and not otherwise; `context-refresh` follows an ADR or a phase close; `place-knowledge` onboards a repository once; `dispose-proposals` is the weekly gate. A gate naming all six on every call would name five things that do not apply, and the severity is worth exactly as much as the attention it still commands.
+
+Read that as a judgement about these skills rather than a target ratio. Two of eight is the smallest gated fraction of any migrated persona — architect gates three of three because none of its skills is situational — and the reason is that this phase's toolkit is unusually condition-driven, not that curator's obligations are weaker.
+
+They are declared as bare strings, which the loader reads as `EnforceUnset` and the gate refuses to act on. That is a recorded state, not an oversight — `dotf harness gate` and `dotf doctor` both list them as ungated, so nothing here is invisible.
+
+This is why the loader applies **no default severity**. Defaulting to `warn` would make an unmigrated persona *"silently inert while every check reported it as wired — presence dressed as enforcement"*; defaulting to `block` would turn every already-declared skill into a hard gate the day it shipped. So a skill is gated because someone chose to gate it, and the ungated ones are listed rather than assumed.
+
+Raising either of these to `block` is gated on evidence, not on confidence: no severity moves until a real dispatch is observed resolving this persona **from the deployed record**, with two dispatches of one role carrying different `agent_id`s.
+
+The deployed half of that sentence is the one that bites. The gate reads the deploy directory, never your checkout, so a migration that is merged is not a migration that is in force — and the record written while it is inert is indistinguishable from the record written when everything passed. An unmigrated persona has nothing to enforce, so the gate reports `allow` with *"all blocking skills consumed"*, which is the same line a persona that satisfied every obligation produces.
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary

- **curator declared all eight skills in the flat list**, which the loader reads as `EnforceUnset`, so the gate resolved the persona and then acted on nothing. Its prose said they were *"enforced by hook, not left to memory"* — false for all eight, and false since the record was written.
- **`crystallize` and `handoff` now carry `enforce: warn`.** They are the two that hold on every invocation: this persona's trigger is *"after a substantial session"*, and those two **are** that phase — the promotion of session output into durable knowledge, and the checklist that makes a session's end a record rather than an ending.
- **The other six stay bare strings, and their own descriptions say why**: each names a trigger condition. `insights` is weekly maintenance or a pre-sprint check; `vault-doctor` runs when the vault reports structural failures; `genre-picker` applies when creating an artifact; `context-refresh` follows an ADR or a phase close; `place-knowledge` onboards a repository once; `dispose-proposals` is the weekly human gate. Gating all six would name five inapplicable obligations on every call and teach the reader to scroll past `[gate]` lines.

Fixed at the source (`knowledge` `331f2e91`), not in the generated record — `harness/agents/curator/AGENT.md` carries a `generated_sha` and a direct edit would be reverted by the next `--refresh`.

### Two of eight is the smallest gated fraction so far, and the prose says why

| persona | gated | of | rationale |
|---|---|---|---|
| architect | 3 | 3 | no skill in the list is situational |
| shipper | 3 | 5 | helm/terraform deliver nothing in this repo |
| curator | **2** | **8** | six of eight are condition-triggered by their own definition |
| builder | 2 | 9 | list mixes always-applicable with situational |

The record states this is a judgement about *these skills* rather than a weaker standard for this persona — otherwise the ratio reads as a target someone will later try to hit.

### Measured

- **Presence payload cost: 0 characters.** The declared id set is byte-identical before and after; severity is not rendered into the presence block. Same result #1504 measured for shipper.
- **Gate behaviour before this change**, driving v0.54.0 against the deployed record: curator was **silent** — `outcome: allow`, nothing warned. architect/shipper/builder each warned on their declared skills from the same binary and the same deploy dir. That contrast is the reason this PR exists.

## SDD checklist

- [x] Issue exists on the bitácora GitHub Project — `Refs #1497`
- [x] Diff conforms to ~300 LOC atomic cap — 29 insertions, 3 deletions, one generated record
- [ ] Spec folder `specs/<feature-id>/` is included in this PR (or `skip-sdd` label below)
- [ ] `proposal.md` has filled Why / What / Acceptance criteria
- [ ] `tasks.md` is in TDD order
- [ ] `verification.md` will be filled before merge (evidence + commit hashes)

## SDD skip rationale

One record migrated from the flat `skills:` list to the mapping form already specced, reviewed and shipped four times (#1412 reviewer, #1494 builder, #1504 shipper, #1509 architect). No logic, no contract change, no new dependency — the loader, the gate and the join all already handle both forms. Under the 50-LOC production threshold, which is why this is one persona per PR rather than curator and planner together.

## Test plan

- [x] `cd cli && go build ./... && go vet ./... && go test ./internal/harness/ ./internal/cmd/` — ok
- [x] `./scripts/compile-harness.sh --check` — `rc=0`, no harness drift
- [x] `--refresh` reproduces this record exactly from the vault source
- [x] Manual verification: declared id set compared before/after — identical, so the presence payload is unchanged

## Note for the reviewer

`--refresh` in this worktree also regenerates `harness/agents/shipper/AGENT.md`, because that record's vault source was corrected in `eceee5da`. That change belongs to **#1524** and was deliberately reverted out of this branch — this PR touches one file.
