### PR TITLE
fix(harness): qualify the Major severity definition by reality, and make f7 assert

### DIFF
--- a/docs/lessons/lesson-275-a-review-that-demands-contract-edits-invalidates-itself.md
+++ b/docs/lessons/lesson-275-a-review-that-demands-contract-edits-invalidates-itself.md
@@ -54,8 +54,10 @@ the spec archives, or the archived artifact is internally inconsistent. Editing 
 to correct a stale number creates a worse inconsistency than the one it removes.
 
 Two other exits were also wrong: `--force-without-review` discards a review that exists and passed,
-and `review: waived` asserts no review happened. Both are lies in the opposite direction from the
-stale number.
+and `review: waived` declares the requirement does not apply at all — `checkReviewGate` returns on a
+waiver with a reason *before* it calls `FindReview`, so a passing review sitting in the folder is
+never even read. Both walk past a verdict that was earned, in the opposite direction from the stale
+number.
 
 ## What to do instead
 

--- a/harness/skills/adversarial-review/SKILL.md
+++ b/harness/skills/adversarial-review/SKILL.md
@@ -150,7 +150,7 @@ For each acceptance criterion / scenario:
 Classify each finding:
 
 - **Blocker**: incorrect behavior, security/privacy issue, or spec violation that should stop archive.
-- **Major**: likely bug or significant gap; fix or spec update required, and a re-review after it.
+- **Major**: likely bug or significant gap. **Reality decides what it costs**: a REAL Major requires a fix and a re-review after it; a THEORETICAL or SPECULATIVE one is tracked with a disposition and can stand under PASS WITH GAPS. Read this with the reality axis below — severity alone never settles it.
 - **Minor**: clarity, maintainability, or low-risk gap; can follow up.
 - **Question / assumption**: needs human or author confirmation.
 

--- a/specs/HARNESS-111-review-base-and-reality/features.json
+++ b/specs/HARNESS-111-review-base-and-reality/features.json
@@ -29,10 +29,10 @@
   },
   {
     "id": "HARNESS-111-f5",
-    "behavior": "The skill's verdict list honours the reality axis it already defines, and a Blocker still blocks at any reality",
+    "behavior": "The skill's verdict list AND its Major severity definition both honour the reality axis it already defines, and a Blocker still blocks at any reality",
     "verification": "~/.local/bin/bats tests/guard-review-verdict-honours-reality.bats",
     "state": "verified",
-    "evidence": "6/6 ok; mutation-proven — reintroducing the old unqualified FAIL line turns 3 of 6 red"
+    "evidence": "7/7 ok; mutation-proven in both halves — reintroducing the old unqualified FAIL line turns 3 of 7 red, and reverting the Major severity line to the unqualified \"fix or spec update required, and a re-review after it\" turns test 6 red. The severity definition was a third statement of the same rule that the first guard could not see, because it only read the verdict list."
   },
   {
     "id": "HARNESS-111-f6",
@@ -44,9 +44,9 @@
   {
     "id": "HARNESS-111-f7",
     "behavior": "The review skill no longer asks for contract-file edits before archive; it routes recommendations by set, and both the repo record and the vault source carry the same text",
-    "verification": "for f in harness/skills/adversarial-review/SKILL.md \"$(dotf env path VAULT_PATH)/00_meta/skills/adversarial-review/SKILL.md\"; do grep -cE 'required before archive|next steps \\(before archive\\)' \"$f\"; grep -cE 'contract set|Route every recommendation by set' \"$f\"; done",
+    "verification": "bash -c 'rc=0; for f in harness/skills/adversarial-review/SKILL.md \"$(dotf env path VAULT_PATH)/00_meta/skills/adversarial-review/SKILL.md\"; do df=$(grep -cE \"required before archive|next steps .before archive.\" \"$f\"); r=$(grep -cE \"contract set|Route every recommendation by set\" \"$f\"); echo \"$f defective=$df routing=$r\"; [ \"$df\" -eq 0 ] || rc=1; [ \"$r\" -eq 4 ] || rc=1; done; exit $rc'",
     "state": "verified",
-    "evidence": "0 defective forms and 4 routing-rule lines in each copy. A bare grep for 'before archive' still returns 3 per copy and is the wrong command: two are the skill describing when it runs, and the third is the new instruction not to use the phrase."
+    "evidence": "rc=0, printing defective=0 routing=4 for both copies. The command asserts rather than prints: the previous form ran two bare `grep -c` and discarded the first status, so the loop's exit code was the last grep's and the \"zero defective forms\" half was never checked. Mutation-proven: reinstating `next steps (before archive)` in either copy turns it rc=1. A bare grep for 'before archive' still returns 3 per copy and is the wrong pattern — two are the skill describing when it runs, the third is the new instruction not to use the phrase."
   },
   {
     "id": "HARNESS-111-f8",

--- a/specs/HARNESS-111-review-base-and-reality/tasks.md
+++ b/specs/HARNESS-111-review-base-and-reality/tasks.md
@@ -46,6 +46,15 @@ created: "2026-09-05"
 - [x] Name the review-preserving exit in the staleness refusal, ahead of the three overrides.
 - [x] `TestStaleRefusalOffersTheExitThatKeepsTheReview` — asserts the exit is present, says where the
       dispositions go, and is offered *before* each override. Mutation-proven against the old message.
+- [x] Qualify the **Major severity definition** by reality too. It was a third statement of the rule
+      root 2 fixed in the verdict list, and it drifted the same way: it demanded a fix and a
+      re-review for every Major while the list sent a THEORETICAL one to PASS WITH GAPS. The
+      routing paragraph already said *REAL* Major; the definition did not. Both SKILL.md copies.
+- [x] Extend `guard-review-verdict-honours-reality.bats` to read that definition, not only the
+      verdict list — the existing 6 assertions were blind to it. 7/7, mutation-proven.
+- [x] Make f7's verification command **assert** instead of print. It ran two bare `grep -c` and
+      discarded the first status, so the loop's exit code was the last grep's and the "zero
+      defective forms" half was never checked — the class `.claude/CLAUDE.md` documents.
 
 ## Not done, deliberately
 

--- a/tests/guard-review-verdict-honours-reality.bats
+++ b/tests/guard-review-verdict-honours-reality.bats
@@ -61,6 +61,18 @@ setup() {
     printf '%s\n' "$output" | grep -q 'any reality'
 }
 
+@test "guard: the Major severity definition defers to reality, like the verdict list" {
+    # A THIRD statement of the same rule, one section above the verdict list, and
+    # it drifted the same way: while the list sent a THEORETICAL Major to PASS
+    # WITH GAPS, this definition demanded a fix and a re-review for every Major.
+    # The tests above could not see it — they only read the verdict list. Found
+    # by review on #1543, which is why the guard now reads both halves.
+    run grep -n '^- \*\*Major\*\*:' "$SKILL"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q 'REAL'
+    printf '%s\n' "$output" | grep -q 'THEORETICAL'
+}
+
 @test "guard: the Reality classification the verdict defers to is still present" {
     run grep -q 'severity . reality' "$SKILL"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Refs #1533. Follow-up to #1543, which merged three minutes after CodeRabbit posted its first
non-notice review of the session and before those findings were dispositioned. All three are
applied here; each was confirmed against the code before applying, not taken on the reviewer's word.

## 1. The Major severity definition contradicted the verdict list (Major)

Root 2 of HARNESS-111 fixed the *verdict list* so a THEORETICAL Major routes to PASS WITH GAPS
instead of FAIL. The **severity definition** one section above it is a third statement of the same
rule, and it had drifted the same way — #1543 left it reading *"fix or spec update required, and a
re-review after it"* for every Major, unqualified. The routing paragraph #1543 added already scoped
the cost to a **REAL** Major; the definition above it did not.

A reviewer could follow either. That is exactly the failure mode HARNESS-111 exists to remove, one
section earlier than where it was found.

`guard-review-verdict-honours-reality.bats` could not see it: its six assertions only read the
verdict list. It now reads both halves — 7/7, and reverting the line turns assertion 6 red.

## 2. f7's verification command printed instead of asserting (Major)

```
for f in <two SKILL.md copies>; do grep -cE '<defective forms>' "$f"; grep -cE '<routing rules>' "$f"; done
```

`grep -c` prints the count and the loop's exit status is the *last* grep's, so the "zero defective
forms" half was never asserted — a later successful routing-rule match produced rc=0 regardless.
This is the class `.claude/CLAUDE.md` documents under *"a verification that reads a pipeline's exit
status is exactly where this bites"*, sitting in the evidence command for an acceptance criterion.

It now tests both counts per file and exits non-zero on either. Mutation-proven both ways:
reinstating `next steps (before archive)` → rc=1; deleting a routing-rule line → rc=1; clean → rc=0.

## 3. The lesson misdescribed `review: waived` (Minor)

Lesson 275 said the waiver *"asserts no review happened"*. It asserts nothing:
`checkReviewGate` (`cli/internal/spec/review.go:281-287`) returns `nil` on a waiver carrying a reason
**before** it calls `FindReview`, so a passing `review.md` in the folder is never read. Same wrong
exit, accurate mechanism.

## Verification

```
scripts/compile-harness.sh --check                      # rc=0, no harness drift
bats tests/guard-review-verdict-honours-reality.bats    # 7/7, mutation-proven
cd cli && go build ./... && go vet ./... && GOOS=windows go vet ./... && go test ./...   # all ok
<f7's new command>                                      # rc=0, defective=0 routing=4 in both copies
```

Both SKILL.md copies carry finding 1 — the committed record under `harness/skills/` and the vault
source at `00_meta/skills/` — because nothing yet detects the two diverging (#1545).

## Note on the contract set

This edits `features.json` and `tasks.md`, which are the contract set the archive gate measures.
That is legitimate *only* because HARNESS-111 has no review yet: the review runs after this merges.
Once it does, these three files are closed and further findings go to `verification.md`. That
ordering is the rule #1543 established, applied to itself.
