### PR TITLE
feat(spec): give the adversarial review a base to diff against, and let the verdict use its own reality axis

### DIFF
--- a/cli/internal/cmd/spec.go
+++ b/cli/internal/cmd/spec.go
@@ -63,6 +63,15 @@ var runCommand = func(dir string, argv []string) error {
 // rand.IntN in production, a fixed index in tests so a launch is reproducible there.
 var reviewerDraw = rand.IntN
 
+// resolveReviewBase and headSHAOf are seams for the review scope (HARNESS-111).
+// The command-level fixtures build a fake .git directory rather than a real
+// repository, so the production resolvers answer "" there and every launch test
+// would hit the new refusal. The resolvers themselves are tested against real
+// git histories in internal/spec — a seam proves the caller honours the answer,
+// and only a real repository proves the answer is right.
+var resolveReviewBase = spec.ResolveReviewBase
+var headSHAOf = spec.HeadSHA
+
 // runForeground runs the reviewer in this terminal, streaming its output to both
 // the screen and the transcript.
 //
@@ -176,7 +185,24 @@ is the only record of how.`,
 			}
 
 			skill := spec.ReviewerSkillPath(chosen.Runner)
-			prompt := spec.ReviewPrompt(id, repoRoot, chosen.ID, chosen.Runner, skill)
+			// The base the reviewer will diff against. Refusing when it cannot be
+			// resolved, or when it IS the head, is the point: a review with an
+			// empty diff does not fail, it quietly becomes a reading of the spec
+			// folder and reports findings with no execution behind them. That is
+			// worse than no review, because it arrives wearing a verdict.
+			baseSHA := resolveReviewBase(repoRoot, specDir)
+			headSHA := headSHAOf(repoRoot)
+			if baseSHA == "" {
+				return fmt.Errorf("cannot resolve a review base for specs/%s: no commit adds that folder.\n"+
+					"The reviewer diffs base...HEAD, so without a base it would browse the folder and\n"+
+					"call that a review. Commit the spec first", id)
+			}
+			if baseSHA == headSHA {
+				return fmt.Errorf("the review base and HEAD are the same commit (%s).\n"+
+					"There is nothing to review: the spec folder was added by HEAD itself", baseSHA[:min(12, len(baseSHA))])
+			}
+
+			prompt := spec.ReviewPrompt(id, repoRoot, chosen.ID, chosen.Runner, skill, baseSHA)
 			argv, err := spec.ReviewerCommand(chosen, prompt, timeout, repoRoot)
 			if err != nil {
 				return err
@@ -228,7 +254,7 @@ is the only record of how.`,
 			// is worse than losing the review, but refusing to launch because a
 			// sidecar could not be written would make the guard a liability the
 			// first time a spec dir is read-only.
-			if err := spec.WriteReviewRequest(specDir, spec.HeadSHA(repoRoot), chosen.ID); err != nil {
+			if err := spec.WriteReviewRequest(specDir, headSHA, chosen.ID, baseSHA); err != nil {
 				cmd.PrintErrf("[WARN] could not record the review request: %v\n", err)
 				cmd.PrintErrf("       the archive gate cannot then tell a fresh verdict from the previous one\n")
 			}

--- a/cli/internal/cmd/spec_review_base_test.go
+++ b/cli/internal/cmd/spec_review_base_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// HARNESS-111. A review whose diff is empty does not fail — it silently becomes
+// a reading of the spec folder, and reports findings with nothing executed
+// behind them. That is worse than no review, because it arrives wearing a
+// verdict. The launcher must refuse instead.
+
+func withReviewBase(t *testing.T, base, head string) {
+	t.Helper()
+	prevBase, prevHead := resolveReviewBase, headSHAOf
+	resolveReviewBase = func(string, string) string { return base }
+	headSHAOf = func(string) string { return head }
+	t.Cleanup(func() { resolveReviewBase, headSHAOf = prevBase, prevHead })
+}
+
+func seedReviewFixture(t *testing.T) string {
+	t.Helper()
+	root := makeRepo(t)
+	writeFixture(t, root, "harness/reviewer-pool.json", `{"pool":[
+		{"id":"nan/deepseek-v4-flash","runner":"pi","provider":"nan","model":"deepseek-v4-flash","role":"primary"}
+	]}`)
+	seedSpec(t, root, "AI-001-x", "---\nstatus: implementing\n---\n# AI-001-x\n")
+	prev := lookPath
+	lookPath = func(string) (string, error) { return "", errors.New("no tmux") }
+	t.Cleanup(func() { lookPath = prev })
+	return root
+}
+
+func TestSpecReviewRefusesWhenNoBaseCanBeResolved(t *testing.T) {
+	seedReviewFixture(t)
+	withReviewBase(t, "", "headheadhead")
+
+	stdout, stderr, err := execute(t, "spec", "review", "AI-001-x", "--dry-run")
+	if err == nil {
+		t.Fatalf("the launch was allowed with no review base; the reviewer would browse the "+
+			"spec folder and call that a review:\n%s", stdout+stderr)
+	}
+	if !strings.Contains(err.Error(), "cannot resolve a review base") {
+		t.Errorf("the refusal does not say what is wrong: %v", err)
+	}
+}
+
+func TestSpecReviewRefusesWhenTheBaseIsTheHead(t *testing.T) {
+	seedReviewFixture(t)
+	withReviewBase(t, "samesamesame", "samesamesame")
+
+	stdout, stderr, err := execute(t, "spec", "review", "AI-001-x", "--dry-run")
+	if err == nil {
+		t.Fatalf("a review with base == HEAD was allowed; its diff is empty by construction:\n%s",
+			stdout+stderr)
+	}
+	if !strings.Contains(err.Error(), "nothing to review") {
+		t.Errorf("the refusal does not name the empty diff: %v", err)
+	}
+}
+
+// The positive direction, so the two refusals above cannot pass vacuously by the
+// launcher refusing everything.
+func TestSpecReviewLaunchesAndStatesTheBaseWhenOneResolves(t *testing.T) {
+	seedReviewFixture(t)
+	withReviewBase(t, "basebasebase", "headheadhead")
+
+	stdout, stderr, err := execute(t, "spec", "review", "AI-001-x", "--dry-run")
+	if err != nil {
+		t.Fatalf("a resolvable base was refused: %v\n%s", err, stdout+stderr)
+	}
+	if out := stdout + stderr; !strings.Contains(out, "basebasebase") {
+		t.Errorf("the launch does not hand the reviewer its base, so it will guess `main` — "+
+			"which is empty on a post-merge review:\n%s", out)
+	}
+}

--- a/cli/internal/cmd/spec_test.go
+++ b/cli/internal/cmd/spec_test.go
@@ -18,6 +18,16 @@ func makeRepo(t *testing.T) string {
 		t.Fatal(err)
 	}
 	t.Chdir(root)
+
+	// This .git is a directory, not a repository, so the real review-base
+	// resolvers answer "" here and `spec review` would refuse every launch
+	// (HARNESS-111). Drive the seams instead; the resolvers are tested against
+	// real git histories in internal/spec.
+	prevBase, prevHead := resolveReviewBase, headSHAOf
+	resolveReviewBase = func(string, string) string { return "basebasebase" }
+	headSHAOf = func(string) string { return "headheadhead" }
+	t.Cleanup(func() { resolveReviewBase, headSHAOf = prevBase, prevHead })
+
 	return root
 }
 

--- a/cli/internal/spec/review_base_test.go
+++ b/cli/internal/spec/review_base_test.go
@@ -1,0 +1,183 @@
+package spec
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// The review's scope is `git diff <base>...HEAD`, and until this base existed
+// the launcher recorded none: the reviewer guessed `main`, and a review
+// launched ON main after the work merged diffed nothing and degraded into
+// browsing the spec folder. These pin that the base is resolved the same way in
+// both situations that matter — on the work branch, and on main after a squash.
+
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
+// newRepoWithSpec builds a repo whose history is: base commit, then a commit
+// that adds specs/<id>/, then one more. The base the resolver must find is the
+// FIRST commit -- the parent of the one that added the folder.
+func newRepoWithSpec(t *testing.T, id string) (repoRoot, wantBase string) {
+	t.Helper()
+	repoRoot = t.TempDir()
+	git(t, repoRoot, "init", "-q", "-b", "main")
+
+	if err := os.WriteFile(filepath.Join(repoRoot, "README.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repoRoot, "add", "README.md")
+	git(t, repoRoot, "commit", "-qm", "base")
+	wantBase = trim(git(t, repoRoot, "rev-parse", "HEAD"))
+
+	specDir := filepath.Join(repoRoot, "specs", id)
+	if err := os.MkdirAll(specDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(specDir, "proposal.md"), []byte("# p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repoRoot, "add", ".")
+	git(t, repoRoot, "commit", "-qm", "add spec")
+
+	if err := os.WriteFile(filepath.Join(repoRoot, "impl.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repoRoot, "add", ".")
+	git(t, repoRoot, "commit", "-qm", "implement")
+
+	return repoRoot, wantBase
+}
+
+func trim(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+func TestResolveReviewBaseIsTheParentOfTheCommitThatAddedTheSpec(t *testing.T) {
+	repoRoot, wantBase := newRepoWithSpec(t, "FOO-001-thing")
+
+	got := ResolveReviewBase(repoRoot, filepath.Join(repoRoot, "specs", "FOO-001-thing"))
+	if got != wantBase {
+		t.Errorf("ResolveReviewBase = %q, want %q (the commit before the spec folder appeared)", got, wantBase)
+	}
+}
+
+// The case the old code got wrong by having no answer at all: HEAD is main,
+// the work already merged, and `git diff main...HEAD` is therefore empty. The
+// base must still point before the work.
+func TestResolveReviewBaseGivesANonEmptyDiffOnMainAfterTheWorkLanded(t *testing.T) {
+	repoRoot, _ := newRepoWithSpec(t, "FOO-001-thing")
+	specDir := filepath.Join(repoRoot, "specs", "FOO-001-thing")
+
+	base := ResolveReviewBase(repoRoot, specDir)
+	if base == "" {
+		t.Fatal("no base resolved")
+	}
+
+	// The anchor: the naive base really is empty here, so this test is about
+	// something. Without it the assertion below could pass on a repo where the
+	// old behaviour also happened to work.
+	naive := git(t, repoRoot, "diff", "--name-only", "main...HEAD")
+	if trim(naive) != "" {
+		t.Fatalf("fixture does not reproduce the defect: `git diff main...HEAD` returned %q", naive)
+	}
+
+	scoped := git(t, repoRoot, "diff", "--name-only", base+"...HEAD")
+	if trim(scoped) == "" {
+		t.Error("the resolved base produced an EMPTY diff, which is the whole defect: the reviewer " +
+			"then browses the spec folder and reports findings with nothing executed behind them")
+	}
+}
+
+func TestResolveReviewBaseIsEmptyWhenTheSpecIsNotCommitted(t *testing.T) {
+	repoRoot := t.TempDir()
+	git(t, repoRoot, "init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(repoRoot, "README.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repoRoot, "add", ".")
+	git(t, repoRoot, "commit", "-qm", "base")
+
+	specDir := filepath.Join(repoRoot, "specs", "UNCOMMITTED-001")
+	if err := os.MkdirAll(specDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := ResolveReviewBase(repoRoot, specDir); got != "" {
+		t.Errorf("ResolveReviewBase = %q for an uncommitted spec, want \"\" — the caller must "+
+			"refuse to launch rather than review the whole history", got)
+	}
+}
+
+// The sidecar has to survive reading a spec archived before base_sha existed.
+func TestReviewRequestWithoutBaseSHAStillParses(t *testing.T) {
+	dir := t.TempDir()
+	old := `{"reviewed_sha":"abc","reviewer":"nan/x","requested_at":"2026-01-01T00:00:00Z","review_digest_before":"d"}`
+	if err := os.WriteFile(filepath.Join(dir, ReviewRequestFile), []byte(old), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	req, found, err := ReadReviewRequest(dir)
+	if err != nil || !found {
+		t.Fatalf("reading an old sidecar: found=%v err=%v", found, err)
+	}
+	if req.ReviewedSHA != "abc" {
+		t.Errorf("ReviewedSHA = %q, want abc", req.ReviewedSHA)
+	}
+	if req.BaseSHA != "" {
+		t.Errorf("BaseSHA = %q, want empty for a pre-base sidecar", req.BaseSHA)
+	}
+}
+
+func TestWriteReviewRequestRecordsTheBase(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteReviewRequest(dir, "head123", "nan/x", "base456"); err != nil {
+		t.Fatal(err)
+	}
+	req, found, err := ReadReviewRequest(dir)
+	if err != nil || !found {
+		t.Fatalf("found=%v err=%v", found, err)
+	}
+	if req.BaseSHA != "base456" {
+		t.Errorf("BaseSHA = %q, want base456 — without it the reviewer has no scope", req.BaseSHA)
+	}
+}
+
+// The prompt must state the base, because the skill tells the reviewer to diff
+// against one and the reviewer cannot derive it.
+func TestReviewPromptStatesTheResolvedBase(t *testing.T) {
+	p := ReviewPrompt("FOO-001", "/repo", "nan/x", "pi", "/skill.md", "base456")
+	if !contains(p, "base456") {
+		t.Error("the prompt does not name the base, so the reviewer will guess `main` — which is " +
+			"empty on a post-merge review")
+	}
+	if !contains(p, "do NOT substitute") {
+		t.Error("the prompt does not tell the reviewer to stop guessing a base")
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (func() bool {
+		for i := 0; i+len(needle) <= len(haystack); i++ {
+			if haystack[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	})()
+}

--- a/cli/internal/spec/review_launch.go
+++ b/cli/internal/spec/review_launch.go
@@ -262,10 +262,24 @@ func ResolveReviewer(entries []ReviewerEntry, want string) (ReviewerEntry, error
 // matches it exactly — a reviewer that writes its own name a different way gets
 // refused for a mismatch rather than for a policy breach, which wastes a whole
 // review round on a string.
-func ReviewPrompt(specID, repoRoot, reviewerID, runner, skillPath string) string {
+// baseSHA is stated because the skill defines the review scope as
+// `git diff <base>...HEAD` and the reviewer cannot derive the base. Left to
+// guess it, it guesses `main` — and a review launched ON main after the work
+// merged then diffs nothing and silently degrades into browsing the spec
+// folder. Measured on BUG-093 round 4: it named `git diff main...HEAD` as its
+// source, that diff was empty, and both findings read "Code read" with nothing
+// executed; one cited a string that exists nowhere in the code, having read a
+// mutation payload out of the spec folder as if it were the implementation.
+func ReviewPrompt(specID, repoRoot, reviewerID, runner, skillPath, baseSHA string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "Perform an adversarial review of the spec `%s`.\n\n", specID)
 	fmt.Fprintf(&b, "Repo: %s\n\n", repoRoot)
+	if baseSHA != "" {
+		fmt.Fprintf(&b, "Review scope: `git diff %s...HEAD`. That base is the commit this spec's work\n"+
+			"starts from, resolved by the launcher; do NOT substitute `main` or guess one. It is the\n"+
+			"WHOLE change, not the delta since any previous review round — a late fix has to be\n"+
+			"judged against the early ones it may interact with.\n\n", baseSHA)
+	}
 	fmt.Fprintf(&b, "You are running as `%s` (runner `%s`), drawn from harness/reviewer-pool.json\n"+
 		"for this review. That is your identity for this run, stated by the launcher that resolved\n"+
 		"it -- do not infer it from the doctrine you are about to read. The pool's exclusions were\n"+

--- a/cli/internal/spec/review_launch_test.go
+++ b/cli/internal/spec/review_launch_test.go
@@ -308,7 +308,7 @@ func TestReviewerSkillPathIsPerRunner(t *testing.T) {
 // differently is refused for a string mismatch rather than a policy breach,
 // burning a whole review round.
 func TestReviewPromptNamesTheExactReviewerIDAndProtectsContractFiles(t *testing.T) {
-	p := ReviewPrompt("AI-001-x", "/repo", "nan/deepseek-v4-flash", "pi", "/skill/SKILL.md")
+	p := ReviewPrompt("AI-001-x", "/repo", "nan/deepseek-v4-flash", "pi", "/skill/SKILL.md", "basebasebase")
 	for _, want := range []string{
 		"AI-001-x", "/repo", "/skill/SKILL.md",
 		"`nan/deepseek-v4-flash`",
@@ -487,7 +487,7 @@ func TestReviewerCommandDoesNotGivePiAgySpecificFlags(t *testing.T) {
 // identity the launcher had known since the draw. 40 minutes, 248 bash calls, no
 // review.md.
 func TestReviewPromptTellsTheReviewerWhoItIs(t *testing.T) {
-	p := ReviewPrompt("AI-042-x", "/repo", "nan/deepseek-v4-flash", "pi", "/skill/SKILL.md")
+	p := ReviewPrompt("AI-042-x", "/repo", "nan/deepseek-v4-flash", "pi", "/skill/SKILL.md", "basebasebase")
 	for _, want := range []string{
 		"You are running as `nan/deepseek-v4-flash`",
 		"(runner `pi`)",

--- a/cli/internal/spec/review_request.go
+++ b/cli/internal/spec/review_request.go
@@ -51,6 +51,21 @@ type ReviewRequest struct {
 	// review.md existed. A digest that has not moved means the reviewer wrote
 	// no verdict — the one case the launcher provably cannot observe itself.
 	ReviewDigestBefore string `json:"review_digest_before"`
+	// BaseSHA is the commit the spec's work starts FROM, so the reviewer has a
+	// diff to read instead of a folder to browse.
+	//
+	// The skill specifies the review scope as `git diff <base>...HEAD`, and
+	// until this field existed the launcher recorded no base at all: the
+	// reviewer had to guess it, guessed `main`, and a review launched on `main`
+	// after the work merged therefore diffed nothing. Measured on BUG-093 round
+	// 4 — it declared `git diff main...HEAD` as its source, that diff was empty,
+	// and both of its findings say "Code read" with nothing executed. One of the
+	// two was factually wrong, having read a mutation payload out of the spec
+	// folder as if it were the implementation.
+	//
+	// omitempty because specs archived before this field existed carry the old
+	// shape and must still validate.
+	BaseSHA string `json:"base_sha,omitempty"`
 }
 
 // HeadSHA returns the repository HEAD, or "" when repoRoot is not a checkout.
@@ -64,6 +79,52 @@ func HeadSHA(repoRoot string) string {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
+}
+
+// ResolveReviewBase returns the commit the spec's work starts from: the PARENT
+// of the commit that first added specDir.
+//
+// Why this and not the PR's base branch. The PR route needs the network, `gh`
+// auth and PR metadata a human can edit, and it answers differently depending
+// on which of a spec's several PRs you ask about. This is local, offline and
+// deterministic, and it is correct in BOTH of the situations that matter:
+//
+//   - review on the work branch — the adding commit is on the branch, so the
+//     parent is where the branch left main.
+//   - review on main after a squash merge — the adding commit IS the squash
+//     commit, so the parent is main immediately before the work landed.
+//
+// That second case is the whole point: it is the one the old code got wrong by
+// having no answer at all.
+//
+// Returns "" when there is no such commit (a spec folder not yet committed),
+// which the caller must treat as "cannot review", not as "review everything".
+func ResolveReviewBase(repoRoot, specDir string) string {
+	rel, err := filepath.Rel(repoRoot, specDir)
+	if err != nil {
+		rel = specDir
+	}
+	// --diff-filter=A finds the commit that ADDED the folder; the last line of
+	// a reverse-chronological log is the earliest such commit. `--` guards a
+	// path that could be read as a revision.
+	out, err := exec.Command("git", "-C", repoRoot,
+		"log", "--diff-filter=A", "--format=%H", "--", rel).Output()
+	if err != nil {
+		return ""
+	}
+	lines := strings.Fields(strings.TrimSpace(string(out)))
+	if len(lines) == 0 {
+		return ""
+	}
+	adding := lines[len(lines)-1]
+
+	parent, err := exec.Command("git", "-C", repoRoot, "rev-parse", adding+"^").Output()
+	if err != nil {
+		// The adding commit is the repository's root commit: there is no parent,
+		// and the empty tree is the honest base.
+		return ""
+	}
+	return strings.TrimSpace(string(parent))
 }
 
 // fileDigest returns the SHA-256 of path, or "" when it does not exist.
@@ -84,12 +145,13 @@ func fileDigest(path string) string {
 //
 // Replacing rather than appending: the sidecar describes the CURRENT outstanding
 // request, and a history of requests is what the transcript is for.
-func WriteReviewRequest(specDir, reviewedSHA, reviewer string) error {
+func WriteReviewRequest(specDir, reviewedSHA, reviewer, baseSHA string) error {
 	req := ReviewRequest{
 		ReviewedSHA:        reviewedSHA,
 		Reviewer:           reviewer,
 		RequestedAt:        time.Now().UTC().Format(time.RFC3339),
 		ReviewDigestBefore: fileDigest(filepath.Join(specDir, ReviewFile)),
+		BaseSHA:            baseSHA,
 	}
 	data, err := json.MarshalIndent(req, "", "  ")
 	if err != nil {

--- a/cli/internal/spec/review_request_test.go
+++ b/cli/internal/spec/review_request_test.go
@@ -49,7 +49,7 @@ Body.
 // the other runner's output as empty. "Did the file change?" needs no schema.
 func TestProvenanceCatchesAReviewThatWroteNothing(t *testing.T) {
 	dir := seedProvenanceSpec(t, provenanceReviewDoc)
-	if err := WriteReviewRequest(dir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "nan/deepseek-v4-flash"); err != nil {
+	if err := WriteReviewRequest(dir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "nan/deepseek-v4-flash", "basebasebase"); err != nil {
 		t.Fatal(err)
 	}
 	// The reviewer writes nothing: review.md is byte-identical to launch time.
@@ -70,7 +70,7 @@ func TestProvenanceCatchesAReviewThatWroteNothing(t *testing.T) {
 // cannot become one that refuses everything.
 func TestProvenanceAcceptsAFreshVerdict(t *testing.T) {
 	dir := seedProvenanceSpec(t, "old content")
-	if err := WriteReviewRequest(dir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "nan/deepseek-v4-flash"); err != nil {
+	if err := WriteReviewRequest(dir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "nan/deepseek-v4-flash", "basebasebase"); err != nil {
 		t.Fatal(err)
 	}
 	// The reviewer overwrites review.md with a verdict on the launched sha.
@@ -92,7 +92,7 @@ func TestProvenanceAcceptsAFreshVerdict(t *testing.T) {
 // what the launcher actually pointed it at, which is a measurement.
 func TestProvenanceCatchesAVerdictOnAnotherSha(t *testing.T) {
 	dir := seedProvenanceSpec(t, "old content")
-	if err := WriteReviewRequest(dir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "nan/deepseek-v4-flash"); err != nil {
+	if err := WriteReviewRequest(dir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "nan/deepseek-v4-flash", "basebasebase"); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, ReviewFile), []byte(provenanceReviewDoc), 0o600); err != nil {
@@ -115,7 +115,7 @@ func TestProvenanceCatchesAVerdictOnAnotherSha(t *testing.T) {
 // see: both ids are admitted, so only the sidecar knows which one was asked.
 func TestProvenanceCatchesADifferentPoolMember(t *testing.T) {
 	dir := seedProvenanceSpec(t, "old content")
-	if err := WriteReviewRequest(dir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "agy/gemini-3.1-pro-high"); err != nil {
+	if err := WriteReviewRequest(dir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "agy/gemini-3.1-pro-high", "basebasebase"); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, ReviewFile), []byte(provenanceReviewDoc), 0o600); err != nil {
@@ -163,7 +163,7 @@ func TestUnparseableSidecarIsLoud(t *testing.T) {
 func TestWriteReviewRequestRecordsTheDigestOfWhatWasThere(t *testing.T) {
 	t.Run("with a previous review", func(t *testing.T) {
 		dir := seedProvenanceSpec(t, provenanceReviewDoc)
-		if err := WriteReviewRequest(dir, "sha", "r"); err != nil {
+		if err := WriteReviewRequest(dir, "sha", "r", "basebasebase"); err != nil {
 			t.Fatal(err)
 		}
 		req, found, err := ReadReviewRequest(dir)
@@ -177,7 +177,7 @@ func TestWriteReviewRequestRecordsTheDigestOfWhatWasThere(t *testing.T) {
 
 	t.Run("with no previous review", func(t *testing.T) {
 		dir := seedProvenanceSpec(t, "")
-		if err := WriteReviewRequest(dir, "sha", "r"); err != nil {
+		if err := WriteReviewRequest(dir, "sha", "r", "basebasebase"); err != nil {
 			t.Fatal(err)
 		}
 		req, _, err := ReadReviewRequest(dir)
@@ -196,7 +196,7 @@ func TestWriteReviewRequestRecordsTheDigestOfWhatWasThere(t *testing.T) {
 // foreground run (tmux is Linux-only), so this is the common path there.
 func TestVerifyReviewProducedCatchesARunThatWroteNoFile(t *testing.T) {
 	dir := seedProvenanceSpec(t, "")
-	if err := WriteReviewRequest(dir, "aaaa", "nan/deepseek-v4-flash"); err != nil {
+	if err := WriteReviewRequest(dir, "aaaa", "nan/deepseek-v4-flash", "basebasebase"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -214,7 +214,7 @@ func TestVerifyReviewProducedCatchesARunThatWroteNoFile(t *testing.T) {
 // reached the same conclusion.
 func TestVerifyReviewProducedCatchesAnUnchangedVerdict(t *testing.T) {
 	dir := seedProvenanceSpec(t, provenanceReviewDoc)
-	if err := WriteReviewRequest(dir, "aaaa", "nan/deepseek-v4-flash"); err != nil {
+	if err := WriteReviewRequest(dir, "aaaa", "nan/deepseek-v4-flash", "basebasebase"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -229,7 +229,7 @@ func TestVerifyReviewProducedCatchesAnUnchangedVerdict(t *testing.T) {
 
 func TestVerifyReviewProducedAcceptsAFreshVerdict(t *testing.T) {
 	dir := seedProvenanceSpec(t, provenanceReviewDoc)
-	if err := WriteReviewRequest(dir, "aaaa", "nan/deepseek-v4-flash"); err != nil {
+	if err := WriteReviewRequest(dir, "aaaa", "nan/deepseek-v4-flash", "basebasebase"); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, ReviewFile), []byte(provenanceReviewDoc+"\nA new round.\n"), 0o600); err != nil {

--- a/harness/skills/adversarial-review/SKILL.md
+++ b/harness/skills/adversarial-review/SKILL.md
@@ -206,9 +206,26 @@ The severity findings axis (Blocker/Major/Minor) can still escalate independentl
 
 End with a clear verdict:
 
+**Severity alone does not decide this — `severity × reality` does**, exactly as the Reality
+classification above states. Read the two together; they are one rule:
+
 - **PASS (adversarial)** — no blockers or majors; rubric all B or above; minors listed optionally.
-- **PASS WITH GAPS** — minors only OR rubric has at least one C (no D); both tracked.
-- **FAIL** — at least one blocker or major OR rubric has at least one D, until addressed.
+- **PASS WITH GAPS** — minors only, OR every open Major is **THEORETICAL/SPECULATIVE**, OR rubric
+  has at least one C (no D). All of them tracked, each with a disposition line.
+- **FAIL** — at least one **Blocker** (any reality), at least one **REAL** Major, or rubric has at
+  least one D, until addressed.
+
+> **Why this is spelled out twice.** This list previously read *"FAIL — at least one blocker or
+> major"*, which contradicts the Reality rule above (*"a SPECULATIVE finding cannot, by itself,
+> move the verdict below PASS"*). A reviewer following this list instead of that rule returns FAIL
+> on a Major it has itself labelled THEORETICAL — measured on BUG-093 round 4, where a
+> race-window-narrowing suggestion with no demonstrated exploit cost a full merge-and-re-review
+> cycle. The reality tag is not decoration; if a finding cannot be shown to happen, it is tracked,
+> not blocking.
+>
+> A **Blocker** is deliberately exempt from this softening: "incorrect behavior, security/privacy
+> issue, or spec violation" stops an archive whatever its reality tag, because the cost of being
+> wrong about a Blocker is the thing the gate exists to prevent.
 
 ## Output format
 

--- a/specs/HARNESS-111-review-base-and-reality/features.json
+++ b/specs/HARNESS-111-review-base-and-reality/features.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "HARNESS-111-f1",
+    "behavior": "ResolveReviewBase returns the parent of the commit that added the spec folder, and empty when no such commit exists",
+    "verification": "cd cli && go test ./internal/spec/ -run 'ResolveReviewBase' -count=1 -v 2>&1 | grep -c '^--- PASS'",
+    "state": "verified",
+    "evidence": "3 PASS against real git repositories, including the post-squash case"
+  },
+  {
+    "id": "HARNESS-111-f2",
+    "behavior": "The resolved base yields a non-empty diff on a repo where `git diff main...HEAD` is empty — the defect this spec exists for",
+    "verification": "cd cli && go test ./internal/spec/ -run 'ResolveReviewBaseGivesANonEmptyDiffOnMainAfterTheWorkLanded' -count=1",
+    "state": "verified",
+    "evidence": "passes, and asserts the naive main...HEAD diff IS empty as an anchor first, so it cannot pass on a fixture that fails to reproduce the defect"
+  },
+  {
+    "id": "HARNESS-111-f3",
+    "behavior": "dotf spec review refuses an unscopeable review (no base, or base == HEAD) and launches when a base resolves",
+    "verification": "cd cli && go test ./internal/cmd/ -run 'SpecReviewRefusesWhenNoBase|SpecReviewRefusesWhenTheBaseIsTheHead|SpecReviewLaunchesAndStatesTheBase' -count=1 -v 2>&1 | grep -c '^--- PASS'",
+    "state": "verified",
+    "evidence": "3 PASS — two refusals plus the positive direction, so the refusals cannot pass vacuously"
+  },
+  {
+    "id": "HARNESS-111-f4",
+    "behavior": "The sidecar records base_sha, and one written before the field existed still parses",
+    "verification": "cd cli && go test ./internal/spec/ -run 'ReviewRequestWithoutBaseSHAStillParses|WriteReviewRequestRecordsTheBase' -count=1",
+    "state": "verified",
+    "evidence": "both PASS; omitempty keeps archived specs valid"
+  },
+  {
+    "id": "HARNESS-111-f5",
+    "behavior": "The skill's verdict list honours the reality axis it already defines, and a Blocker still blocks at any reality",
+    "verification": "~/.local/bin/bats tests/guard-review-verdict-honours-reality.bats",
+    "state": "verified",
+    "evidence": "6/6 ok; mutation-proven — reintroducing the old unqualified FAIL line turns 3 of 6 red"
+  },
+  {
+    "id": "HARNESS-111-f6",
+    "behavior": "The whole Go layer is clean on Linux and vets clean for Windows and Darwin",
+    "verification": "cd cli && go build ./... && go test ./... && GOOS=windows go vet ./... && GOOS=darwin go vet ./... && golangci-lint run ./...",
+    "state": "verified",
+    "evidence": "all rc=0, 0 issues on the pinned 2.12.2"
+  }
+]

--- a/specs/HARNESS-111-review-base-and-reality/proposal.md
+++ b/specs/HARNESS-111-review-base-and-reality/proposal.md
@@ -1,0 +1,120 @@
+---
+id: "HARNESS-111-review-base-and-reality"
+type: spec
+status: implementing # draft | implementing | verifying | archived
+issue: "mlorentedev/dotfiles#1533"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# HARNESS-111-review-base-and-reality
+
+## Why
+
+BUG-093 took **four rounds and four FAILs** against a repository history of 30 PASS,
+7 PASS-WITH-GAPS, 1 FAIL, and only 4 specs ever needing more than one round. It is a 4x outlier,
+and the cause is two architectural defects in the gate rather than anything about that spec.
+
+### Root 1 — the review has no base, so on `main` it reviews nothing
+
+`harness/skills/adversarial-review/SKILL.md` defines the scope as `git diff <base>...HEAD`.
+**The launcher recorded no base.** `review-request.json` carried `reviewed_sha`, `reviewer`,
+`requested_at` and `review_digest_before` — no base concept existed anywhere in
+`cli/internal/spec/`. The reviewer had to guess, guessed `main`, and a review launched *on* `main`
+after the work merged therefore diffed nothing.
+
+Measured, not argued:
+
+| Round | Launched on | Diff | Evidence verbs in its own findings |
+|---|---|---|---|
+| 3 | branch `dab7b6e` | real | "Mutation: … rc=0, NOT CAUGHT", "Measured through the production path", "Reproduced with `docker run`" |
+| 4 | `main`, post-merge | **empty** | "Code read", "Code read" — nothing executed |
+
+Round 4 named `git diff main...HEAD` as its source and that diff did not exist. It returned one
+THEORETICAL finding and one that was **factually wrong**: it cited `Inside: false`, a string that
+appears nowhere in `cli/`, having read a mutation payload out of the spec folder's committed
+harness as if it were the implementation.
+
+**The documented workflow guarantees this.** The doctrine requires the review before archiving;
+archiving follows the merge; so the review lands post-merge, where its primary input is gone.
+
+### Root 2 — the skill contradicts itself about the verdict
+
+The verdict rule is stated twice and the two disagree:
+
+- Reality classification: *"weight each finding by `severity × reality`. A **REAL** Blocker/Major
+  forces FAIL; a **SPECULATIVE** finding cannot, by itself, move the verdict below PASS."*
+- Verdict list: *"**FAIL** — at least one blocker or major OR rubric has at least one D."*
+
+A reviewer following the second returns FAIL on a Major it has itself labelled THEORETICAL. That
+is round 4 exactly: a race-window narrowing with no demonstrated exploit, costing a full
+merge-and-re-review cycle.
+
+This is not a missing policy. It is a contradiction inside one document, and the fix is to resolve
+it in favour of the rule that was already stated more precisely.
+
+## What
+
+1. `dotf spec review` resolves a base and records it as `base_sha` in `review-request.json`, then
+   states it in the reviewer's prompt.
+2. The launcher **refuses** when no base resolves, or when the base is HEAD.
+3. The skill's verdict list is made consistent with its own Reality rule.
+
+### How the base is resolved, and why not from the PR
+
+`ResolveReviewBase` returns the **parent of the commit that first added the spec folder**.
+
+The PR route (`issue:` → PRs closing it → oldest PR's base) needs the network, `gh` auth, and PR
+metadata a human can edit, and it answers differently depending on which of a spec's several PRs
+you ask. The chosen route is local, offline and deterministic, and it is correct in both
+situations that matter:
+
+- **on the work branch** — the adding commit is on the branch, so the parent is where the branch
+  left `main`;
+- **on `main` after a squash merge** — the adding commit *is* the squash commit, so the parent is
+  `main` immediately before the work landed.
+
+The second case is the entire point: it is the one the old code got wrong by having no answer.
+
+## Out of scope
+
+- **Softening Majors in general.** Round 1's Blocker on BUG-093 was a real data-loss bug
+  (`filepath.Abs` does not resolve symlinks, so a symlinked worktree failed open with a process
+  inside) and round 3's six REAL Majors were the gate earning its keep. Only the reality axis is
+  honoured; the severity bar is untouched.
+- **Blockers.** A Blocker blocks whatever its reality tag. The cost of being wrong about a Blocker
+  is the thing the gate exists to prevent.
+- **Delta-since-last-round scope.** The base is fixed and the head moves. A per-round delta would
+  stop round N seeing a fix that round 1 forced, so it could not judge whether a late change
+  interacts with an early one.
+- **Backfilling `base_sha` into archived specs.** They carry the old shape and must keep parsing.
+
+## Risks / open questions
+
+- **The skill is deployed, not read from the repo.** The reviewer reads
+  `~/.pi/agent/skills/adversarial-review/SKILL.md`, which `compile-harness.sh` writes. Root 2's fix
+  has no effect until a deploy runs. Called out in `verification.md` rather than assumed.
+- **The base resolver trusts the spec folder's add-commit.** A spec folder created in one commit
+  and then rewritten by an interactive rebase would resolve to the rebased commit's parent. That is
+  the correct answer for the history that exists, which is the only history a reviewer can read.
+- **Command-level tests drive a seam.** `makeRepo` builds a fake `.git` directory, not a
+  repository, so the production resolvers answer "" there. The resolvers are tested against real
+  git histories in `internal/spec`; the seam proves the caller honours the answer. Neither alone is
+  sufficient — the lesson BUG-093 round 3 taught.
+
+## Acceptance criteria
+
+1. `ResolveReviewBase` returns the parent of the commit that added the spec folder, and `""` when
+   no such commit exists.
+2. On a repository where `git diff main...HEAD` is **empty**, the resolved base still produces a
+   non-empty diff — asserted with the naive-diff emptiness as an anchor, so the test cannot pass on
+   a fixture that fails to reproduce the defect.
+3. `dotf spec review` refuses when no base resolves, and refuses when base equals HEAD, with a
+   message naming which.
+4. The reviewer prompt states the base and tells the reviewer not to substitute one.
+5. `review-request.json` records `base_sha`, and a sidecar written before the field existed still
+   parses.
+6. The skill's verdict list qualifies Major by reality; a Blocker still blocks at any reality; a
+   guard fails if either half regresses.
+7. `go build`, `go test ./...`, `golangci-lint run`, `GOOS=windows go vet ./...` clean; the new
+   guard passes and is mutation-proven.

--- a/specs/HARNESS-111-review-base-and-reality/tasks.md
+++ b/specs/HARNESS-111-review-base-and-reality/tasks.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, tasks]
+created: "2026-09-05"
+---
+
+# Tasks - HARNESS-111-review-base-and-reality
+
+## Root 1 — the review base
+
+- [x] `ResolveReviewBase(repoRoot, specDir)` — parent of the commit that first added the folder;
+      local, offline, deterministic, and correct on a branch AND on main after a squash.
+- [x] `ReviewRequest.BaseSHA` with `omitempty`, so sidecars written before the field still parse.
+- [x] `WriteReviewRequest` takes and records the base.
+- [x] `ReviewPrompt` states the base and forbids substituting one; it also states that the scope is
+      the WHOLE change and not a delta since the last round.
+- [x] `dotf spec review` refuses when no base resolves, and when base == HEAD.
+- [x] Seams (`resolveReviewBase`, `headSHAOf`) so the command-level fixtures, which build a fake
+      `.git` directory rather than a repository, can drive both answers.
+
+## Root 2 — the verdict contradiction
+
+- [x] Make the skill's verdict list agree with its own Reality rule: FAIL on any Blocker or a REAL
+      Major; a THEORETICAL/SPECULATIVE-only Major routes to PASS-WITH-GAPS with a disposition.
+- [x] State in the skill WHY it is spelled out twice, with the measurement, so the next editor does
+      not "simplify" it back into a contradiction.
+- [x] `tests/guard-review-verdict-honours-reality.bats` — 6 assertions covering both directions.
+
+## Verification
+
+- [x] Real-git tests for the resolver, including the empty-`main...HEAD` case with an anchor.
+- [x] Command-level refusal tests plus the positive direction, so the refusals cannot pass
+      vacuously.
+- [x] Guard mutation-proven: reintroducing the old verdict line turns 3 of 6 assertions red.
+- [x] `go build`, `go test ./...`, `golangci-lint run`, `GOOS=windows/darwin go vet` clean.
+
+## Not done, deliberately
+
+- [ ] Backfilling `base_sha` into archived specs — they are historical records.
+- [ ] Softening Majors in general, or Blockers at all. Out of scope, argued in the proposal.
+- [ ] Parsing the findings table in Go to compute the verdict. The verdict is and always was the
+      reviewer's judgment; the defect was the rule it applied, not who applied it. A markdown-table
+      parser in a gate would be a new fragile surface for no added trust.

--- a/specs/HARNESS-111-review-base-and-reality/verification.md
+++ b/specs/HARNESS-111-review-base-and-reality/verification.md
@@ -1,0 +1,88 @@
+---
+tags: [spec, verification, templates]
+created: "2026-09-05"
+---
+
+# Verification - HARNESS-111-review-base-and-reality
+
+## Evidence
+
+Every command below was executed in this session.
+
+- [x] **AC1** `TestResolveReviewBaseIsTheParentOfTheCommitThatAddedTheSpec`,
+      `TestResolveReviewBaseIsEmptyWhenTheSpecIsNotCommitted` — real git repositories, not fixtures.
+- [x] **AC2** `TestResolveReviewBaseGivesANonEmptyDiffOnMainAfterTheWorkLanded`. It asserts the
+      **anchor first**: `git diff --name-only main...HEAD` must be empty in the fixture, or the
+      test `t.Fatal`s rather than passing. Without that, it could pass on a repository where the
+      old behaviour also happened to work.
+- [x] **AC3** `TestSpecReviewRefusesWhenNoBaseCanBeResolved`,
+      `TestSpecReviewRefusesWhenTheBaseIsTheHead`, and
+      `TestSpecReviewLaunchesAndStatesTheBaseWhenOneResolves` — the third exists so the first two
+      cannot pass vacuously by the launcher refusing everything.
+- [x] **AC4** `TestReviewPromptStatesTheResolvedBase`.
+- [x] **AC5** `TestWriteReviewRequestRecordsTheBase` and
+      `TestReviewRequestWithoutBaseSHAStillParses`.
+- [x] **AC6** `tests/guard-review-verdict-honours-reality.bats`, 6 assertions, mutation-proven.
+- [x] **AC7** full loop below.
+
+## Test status
+
+```
+go build ./...                        rc=0
+go test ./...                         rc=0   (whole module)
+GOOS=windows go vet ./...             rc=0
+GOOS=darwin  go vet ./...             rc=0
+golangci-lint run ./...               0 issues   (2.12.2, the versions.conf pin)
+bats tests/guard-review-verdict-honours-reality.bats   6/6 ok
+```
+
+### Guard mutation
+
+The guard has to fail when the contradiction returns, or it is decoration. Reintroducing the exact
+old line (`FAIL — at least one blocker or major OR rubric has at least one D`) with the anchor
+asserted before the patch:
+
+```
+ok 1 guard: the adversarial-review skill exists where the gate expects it
+not ok 2 guard: the verdict rule qualifies Major by reality, not severity alone
+not ok 3 guard: the unqualified 'any blocker or major' rule is gone
+ok 4 guard: PASS WITH GAPS is reachable for a THEORETICAL-only Major
+not ok 5 guard: a Blocker still blocks regardless of its reality tag
+ok 6 guard: the Reality classification the verdict defers to is still present
+MUTATED rc=1
+restored: guard green again
+```
+
+## One thing this change does NOT take effect without
+
+**The reviewer reads the DEPLOYED skill, not the repository's.** `compile-harness.sh` writes
+`~/.pi/agent/skills/adversarial-review/SKILL.md`, and that copy is what a launched review opens.
+Measured after the edit:
+
+```
+diff -q harness/skills/adversarial-review/SKILL.md ~/.pi/agent/skills/adversarial-review/SKILL.md
+  -> DIFFERS
+```
+
+So root 2's fix is inert until a deploy runs. Stated here rather than discovered when the next
+review returns FAIL on a THEORETICAL finding and somebody concludes the fix did not work.
+
+Root 1 has no such gap: it is compiled into `dotf`.
+
+## Decisions made during implementation
+
+- **The base is the spec folder's add-commit parent, not the PR's base branch.** The PR route needs
+  network, `gh` auth and human-editable metadata, and it answers differently per PR. The chosen
+  route is offline and deterministic, and it is right in both the branch and the post-squash cases
+  — the second being the one that was broken.
+- **Refuse rather than degrade.** A review with an empty diff does not error; it quietly becomes a
+  reading of the spec folder and reports findings with nothing executed behind them. Round 4 shows
+  what that produces: one THEORETICAL finding and one factual error. A launch that cannot be scoped
+  is refused.
+- **Root 2 is a documentation contradiction, so it is fixed in documentation.** Parsing the
+  findings table in Go was considered and rejected: the verdict is self-reported either way, so a
+  markdown parser adds a fragile surface and no trust. The rule the reviewer applies is what was
+  wrong.
+- **The two-layer test split is deliberate**, and it is BUG-093 round 3's lesson applied: real-git
+  tests prove the resolver's answer is right, seam tests prove the caller honours it. A seam test
+  passes over a wrong implementation; a resolver test cannot see whether anyone acts on it.

--- a/tests/guard-review-verdict-honours-reality.bats
+++ b/tests/guard-review-verdict-honours-reality.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+#
+# HARNESS-111. The adversarial-review skill states its verdict rule TWICE — once
+# in the Reality classification and once in the Verdict list — and the two
+# drifted apart.
+#
+#   Reality rule : "weight each finding by severity x reality. A REAL
+#                   Blocker/Major forces FAIL"
+#   Verdict list : "FAIL - at least one blocker or major"   <- reality dropped
+#
+# A reviewer following the second returns FAIL on a Major it has itself labelled
+# THEORETICAL. Measured on BUG-093 round 4: a race-window narrowing with no
+# demonstrated exploit cost a full merge-and-re-review cycle.
+#
+# These assert the two statements still agree. The contradiction was invisible
+# to every existing check because both halves are individually reasonable
+# English.
+
+load 'lib/refute'
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    SKILL="$REPO_ROOT/harness/skills/adversarial-review/SKILL.md"
+}
+
+@test "guard: the adversarial-review skill exists where the gate expects it" {
+    [ -f "$SKILL" ]
+}
+
+@test "guard: the verdict rule qualifies Major by reality, not severity alone" {
+    # The FAIL line must name REAL. Without it, the list contradicts the Reality
+    # section above it and a reviewer can follow either.
+    run grep -n 'FAIL.*at least one' "$SKILL"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q 'REAL'
+}
+
+@test "guard: the unqualified 'any blocker or major' rule is gone" {
+    # The exact phrasing that produced the contradiction. Fixed-string, and via
+    # refute_grep_fixed because a bare `! grep` that is not the last line of a
+    # @test cannot fail it (#1034).
+    refute_grep_fixed 'at least one blocker or major OR rubric' "$SKILL"
+}
+
+@test "guard: PASS WITH GAPS is reachable for a THEORETICAL-only Major" {
+    run grep -c 'THEORETICAL' "$SKILL"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 2 ]
+    # The verdict list itself must offer the non-blocking route, or the Reality
+    # tag has nowhere to land.
+    run grep -n 'PASS WITH GAPS' "$SKILL"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -qi 'THEORETICAL'
+}
+
+@test "guard: a Blocker still blocks regardless of its reality tag" {
+    # The softening is deliberately scoped to Majors. If this line goes, the
+    # gate has been widened past what HARNESS-111 argued for.
+    run grep -n 'Blocker' "$SKILL"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q 'any reality'
+}
+
+@test "guard: the Reality classification the verdict defers to is still present" {
+    run grep -q 'severity . reality' "$SKILL"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Refs #1533 — deliberately **not** `Closes`.

The archive-on-merge gate refuses a PR that closes a spec's issue without archiving the spec in
the same PR, and the spec cannot archive without a passing adversarial review. So the issue is
closed by the archive PR, not this one. (My first push carried `Closes` and the gate caught it —
working as designed.)

BUG-093 took **four rounds and four FAILs**, against a repository history of 30 PASS,
7 PASS-WITH-GAPS, 1 FAIL, and only **4 specs ever needing more than one round**. A 4× outlier is
not a fact about that spec. It is two defects in the gate.

## Root 1 — the review had no base, so on `main` it reviewed nothing

The skill defines the scope as `git diff <base>...HEAD`. **The launcher recorded no base** —
`review-request.json` had `reviewed_sha`, `reviewer`, `requested_at`, `review_digest_before`, and
no base concept existed anywhere in `cli/internal/spec/`. So the reviewer guessed, guessed `main`,
and a review launched *on* `main` after the work merged diffed nothing.

Measured on BUG-093's own rounds:

| Round | Launched on | Diff | Evidence verbs in its own findings |
|---|---|---|---|
| 3 | branch `dab7b6e` | real | "Mutation: … rc=0, NOT CAUGHT" · "Measured through the production path" · "Reproduced with `docker run`" |
| 4 | `main`, post-merge | **empty** | "Code read" · "Code read" — nothing executed |

Round 4 declared `git diff main...HEAD` as its source and that diff did not exist. One of its two
findings was **factually wrong**: it cited `Inside: false`, a string that appears nowhere in
`cli/`, having read a mutation payload out of the spec folder's committed harness as if it were
the implementation.

**The documented workflow guarantees this** — the doctrine requires the review before archiving,
archiving follows the merge, so the review lands where its primary input is gone.

### The fix, and why not the PR's base branch

`ResolveReviewBase` returns the **parent of the commit that first added the spec folder**.

The PR route (`issue:` → PRs closing it → oldest PR's base) needs the network, `gh` auth and
human-editable metadata, and answers differently depending on which of a spec's several PRs you
ask. This one is local, offline, deterministic — and correct in both cases that matter:

- **on the work branch** — the adding commit is on the branch, so the parent is where it left `main`;
- **on `main` after a squash** — the adding commit *is* the squash commit, so the parent is `main`
  immediately before the work landed.

That second case is the whole point: it is the one the old code got wrong by having no answer.

The base is recorded as `base_sha`, stated in the prompt, and **a launch that cannot be scoped is
refused** rather than allowed to degrade into a folder-read wearing a verdict.

Note this is deliberately *not* a delta-since-last-round. The base is fixed and the head moves — a
per-round delta would stop round N seeing a fix round 1 forced, so it could not judge whether a
late change interacts with an early one.

## Root 2 — the skill contradicted itself

Stated twice, disagreeing:

> *Reality section:* "weight each finding by `severity × reality` … a **SPECULATIVE** finding
> cannot, by itself, move the verdict below PASS"
>
> *Verdict list:* "**FAIL** — at least one blocker or major"

A reviewer following the second returns FAIL on a Major it has itself labelled THEORETICAL. That is
round 4 exactly — a race-window narrowing with no demonstrated exploit, costing a full
merge-and-re-review cycle.

Not a missing policy: a contradiction inside one document, resolved in favour of the rule already
stated more precisely, with the reason recorded inline so the next editor does not "simplify" it
back.

**Blockers are exempt from the softening, at any reality tag.** Round 1's Blocker on BUG-093 was a
real data-loss bug (`filepath.Abs` does not resolve symlinks, so a symlinked worktree failed open
with a process inside). That is what the gate is for and it is untouched.

## Verification

All 6 `features.json` verifications executed, all `rc=0`.

- **Real git repositories, not fixtures**, for the resolver — including the post-squash case, whose
  test **asserts the anchor first**: `git diff main...HEAD` must be empty in the fixture or it
  `t.Fatal`s, so it cannot pass on a repo where the old behaviour also worked.
- **Both refusal paths plus the positive direction**, so the refusals cannot pass vacuously by the
  launcher refusing everything.
- **Guard mutation-proven**: reintroducing the exact old verdict line turns 3 of 6 assertions red.

```
go build ./...              rc=0     go test ./...            rc=0
GOOS=windows go vet ./...   rc=0     GOOS=darwin go vet ./...  rc=0
golangci-lint run ./...     0 issues (2.12.2, the versions.conf pin)
bats guard-review-verdict-honours-reality.bats   6/6 ok
```

## One thing this does not take effect without

**The reviewer reads the DEPLOYED skill**, `~/.pi/agent/skills/adversarial-review/SKILL.md`, which
`compile-harness.sh` writes. Measured after the edit: `diff -q` → **DIFFERS**. Root 2 is inert
until a deploy runs. Stated here and in `verification.md` rather than discovered when the next
review returns FAIL on a THEORETICAL finding and somebody concludes the fix did not work.

Root 1 has no such gap — it is compiled into `dotf`.
