### PR TITLE
chore(secrets): declare every fleet repo's CI as a NAN_API_KEY consumer

### DIFF
--- a/secrets/registry.yaml
+++ b/secrets/registry.yaml
@@ -110,7 +110,26 @@ secrets:
     # holds exactly one credential — see #1025 for the cost of the alternative.
     # daemon:hive-worker added by CLI-042 (#1190): the hive serve unit takes it
     # from `dotf secrets run`, so it is a consumer that holds nothing at rest.
-    consumers: ["agent:opencode", "agent:pi", "ci:mlorentedev/dotfiles", "daemon:hive-worker"]
+    # The other ci:… entries (2026-09-06): the pr-agent workflow rolled out to
+    # every repository in the fleet, each one a consumer of the same credential.
+    # Declared here so `dotf secrets sync ci --repo mlorentedev/<repo>` selects it;
+    # the sync itself is a separate, per-repo action by the owner.
+    consumers:
+      - agent:opencode
+      - agent:pi
+      - daemon:hive-worker
+      - ci:mlorentedev/dotfiles
+      - ci:mlorentedev/ts-bridge
+      - ci:mlorentedev/kubelab
+      - ci:mlorentedev/web
+      - ci:mlorentedev/garsync
+      - ci:mlorentedev/hive
+      - ci:mlorentedev/iris
+      - ci:mlorentedev/mail2markdown
+      - ci:mlorentedev/pdf-modifier-mcp
+      - ci:mlorentedev/pollex
+      - ci:mlorentedev/svqtriana.github.io
+      - ci:mlorentedev/yt-metrics-cli
     rotate: 90d
 
   - id: POLLEX_API_KEY


### PR DESCRIPTION
## Summary

The pr-agent workflow is being rolled out to every repository in the fleet today. Each workflow reads `NAN_API_KEY` from that repo's Actions secrets, and `dotf secrets sync ci --repo mlorentedev/<repo>` only uploads what `secrets/registry.yaml` declares as a `ci:<repo>` consumer.

- `NAN_API_KEY.consumers` gains `ci:mlorentedev/<repo>` for ts-bridge, kubelab, web, garsync, hive, iris, mail2markdown, pdf-modifier-mcp, pollex, svqtriana.github.io and yt-metrics-cli. The existing entries (`agent:opencode`, `agent:pi`, `ci:mlorentedev/dotfiles`, `daemon:hive-worker`) stay.
- The list moves from flow to block style so each repo is one line; no other field changes.

## After merge

The registry declares; it does not upload. For each repo the owner runs:

```
dotf secrets sync ci --repo mlorentedev/<repo>
```

Note that the secret exposes two vars (`NAN_API_KEY` and `HIVE_WORKER_API_KEY`, one credential under two names), so the sync will set both on every repo. That is the existing shape of the entry, not something this PR introduces.

## SDD skip rationale

Registry data change: one list extended, no code.

## Test plan

- [x] `go test ./internal/secrets/...` -> ok
- [x] Parsed the real `secrets/registry.yaml` with `ParseRegistry` and called `SelectCI("mlorentedev/<repo>")` for all eleven repos plus dotfiles in a throwaway test: every one selects `NAN_API_KEY,HIVE_WORKER_API_KEY` for upload (dotfiles additionally `RELEASE_TOKEN,BITACORA_PAT`). Not run: the real sync, which needs Bitwarden and is the owner's step.
- [x] `bats tests/agent-runtime-deployment.bats tests/secrets-show-callsites.bats tests/sensitive-hygiene.bats` -> 22 ok