### PR TITLE
feat(harness): planner becomes the sixth enforceable persona, gating one of six

### DIFF
--- a/cli/internal/harness/persona_test.go
+++ b/cli/internal/harness/persona_test.go
@@ -249,7 +249,13 @@ func TestMigratedPersonasStillGateSomething(t *testing.T) {
 		byName[p.Name] = p
 	}
 
-	for _, name := range []string{"reviewer", "builder", "shipper", "architect"} {
+	for _, name := range []string{
+		"reviewer",
+		"builder",
+		"shipper",
+		"architect",
+		"planner",
+	} {
 		p, ok := byName[name]
 		if !ok {
 			t.Errorf("%s is missing from the roster", name)

--- a/harness/agents/planner/AGENT.md
+++ b/harness/agents/planner/AGENT.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/agents/definitions/planner/AGENT.md
-generated_sha: d47c36b771742723
+generated_sha: 8965f5db19a175a7
 id: agent-planner
 type: agent
 status: active
@@ -11,7 +11,14 @@ description: Plan-phase persona. Invoke once a decision exists and the work need
 kind: invocable
 model: mid
 capabilities: [read, search, edit, shell, skill]
-skills: [spec, enrich-us, writing-plans, executing-plans, prd-to-issues, new-ticket]
+skills:
+  - id: spec
+    enforce: warn
+  - enrich-us
+  - writing-plans
+  - executing-plans
+  - prd-to-issues
+  - new-ticket
 owner: manu
 ---
 
@@ -32,7 +39,23 @@ Make the work executable and its completion checkable. You decide what "done" is
 
 ## Forced skills
 
-Your phase's skills are enforced by hook, not left to memory: `spec`, `enrich-us`, `writing-plans`, `executing-plans`, `prd-to-issues`, `new-ticket`. Reach for the one that fits rather than improvising; `spec` is gated on an open ticket by design, because a spec with no ticket has no owner.
+Your phase's skills: `spec`, `enrich-us`, `writing-plans`, `executing-plans`, `prd-to-issues`, `new-ticket`. Reach for the one that fits rather than improvising; `spec` is gated on an open ticket by design, because a spec with no ticket has no owner.
+
+**One of the six is watched by hook.** `spec` carries `enforce: warn` — `dotf harness gate` names it on stderr when you have not invoked it, and lets the call through.
+
+It is gated because in this repository the plan phase's output *is* a spec folder, and that is enforced downstream by a machine rather than by taste: `spec-gate` fails any pull request over the production-LOC threshold that does not touch `specs/<id>/`. So skipping `spec` is not a stylistic omission — it is the one that a CI job rejects later, after the work is written, which is the most expensive moment to discover it. It is also the only one of the six carrying a structural gate of its own: `spec init` refuses to scaffold without an open issue (ADR-018).
+
+**The other five each need something to already exist, and that is why they are ungated.** `enrich-us` needs a backlog item or a pasted user story to rewrite; `writing-plans` needs a spec or gathered requirements; `executing-plans` needs a written plan file; `prd-to-issues` needs a PRD; `new-ticket` files a single ticket and is triggered by the detect-then-ticket standing order rather than by the phase. A gate naming all six on every call would name five preconditions that are usually absent, and the severity is worth exactly as much as the attention it still commands.
+
+One of the five is worth reading twice. `executing-plans` runs a plan rather than shaping one, which sits oddly beside the Boundaries below — *you do not write the implementation*. It is left declared and ungated rather than quietly re-homed, because moving a skill between personas is a decision about the work cycle and not a detail of this migration.
+
+They are declared as bare strings, which the loader reads as `EnforceUnset` and the gate refuses to act on. That is a recorded state, not an oversight — `dotf harness gate` and `dotf doctor` both list them as ungated, so nothing here is invisible.
+
+This is why the loader applies **no default severity**. Defaulting to `warn` would make an unmigrated persona *"silently inert while every check reported it as wired — presence dressed as enforcement"*; defaulting to `block` would turn every already-declared skill into a hard gate the day it shipped. So a skill is gated because someone chose to gate it, and the ungated ones are listed rather than assumed.
+
+Raising `spec` to `block` is gated on evidence, not on confidence: no severity moves until a real dispatch is observed resolving this persona **from the deployed record**, with two dispatches of one role carrying different `agent_id`s.
+
+The deployed half of that sentence is the one that bites. The gate reads the deploy directory, never your checkout, so a migration that is merged is not a migration that is in force — and the record written while it is inert is indistinguishable from the record written when everything passed. An unmigrated persona has nothing to enforce, so the gate reports `allow` with *"all blocking skills consumed"*, which is the same line a persona that satisfied every obligation produces.
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary

- **planner declared all six skills in the flat list**, which the loader reads as `EnforceUnset`, so the gate resolved the persona and then acted on nothing. Its prose said they were *"enforced by hook, not left to memory"* — false for all six. **This is the last record carrying that sentence.**
- **`spec` now carries `enforce: warn`**, and it is gated for a reason no other skill in this epic has: the obligation is *already enforced downstream by a machine*. `spec-gate` fails any PR over the production-LOC threshold that does not touch `specs/<id>/`. So skipping `spec` is not a stylistic omission — it is the one a CI job rejects **after the work is written**, which is the most expensive moment to discover it. `spec init` also refuses to scaffold without an open issue (ADR-018), making it the only one of the six with a structural gate of its own.
- **The other five each need something to already exist** before they apply: a backlog item (`enrich-us`), a spec or gathered requirements (`writing-plans`), a written plan file (`executing-plans`), a PRD (`prd-to-issues`), or a single ticket to file (`new-ticket`). Gating them would name five usually-absent preconditions on every call.

Fixed at the source (`knowledge` `c9e756c1`), not in the generated record.

### An observation recorded, deliberately not acted on

`executing-plans` runs a plan rather than shaping one, which sits oddly beside this record's own Boundaries — *"you do not write the implementation"*. It is left declared and ungated rather than quietly re-homed to builder: **moving a skill between personas is a decision about the work cycle, not a detail of this migration.** The record now says so in prose, so the next reader finds the question rather than re-deriving it. Flagging for the owner — happy to file it if it is worth a ticket.

### This completes the epic

| persona | gated | of | issue |
|---|---|---|---|
| reviewer | 4 | 4 | #1412 |
| builder | 2 | 9 | #1494 |
| shipper | 3 | 5 | #1504 (+ #1524 prose) |
| architect | 3 | 3 | #1509 |
| curator | 2 | 8 | #1527 |
| **planner** | **1** | **6** | **this** |

`hermes-nan` is excluded rather than pending (#1507): `kind: autonomous`, zero gate decisions in ~8200 records.

### Measured

- **Presence payload cost: 0 characters.** The declared id set is unchanged; severity is not rendered into the presence block.
- **Gate behaviour before this change**, driving v0.54.0 against the deployed record: planner was **silent** — `outcome: allow`, nothing warned — while architect, shipper and builder each warned from the same binary and the same deploy dir.

## SDD checklist

- [x] Issue exists on the bitácora GitHub Project — `Refs #1497`
- [x] Diff conforms to ~300 LOC atomic cap — 26 insertions, 3 deletions, one generated record
- [ ] Spec folder `specs/<feature-id>/` is included in this PR (or `skip-sdd` label below)
- [ ] `proposal.md` has filled Why / What / Acceptance criteria
- [ ] `tasks.md` is in TDD order
- [ ] `verification.md` will be filled before merge (evidence + commit hashes)

## SDD skip rationale

One record migrated from the flat `skills:` list to the mapping form already specced, reviewed and shipped five times (#1412, #1494, #1504, #1509, #1527). No logic, no contract change, no new dependency — the loader, the gate and the join already handle both forms. Under the 50-LOC production threshold, which is why this is one persona per PR rather than curator and planner together.

## Test plan

- [x] `cd cli && go build ./... && go vet ./... && go test ./internal/harness/ ./internal/cmd/` — ok
- [x] `./scripts/compile-harness.sh --check` — `rc=0`, no harness drift
- [x] `--refresh` reproduces this record exactly from the vault source
- [x] Manual verification: declared id set compared before/after — identical, so the presence payload is unchanged

## Note for the reviewer

`--refresh` in this worktree also regenerates the `shipper` and `curator` records, whose vault sources were corrected in `eceee5da` and `331f2e91`. Those belong to **#1524** and **#1527** and were deliberately reverted out of this branch — this PR touches one file.
