### PR TITLE
fix(lessons): main is red — renumber two colliding lessons to 279 and 280

### DIFF
--- a/docs/lessons/_index.md
+++ b/docs/lessons/_index.md
@@ -296,3 +296,5 @@ tags: [lessons, index, dotfiles]
 | [276 - Intercepting Cobra errors without breaking `SilenceErrors`](lesson-276-intercepting-cobra-errors-without-breaking-silenceerrors.md) | 2026-08-30 |  |
 | [277 - One invalid field rejects the whole file, and the deployed copy hides it until a deploy](lesson-277-one-invalid-field-rejects-the-whole-file-and-the-deployed-copy-hides-it.md) | 2026-09-05 |  |
 | [278 - A cap asserted in one unit while the payload overflowed in another](lesson-278-a-cap-asserted-in-one-unit-while-the-platform-counts-another.md) | 2026-09-05 |  |
+| [279 - A helper written to "mirror" an existing parser is the defect; the transcription bug is only how you find out](lesson-279-a-helper-written-to-mirror-a-parser-is-the-defect.md) | 2026-09-05 |  |
+| [280 - A diagnosis repeated often enough becomes indistinguishable from evidence](lesson-280-a-diagnosis-repeated-often-enough-reads-as-evidence.md) | 2026-09-06 |  |

--- a/docs/lessons/lesson-279-a-helper-written-to-mirror-a-parser-is-the-defect.md
+++ b/docs/lessons/lesson-279-a-helper-written-to-mirror-a-parser-is-the-defect.md
@@ -1,5 +1,5 @@
 ---
-id: lesson-276
+id: lesson-279
 type: lesson
 status: active
 created: "2026-09-05"
@@ -7,7 +7,7 @@ owner: manu
 tags: [lesson, go, parsing, duplication, unicode, build]
 ---
 
-# 276 — A helper written to "mirror" an existing parser is the defect; the transcription bug is only how you find out
+# 279 — A helper written to "mirror" an existing parser is the defect; the transcription bug is only how you find out
 
 ## What happened
 

--- a/docs/lessons/lesson-280-a-diagnosis-repeated-often-enough-reads-as-evidence.md
+++ b/docs/lessons/lesson-280-a-diagnosis-repeated-often-enough-reads-as-evidence.md
@@ -1,5 +1,5 @@
 ---
-id: lesson-277
+id: lesson-280
 type: lesson
 status: active
 created: "2026-09-06"
@@ -7,7 +7,7 @@ owner: manu
 tags: [lesson, handoff, diagnosis, testing, evidence, session-continuity]
 ---
 
-# 277 — A diagnosis repeated often enough becomes indistinguishable from evidence
+# 280 — A diagnosis repeated often enough becomes indistinguishable from evidence
 
 ## What happened
 
@@ -175,3 +175,45 @@ the other. In the `--tier` case the right fix was in a third place neither the
 reviewer nor the original diff had named — `ResolveChain`, where both paths
 already meet — which is the usual shape once you stop taking the suggested
 location as part of the finding.
+
+## Postscript: this lesson collided with itself
+
+This file was written as 277 after a 275 collision with a parallel session. Both
+of us announced our numbers to each other explicitly, in writing, and still
+raced — ninety seconds apart.
+
+Then it happened **twice more, on this file and its sibling**, and left `main`
+red:
+
+```
+not ok 1 guard: no two lesson files share a number
+#   lesson-276
+#   lesson-277
+not ok 2 guard: every lesson file is listed in _index.md
+#   lesson-276-a-helper-written-to-mirror-a-parser-is-the-defect.md
+#   lesson-277-a-diagnosis-repeated-often-enough-reads-as-evidence.md
+```
+
+Renumbered to 279 and 280. The second failure is the sharper one: different
+filenames meant no conflict on the *files*, so whichever `_index.md` merged last
+simply won, and two lesson files landed in `main` **with no index entry at all**
+— which the guard's own message names exactly: *"the index is the only surface
+anything reads, so a lesson absent from it is a lesson nobody will find."* A
+silent loss, not a noisy one.
+
+**Neither PR was wrong and both were green when they merged.** Each was green
+against a `main` that did not yet contain the other. The guard fires on the merge
+commit, and a merge commit only exists once both have landed — so for two PRs
+merging inside the same window, **there is no moment at which either could have
+seen the collision.**
+
+That is the finding worth keeping, and it generalises past lesson numbers:
+
+**A check that runs at merge time cannot prevent a same-window collision. It can
+only report one afterwards.** Detection and allocation are different jobs, and a
+guard is only the first. Four instances in one evening, two of them while
+actively coordinating about the exact hazard, is not carelessness — it is what a
+net does when the thing it is asked to do is a lock's job.
+
+Tracked as #1542, which is the same defect for `dotf spec init`'s AREA-NNN ids.
+


### PR DESCRIPTION
Refs #1542. **`main` is currently red.** Documentation only — two renames, two `_index.md` rows, one postscript.

## The failure on `origin/main` right now

```
not ok 1 guard: no two lesson files share a number
#   lesson-276
#   lesson-277
not ok 2 guard: every lesson file is listed in _index.md
#   lesson-276-a-helper-written-to-mirror-a-parser-is-the-defect.md
#   lesson-277-a-diagnosis-repeated-often-enough-reads-as-evidence.md
```

Two files claim 276, two claim 277, and **both of mine are missing from the index.**

**The second failure is the one that matters.** Different filenames meant no conflict on the *files*, so whichever `_index.md` merged last simply won. Two lesson files are sitting in `main` with no index entry — which the guard's own message names exactly:

> the index is the only surface anything reads, so a lesson absent from it is a lesson nobody will find

A silent loss, not a noisy one. The number collision is the visible half; this is the half that would have cost something.

## The fix

`276-a-helper-written-to-mirror-a-parser` → **279**, `277-a-diagnosis-repeated-often-enough` → **280**. Filename, `id:` frontmatter, `#` heading, and the two restored index rows.

Renumbered **mine** rather than the others because the index already lists theirs — that is the coherent direction, not a claim about who was first. No file belonging to anyone else is touched.

## Nobody did anything wrong, and that is the point

**Both PRs were green when they merged.** Each was green against a `main` that did not yet contain the other. The guard fires on the *merge commit*, and a merge commit only exists once both have landed — so for two PRs merging inside the same window, **there is no moment at which either could have seen the collision.**

This is the **third and fourth instance today.** The first two were on lesson 275, between two sessions that had explicitly announced their numbers to each other in writing, ninety seconds apart — while writing up the lesson about lesson-number collisions.

Recorded as a postscript in 280 itself, because the generalisation is worth more than the incident:

> A check that runs at merge time cannot prevent a same-window collision. It can only report one afterwards. Detection and allocation are different jobs, and a guard is only the first.

Four instances in one evening, two of them while actively coordinating about the exact hazard, is not carelessness — it is what a net does when the thing it is asked to do is a lock's job. **#1542** is the same defect for `dotf spec init`'s `AREA-NNN` ids, and this should settle the shape of its AC1: allocation, not better detection.

## Verified

`guard-lesson-numbers-unique.bats` 4/4 and `check-md-escapes.bats` 13/13 on this branch.