### PR TITLE
fix(harness): the gate's allow reason was vacuously true, so an inert gate read like a passing one

### DIFF
--- a/cli/internal/harness/gate.go
+++ b/cli/internal/harness/gate.go
@@ -144,7 +144,47 @@ func Decide(in GateInput) GateResult {
 				in.Persona.Name, plural(len(missing), "skill"), strings.Join(missing, ", ")),
 		}
 	}
-	return GateResult{Decision: Allow, Warned: warned, Reason: "all blocking skills consumed"}
+	// THREE DISTINGUISHABLE STATES SHARED ONE SENTENCE, AND IT WAS THE WRONG ONE.
+	//
+	// "all blocking skills consumed" was returned for a persona that satisfied
+	// every obligation, for one that skipped every warn-level obligation it has,
+	// and for one that declares no severities at all. It is not false — "blocking"
+	// means `enforce: block`, and no persona carries one — which is exactly the
+	// problem: the predicate is VACUOUSLY true, so it was true in all 11526
+	// decisions ever recorded and discriminated none of them.
+	//
+	// The cost is not cosmetic. Both architect's and shipper's records tell the
+	// reader that a merged migration cannot be trusted as an enforced one BECAUSE
+	// an inert gate and a passing gate write the same line. That is doctrine in
+	// two shipped persona records, and it stays true until this reads differently.
+	//
+	// Counted over the persona's declared skills rather than over `warned`,
+	// because the question "does this persona gate anything at all" is about the
+	// record, not about this call.
+	gated := 0
+	for _, s := range in.Persona.Skills {
+		if s.Enforce != EnforceUnset {
+			gated++
+		}
+	}
+
+	switch {
+	case len(warned) > 0:
+		// Reached with Decision: Allow — a warn is reported, never enforced. The
+		// reason has to say which, because `Warned` is the only other evidence and
+		// a human reads this line first.
+		return GateResult{Decision: Allow, Warned: warned, Reason: fmt.Sprintf(
+			"%s not consumed: %s", plural(len(warned), "warn-level skill"), strings.Join(warned, ", "))}
+	case gated == 0:
+		// ENFORCEMENT IS OFF FOR THIS PERSONA, and nothing else in the record says
+		// so. This is the state a stale vault half or an unmigrated record leaves
+		// behind, and the one the old sentence hid best.
+		return GateResult{Decision: Allow, Reason: fmt.Sprintf(
+			"persona %q declares no severities — nothing to enforce", in.Persona.Name)}
+	default:
+		return GateResult{Decision: Allow, Reason: fmt.Sprintf(
+			"all %s consumed", plural(gated, "gated skill"))}
+	}
 }
 
 func plural(n int, word string) string {

--- a/cli/internal/harness/gate_test.go
+++ b/cli/internal/harness/gate_test.go
@@ -181,3 +181,68 @@ func TestGateStatePathContainsNoTraversal(t *testing.T) {
 		}
 	}
 }
+
+// #1510: the three ALLOW states must be distinguishable from each other.
+//
+// They shared one sentence — "all blocking skills consumed" — which was
+// vacuously true (no persona carries `enforce: block`, so the predicate held in
+// all 11526 decisions ever recorded) and therefore discriminated nothing. An
+// inert gate and a passing gate wrote the same line, which is precisely what
+// architect's and shipper's shipped records cite as the reason a merged
+// migration cannot be trusted as an enforced one.
+//
+// Asserted as PAIRWISE DISTINCTNESS rather than against three literal strings:
+// the property that matters is that a reader can tell the states apart, and
+// pinning the wording would make this a chore on every rephrasing without
+// testing anything more.
+func TestGateAllowReasonsAreDistinguishable(t *testing.T) {
+	call := ToolCall{Tool: "Bash"}
+
+	nothingToEnforce := Decide(GateInput{
+		Persona:  gatePersona(SkillBinding{ID: "helm"}, SkillBinding{ID: "terraform"}),
+		Call:     call,
+		Consumed: map[string]bool{},
+	})
+	skippedEverything := Decide(GateInput{
+		Persona:  gatePersona(SkillBinding{ID: "audit", Enforce: EnforceWarn}),
+		Call:     call,
+		Consumed: map[string]bool{},
+	})
+	satisfied := Decide(GateInput{
+		Persona:  gatePersona(SkillBinding{ID: "audit", Enforce: EnforceWarn}),
+		Call:     call,
+		Consumed: map[string]bool{"audit": true},
+	})
+
+	for _, r := range []GateResult{nothingToEnforce, skippedEverything, satisfied} {
+		if r.Decision != Allow {
+			t.Fatalf("all three states allow; got %v (%s)", r.Decision, r.Reason)
+		}
+	}
+
+	seen := map[string][]string{}
+	for name, r := range map[string]GateResult{
+		"nothing to enforce": nothingToEnforce,
+		"skipped everything": skippedEverything,
+		"satisfied":          satisfied,
+	} {
+		seen[r.Reason] = append(seen[r.Reason], name)
+	}
+	for reason, names := range seen {
+		if len(names) > 1 {
+			t.Errorf("these states are indistinguishable, all reporting %q: %v — "+
+				"an inert gate reads exactly like a passing one", reason, names)
+		}
+	}
+
+	// The state that hid best, called out on its own: a persona declaring no
+	// severity enforces nothing, and the line a human reads must say so.
+	if !strings.Contains(nothingToEnforce.Reason, "nothing to enforce") {
+		t.Errorf("a persona with no severities must say enforcement is off, got %q", nothingToEnforce.Reason)
+	}
+	// And the warn state must name what was skipped, since Warned is otherwise
+	// the only record of it.
+	if !strings.Contains(skippedEverything.Reason, "audit") {
+		t.Errorf("the warn reason must name the skipped skill, got %q", skippedEverything.Reason)
+	}
+}

--- a/harness/agents/architect/AGENT.md
+++ b/harness/agents/architect/AGENT.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/agents/definitions/architect/AGENT.md
-generated_sha: d990d292892a6ab9
+generated_sha: bbf341dd5ad16426
 id: agent-architect
 type: agent
 status: active
@@ -50,7 +50,7 @@ This is why the loader applies **no default severity**. Defaulting to `warn` wou
 
 Raising any of these to `block` is gated on evidence, not on confidence: no severity moves until a real dispatch is observed resolving this persona **from the deployed record**, with two dispatches of one role carrying different `agent_id`s.
 
-The deployed half of that sentence is the one that bites. The gate reads the deploy directory, never your checkout, so a migration that is merged is not a migration that is in force — and the record it reads then reports `allow` with *"all blocking skills consumed"*, which is what a persona that satisfied every obligation also produces. Enforcement being off and enforcement passing are the same line in the journal.
+The deployed half of that sentence is the one that bites. The gate reads the deploy directory, never your checkout, so a migration that is merged is not a migration that is in force. Until #1510 the journal could not tell you which: a record written while enforcement was off and one written when every obligation was satisfied both reported `allow` with *"all blocking skills consumed"* — a sentence that was true in every decision ever recorded, because no persona carries `enforce: block` for it to be about. The gate now names the difference: a persona declaring no severities records *"declares no severities — nothing to enforce"*. So check the journal rather than trusting the merge, and know that the line means something now.
 
 A named dispatch used to defeat role resolution outright; that is fixed for a **witnessed** dispatch, which the gate maps back to its true type. The residual is the unwitnessed one, which still falls through to the roster and finds no persona under its name.
 

--- a/harness/agents/curator/AGENT.md
+++ b/harness/agents/curator/AGENT.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/agents/definitions/curator/AGENT.md
-generated_sha: 89cb42c92f5098a8
+generated_sha: c9c74df5f9e8dabd
 id: agent-curator
 type: agent
 status: active
@@ -58,7 +58,7 @@ This is why the loader applies **no default severity**. Defaulting to `warn` wou
 
 Raising either of these to `block` is gated on evidence, not on confidence: no severity moves until a real dispatch is observed resolving this persona **from the deployed record**, with two dispatches of one role carrying different `agent_id`s.
 
-The deployed half of that sentence is the one that bites. The gate reads the deploy directory, never your checkout, so a migration that is merged is not a migration that is in force — and the record written while it is inert is indistinguishable from the record written when everything passed. An unmigrated persona has nothing to enforce, so the gate reports `allow` with *"all blocking skills consumed"*, which is the same line a persona that satisfied every obligation produces.
+The deployed half of that sentence is the one that bites. The gate reads the deploy directory, never your checkout, so a migration that is merged is not a migration that is in force. Until #1510 the journal could not tell you which: a record written while enforcement was off and one written when every obligation was satisfied both reported `allow` with *"all blocking skills consumed"* — a sentence that was true in every decision ever recorded, because no persona carries `enforce: block` for it to be about. The gate now names the difference: a persona declaring no severities records *"declares no severities — nothing to enforce"*. So check the journal rather than trusting the merge, and know that the line means something now.
 
 ## Boundaries
 

--- a/harness/agents/planner/AGENT.md
+++ b/harness/agents/planner/AGENT.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/agents/definitions/planner/AGENT.md
-generated_sha: 8965f5db19a175a7
+generated_sha: 94568903c57ad315
 id: agent-planner
 type: agent
 status: active
@@ -55,7 +55,7 @@ This is why the loader applies **no default severity**. Defaulting to `warn` wou
 
 Raising `spec` to `block` is gated on evidence, not on confidence: no severity moves until a real dispatch is observed resolving this persona **from the deployed record**, with two dispatches of one role carrying different `agent_id`s.
 
-The deployed half of that sentence is the one that bites. The gate reads the deploy directory, never your checkout, so a migration that is merged is not a migration that is in force — and the record written while it is inert is indistinguishable from the record written when everything passed. An unmigrated persona has nothing to enforce, so the gate reports `allow` with *"all blocking skills consumed"*, which is the same line a persona that satisfied every obligation produces.
+The deployed half of that sentence is the one that bites. The gate reads the deploy directory, never your checkout, so a migration that is merged is not a migration that is in force. Until #1510 the journal could not tell you which: a record written while enforcement was off and one written when every obligation was satisfied both reported `allow` with *"all blocking skills consumed"* — a sentence that was true in every decision ever recorded, because no persona carries `enforce: block` for it to be about. The gate now names the difference: a persona declaring no severities records *"declares no severities — nothing to enforce"*. So check the journal rather than trusting the merge, and know that the line means something now.
 
 ## Boundaries
 

--- a/harness/agents/shipper/AGENT.md
+++ b/harness/agents/shipper/AGENT.md
@@ -1,7 +1,7 @@
 ---
 generated: true
 generated_from: 00_meta/agents/definitions/shipper/AGENT.md
-generated_sha: 00ca37afa44c04ca
+generated_sha: 36bf2da6871ef1c6
 id: agent-shipper
 type: agent
 status: active
@@ -56,7 +56,7 @@ This is why the loader applies **no default severity**. Defaulting to `warn` wou
 
 Raising any of these to `block` is gated on evidence, not on confidence: no severity moves until a real dispatch is observed resolving this persona **from the deployed record**, with two dispatches of one role carrying different `agent_id`s.
 
-The deployed half of that sentence is the one that bites. The gate reads the deploy directory, never your checkout, so a migration that is merged is not a migration that is in force — and the record written while it is inert is indistinguishable from the record written when everything passed. An unmigrated persona has nothing to enforce, so the gate reports `allow` with *"all blocking skills consumed"*, which is the same line a persona that satisfied every obligation produces.
+The deployed half of that sentence is the one that bites. The gate reads the deploy directory, never your checkout, so a migration that is merged is not a migration that is in force. Until #1510 the journal could not tell you which: a record written while enforcement was off and one written when every obligation was satisfied both reported `allow` with *"all blocking skills consumed"* — a sentence that was true in every decision ever recorded, because no persona carries `enforce: block` for it to be about. The gate now names the difference: a persona declaring no severities records *"declares no severities — nothing to enforce"*. So check the journal rather than trusting the merge, and know that the line means something now.
 
 A named dispatch used to defeat role resolution outright; that is fixed for a **witnessed** dispatch, which the gate maps back to its true type. The residual is the unwitnessed one, which still falls through to the roster and finds no persona under its name.
 


### PR DESCRIPTION
## Summary

- **`Decide` returned one sentence for three distinguishable states.** `"all blocking skills consumed"` was written for a persona that satisfied every obligation, for one that skipped every warn-level obligation it has, and for one declaring no severities at all.
- **The sentence is not false — it is vacuously true, which is worse.** "Blocking" means `enforce: block`, and no persona carries one, so the predicate held in **all 11 526 gate decisions ever recorded** on this machine and discriminated none of them. Measured: **123 of 123** `warn` records carry it beside a *non-empty* `warned` array.
- **Now three reasons**: the warn case names what was skipped, the no-severity case says enforcement is off for that persona, and the satisfied case counts what it satisfied.

### Why this was worth doing before anything is promoted to `block`

Four shipped persona records tell the reader that *a merged migration cannot be trusted as an enforced one* **because** an inert gate and a passing gate write the same line. That was doctrine in four deployed records, and it stayed true until this read differently. It is also the first precondition listed on **#1532**, the plan for making the orchestrator binding.

### The prose is corrected in the same PR, deliberately

The four records quote the old string. Merging the code alone would leave them documenting a behaviour that no longer exists — **the exact defect #1524 was opened to fix, committed knowingly this time**. So `architect`, `shipper`, `curator` and `planner` are corrected here, at the vault source (`knowledge` `9ff03d21`), and these are the regenerated records.

That is also why the two halves cannot be split into separate PRs: whichever merged first would be wrong until the other landed.

### Verified by mutation, not by the suite going green

`TestGateAllowReasonsAreDistinguishable` asserts **pairwise distinctness** rather than three literal strings — the property that matters is that a reader can tell the states apart, and pinning the wording would be a chore on every rephrasing while testing nothing more. Restoring the single reason fails it with all three states collapsed:

```
--- FAIL: TestGateAllowReasonsAreDistinguishable
    gate_test.go:233: these states are indistinguishable, all reporting
      "all blocking skills consumed": [nothing to enforce skipped everything satisfied]
      — an inert gate reads exactly like a passing one
    gate_test.go:241: a persona with no severities must say enforcement is off
    gate_test.go:246: the warn reason must name the skipped skill
```

## SDD checklist

- [x] Issue exists on the bitácora GitHub Project — `Closes #1510`
- [x] Diff conforms to ~300 LOC atomic cap — 58 production LOC (42 in `gate.go`, of which most is the comment explaining the vacuity; 16 across four one-paragraph record corrections)
- [ ] Spec folder `specs/<feature-id>/` is included in this PR (or `skip-sdd` label below)
- [ ] `proposal.md` has filled Why / What / Acceptance criteria
- [ ] `tasks.md` is in TDD order
- [ ] `verification.md` will be filled before merge (evidence + commit hashes)

## SDD skip rationale

Single-issue bug fix with a measured cause and a guard, 8 LOC over the threshold.

The change is one `return` becoming a three-way `switch` plus the comment that records why; the cause was measured (11 526 decisions, 123/123 warn records), the fix is local to one function, and the regression guard ships with it and was demonstrated red by mutation. No contract change, no new dependency, no multi-PR sequence.

The threshold is crossed only because the four persona-record corrections are in the same PR — and they are in the same PR *because splitting them would ship a false record*, which is the failure mode this repository has now hit twice (#1490→#1495, #1504→#1524). Scaffolding a spec folder to describe a one-line behaviour fix would be construction where the standing rule for guard/harness machinery asks for the cheapest honest fix.

## Test plan

- [x] `cd cli && go build ./... && go vet ./... && go test ./internal/harness/ ./internal/cmd/` — ok
- [x] `./scripts/compile-harness.sh --check` — `rc=0`, no harness drift
- [x] `--refresh` reproduces all four records exactly from the vault source
- [x] Mutation: reverting `gate.go` to the single reason fails the new guard with all three states collapsed onto one line; restoring it passes
- [ ] Manual verification after deploy: a curator or planner dispatch should now record a reason that names the skipped skills rather than the old sentence
